### PR TITLE
🔧 Fix version to 0.4.0.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
The squash merge accidentally retained 1.0.0 from the feature branch. Correct version is 0.4.0.