### PR TITLE
🔧 Rename package to @celestia-island/hikari.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   publish:
-    name: Publish @hikari/vue to npm
+    name: Publish @celestia-island/hikari to npm
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
             v="${GITHUB_REF_NAME#v}"
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
-          echo "Publishing @hikari/vue@$v"
+          echo "Publishing @celestia-island/hikari@$v"
 
       - name: Bump version
         shell: bash

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,12 +1,12 @@
-# @hikari/vue
+# @celestia-island/hikari
 
 Vue 3 component library sharing SCSS styles with the hikari Rust/WASM renderer.
 
 ## Installation
 
 ```bash
-npm install @hikari/vue
-pnpm add @hikari/vue
+npm install @celestia-island/hikari
+pnpm add @celestia-island/hikari
 ```
 
 ## Usage
@@ -15,7 +15,7 @@ Import styles once in your app entry point:
 
 ```ts
 // main.ts
-import "@hikari/vue/styles";
+import "@celestia-island/hikari/styles";
 import { createApp } from "vue";
 import App from "./App.vue";
 
@@ -26,7 +26,7 @@ Use components in your templates:
 
 ```vue
 <script setup lang="ts">
-import { HkButton, HkCard, HkInput } from "@hikari/vue";
+import { HkButton, HkCard, HkInput } from "@celestia-island/hikari";
 </script>
 
 <template>

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hikari/vue",
+  "name": "@celestia-island/hikari",
   "version": "0.3.0",
   "private": false,
   "type": "module",

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -12,8 +12,8 @@
     "skipLibCheck": true,
     "noEmit": true,
     "paths": {
-      "@hikari/vue": ["./src/index.ts"],
-      "@hikari/vue/styles": ["./src/styles/index.scss"]
+      "@celestia-island/hikari": ["./src/index.ts"],
+      "@celestia-island/hikari/styles": ["./src/styles/index.scss"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.d.ts"],


### PR DESCRIPTION
Rename `@hikari/vue` to `@celestia-island/hikari` to follow the standard celestia-island npm naming convention (same pattern as `@celestia-island/kou`, `@celestia-island/shirabe`, `@celestia-island/seia`).