### PR TITLE
🔧 Bump publish timeout from 15→30 min for 6-package release.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,7 +61,7 @@ jobs:
   publish:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: verify-versions
 
     steps:


### PR DESCRIPTION
6 publishable crates × up to 5 min crates.io indexing wait = need 30 min budget. Matches the same fix applied in tairitsu#30.