### PR TITLE
🎨 Migrate ColorPicker from shittim-chest to hikari.

### DIFF
--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -1,0 +1,148 @@
+.hk-color-picker {
+  display: inline-flex;
+}
+
+.hk-color-picker-trigger {
+  outline: none;
+}
+
+.hk-color-picker-swatch-btn {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  cursor: pointer;
+  outline: none;
+}
+
+.hk-color-picker-swatch {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: calc(var(--radius-xs) - 1px);
+  border: 2px solid rgb(0 0 0 / 10%);
+  transition: border-color var(--duration-short);
+
+  .hk-color-picker-swatch-btn:hover & {
+    border-color: rgb(var(--color-primary));
+  }
+}
+
+.hk-color-picker-label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: rgb(var(--color-muted));
+  white-space: nowrap;
+  line-height: 1;
+  transition: color var(--duration-short);
+
+  .hk-color-picker-swatch-btn:hover & {
+    color: rgb(var(--color-primary));
+  }
+}
+
+.hk-color-picker-panel {
+  padding: var(--space-12);
+  background: rgb(var(--color-surface));
+  backdrop-filter: blur(var(--blur-lg));
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-modal);
+  outline: none;
+}
+
+.hk-color-picker-body {
+  display: flex;
+}
+
+.hk-color-picker-controls {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  min-width: 200px;
+}
+
+.hk-color-picker-sliders {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.hk-color-picker-slider-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.hk-color-picker-slider-label {
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  color: rgb(var(--color-muted));
+  width: 10px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.hk-color-picker-channel-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 1;
+  height: 14px;
+  touch-action: none;
+  user-select: none;
+}
+
+.hk-color-picker-slider-track {
+  position: relative;
+  flex: 1;
+  min-width: 60px;
+  height: 10px;
+  border-radius: var(--radius-full);
+  display: block;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 10%);
+}
+
+.hk-color-picker-slider-thumb {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  border: 2px solid rgb(255 255 255 / 80%);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 15%), 0 1px 2px rgb(0 0 0 / 20%);
+  cursor: grab;
+  outline: none;
+  transition: transform 0.1s;
+
+  &:hover { transform: scale(1.15); }
+  &:active { cursor: grabbing; }
+}
+
+.hk-color-picker-slider-value {
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  color: rgb(var(--color-muted));
+  width: 26px;
+  text-align: right;
+  flex-shrink: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-color-picker-hex-row {
+  width: 100%;
+}
+
+.hk-color-picker-hex-hash {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: rgb(var(--color-muted));
+  user-select: none;
+  pointer-events: none;
+  line-height: 1;
+}

--- a/packages/vue/src/components/HkColorPicker.tsx
+++ b/packages/vue/src/components/HkColorPicker.tsx
@@ -1,0 +1,204 @@
+import { computed, defineComponent, ref } from "vue";
+
+import HInput from "./HkInput";
+import HPopover from "./HkPopover";
+import "./HkColorPicker.scss";
+
+const CHANNELS = [
+  { key: "r", label: "R" },
+  { key: "g", label: "G" },
+  { key: "b", label: "B" },
+] as const;
+
+type Channel = "r" | "g" | "b";
+
+function clamp(v: number, min = 0, max = 255): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    "#" +
+    [r, g, b]
+      .map((v) => clamp(v).toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+function channelGradient(r: number, g: number, b: number, ch: Channel): string {
+  const from: Record<Channel, string> = {
+    r: rgbToHex(0, g, b),
+    g: rgbToHex(r, 0, b),
+    b: rgbToHex(r, g, 0),
+  };
+  const to: Record<Channel, string> = {
+    r: rgbToHex(255, g, b),
+    g: rgbToHex(r, 255, b),
+    b: rgbToHex(r, g, 255),
+  };
+  return `linear-gradient(to right, ${from[ch]}, ${to[ch]})`;
+}
+
+const ColorSlider = defineComponent({
+  name: "HkColorSlider",
+  props: {
+    value: { type: Number, required: true },
+    r: { type: Number, required: true },
+    g: { type: Number, required: true },
+    b: { type: Number, required: true },
+    channel: { type: String as () => Channel, required: true },
+  },
+  emits: {
+    change: (_value: number) => true,
+  },
+  setup(props, { emit }) {
+    const trackRef = ref<HTMLElement>();
+    let dragging = false;
+
+    function getValueFromX(clientX: number): number {
+      const el = trackRef.value;
+      if (!el) return props.value;
+      const rect = el.getBoundingClientRect();
+      const pct = clamp((clientX - rect.left) / rect.width, 0, 1);
+      return Math.round(pct * 255);
+    }
+
+    function onPointerDown(e: PointerEvent) {
+      dragging = true;
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      emit("change", getValueFromX(e.clientX));
+    }
+
+    function onPointerMove(e: PointerEvent) {
+      if (!dragging) return;
+      emit("change", getValueFromX(e.clientX));
+    }
+
+    function onPointerUp() {
+      dragging = false;
+    }
+
+    const pct = computed(() => (props.value / 255) * 100);
+
+    return () => (
+      <div
+        class="hk-color-picker-channel-slider"
+        onPointerdown={onPointerDown}
+        onPointermove={onPointerMove}
+        onPointerup={onPointerUp}
+      >
+        <div
+          ref={trackRef}
+          class="hk-color-picker-slider-track"
+          style={{ background: channelGradient(props.r, props.g, props.b, props.channel) }}
+        />
+        <div
+          class="hk-color-picker-slider-thumb"
+          style={{ left: `${pct.value}%` }}
+        />
+      </div>
+    );
+  },
+});
+
+export default defineComponent({
+  name: "HkColorPicker",
+  props: {
+    r: { type: Number, required: true },
+    g: { type: Number, required: true },
+    b: { type: Number, required: true },
+    label: { type: String, default: "" },
+  },
+  emits: {
+    change: (_rgb: { r: number; g: number; b: number }) => true,
+  },
+  setup(props, { emit }) {
+    const isOpen = ref(false);
+    const triggerRef = ref<HTMLElement>();
+
+    const hex = computed(() => rgbToHex(props.r, props.g, props.b));
+    const hexDisplay = computed(() => hex.value.replace(/^#/, ""));
+
+    function updateChannel(ch: Channel, value: number) {
+      const next = { r: props.r, g: props.g, b: props.b };
+      next[ch] = clamp(value);
+      emit("change", next);
+    }
+
+    function onHexInput(v: string) {
+      if (/^[0-9a-fA-F]{0,6}$/.test(v) && v.length === 6) {
+        emit("change", {
+          r: parseInt(v.slice(0, 2), 16),
+          g: parseInt(v.slice(2, 4), 16),
+          b: parseInt(v.slice(4, 6), 16),
+        });
+      }
+    }
+
+    return () => (
+      <div class="hk-color-picker">
+        <button
+          ref={triggerRef}
+          type="button"
+          class="hk-color-picker-swatch-btn"
+          onClick={() => { isOpen.value = !isOpen.value; }}
+        >
+          <div
+            class="hk-color-picker-swatch"
+            style={{ background: hex.value }}
+          />
+          {props.label && (
+            <span class="hk-color-picker-label">{props.label}</span>
+          )}
+        </button>
+        <HPopover
+          modelValue={isOpen.value}
+          onUpdate:modelValue={(v: boolean) => { isOpen.value = v; }}
+          anchorRef={triggerRef.value ?? null}
+          placement="bottom-start"
+          offset={6}
+          backdrop={false}
+          class="hk-color-picker-panel"
+        >
+          <div class="hk-color-picker-body">
+            <div class="hk-color-picker-controls">
+              <div class="hk-color-picker-sliders">
+                {CHANNELS.map((def) => (
+                  <div key={def.key} class="hk-color-picker-slider-row">
+                    <span class="hk-color-picker-slider-label">
+                      {def.label}
+                    </span>
+                    <ColorSlider
+                      value={props[def.key]}
+                      r={props.r}
+                      g={props.g}
+                      b={props.b}
+                      channel={def.key}
+                      onChange={(v: number) => updateChannel(def.key, v)}
+                    />
+                    <span class="hk-color-picker-slider-value">
+                      {props[def.key]}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div class="hk-color-picker-hex-row">
+                <HInput
+                  modelValue={hexDisplay.value}
+                  onUpdate:modelValue={onHexInput}
+                >
+                  {{
+                    prefixIcon: () => (
+                      <span class="hk-color-picker-hex-hash">#</span>
+                    ),
+                  }}
+                </HInput>
+              </div>
+            </div>
+          </div>
+        </HPopover>
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkRollingNumber.scss
+++ b/packages/vue/src/components/HkRollingNumber.scss
@@ -1,0 +1,37 @@
+.hk-rolling-number {
+  display: inline-flex;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+
+  [data-el="char"] {
+    display: inline-block;
+  }
+
+  [data-el="slot"] {
+    display: inline-block;
+    position: relative;
+    overflow: hidden;
+    vertical-align: baseline;
+    height: 1em;
+  }
+
+  [data-el="roll"] {
+    display: flex;
+    flex-direction: column;
+    animation: hk-rolling-number-up var(--hi-duration-instant, 0.1s) cubic-bezier(0.4, 0, 0.2, 1) forwards;
+  }
+
+  [data-el="digit"] {
+    display: block;
+    height: 1em;
+  }
+}
+
+@keyframes hk-rolling-number-up {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-1em);
+  }
+}

--- a/packages/vue/src/components/HkRollingNumber.tsx
+++ b/packages/vue/src/components/HkRollingNumber.tsx
@@ -1,0 +1,97 @@
+import { defineComponent, onBeforeUnmount, ref, watch, type PropType } from "vue";
+
+import { useReportedTransition } from "../composables/useReportedTransition";
+import "./HkRollingNumber.scss";
+
+export default defineComponent({
+  name: "HkRollingNumber",
+  props: {
+    value: { type: [Number, String] as PropType<number | string>, required: true },
+  },
+  setup(props) {
+    interface CharState {
+      current: string;
+      prev: string;
+      animating: boolean;
+    }
+
+    const chars = ref<CharState[]>([]);
+
+    const ROLL_ANIM_MS = 100;
+    const rollAnim = useReportedTransition(ROLL_ANIM_MS);
+
+    function update(newStr: string): boolean {
+      const newChars = newStr.split("");
+      const oldLen = chars.value.length;
+
+      if (newChars.length !== oldLen) {
+        chars.value = newChars.map((ch) => ({
+          current: ch,
+          prev: ch,
+          animating: false,
+        }));
+        return false;
+      }
+
+      let anyRolled = false;
+      for (let i = 0; i < newChars.length; i++) {
+        const prev = chars.value[i].current;
+        const next = newChars[i];
+        if (prev !== next) {
+          chars.value[i] = {
+            current: next,
+            prev,
+            animating: true,
+          };
+          anyRolled = true;
+        }
+      }
+      return anyRolled;
+    }
+
+    const stopWatch = watch(
+      () => String(props.value),
+      (val) => {
+        if (update(val)) rollAnim.run();
+      },
+      { immediate: true },
+    );
+    onBeforeUnmount(stopWatch);
+
+    function onAnimEnd(i: number) {
+      if (chars.value[i]) {
+        chars.value[i].animating = false;
+      }
+    }
+
+    return () => (
+      <span class="hk-rolling-number">
+        {chars.value.map((ch, i) => {
+          const isDigit = /^[0-9]$/.test(ch.current);
+          if (!isDigit || !ch.animating) {
+            return (
+              <span key={i} data-el="char">
+                {ch.current}
+              </span>
+            );
+          }
+          return (
+            <span key={i} data-el="slot">
+              <span
+                data-el="roll"
+                onAnimationend={() => onAnimEnd(i)}
+              >
+                <span data-el="digit" data-variant="old">
+                  {ch.prev}
+                </span>
+                <span data-el="digit" data-variant="new">
+                  {ch.current}
+                </span>
+              </span>
+            </span>
+          );
+        })}
+      </span>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -7,6 +7,7 @@ export { default as HButton } from "./components/HkButton";
 export { default as HCard } from "./components/HkCard";
 export { default as HCheckbox } from "./components/HkCheckbox";
 export { default as HCollapse } from "./components/HkCollapse";
+export { default as HColorPicker } from "./components/HkColorPicker";
 export { default as HConfirmDialog } from "./components/HkConfirmDialog";
 export { default as HDivider } from "./components/HkDivider";
 export { default as HDrawer } from "./components/HkDrawer";
@@ -25,6 +26,7 @@ export { default as HPasswordInput } from "./components/HkPasswordInput";
 export { default as HPhaseTransition } from "./components/HkPhaseTransition";
 export { default as HGaugeRing } from "./components/HkGaugeRing";
 export { default as HProgressRing } from "./components/HkProgressRing";
+export { default as HRollingNumber } from "./components/HkRollingNumber";
 export { default as HLocalePickerPopup } from "./components/HkLocalePickerPopup";
 export { default as HHoverRevealAction } from "./components/HkHoverRevealAction";
 export { default as HKeywordSearchModal } from "./components/HkKeywordSearchModal";
@@ -96,6 +98,9 @@ export {
   isOverlayOpen,
   TOAST_DURATION,
   type AnimationHandle,
+  useReportedTransition,
+  type ReportedTransition,
+  type ReportedTransitionTrack,
   type CronHandle,
   type FrameContext,
   type OverlayHandle,


### PR DESCRIPTION
Migrate the ColorPicker component from shittim-chest to hikari.

## Changes
- Add `HkColorPicker.tsx` — Vue 3 component with RGB sliders and hex input
- Add `HkColorPicker.scss` — styles using hikari design tokens
- Export `HColorPicker` from hikari index

Dependencies: `HInput`, `HPopover` (already present in hikari)