### PR TITLE
🔧 Fix missing HkNavItem export in index.ts.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -17,6 +17,7 @@ export { default as HkInput } from "./components/HkInput";
 export { default as HkKbd } from "./components/HkKbd";
 export { default as HkListTransition } from "./components/HkListTransition";
 export { default as HkModal } from "./components/HkModal";
+export { default as HkNavItem } from "./components/HkNavItem";
 export { default as HkNumberInput } from "./components/HkNumberInput";
 export { default as HkPasswordInput } from "./components/HkPasswordInput";
 export { default as HkPopover } from "./components/HkPopover";


### PR DESCRIPTION
The HkNavItem component was created but its export was missing from the barrel file.