### PR TITLE
✨ Add HkSplash and HkMarkdownRenderer components.

### DIFF
--- a/packages/vue/src/components/HkMarkdownRenderer.tsx
+++ b/packages/vue/src/components/HkMarkdownRenderer.tsx
@@ -1,0 +1,74 @@
+import { defineComponent, computed } from "vue";
+
+const ESCAPE_MAP: Record<string, string> = {
+  "&": "&amp;", "<": "&lt;", ">": "&gt;",
+};
+
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>]/g, (c) => ESCAPE_MAP[c] || c);
+}
+
+function renderMarkdown(md: string): string {
+  let html = escapeHtml(md);
+
+  // Code blocks (fenced)
+  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, lang, code) => {
+    const escaped = escapeHtml(code.trimEnd());
+    return `<pre class="hk-md-pre"><code class="hk-md-code${lang ? ` language-${lang}` : ""}">${escaped}</code></pre>`;
+  });
+
+  // Inline code
+  html = html.replace(/`([^`]+)`/g, "<code class=\"hk-md-inline\">$1</code>");
+
+  // Bold + italic
+  html = html.replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>");
+  html = html.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/\*(.+?)\*/g, "<em>$1</em>");
+
+  // Headers
+  html = html.replace(/^#### (.+)$/gm, "<h4>$1</h4>");
+  html = html.replace(/^### (.+)$/gm, "<h3>$1</h3>");
+  html = html.replace(/^## (.+)$/gm, "<h2>$1</h2>");
+  html = html.replace(/^# (.+)$/gm, "<h1>$1</h1>");
+
+  // Unordered lists
+  html = html.replace(/^[\*\-] (.+)$/gm, "<li>$1</li>");
+  html = html.replace(/(<li>.*<\/li>\n?)+/g, "<ul>$&</ul>");
+
+  // Ordered lists
+  html = html.replace(/^\d+\. (.+)$/gm, "<li>$1</li>");
+
+  // Blockquotes
+  html = html.replace(/^> (.+)$/gm, "<blockquote>$1</blockquote>");
+
+  // Links
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+
+  // Horizontal rules
+  html = html.replace(/^---$/gm, "<hr>");
+
+  // Paragraphs — wrap remaining text blocks
+  html = html.replace(/\n{2,}/g, "</p><p>");
+  html = `<p>${html}</p>`;
+  html = html.replace(/<p>\s*<\/p>/g, "");
+
+  return html;
+}
+
+export default defineComponent({
+  name: "HkMarkdownRenderer",
+  props: {
+    content: { type: String, default: "" },
+    inline: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const html = computed(() => renderMarkdown(props.content));
+
+    return () => {
+      if (props.inline) {
+        return <span class="hk-markdown hk-markdown--inline" innerHTML={html.value} />;
+      }
+      return <div class="hk-markdown" innerHTML={html.value} />;
+    };
+  },
+});

--- a/packages/vue/src/components/HkSplash.scss
+++ b/packages/vue/src/components/HkSplash.scss
@@ -1,0 +1,60 @@
+.hk-splash {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--hi-color-bg-canvas, #0d1117);
+  color: var(--hi-color-text-primary, #c9d1d9);
+  font-family: system-ui, -apple-system, sans-serif;
+}
+
+.hk-splash__main {
+  text-align: center;
+  max-width: 480px;
+  padding: 2rem;
+}
+
+.hk-splash__logo {
+  width: 80px;
+  height: 80px;
+  margin-bottom: 1.5rem;
+  border-radius: 16px;
+}
+
+.hk-splash__title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--hi-color-primary, #58a6ff);
+  margin: 0 0 0.5rem;
+}
+
+.hk-splash__subtitle {
+  font-size: 1.1rem;
+  color: var(--hi-color-text-secondary, #8b949e);
+  margin: 0 0 0.5rem;
+}
+
+.hk-splash__description {
+  font-size: 0.9rem;
+  color: var(--hi-color-text-tertiary, #6e7681);
+  margin-bottom: 1rem;
+}
+
+.hk-splash__status {
+  margin-bottom: 1.5rem;
+}
+
+.hk-splash__actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.hk-splash__footer {
+  margin-top: auto;
+  padding: 1rem;
+  font-size: 0.75rem;
+  color: var(--hi-color-text-tertiary, #484f58);
+}

--- a/packages/vue/src/components/HkSplash.tsx
+++ b/packages/vue/src/components/HkSplash.tsx
@@ -1,0 +1,40 @@
+import { defineComponent, type PropType } from "vue";
+import HkBadge from "./HkBadge";
+import "./HkSplash.scss";
+
+export default defineComponent({
+  name: "HkSplash",
+  props: {
+    logo: { type: String, default: "" },
+    title: { type: String, default: "" },
+    subtitle: { type: String, default: "" },
+    status: { type: String as PropType<"online" | "offline" | "loading" | "coming-soon">, default: "coming-soon" },
+    statusLabel: { type: String, default: "" },
+  },
+  setup(props, { slots }) {
+    const statusVariant: Record<string, "success" | "danger" | "warning" | "primary"> = {
+      online: "success",
+      offline: "danger",
+      loading: "warning",
+      "coming-soon": "primary",
+    };
+
+    return () => (
+      <div class="hk-splash">
+        <main class="hk-splash__main">
+          {props.logo ? <img class="hk-splash__logo" src={props.logo} alt={props.title || "logo"} /> : null}
+          <h1 class="hk-splash__title">{props.title || slots.title?.()}</h1>
+          {props.subtitle ? <p class="hk-splash__subtitle">{props.subtitle}</p> : null}
+          {slots.description ? <div class="hk-splash__description">{slots.description?.()}</div> : null}
+          <div class="hk-splash__status">
+            <HkBadge variant={statusVariant[props.status] || "primary"} size="md">
+              {props.statusLabel || props.status}
+            </HkBadge>
+          </div>
+          {slots.actions ? <div class="hk-splash__actions">{slots.actions?.()}</div> : null}
+        </main>
+        {slots.footer ? <footer class="hk-splash__footer">{slots.footer?.()}</footer> : null}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -16,6 +16,7 @@ export { default as HkIconButton } from "./components/HkIconButton";
 export { default as HkInput } from "./components/HkInput";
 export { default as HkKbd } from "./components/HkKbd";
 export { default as HkListTransition } from "./components/HkListTransition";
+export { default as HkMarkdownRenderer } from "./components/HkMarkdownRenderer";
 export { default as HkModal } from "./components/HkModal";
 export { default as HkNavItem } from "./components/HkNavItem";
 export { default as HkNumberInput } from "./components/HkNumberInput";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -26,6 +26,7 @@ export { default as HkProgressRing } from "./components/HkProgressRing";
 export { default as HkRadio } from "./components/HkRadio";
 export { default as HkScrollContainer } from "./components/HkScrollContainer";
 export { default as HkSearchInput } from "./components/HkSearchInput";
+export { default as HkSplash } from "./components/HkSplash";
 export { default as HkSelect } from "./components/HkSelect";
 export { default as HkSidebar } from "./components/HkSidebar";
 export { default as HkSkeleton } from "./components/HkSkeleton";


### PR DESCRIPTION
Add two new shared components:

- HkSplash: Landing/splash page with logo, title, status badge, and action slots
- HkMarkdownRenderer: Lightweight markdown-to-HTML renderer with code blocks, lists, links, headers

Both usable by arona.celestia.world, arona engine webui, and shittim-chest.