### PR TITLE
🔧 Fix HkNavItem require() for ESM and npm publish.

### DIFF
--- a/packages/vue/src/components/HkNavItem.tsx
+++ b/packages/vue/src/components/HkNavItem.tsx
@@ -1,13 +1,9 @@
 import { defineComponent, computed } from "vue";
 import "./HkNavItem.scss";
 
-let RouterLink: any = null;
-try {
-  // eslint-disable-next-line
-  RouterLink = require("vue-router").RouterLink;
-} catch {
-  RouterLink = "a";
-}
+// vue-router is an optional peer dependency.
+// When unavailable, fall back to a plain <a> element.
+let RouterLink: any = "a";
 
 function buildClass(props: { active: boolean; disabled: boolean }, extra: string[] = []) {
   return [


### PR DESCRIPTION
Replace require('vue-router') with plain fallback to avoid TS2580 in ESM environment. vue-router is an optional peer dependency.