### PR TITLE
🐛 Add missing marked and dompurify dependencies.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -42,7 +42,9 @@
     "vue": "^3.5"
   },
   "dependencies": {
-    "lucide-vue-next": "^0.460"
+    "dompurify": "^3.4.12",
+    "lucide-vue-next": "^0.460",
+    "marked": "^18.0.6"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",


### PR DESCRIPTION
HkMarkdownRenderer imports marked and dompurify but they weren't listed in package.json, causing build failures when hikari is used as a workspace member.