### PR TITLE
🐛 Add SCSS styles directory as grass load path in build script.

### DIFF
--- a/packages/theme/build.rs
+++ b/packages/theme/build.rs
@@ -32,7 +32,9 @@ fn build_scss_bundle() -> Result<()> {
     let mut all_css = String::new();
 
     for scss_file in &scss_files {
-        let css = grass::from_path(scss_file, &grass::Options::default())?;
+        let mut options = grass::Options::default();
+        options = options.load_path(&scss_dir);
+        let css = grass::from_path(scss_file, &options)?;
         all_css.push_str(&css);
         all_css.push('\n');
     }


### PR DESCRIPTION
grass::from_path() without explicit load paths cannot resolve @use imports (tokens, glass, scrollbar) in foundation.scss on macOS CI. Adding the styles/ directory as a load path fixes this.