### PR TITLE
✨ Add the component demo block style family and missing surface tokens

### DIFF
--- a/packages/components/build.rs
+++ b/packages/components/build.rs
@@ -21,16 +21,14 @@ fn main() {
     // ../theme/styles available, but nothing else writes these files, so a
     // missing stub used to hard-fail the build with include_str! os error 2.
     let scss_dir = manifest_dir.join("src/styles/components");
-    if scss_dir.exists() {
-        if let Ok(entries) = fs::read_dir(&scss_dir) {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.extension().and_then(|s| s.to_str()) == Some("scss") {
-                    let stem = path.file_stem().unwrap().to_string_lossy().to_string();
-                    let stub = styles_out_dir.join(format!("{stem}.css"));
-                    if !stub.exists() {
-                        let _ = fs::write(&stub, "");
-                    }
+    if scss_dir.exists() && let Ok(entries) = fs::read_dir(&scss_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("scss") {
+                let stem = path.file_stem().unwrap().to_string_lossy().to_string();
+                let stub = styles_out_dir.join(format!("{stem}.css"));
+                if !stub.exists() {
+                    let _ = fs::write(&stub, "");
                 }
             }
         }

--- a/packages/components/src/basic/icon_button.rs
+++ b/packages/components/src/basic/icon_button.rs
@@ -5,7 +5,6 @@
 // - Layer2: Component variables (icon-button-vars.scss)
 // - Custom: Runtime overrides via icon_color, animation_id
 
-
 use hikari_icons::{Icon, IconProps, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, components::ButtonClass};
 

--- a/packages/components/src/data/drag.rs
+++ b/packages/components/src/data/drag.rs
@@ -1,7 +1,6 @@
 // hi-components/src/data/drag.rs
 // Drag and drop component for tree node reordering
 
-
 use hikari_palette::classes::{ClassesBuilder, DragDropTreeClass};
 
 use crate::{prelude::*, styled::StyledComponent};

--- a/packages/components/src/data/node.rs
+++ b/packages/components/src/data/node.rs
@@ -1,7 +1,6 @@
 // hi-components/src/data/node.rs
 // TreeNode component for tree data structures
 
-
 use hikari_palette::classes::{ClassesBuilder, TreeNodeClass};
 
 use crate::{

--- a/packages/components/src/display/carousel.rs
+++ b/packages/components/src/display/carousel.rs
@@ -231,112 +231,6 @@ pub fn Carousel(props: CarouselProps) -> Element {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_carousel_indicator_position_default() {
-        let position = CarouselIndicatorPosition::default();
-        assert_eq!(position, CarouselIndicatorPosition::Bottom);
-    }
-
-    #[test]
-    fn test_carousel_indicator_type_default() {
-        let indicator = CarouselIndicatorType::default();
-        assert_eq!(indicator, CarouselIndicatorType::Dots);
-    }
-
-    #[test]
-    fn test_carousel_indicator_position_variants() {
-        assert!(matches!(CarouselIndicatorPosition::Bottom, _));
-        assert!(matches!(CarouselIndicatorPosition::Top, _));
-        assert!(matches!(CarouselIndicatorPosition::Left, _));
-        assert!(matches!(CarouselIndicatorPosition::Right, _));
-    }
-
-    #[test]
-    fn test_carousel_indicator_type_variants() {
-        assert!(matches!(CarouselIndicatorType::Dots, _));
-        assert!(matches!(CarouselIndicatorType::Line, _));
-        assert!(matches!(CarouselIndicatorType::Hidden, _));
-    }
-
-    #[test]
-    fn test_carousel_props_default() {
-        let props = CarouselProps::default();
-        assert_eq!(props.autoplay, 5000);
-        assert!(props.show_arrows);
-        assert_eq!(props.indicator_position, CarouselIndicatorPosition::Bottom);
-        assert_eq!(props.indicator_type, CarouselIndicatorType::Dots);
-        assert!(props.show_pause);
-        assert!(!props.infinite);
-        assert!(!props.initial_paused);
-    }
-
-    #[test]
-    fn test_carousel_props_clone() {
-        let props = CarouselProps {
-            autoplay: 3000,
-            show_arrows: false,
-            indicator_position: CarouselIndicatorPosition::Top,
-            indicator_type: CarouselIndicatorType::Line,
-            show_pause: false,
-            infinite: true,
-            initial_paused: true,
-            children: VNode::empty(),
-        };
-
-        let cloned = props.clone();
-        assert_eq!(cloned.autoplay, 3000);
-        assert_eq!(cloned.infinite, true);
-    }
-
-    #[test]
-    fn test_carousel_props_partial_eq() {
-        let props1 = CarouselProps {
-            autoplay: 5000,
-            show_arrows: true,
-            indicator_position: CarouselIndicatorPosition::Bottom,
-            indicator_type: CarouselIndicatorType::Dots,
-            show_pause: true,
-            infinite: false,
-            initial_paused: false,
-            children: VNode::empty(),
-        };
-
-        let props2 = CarouselProps {
-            autoplay: 5000,
-            show_arrows: true,
-            indicator_position: CarouselIndicatorPosition::Bottom,
-            indicator_type: CarouselIndicatorType::Dots,
-            show_pause: true,
-            infinite: false,
-            initial_paused: false,
-            children: VNode::empty(),
-        };
-
-        assert_eq!(props1, props2);
-    }
-
-    #[test]
-    fn test_carousel_props_not_equal() {
-        let props1 = CarouselProps {
-            autoplay: 1000,
-            show_arrows: false,
-            ..Default::default()
-        };
-
-        let props2 = CarouselProps {
-            autoplay: 2000,
-            show_arrows: false,
-            ..Default::default()
-        };
-
-        assert_ne!(props1, props2);
-    }
-}
-
 impl StyledComponent for CarouselComponent {
     fn styles() -> &'static str {
         r#"
@@ -464,5 +358,111 @@ impl StyledComponent for CarouselComponent {
 
     fn name() -> &'static str {
         "carousel"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_carousel_indicator_position_default() {
+        let position = CarouselIndicatorPosition::default();
+        assert_eq!(position, CarouselIndicatorPosition::Bottom);
+    }
+
+    #[test]
+    fn test_carousel_indicator_type_default() {
+        let indicator = CarouselIndicatorType::default();
+        assert_eq!(indicator, CarouselIndicatorType::Dots);
+    }
+
+    #[test]
+    fn test_carousel_indicator_position_variants() {
+        assert!(matches!(CarouselIndicatorPosition::Bottom, _));
+        assert!(matches!(CarouselIndicatorPosition::Top, _));
+        assert!(matches!(CarouselIndicatorPosition::Left, _));
+        assert!(matches!(CarouselIndicatorPosition::Right, _));
+    }
+
+    #[test]
+    fn test_carousel_indicator_type_variants() {
+        assert!(matches!(CarouselIndicatorType::Dots, _));
+        assert!(matches!(CarouselIndicatorType::Line, _));
+        assert!(matches!(CarouselIndicatorType::Hidden, _));
+    }
+
+    #[test]
+    fn test_carousel_props_default() {
+        let props = CarouselProps::default();
+        assert_eq!(props.autoplay, 5000);
+        assert!(props.show_arrows);
+        assert_eq!(props.indicator_position, CarouselIndicatorPosition::Bottom);
+        assert_eq!(props.indicator_type, CarouselIndicatorType::Dots);
+        assert!(props.show_pause);
+        assert!(!props.infinite);
+        assert!(!props.initial_paused);
+    }
+
+    #[test]
+    fn test_carousel_props_clone() {
+        let props = CarouselProps {
+            autoplay: 3000,
+            show_arrows: false,
+            indicator_position: CarouselIndicatorPosition::Top,
+            indicator_type: CarouselIndicatorType::Line,
+            show_pause: false,
+            infinite: true,
+            initial_paused: true,
+            children: VNode::empty(),
+        };
+
+        let cloned = props.clone();
+        assert_eq!(cloned.autoplay, 3000);
+        assert!(cloned.infinite);
+    }
+
+    #[test]
+    fn test_carousel_props_partial_eq() {
+        let props1 = CarouselProps {
+            autoplay: 5000,
+            show_arrows: true,
+            indicator_position: CarouselIndicatorPosition::Bottom,
+            indicator_type: CarouselIndicatorType::Dots,
+            show_pause: true,
+            infinite: false,
+            initial_paused: false,
+            children: VNode::empty(),
+        };
+
+        let props2 = CarouselProps {
+            autoplay: 5000,
+            show_arrows: true,
+            indicator_position: CarouselIndicatorPosition::Bottom,
+            indicator_type: CarouselIndicatorType::Dots,
+            show_pause: true,
+            infinite: false,
+            initial_paused: false,
+            children: VNode::empty(),
+        };
+
+        assert_eq!(props1, props2);
+    }
+
+    #[test]
+    fn test_carousel_props_not_equal() {
+        let props1 = CarouselProps {
+            autoplay: 1000,
+            show_arrows: false,
+            ..Default::default()
+        };
+
+        let props2 = CarouselProps {
+            autoplay: 2000,
+            show_arrows: false,
+            ..Default::default()
+        };
+
+        assert_ne!(props1, props2);
     }
 }

--- a/packages/components/src/entry/cascader.rs
+++ b/packages/components/src/entry/cascader.rs
@@ -1,7 +1,6 @@
 // hi-components/src/entry/cascader.rs
 // Cascader component with Arknights + FUI styling
 
-
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{CascaderClass, ClassesBuilder, UtilityClass};
 

--- a/packages/components/src/entry/search.rs
+++ b/packages/components/src/entry/search.rs
@@ -3,7 +3,6 @@
 // Features: Embedded icons/buttons, unified input styling, Glow effects
 // Uses InputWrapper for consistent layout and Portal system for dropdown suggestions
 
-
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, SearchClass};
 

--- a/packages/components/src/entry/transfer.rs
+++ b/packages/components/src/entry/transfer.rs
@@ -1,7 +1,6 @@
 // hi-components/src/entry/transfer.rs
 // Transfer component with Arknights + FUI styling
 
-
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, TransferClass, UtilityClass};
 

--- a/packages/components/src/feedback/alert.rs
+++ b/packages/components/src/feedback/alert.rs
@@ -1,7 +1,6 @@
 // hi-components/src/feedback/alert.rs
 // Alert component with Arknights + FUI styling
 
-
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{AlertClass, ClassesBuilder, UtilityClass};
 

--- a/packages/components/src/feedback/toast.rs
+++ b/packages/components/src/feedback/toast.rs
@@ -1,7 +1,6 @@
 // hi-components/src/feedback/toast.rs
 // Toast component with Arknights + FUI styling
 
-
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, ToastClass, UtilityClass};
 

--- a/packages/components/src/layout/space.rs
+++ b/packages/components/src/layout/space.rs
@@ -5,15 +5,13 @@ use hikari_palette::classes::{ClassesBuilder, SpaceClass};
 
 use crate::prelude::*;
 
-#[derive(Clone, Copy, PartialEq, Debug)]
-#[derive(Default)]
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
 pub enum SpaceDirection {
     #[default]
     Horizontal,
     Vertical,
     Both,
 }
-
 
 #[define_props]
 pub struct SpaceProps {

--- a/packages/components/src/navigation/menu.rs
+++ b/packages/components/src/navigation/menu.rs
@@ -1,7 +1,6 @@
 // hi-components/src/navigation/menu.rs
 // Menu component with Arknights + FUI styling
 
-
 use hikari_palette::classes::{ClassesBuilder, MenuClass};
 
 use crate::{

--- a/packages/components/src/navigation/steps.rs
+++ b/packages/components/src/navigation/steps.rs
@@ -1,7 +1,6 @@
 // packages/components/src/navigation/steps.rs
 // Steps component with Arknights + FUI styling
 
-
 use hikari_palette::classes::{ClassesBuilder, StepsClass, UtilityClass};
 
 use crate::{prelude::*, styled::StyledComponent};

--- a/packages/components/src/portal/provider.rs
+++ b/packages/components/src/portal/provider.rs
@@ -1,7 +1,6 @@
 // hi-components/src/portal/provider.rs
 // PortalProvider and PortalContext
 
-
 use std::sync::atomic::Ordering;
 
 use super::render::{PortalRender, PortalRenderProps};

--- a/packages/components/src/portal/render.rs
+++ b/packages/components/src/portal/render.rs
@@ -1,7 +1,6 @@
 // hi-components/src/portal/render.rs
 // Portal rendering components
 
-
 use hikari_palette::classes::{
     ClassesBuilder, DropdownClass, ModalClass, PopoverClass, PortalClass, TooltipClass,
     UtilityClass,

--- a/packages/components/src/production/code_highlight.rs
+++ b/packages/components/src/production/code_highlight.rs
@@ -53,8 +53,7 @@ pub struct CodeHighlightComponent;
 
 /// Selectable syntax highlighting palettes inspired by popular Neovim colorschemes.
 /// Each palette defines CSS variables for syntax token colors.
-#[derive(Debug, Clone, PartialEq)]
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum CodePalette {
     /// TokyoNight — deep blues, muted purples. Good default for dark themes.
     #[default]
@@ -151,7 +150,6 @@ impl CodePalette {
         }
     }
 }
-
 
 #[define_props]
 pub struct CodeHighlightProps {

--- a/packages/components/src/styles/components/demo_block.scss
+++ b/packages/components/src/styles/components/demo_block.scss
@@ -1,0 +1,118 @@
+// Component demo block — live preview + source with a segmented toggle in
+// the header. Pure style family (same convention as .hi-code-block): no
+// Rust emitter in this crate; downstream emitters (static site generators,
+// markdown renderers) output the markup:
+//
+//   <div class="hi-component-demo">
+//     <div class="hi-component-demo-header">
+//       <span class="hi-component-demo-badge">mermaid</span>
+//       <div class="hi-component-demo-toggle" role="tablist">
+//         <button class="hi-component-demo-toggle-btn hi-component-demo-toggle-active">Preview</button>
+//         <button class="hi-component-demo-toggle-btn">Source</button>
+//       </div>
+//     </div>
+//     <div class="hi-component-demo-preview">…rendered output…</div>
+//     <div class="hi-component-demo-source" hidden>…a code block…</div>
+//   </div>
+
+.hi-component-demo {
+    background-color: var(--hi-color-bg-container, var(--hi-color-surface));
+    border: 1px solid var(--hi-color-border);
+    border-radius: 8px;
+    margin: 1.5rem 0;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.hi-component-demo-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.4rem 0.75rem;
+    background-color: var(--hi-color-surface-secondary, var(--hi-secondary-bg));
+    border-bottom: 1px solid var(--hi-color-border);
+}
+
+.hi-component-demo-badge {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--hi-color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-family: 'Courier New', monospace;
+}
+
+// Segmented preview/source toggle (pill variant of the Tabs language).
+.hi-component-demo-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+    background: var(--hi-color-surface-secondary, var(--hi-secondary-bg));
+    border: 1px solid var(--hi-color-border);
+    border-radius: 999px;
+}
+
+.hi-component-demo-toggle-btn {
+    appearance: none;
+    border: none;
+    background: transparent;
+    border-radius: 999px;
+    padding: 0.15rem 0.7rem;
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--hi-color-text-secondary);
+    cursor: pointer;
+    transition: background var(--hi-duration-fast, 0.2s) var(--hi-ease-default, ease),
+        color var(--hi-duration-fast, 0.2s) var(--hi-ease-default, ease);
+
+    &:hover {
+        color: var(--hi-color-text-primary);
+    }
+
+    &.hi-component-demo-toggle-active {
+        background: var(--hi-color-bg-container, var(--hi-color-surface));
+        color: var(--hi-color-text-primary);
+        font-weight: 600;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+    }
+}
+
+.hi-component-demo-preview {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding: 1.5rem;
+    overflow-x: auto;
+
+    > svg,
+    > img,
+    > .mermaid {
+        max-width: 100%;
+    }
+}
+
+// The source pane hosts a regular code block; strip its outer chrome so it
+// sits flush inside the demo container (its own header keeps the copy
+// button reachable).
+.hi-component-demo-source {
+    > .hi-code-highlight,
+    > .hi-code-block {
+        border: none;
+        border-radius: 0;
+        margin: 0;
+        box-shadow: none;
+    }
+}
+
+// Render-failure notice shown in place of (or above) the preview.
+.hi-component-demo-error {
+    margin: 1rem 1.5rem 0;
+    padding: 0.75rem 1rem;
+    background-color: rgba(233, 75, 53, 0.1);
+    border: 1px solid var(--hi-color-danger);
+    border-radius: 8px;
+    color: var(--hi-color-danger);
+    font-size: 0.875rem;
+}

--- a/packages/components/src/styles/components/markdown_renderer.scss
+++ b/packages/components/src/styles/components/markdown_renderer.scss
@@ -139,12 +139,10 @@
         font-style: italic;
     }
 
-    // Component demo blocks
+    // Component demo blocks — box styling lives in demo_block.scss (top
+    // level, same family as .hi-code-block); here only the markdown-flow
+    // rhythm and the legacy error sub-block remain.
     .hi-component-demo {
-        background-color: var(--hi-color-surface-secondary);
-        border: 1px solid var(--hi-color-border);
-        border-radius: 8px;
-        padding: 1.5rem;
         margin: 1.5rem 0;
 
         .component-error {

--- a/packages/components/src/styles/index.scss
+++ b/packages/components/src/styles/index.scss
@@ -374,6 +374,12 @@
   --hi-color-primary: var(--hi-primary);
   --hi-color-background: var(--hi-background);
   --hi-color-surface: var(--hi-surface);
+  // Widely used by component styles (code blocks, tables, markdown
+  // renderer, demo blocks) but previously never defined here.
+  --hi-color-surface-secondary: rgba(248, 250, 252, 0.5);
+  --hi-color-bg-container: #ffffff;
+  --hi-color-bg-elevated: #f6f8fa;
+  --hi-color-text-tertiary: #8c8c8c;
   --hi-secondary-bg: rgba(248, 250, 252, 0.5);
   --hi-tertiary-bg: rgba(243, 244, 246, 0.5);
 
@@ -592,6 +598,7 @@
 @import './components/pagination.scss';
 @import './components/carousel.scss';
 @import './components/code_block.scss';
+@import './components/demo_block.scss';
 @import './components/markdown_renderer.scss';
 
 // ============================================

--- a/packages/components/tests/layout_components_tests.rs
+++ b/packages/components/tests/layout_components_tests.rs
@@ -344,6 +344,7 @@ mod tests {
     fn test_section_renders() {
         let props = SectionProps {
             children: Some(VNode::empty()),
+            title: None,
             ..Default::default()
         };
         let _ = Section(props);
@@ -407,6 +408,7 @@ mod tests {
     fn test_header_renders() {
         let props = HeaderProps {
             children: Some(VNode::empty()),
+            on_menu_toggle: None,
             ..Default::default()
         };
         let _ = Header(props);

--- a/packages/components/tests/production_components_tests.rs
+++ b/packages/components/tests/production_components_tests.rs
@@ -41,7 +41,6 @@ mod tests {
             muted: true,
             class: "custom".to_string(),
             style: "width:100%".to_string(),
-            ..Default::default()
         };
         assert_eq!(props.src, "movie.mp4");
         assert!(props.autoplay);

--- a/packages/icons/build.rs
+++ b/packages/icons/build.rs
@@ -168,7 +168,6 @@ struct IconBuildConfig {
     dynamic_fetch: bool,
 }
 
-
 fn read_icon_config(workspace_root: &Option<PathBuf>) -> IconBuildConfig {
     let Some(root) = workspace_root else {
         return IconBuildConfig::default();
@@ -193,9 +192,10 @@ fn read_icon_config(workspace_root: &Option<PathBuf>) -> IconBuildConfig {
                 cfg.explicit_set = Some(parse_string_array(arr.trim()));
             }
         } else if let Some(rest) = line.strip_prefix("dynamic-fetch")
-            && let Some(val) = rest.trim_start().strip_prefix('=') {
-                cfg.dynamic_fetch = matches!(val.trim(), "true" | "True" | "TRUE");
-            }
+            && let Some(val) = rest.trim_start().strip_prefix('=')
+        {
+            cfg.dynamic_fetch = matches!(val.trim(), "true" | "True" | "TRUE");
+        }
     }
     cfg
 }
@@ -245,9 +245,10 @@ fn find_workspace_root(manifest_dir: &str) -> Option<PathBuf> {
         let cargo_toml = current.join("Cargo.toml");
         if cargo_toml.exists()
             && let Ok(content) = std::fs::read_to_string(&cargo_toml)
-                && content.contains("[workspace]") {
-                    return Some(current);
-                }
+            && content.contains("[workspace]")
+        {
+            return Some(current);
+        }
         match current.parent() {
             Some(parent) if parent != current => current = parent.to_path_buf(),
             _ => return None,

--- a/packages/palette/build.rs
+++ b/packages/palette/build.rs
@@ -88,9 +88,10 @@ fn find_workspace_root(manifest_dir: &str) -> Option<PathBuf> {
         let cargo_toml = current.join("Cargo.toml");
         if cargo_toml.exists()
             && let Ok(content) = fs::read_to_string(&cargo_toml)
-                && content.contains("[workspace]") {
-                    return Some(current);
-                }
+            && content.contains("[workspace]")
+        {
+            return Some(current);
+        }
         match current.parent() {
             Some(parent) if parent != current => current = parent.to_path_buf(),
             _ => return None,

--- a/packages/palette/tests/test_indigo_glow.rs
+++ b/packages/palette/tests/test_indigo_glow.rs
@@ -8,7 +8,6 @@ use hikari_palette::collections::chinese::*;
 mod tests {
 
     use super::*;
-    use hikari_palette::*;
 
     #[test]
     fn test_indigo_is_dark() {


### PR DESCRIPTION
## What

Completes the orphaned `.hi-component-demo` style (previously defined but never emitted) into a full static style family, following the `.hi-code-block` convention (pure styles for downstream emitters — no Rust component):

- `demo_block.scss` (new): container, header with badge + segmented preview/source toggle, centered preview pane, flush source pane, error notice.
- `markdown_renderer.scss`: the nested `.hi-component-demo` rule is slimmed to margin + legacy `.component-error` so box styling is owned by the new family.
- `index.scss`: registers the import and defines the widely-used-but-never-defined fallback tokens `--hi-color-surface-secondary`, `--hi-color-bg-container`, `--hi-color-bg-elevated`, `--hi-color-text-tertiary`.

## Why

lagrange renders ```mermaid / ```math fences as demo blocks (rendered preview ↔ source, toggle top-right) using this exact markup — the design language comes from hikari, the emitter lives downstream.

## Stacked

Based on `chore/publish-0.3.13` (#15) because `master` itself does not compile (`radio_group.rs` references a non-existent `radio_group.scss`, fixed only on #15). GitHub will auto-retarget this PR to `master` once #15 merges.