### PR TITLE
♻️ Export PopupPlacement type from HPopover module for downstream consumption.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -32,7 +32,7 @@ export { default as HLocalePickerPopup } from "./components/HkLocalePickerPopup"
 export { default as HHoverRevealAction } from "./components/HkHoverRevealAction";
 export { default as HKeywordSearchModal } from "./components/HkKeywordSearchModal";
 export { default as HModalBreadcrumb } from "./components/HkModalBreadcrumb";
-export { default as HPopover } from "./components/HkPopover";
+export { default as HPopover, type PopupPlacement } from "./components/HkPopover";
 export { default as HPopupSelect, isAnyPopupOpen, closeAllPopups, type HkPopupSelectOption } from "./components/HkPopupSelect";
 export { default as HProgressBar } from "./components/HkProgressBar";
 export { default as HProgressDialog } from "./components/HkProgressDialog";


### PR DESCRIPTION
Push the locally committed PopupPlacement export (190d2bd) that was not yet on origin master. Required prerequisite for converting kei-webui hikari path dependencies to git references (P0#4 path-dep cleanup).