### PR TITLE
🐛 Remove dead Language variants in i18n crate.

### DIFF
--- a/packages/i18n/src/lib.rs
+++ b/packages/i18n/src/lib.rs
@@ -212,8 +212,6 @@ fn hikari_default_keys(language: &Language) -> I18nKeys {
         Language::Russian => "ru",
         Language::Arabic => "ar",
         Language::English => "en",
-        Language::German => "en",
-        Language::Portuguese => "en",
     };
 
     let mut keys = I18nKeys::new();


### PR DESCRIPTION
Remove  and  references that don't exist in the enum.