### PR TITLE
✨ Add Vue 3 component library sharing hikari SCSS styles.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 exclude = [
     "examples/*",
     "examples/demo",
+    "packages/vue",
 ]
 
 [workspace.package]

--- a/packages/vue/index.html
+++ b/packages/vue/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Hikari Vue 3 Demo</title></head>
+<body><div id="app"></div><script type="module" src="/src/demo.ts"></script></body>
+</html>

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@hikari/vue",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "description": "Hikari Vue 3 component library — shares SCSS with hikari Rust/WASM renderer",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./styles": "./src/styles/index.scss"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "vue": "^3.5"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "sass": "^1.80.0",
+    "typescript": "^5.7",
+    "vite": "^6.0.0",
+    "vue-tsc": "^2.0.0"
+  }
+}

--- a/packages/vue/src/components/Avatar.vue
+++ b/packages/vue/src/components/Avatar.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+defineProps<{ src?: string; name?: string; size?: 'sm' | 'md' | 'lg' }>();
+</script>
+<template>
+  <div class="hikari-avatar" :class="[`hikari-avatar--${size ?? 'md'}`]">
+    <img v-if="src" :src="src" :alt="name" />
+    <span v-else class="hikari-avatar__fallback">{{ name?.charAt(0)?.toUpperCase() ?? '?' }}</span>
+  </div>
+</template>
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/avatar.scss";
+</style>

--- a/packages/vue/src/components/Button.vue
+++ b/packages/vue/src/components/Button.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+defineProps<{
+  variant?: 'primary' | 'secondary' | 'danger' | 'ghost';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  loading?: boolean;
+}>();
+
+defineEmits<{
+  click: [e: MouseEvent];
+}>();
+</script>
+
+<template>
+  <button
+    class="hikari-btn"
+    :class="[`hikari-btn--${variant ?? 'primary'}`, `hikari-btn--${size ?? 'md'}`]"
+    :disabled="disabled ?? loading"
+    @click="$emit('click', $event)"
+  >
+    <span v-if="loading" class="hikari-btn__spinner" />
+    <slot />
+  </button>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/button.scss";
+@use "../../../components/src/styles/components/button-vars.scss";
+</style>

--- a/packages/vue/src/components/Card.vue
+++ b/packages/vue/src/components/Card.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{
+  padding?: 'none' | 'sm' | 'md' | 'lg';
+  hoverable?: boolean;
+}>();
+</script>
+
+<template>
+  <div class="hikari-card" :class="[`hikari-card--${padding ?? 'md'}`, { 'hikari-card--hoverable': hoverable }]">
+    <slot />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/card.scss";
+@use "../../../components/src/styles/components/card-vars.scss";
+</style>

--- a/packages/vue/src/components/Input.vue
+++ b/packages/vue/src/components/Input.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { computed, useAttrs } from 'vue';
+
+const props = defineProps<{
+  modelValue: string | number;
+  type?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  error?: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | number];
+}>();
+
+const attrs = useAttrs();
+const inputAttrs = computed(() => {
+  const { class: _, ...rest } = attrs;
+  return rest;
+});
+</script>
+
+<template>
+  <div class="hikari-input-wrapper" :class="{ 'hikari-input-wrapper--error': error }">
+    <input
+      class="hikari-input"
+      :type="type ?? 'text'"
+      :value="modelValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      v-bind="inputAttrs"
+      @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    />
+    <span v-if="error" class="hikari-input__error">{{ error }}</span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/input.scss";
+@use "../../../components/src/styles/components/input-vars.scss";
+@use "../../../components/src/styles/components/input_wrapper.scss";
+</style>

--- a/packages/vue/src/components/Modal.vue
+++ b/packages/vue/src/components/Modal.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  open: boolean;
+  title?: string;
+  width?: string;
+}>();
+
+defineEmits<{
+  close: [];
+}>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="hikari-modal-overlay" @click.self="$emit('close')">
+      <div class="hikari-modal" :style="{ width: width ?? '520px' }">
+        <div v-if="title" class="hikari-modal__header">
+          <h3>{{ title }}</h3>
+          <button class="hikari-modal__close" @click="$emit('close')">&times;</button>
+        </div>
+        <div class="hikari-modal__body">
+          <slot />
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/modal.scss";
+@use "../../../components/src/styles/components/modal-vars.scss";
+</style>

--- a/packages/vue/src/components/Sidebar.vue
+++ b/packages/vue/src/components/Sidebar.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+defineProps<{
+  width?: string;
+  collapsed?: boolean;
+}>();
+</script>
+
+<template>
+  <aside class="hikari-sidebar" :class="{ 'hikari-sidebar--collapsed': collapsed }" :style="{ width: collapsed ? '64px' : width ?? '240px' }">
+    <slot />
+  </aside>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/sidebar.scss";
+</style>

--- a/packages/vue/src/components/Tabs.vue
+++ b/packages/vue/src/components/Tabs.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref, provide, watch, onMounted } from 'vue';
+
+const props = defineProps<{
+  modelValue?: string;
+  tabs: { key: string; label: string; disabled?: boolean }[];
+}>();
+
+const emit = defineEmits<{ 'update:modelValue': [key: string] }>();
+
+const activeKey = ref(props.modelValue ?? props.tabs[0]?.key ?? '');
+
+watch(() => props.modelValue, (v) => { if (v) activeKey.value = v; });
+watch(activeKey, (v) => emit('update:modelValue', v));
+
+provide('activeTab', activeKey);
+</script>
+
+<template>
+  <div class="hikari-tabs">
+    <div class="hikari-tabs__nav">
+      <button
+        v-for="tab in tabs"
+        :key="tab.key"
+        class="hikari-tabs__tab"
+        :class="{ 'hikari-tabs__tab--active': activeKey === tab.key }"
+        :disabled="tab.disabled"
+        @click="activeKey = tab.key"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+    <div class="hikari-tabs__content">
+      <slot :activeKey="activeKey" />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/tabs.scss";
+</style>

--- a/packages/vue/src/components/Toast.vue
+++ b/packages/vue/src/components/Toast.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+export interface ToastItem {
+  id: number;
+  message: string;
+  type: 'info' | 'success' | 'warning' | 'error';
+}
+
+const toasts = ref<ToastItem[]>([]);
+let nextId = 0;
+
+function show(message: string, type: ToastItem['type'] = 'info', duration = 3000) {
+  const id = nextId++;
+  toasts.value.push({ id, message, type });
+  setTimeout(() => {
+    toasts.value = toasts.value.filter(t => t.id !== id);
+  }, duration);
+}
+
+defineExpose({ show });
+</script>
+
+<template>
+  <div class="hikari-toast-container">
+    <div
+      v-for="toast in toasts"
+      :key="toast.id"
+      class="hikari-toast"
+      :class="`hikari-toast--${toast.type}`"
+    >
+      {{ toast.message }}
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@use "../../../components/src/styles/components/toast.scss";
+</style>

--- a/packages/vue/src/composables/useToast.ts
+++ b/packages/vue/src/composables/useToast.ts
@@ -1,0 +1,21 @@
+import { ref } from 'vue';
+
+interface ToastItem {
+  id: number;
+  message: string;
+  type: 'info' | 'success' | 'warning' | 'error';
+}
+
+const toasts = ref<ToastItem[]>([]);
+let nextId = 0;
+
+export function useToast() {
+  function show(message: string, type: ToastItem['type'] = 'info', duration = 3000) {
+    const id = nextId++;
+    toasts.value.push({ id, message, type });
+    setTimeout(() => {
+      toasts.value = toasts.value.filter(t => t.id !== id);
+    }, duration);
+  }
+  return { toasts, show };
+}

--- a/packages/vue/src/demo.ts
+++ b/packages/vue/src/demo.ts
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./demo/App.vue";
+import "../src/styles/index.scss";
+createApp(App).mount("#app");

--- a/packages/vue/src/demo/App.vue
+++ b/packages/vue/src/demo/App.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { HkButton, HkCard, HkInput, HkModal, HkSidebar, HkTabs } from '../index';
+
+const modalOpen = ref(false);
+const inputValue = ref('');
+const tabs = [
+  { key: 'general', label: 'General' },
+  { key: 'models', label: 'Models' },
+  { key: 'settings', label: 'Settings' },
+];
+const activeTab = ref('general');
+</script>
+
+<template>
+  <div style="display:flex;height:100vh;">
+    <HkSidebar>
+      <div style="padding:1rem">Hikari Vue</div>
+    </HkSidebar>
+    <main style="flex:1;padding:2rem;">
+      <HkCard>
+        <HkTabs v-model="activeTab" :tabs="tabs" />
+        <div style="margin-top:1rem;">
+          <HkInput v-model="inputValue" placeholder="Type something..." />
+          <p style="margin-top:.5rem;">You typed: {{ inputValue }}</p>
+        </div>
+        <div style="margin-top:1rem;">
+          <HkButton @click="modalOpen = true">Open Modal</HkButton>
+          <HkButton variant="secondary" style="margin-left:.5rem;">Cancel</HkButton>
+        </div>
+      </HkCard>
+    </main>
+    <HkModal :open="modalOpen" title="Demo Modal" @close="modalOpen = false">
+      <p>This is a modal dialog.</p>
+      <HkButton @click="modalOpen = false">Close</HkButton>
+    </HkModal>
+  </div>
+</template>

--- a/packages/vue/src/env.d.ts
+++ b/packages/vue/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,9 @@
+export { default as HkButton } from "./components/Button.vue";
+export { default as HkCard } from "./components/Card.vue";
+export { default as HkInput } from "./components/Input.vue";
+export { default as HkModal } from "./components/Modal.vue";
+export { default as HkSidebar } from "./components/Sidebar.vue";
+export { default as HkTabs } from "./components/Tabs.vue";
+export { default as HkToast } from "./components/Toast.vue";
+export { default as HkAvatar } from "./components/Avatar.vue";
+export { useToast } from "./composables/useToast";

--- a/packages/vue/src/styles/index.scss
+++ b/packages/vue/src/styles/index.scss
@@ -1,0 +1,7 @@
+// Re-export shared hikari theme and component styles
+@use "../../../theme/styles/variables.scss";
+@use "../../../theme/styles/mixins.scss";
+@use "../../../theme/styles/foundation.scss";
+@use "../../../theme/styles/base.scss";
+@use "../../../theme/styles/themes.scss";
+@use "../../../components/src/styles/index.scss";

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@hikari/vue": ["./src/index.ts"],
+      "@hikari/vue/styles": ["./src/styles/index.scss"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.d.ts"],
+  "references": []
+}


### PR DESCRIPTION
## Summary

Add `@hikari/vue` — a Vue 3 component library that shares SCSS styles with the existing hikari Rust/WASM renderer.

### Design
- Each Vue component imports the corresponding hikari SCSS file directly
- One source of truth for styles: the shared SCSS in `packages/components/src/styles/` and `packages/theme/styles/`
- Vue 3 Composition API with `<script setup lang="ts">`

### Components
- `HkButton` — primary/secondary/danger/ghost variants with loading state
- `HkCard` — hoverable card with padding options
- `HkInput` — text input with v-model, error state
- `HkModal` — teleported dialog with overlay
- `HkSidebar` — collapsible sidebar
- `HkTabs` — tab navigation with v-model
- `HkToast` — notification composable + component
- `HkAvatar` — image/fallback avatar

### Usage
```
pnpm add @hikari/vue
```

Import styles once:
```ts
import '@hikari/vue/styles'
```

Use components:
```vue
<HkButton variant="primary" @click="...">Click</HkButton>
<HkCard hoverable>Content</HkCard>
```

### Version
Starting at 0.3.0 — aligns with the Rust crate version numbering.

### Future
- This Vue layer is the "current implementation"; the Rust/WASM layer is the "future implementation"
- Both share the same SCSS stylesheets
- Consumers (arona, shittim-chest) can use Vue components now and migrate to WASM later without style changes