### PR TITLE
🐛 Drop `.scss` extension from theme `@use` imports for load-path resolution.

### DIFF
--- a/packages/components/src/styles/checkbox.scss
+++ b/packages/components/src/styles/checkbox.scss
@@ -1,7 +1,7 @@
 // Hikari Checkbox Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Checkbox Component

--- a/packages/components/src/styles/components/alert.scss
+++ b/packages/components/src/styles/components/alert.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Alert Component

--- a/packages/components/src/styles/components/arrow.scss
+++ b/packages/components/src/styles/components/arrow.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Hikari Arrow Component - FUI Styling

--- a/packages/components/src/styles/components/aside.scss
+++ b/packages/components/src/styles/components/aside.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Icon color inheritance for theme support

--- a/packages/components/src/styles/components/avatar.scss
+++ b/packages/components/src/styles/components/avatar.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Hikari Avatar Component

--- a/packages/components/src/styles/components/background.scss
+++ b/packages/components/src/styles/components/background.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Background Component - Gradient Animation

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Badge Component

--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Breadcrumb Component

--- a/packages/components/src/styles/components/button.scss
+++ b/packages/components/src/styles/components/button.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 @use './button-vars.scss' as button-vars;
 
 // ============================================

--- a/packages/components/src/styles/components/card.scss
+++ b/packages/components/src/styles/components/card.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 @use './card-vars.scss' as card-vars;
 
 // ============================================

--- a/packages/components/src/styles/components/cascader.scss
+++ b/packages/components/src/styles/components/cascader.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari // Hikari // Hikari // Hikari // Hikari Cascader Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/checkbox.scss
+++ b/packages/components/src/styles/components/checkbox.scss
@@ -1,7 +1,7 @@
 // Hikari Checkbox Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Checkbox Component

--- a/packages/components/src/styles/components/container.scss
+++ b/packages/components/src/styles/components/container.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Hikari Container Component

--- a/packages/components/src/styles/components/flex.scss
+++ b/packages/components/src/styles/components/flex.scss
@@ -1,7 +1,7 @@
 // hi-components/src/layout/flex.scss
 // FlexBox component styles
 
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // FlexBox Component

--- a/packages/components/src/styles/components/glow.scss
+++ b/packages/components/src/styles/components/glow.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Glow Component - Single Glow Color System

--- a/packages/components/src/styles/components/grid.scss
+++ b/packages/components/src/styles/components/grid.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Hikari Grid System

--- a/packages/components/src/styles/components/header.scss
+++ b/packages/components/src/styles/components/header.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Header Component

--- a/packages/components/src/styles/components/icon_button.scss
+++ b/packages/components/src/styles/components/icon_button.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 @use './icon-button-vars.scss' as icon-button-vars;
 
 // ============================================

--- a/packages/components/src/styles/components/image.scss
+++ b/packages/components/src/styles/components/image.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Hikari Image Component

--- a/packages/components/src/styles/components/input.scss
+++ b/packages/components/src/styles/components/input.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 @use './input-vars.scss' as input-vars;
 
 // ============================================

--- a/packages/components/src/styles/components/input_wrapper.scss
+++ b/packages/components/src/styles/components/input_wrapper.scss
@@ -8,7 +8,7 @@
 // - Input field takes remaining space
 // - Icon sizes: Small(24px), Medium(32px), Large(40px)
 
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Wrapper Container

--- a/packages/components/src/styles/components/layout.scss
+++ b/packages/components/src/styles/components/layout.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Layout Component

--- a/packages/components/src/styles/components/link.scss
+++ b/packages/components/src/styles/components/link.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Link Component

--- a/packages/components/src/styles/components/menu.scss
+++ b/packages/components/src/styles/components/menu.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Menu Component

--- a/packages/components/src/styles/components/modal.scss
+++ b/packages/components/src/styles/components/modal.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 @use './modal-vars.scss' as modal-vars;
 
 // ============================================

--- a/packages/components/src/styles/components/number_input.scss
+++ b/packages/components/src/styles/components/number_input.scss
@@ -1,7 +1,7 @@
 // NumberInput Component Styles
 // Uses InputWrapper for layout, only number-input-specific styles here
 
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // NumberInput Wrapper

--- a/packages/components/src/styles/components/pagination.scss
+++ b/packages/components/src/styles/components/pagination.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari // Hikari // Hikari // Hikari // Hikari Pagination Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/radio.scss
+++ b/packages/components/src/styles/components/radio.scss
@@ -1,7 +1,7 @@
 // Hikari Radio Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Radio Component

--- a/packages/components/src/styles/components/search.scss
+++ b/packages/components/src/styles/components/search.scss
@@ -1,7 +1,7 @@
 // Search Component Styles
 // Uses InputWrapper for layout, only search-specific styles here
 
-@use '../../../../theme/styles/variables.scss' as vars;
+@use '../../../../theme/styles/variables' as vars;
 
 // ============================================
 // Search Wrapper

--- a/packages/components/src/styles/components/section.scss
+++ b/packages/components/src/styles/components/section.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Section Component

--- a/packages/components/src/styles/components/select.scss
+++ b/packages/components/src/styles/components/select.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Select Component — Custom FUI Dropdown

--- a/packages/components/src/styles/components/sidebar.scss
+++ b/packages/components/src/styles/components/sidebar.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Sidebar Component - Multi-level Navigation

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Table Component - FUI Styling

--- a/packages/components/src/styles/components/tabs.scss
+++ b/packages/components/src/styles/components/tabs.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari // Hikari // Hikari // Hikari // Hikari Tabs Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/toast.scss
+++ b/packages/components/src/styles/components/toast.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Toast Component - Emphasis Style

--- a/packages/components/src/styles/components/tooltip.scss
+++ b/packages/components/src/styles/components/tooltip.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Tooltip Component - FUI Styling

--- a/packages/components/src/styles/components/transfer.scss
+++ b/packages/components/src/styles/components/transfer.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari // Hikari // Hikari // Hikari // Hikari Transfer Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/tree.scss
+++ b/packages/components/src/styles/components/tree.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari // Hikari // Hikari // Hikari // Hikari Tree View Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/typography.scss
+++ b/packages/components/src/styles/components/typography.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables.scss' as vars;
-@use '../../../../theme/styles/mixins.scss' as mix;
+@use '../../../../theme/styles/variables' as vars;
+@use '../../../../theme/styles/mixins' as mix;
 
 // ============================================
 // Hikari Typography Component

--- a/packages/components/src/styles/index.scss
+++ b/packages/components/src/styles/index.scss
@@ -9,15 +9,15 @@
 // ============================================
 
 // Use @use with as * to make variables available to all imported files
-@use '../../../theme/styles/variables.scss' as *;
-@use '../../../theme/styles/mixins.scss' as *;
+@use '../../../theme/styles/variables' as *;
+@use '../../../theme/styles/mixins' as *;
 
 // ============================================
 // Theme Base Styles (before components)
 // ============================================
 
 // Import theme base styles with CSS variables for hikari and tairitsu themes
-@import '../../../theme/styles/base.scss';
+@import '../../../theme/styles/base';
 
 // ============================================
 // Utility Classes (Tailwind-compatible)


### PR DESCRIPTION
grass's load-path fallback is skipped when @use/@import carries an explicit .scss extension. Removing the extension allows the scss! macro's load-path mechanism (see tairitsu PR) to find hikari-theme's styles directory.

40 component SCSS files touched, all with the same mechanical change.