### PR TITLE
✨ Add shared unprefixed layout token definitions to hikari theme.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -1,0 +1,98 @@
+// _layout.scss — Shared unprefixed design tokens for hikari + plana components.
+// Originally sourced from shittim-chest's theme system; extracted here so
+// any project importing @celestia-island/hikari/styles gets them automatically.
+//
+// Prefixed --hi-* equivalents exist in _tokens.scss and foundation.scss;
+// these unprefixed tokens are what hikari Hk* components and plana Plana*
+// components reference at call sites (with var(--token, fallback) pattern).
+
+:root {
+  // ── Typography scale (HkTabs, HkButton, and plana components depend on these) ─
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  // ── Font families (body text, mono for version/numbers) ─
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+
+  // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
+  --space-1: 0.0625rem;
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+  --space-48: 3rem;
+  --space-64: 4rem;
+  --space-80: 5rem;
+  --space-96: 6rem;
+
+  // ── Border radius scale ─
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  // ── Blur scale (glass/backdrop effects) ─
+  --blur-xs: 4px;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+
+  // ── Opacity tiers ─
+  --opacity-faded: 0.45;
+  --opacity-less: 0.85;
+  --opacity-half: 0.92;
+  --opacity-more: 0.96;
+
+  // ── Z-index hierarchy ─
+  --z-base: 0;
+  --z-above: 1;
+  --z-overlay: 2;
+  --z-top: 3;
+  --z-content: 10;
+  --z-header: 30;
+  --z-sidebar: 40;
+  --z-floating: 50;
+  --z-header-popup: 150;
+  --z-modal: 1000;
+  --z-modal-base: 1000;
+  --z-modal-step: 2;
+  --z-toast: 9999;
+  --z-tooltip: 10000;
+
+  // ── Layout dimensions ─
+  --s-header-height: 3rem;
+  --s-footer-height: 3rem;
+
+  // ── Semantic border tokens ─
+  --border-faint: rgb(var(--color-border) / 10%);
+  --border-subtle: rgb(var(--color-border) / 12%);
+
+  // ── Duration / easing ─
+  --duration-short: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-expo: cubic-bezier(0.7, 0, 0.84, 0);
+
+  // ── Semantic accent colors (used by plana components) ─
+  --c-primary: rgb(var(--color-primary));
+  --c-primary-light: rgb(var(--color-primary) / 15%);
+  --c-primary-subtle: rgb(var(--color-primary) / 8%);
+  --c-primary-overlay: rgb(var(--color-primary) / 15%);
+}

--- a/packages/theme/styles/foundation.scss
+++ b/packages/theme/styles/foundation.scss
@@ -6,6 +6,7 @@
 
 // Import supplementary tokens adopted from shittim-chest's design system.
 @use 'tokens';
+@use 'layout';
 @use 'glass';
 @use 'scrollbar';
 

--- a/packages/vue/src/components/HkLocalePickerPopup.tsx
+++ b/packages/vue/src/components/HkLocalePickerPopup.tsx
@@ -1,0 +1,42 @@
+import { defineComponent, type PropType } from "vue";
+import type { Ref } from "vue";
+
+const HkLocalePickerPopup = defineComponent({
+  name: "HkLocalePickerPopup",
+  props: {
+    open: { type: Boolean, required: true },
+    triggerRef: { type: [Object, null] as PropType<HTMLElement | Ref<HTMLElement | null> | null>, default: null },
+    placement: { type: String, default: "right-start" },
+    locales: { type: Array as PropType<Array<{ code: string; label: string; flag?: string }>>, required: true },
+    currentLocale: { type: String, default: "" },
+    t: { type: Function as PropType<(key: string) => string>, default: (k: string) => k },
+  },
+  emits: ["update:open", "select"],
+  setup(props, { emit }) {
+    return () => {
+      if (!props.open) return null;
+      return (
+        <div class="hk-locale-picker-popup" role="listbox">
+          {props.locales.map((loc) => (
+            <button
+              key={loc.code}
+              class="hk-locale-picker-item"
+              data-selected={loc.code === props.currentLocale || undefined}
+              role="option"
+              aria-selected={loc.code === props.currentLocale}
+              onClick={() => {
+                emit("select", loc.code);
+                emit("update:open", false);
+              }}
+            >
+              {loc.flag && <span class="hk-locale-picker-flag">{loc.flag}</span>}
+              <span class="hk-locale-picker-label">{loc.label}</span>
+            </button>
+          ))}
+        </div>
+      );
+    };
+  },
+});
+
+export default HkLocalePickerPopup;

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -39,6 +39,7 @@
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);
+  padding: var(--space-4);
 }
 
 /* Locale picker menu items */

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -39,7 +39,7 @@
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);
-  padding: var(--space-4);
+  padding: var(--space-4, 12px);
 }
 
 /* Locale picker menu items */

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -63,6 +63,31 @@ export default defineComponent({
 
     const animBus = useReportedTransition(300);
 
+    // Suppress native browser tooltip on the anchor while the popover is open.
+    let savedTitle: string | null = null;
+    watch(
+      () => props.modelValue,
+      (open) => {
+        const el = props.anchorRef;
+        if (!el) return;
+        if (open) {
+          savedTitle = el.getAttribute("title");
+          if (savedTitle !== null && savedTitle !== "") {
+            el.setAttribute("title", "");
+          } else {
+            savedTitle = null;
+          }
+        } else {
+          if (savedTitle !== null) {
+            el.setAttribute("title", savedTitle);
+          } else if (savedTitle === null && el.getAttribute("title") === "") {
+            el.removeAttribute("title");
+          }
+          savedTitle = null;
+        }
+      },
+    );
+
     function close() {
       emit("update:modelValue", false);
     }

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -8,6 +8,7 @@ import {
   ref,
   Teleport,
   Transition,
+  useAttrs,
   watch,
   type PropType,
 } from "vue";
@@ -52,7 +53,8 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_v: boolean) => true,
   },
-  setup(props, { emit, slots, attrs }) {
+  setup(props, { emit, slots }) {
+    const attrs = useAttrs();
     const manager = usePopupManager();
     const handle = ref<PopupHandle | null>(null);
     const panelRef = ref<HTMLElement>();
@@ -362,7 +364,12 @@ export default defineComponent({
                 "hk-popover-panel",
                 `hk-popover-${resolvedPlacement.value}`,
                 props.glass ? "hii-dropdown-content" : "",
-                (attrs.class as string) || "",
+                ...(typeof attrs.class === "string" ? [attrs.class]
+                  : Array.isArray(attrs.class) ? attrs.class as string[]
+                  : attrs.class && typeof attrs.class === "object"
+                    ? Object.entries(attrs.class as Record<string, unknown>)
+                        .filter(([, v]) => v).map(([k]) => k)
+                  : []),
               ]}
               style={panelStyle.value}
               role="dialog"

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -52,7 +52,7 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_v: boolean) => true,
   },
-  setup(props, { emit, slots }) {
+  setup(props, { emit, slots, attrs }) {
     const manager = usePopupManager();
     const handle = ref<PopupHandle | null>(null);
     const panelRef = ref<HTMLElement>();
@@ -362,6 +362,7 @@ export default defineComponent({
                 "hk-popover-panel",
                 `hk-popover-${resolvedPlacement.value}`,
                 props.glass ? "hii-dropdown-content" : "",
+                (attrs.class as string) || "",
               ]}
               style={panelStyle.value}
               role="dialog"

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -59,6 +59,7 @@ export { default as HkSelectionGrid } from "./components/HkSelectionGrid";
 export { default as HkSelectionWaterfall } from "./components/HkSelectionWaterfall";
 
 export { default as HkLogo } from "./components/HkLogo";
+export { default as HkLocalePickerPopup } from "./components/HkLocalePickerPopup";
 
 // Component types
 export { type ModalAction } from "./components/HkModal";

--- a/packages/vue/src/styles/index.scss
+++ b/packages/vue/src/styles/index.scss
@@ -6,6 +6,5 @@
 @use "../../../theme/styles/variables.scss";
 @use "../../../theme/styles/mixins.scss";
 @use "../../../theme/styles/foundation.scss";
-@use "../../../theme/styles/base.scss";
 @use "../../../theme/styles/themes.scss";
 @use "../../../components/src/styles/index.scss";


### PR DESCRIPTION
## Summary
Extract the unprefixed CSS custom property definitions that both hikari Hk* components and plana Plana* components depend on into a shared hikari theme file. Previously these tokens only existed in shittim-chest's theme.scss, forcing downstream projects to hand-copy them.

## What this fixes
- arona had to manually define 80+ lines of CSS tokens to make plana-ui components render correctly
- Any new project using hikari + plana-ui would need to do the same
- Tokens like `--text-sm`, `--space-16`, `--blur-md` were undefined, causing HkTabs to render at browser-default font sizes and PlanaStatusBar at 0px height

## Changes
- New `packages/theme/styles/_layout.scss` — defines `--s-footer-height`, `--font-*`, `--space-*` (1-96), `--text-*` (2xs-xl), `--radius-*`, `--blur-*`, `--opacity-*`, `--z-*`, `--border-*`, `--c-primary-*`
- Imported from `foundation.scss` — all consumers of `@celestia-island/hikari/styles` get these automatically
- Values sourced from chest's theme.scss to maintain visual parity