### PR TITLE
:globe_with_meridians: i18n(hikari): add i18n keys for hardcoded pagination and user_guide strings

### DIFF
--- a/packages/components/src/data/pagination.rs
+++ b/packages/components/src/data/pagination.rs
@@ -1,6 +1,7 @@
 // hi-components/src/data/pagination.rs
 // Pagination component with Arknights + FUI styling
 
+use hikari_i18n::t;
 use hikari_icons::{Icon, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, PaginationClass};
 
@@ -291,7 +292,7 @@ pub fn Pagination(props: PaginationProps) -> Element {
                 style: "padding: 20px; min-width: 200px;",
                 div {
                     style: "font-weight: 600; margin-bottom: 16px; font-size: 14px;",
-                    "Jump to Page"
+                    { t("hikari.pagination.jump_to_page", "Jump to Page") }
                 }
 
                 div {
@@ -301,7 +302,7 @@ pub fn Pagination(props: PaginationProps) -> Element {
                         size: InputSize::Medium,
                         input_type: Some("number".to_string()),
                         value: Some(jump_to_for_modal1.get()),
-                        placeholder: Some("Page".to_string()),
+                        placeholder: Some(t("hikari.pagination.page_placeholder", "Page")),
                         autofocus: true,
                         oninput: Some(EventHandler::new(move |val: String| {
                             if let Ok(v) = val.parse::<u32>()
@@ -331,7 +332,10 @@ pub fn Pagination(props: PaginationProps) -> Element {
 
                 div {
                     style: "font-size: 12px; color: var(--hi-color-text-secondary);",
-                    "Page 1 to {total_pages}"
+                    {{
+                        let tr = t("hikari.pagination.page_range", "Page {current} to {total}");
+                        tr.replace("{current}", "1").replace("{total}", &total_pages.to_string())
+                    }}
                 }
             }
         }
@@ -360,7 +364,7 @@ pub fn Pagination(props: PaginationProps) -> Element {
                 style: "padding: 20px; min-width: 200px;",
                 div {
                     style: "font-weight: 600; margin-bottom: 16px; font-size: 14px;",
-                    "Jump to Page"
+                    { t("hikari.pagination.jump_to_page", "Jump to Page") }
                 }
 
                 div {
@@ -370,7 +374,7 @@ pub fn Pagination(props: PaginationProps) -> Element {
                         size: InputSize::Medium,
                         input_type: Some("number".to_string()),
                         value: Some(jump_to_for_modal2.get()),
-                        placeholder: Some("Page".to_string()),
+                        placeholder: Some(t("hikari.pagination.page_placeholder", "Page")),
                         autofocus: true,
                         oninput: Some(EventHandler::new(move |val: String| {
                             if let Ok(v) = val.parse::<u32>()
@@ -400,7 +404,10 @@ pub fn Pagination(props: PaginationProps) -> Element {
 
                 div {
                     style: "font-size: 12px; color: var(--hi-color-text-secondary);",
-                    "Page 1 to {total_pages}"
+                    {{
+                        let tr = t("hikari.pagination.page_range", "Page {current} to {total}");
+                        tr.replace("{current}", "1").replace("{total}", &total_pages.to_string())
+                    }}
                 }
             }
         }

--- a/packages/components/src/display/user_guide.rs
+++ b/packages/components/src/display/user_guide.rs
@@ -1,6 +1,7 @@
 // packages/components/src/display/user_guide.rs
 // UserGuide component with Arknights + FUI styling
 
+use hikari_i18n::t;
 use hikari_icons::{Icon, IconProps, MdiIcon};
 use hikari_palette::classes::{ClassesBuilder, UserGuideClass, UtilityClass};
 
@@ -204,9 +205,9 @@ pub fn UserGuide(props: UserGuideProps) -> Element {
                             class: {next_btn_class.clone()},
                             onclick: handle_next,
                             if is_last_step {
-                                "Finish"
+                                { t("hikari.user_guide.finish", "Finish") }
                             } else {
-                                "Next"
+                                { t("hikari.user_guide.next", "Next") }
                             }
                             if !is_last_step {
                                 Icon { icon: MdiIcon::ChevronRight, size: 18 }

--- a/packages/i18n/locales/ar-SA/hikari_components.toml
+++ b/packages/i18n/locales/ar-SA/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "السابق"
 next = "التالي"
 page = "صفحة"
 of = "من"
+jump_to_page = "الانتقال إلى الصفحة"
+page_placeholder = "صفحة"
+page_range = "الصفحة {current} من {total}"
 
 [hikari.form]
 submit = "إرسال"
@@ -44,3 +47,7 @@ alt_fallback = "صورة"
 [hikari.dialog]
 close = "إغلاق"
 confirm = "تأكيد"
+
+[hikari.user_guide]
+finish = "إنهاء"
+next = "التالي"

--- a/packages/i18n/locales/en-US/hikari_components.toml
+++ b/packages/i18n/locales/en-US/hikari_components.toml
@@ -16,6 +16,9 @@ prev = "Previous"
 next = "Next"
 page = "Page"
 of = "of"
+jump_to_page = "Jump to Page"
+page_placeholder = "Page"
+page_range = "Page {current} to {total}"
 
 [hikari.form]
 submit = "Submit"
@@ -47,3 +50,7 @@ alt_fallback = "Image"
 [hikari.dialog]
 close = "Close"
 confirm = "Confirm"
+
+[hikari.user_guide]
+finish = "Finish"
+next = "Next"

--- a/packages/i18n/locales/es-ES/hikari_components.toml
+++ b/packages/i18n/locales/es-ES/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "Anterior"
 next = "Siguiente"
 page = "Página"
 of = "de"
+jump_to_page = "Ir a la página"
+page_placeholder = "Página"
+page_range = "Página {current} de {total}"
 
 [hikari.form]
 submit = "Enviar"
@@ -44,3 +47,7 @@ alt_fallback = "Imagen"
 [hikari.dialog]
 close = "Cerrar"
 confirm = "Confirmar"
+
+[hikari.user_guide]
+finish = "Finalizar"
+next = "Siguiente"

--- a/packages/i18n/locales/fr-FR/hikari_components.toml
+++ b/packages/i18n/locales/fr-FR/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "Précédent"
 next = "Suivant"
 page = "Page"
 of = "sur"
+jump_to_page = "Aller à la page"
+page_placeholder = "Page"
+page_range = "Page {current} sur {total}"
 
 [hikari.form]
 submit = "Envoyer"
@@ -44,3 +47,7 @@ alt_fallback = "Image"
 [hikari.dialog]
 close = "Fermer"
 confirm = "Confirmer"
+
+[hikari.user_guide]
+finish = "Terminer"
+next = "Suivant"

--- a/packages/i18n/locales/ja-JP/hikari_components.toml
+++ b/packages/i18n/locales/ja-JP/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "前へ"
 next = "次へ"
 page = "ページ"
 of = "/"
+jump_to_page = "ページにジャンプ"
+page_placeholder = "ページ"
+page_range = "{current} / {total} ページ"
 
 [hikari.form]
 submit = "送信"
@@ -44,3 +47,7 @@ alt_fallback = "画像"
 [hikari.dialog]
 close = "閉じる"
 confirm = "確認"
+
+[hikari.user_guide]
+finish = "完了"
+next = "次へ"

--- a/packages/i18n/locales/ko-KR/hikari_components.toml
+++ b/packages/i18n/locales/ko-KR/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "이전"
 next = "다음"
 page = "페이지"
 of = "/"
+jump_to_page = "페이지 이동"
+page_placeholder = "페이지"
+page_range = "{current} / {total} 페이지"
 
 [hikari.form]
 submit = "제출"
@@ -44,3 +47,7 @@ alt_fallback = "이미지"
 [hikari.dialog]
 close = "닫기"
 confirm = "확인"
+
+[hikari.user_guide]
+finish = "완료"
+next = "다음"

--- a/packages/i18n/locales/ru-RU/hikari_components.toml
+++ b/packages/i18n/locales/ru-RU/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "Назад"
 next = "Далее"
 page = "Страница"
 of = "из"
+jump_to_page = "Перейти к странице"
+page_placeholder = "Страница"
+page_range = "Страница {current} из {total}"
 
 [hikari.form]
 submit = "Отправить"
@@ -44,3 +47,7 @@ alt_fallback = "Изображение"
 [hikari.dialog]
 close = "Закрыть"
 confirm = "Подтвердить"
+
+[hikari.user_guide]
+finish = "Завершить"
+next = "Далее"

--- a/packages/i18n/locales/zh-CHS/hikari_components.toml
+++ b/packages/i18n/locales/zh-CHS/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "上一页"
 next = "下一页"
 page = "第"
 of = "页，共"
+jump_to_page = "跳转到页面"
+page_placeholder = "页码"
+page_range = "第 {current} 页，共 {total} 页"
 
 [hikari.form]
 submit = "提交"
@@ -44,3 +47,7 @@ alt_fallback = "图片"
 [hikari.dialog]
 close = "关闭"
 confirm = "确认"
+
+[hikari.user_guide]
+finish = "完成"
+next = "下一步"

--- a/packages/i18n/locales/zh-CHT/hikari_components.toml
+++ b/packages/i18n/locales/zh-CHT/hikari_components.toml
@@ -13,6 +13,9 @@ prev = "上一頁"
 next = "下一頁"
 page = "第"
 of = "頁，共"
+jump_to_page = "跳轉到頁面"
+page_placeholder = "頁碼"
+page_range = "第 {current} 頁，共 {total} 頁"
 
 [hikari.form]
 submit = "提交"
@@ -44,3 +47,7 @@ alt_fallback = "圖片"
 [hikari.dialog]
 close = "關閉"
 confirm = "確認"
+
+[hikari.user_guide]
+finish = "完成"
+next = "下一步"


### PR DESCRIPTION
Adds i18n keys to all 9 languages for previously hardcoded English strings in:\n- `packages/components/src/data/pagination.rs` — `jump_to_page`, `page_placeholder`, `page_range`\n- `packages/components/src/display/user_guide.rs` — `finish`, `next`