### PR TITLE
🐛 Fix i18n include_dir path and sync DemoApp with component APIs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Hikari Contributors"]

--- a/packages/i18n/src/lib.rs
+++ b/packages/i18n/src/lib.rs
@@ -199,7 +199,7 @@ pub fn t_lang(dotted_key: &str, fallback: &str) -> (String, Language) {
 
 use include_dir::{Dir, include_dir};
 
-static LOCALES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../../res/i18n/locales");
+static LOCALES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../res/i18n/locales");
 
 fn hikari_default_keys(language: &Language) -> I18nKeys {
     let lang_dir_name = match language {
@@ -217,13 +217,12 @@ fn hikari_default_keys(language: &Language) -> I18nKeys {
     let mut keys = I18nKeys::new();
     if let Some(lang_dir) = LOCALES_DIR.get_dir(lang_dir_name) {
         for file in lang_dir.files() {
-            if file.path().extension().map_or(false, |e| e == "toml") {
-                if let Some(content) = file.contents_utf8() {
-                    if let Ok(parsed) = toml::from_str::<I18nKeys>(content) {
-                        for (k, v) in parsed {
-                            keys.insert(k, v);
-                        }
-                    }
+            if file.path().extension().is_some_and(|e| e == "toml")
+                && let Some(content) = file.contents_utf8()
+                && let Ok(parsed) = toml::from_str::<I18nKeys>(content)
+            {
+                for (k, v) in parsed {
+                    keys.insert(k, v);
                 }
             }
         }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -29,9 +29,9 @@
     <section>
       <h2>HIconButton</h2>
       <div class="row">
-        <HIconButton icon="search" variant="ghost" size="sm" />
-        <HIconButton icon="settings" variant="outline" size="md" />
-        <HIconButton icon="heart" variant="primary" size="lg" />
+        <HIconButton icon="search" variant="ghost" :size="16" />
+        <HIconButton icon="settings" variant="secondary" :size="24" />
+        <HIconButton icon="heart" variant="primary" :size="40" />
       </div>
     </section>
 
@@ -61,7 +61,7 @@
         <HTag>Default</HTag>
         <HTag variant="success">Success</HTag>
         <HTag variant="warning">Warning</HTag>
-        <HTag variant="error">Error</HTag>
+        <HTag variant="danger">Danger</HTag>
         <HTag closable @close="() => {}">Closable</HTag>
       </div>
     </section>
@@ -80,8 +80,8 @@
 
     <section>
       <h2>HProgressBar / HProgressRing / HGaugeRing</h2>
-      <div class="row"><HProgressBar :model-value="65" style="width:200px" /></div>
-      <div class="row"><HProgressRing :model-value="75" :size="80" /><HGaugeRing :model-value="45" :size="80" label="CPU" /></div>
+      <div class="row"><HProgressBar :value="65" style="width:200px" /></div>
+      <div class="row"><HProgressRing :value="75" :size="80" /><HGaugeRing :rings="gaugeRings" :size="80" center-label="CPU" /></div>
     </section>
 
     <section>
@@ -92,7 +92,7 @@
         <HSearchInput v-model="form.search" placeholder="Search..." />
         <HNumberInput v-model="form.number" placeholder="Number" />
         <HPasswordInput v-model="form.password" placeholder="Password" />
-        <HTextarea v-model="form.textarea" placeholder="Textarea" rows="3" />
+        <HTextarea v-model="form.textarea" placeholder="Textarea" :rows="3" />
       </div>
       <p class="result" v-if="anyForm">Form: {{ anyForm }}</p>
     </section>
@@ -103,8 +103,7 @@
         <HCheckbox v-model="flags.a">Option A</HCheckbox>
         <HCheckbox v-model="flags.b">Option B</HCheckbox>
         <HSwitch v-model="flags.on" label="Toggle" />
-        <HRadio v-model="flags.radio" value="x" label="X" />
-        <HRadio v-model="flags.radio" value="y" label="Y" />
+        <HRadio v-model="flags.radio" :options="radioOpts" />
       </div>
     </section>
 
@@ -116,8 +115,8 @@
     <section>
       <h2>HSkeleton / HSkeletonList</h2>
       <div class="row">
-        <HSkeleton :width="100" :height="24" />
-        <HSkeletonList :rows="3" :width="300" />
+        <HSkeleton width="100px" height="24px" />
+        <HSkeletonList :count="3" style="width:300px" />
       </div>
     </section>
 
@@ -139,18 +138,20 @@
       <h2>HDivider</h2>
       <HDivider />
       <p style="opacity:0.5;text-align:center;padding:8px 0">Section above divider</p>
-      <HDivider label="OR" />
+      <HDivider />
       <p style="opacity:0.5;text-align:center;padding:8px 0">Section below divider</p>
     </section>
 
     <section>
       <h2>HAlert</h2>
-      <div class="col"><HAlert>Default info alert</HAlert><HAlert variant="success">Success alert</HAlert><HAlert variant="warning">Warning alert</HAlert><HAlert variant="error">Error alert</HAlert></div>
+      <div class="col"><HAlert message="Default info alert" /><HAlert variant="success" message="Success alert" /><HAlert variant="warning" message="Warning alert" /><HAlert variant="error" message="Error alert" /></div>
     </section>
 
     <section>
       <h2>HEmptyState</h2>
-      <HEmptyState icon="inbox" title="No items" description="Nothing to show here yet." />
+      <HEmptyState title="No items" description="Nothing to show here yet.">
+        <template #icon><HIcon name="inbox" :size="48" /></template>
+      </HEmptyState>
     </section>
 
     <section>
@@ -162,10 +163,10 @@
 
     <section>
       <h2>HTabs / HMorphingTabs</h2>
-      <HTabs v-model="tabs.active" :items="tabs.items" />
+      <HTabs v-model="tabs.active" :tabs="tabs.items" />
       <p class="result" style="margin-top:8px">Active tab: {{ tabs.active }}</p>
       <div style="margin-top:12px" />
-      <HMorphingTabs v-model="morphTabs.active" :items="morphTabs.items" />
+      <HMorphingTabs v-model="morphTabs.active" :tabs="morphTabs.items" />
     </section>
 
     <section>
@@ -189,7 +190,7 @@
 
     <section>
       <h2>HTimeline</h2>
-      <HTimeline :items="timelineItems" />
+      <HTimeline :steps="timelineSteps" current-key="v2" />
     </section>
 
     <section>
@@ -200,7 +201,7 @@
     </section>
 
     <section class="demo-footer">
-      <p>Hikari v0.4.0 — Powered by celestia-island</p>
+      <p>Hikari v0.4.1 — Powered by celestia-island</p>
     </section>
   </div>
 </template>
@@ -224,16 +225,18 @@ const icons = ['home', 'settings', 'user', 'search', 'bell', 'heart', 'star', 'm
 const form = ref({ text: '', search: '', number: 0, password: '', textarea: '' })
 const anyForm = computed(() => Object.values(form.value).filter(v => v !== '' && v !== 0).join(', ') || null)
 const flags = ref({ a: true, b: false, on: false, radio: 'x' })
+const radioOpts = [{ value: 'x', label: 'X' }, { value: 'y', label: 'Y' }]
+const gaugeRings = [{ pct: 45, color: 'rgb(var(--color-primary, 122 162 247))', trackColor: 'rgba(122, 162, 247, 0.15)' }]
 const select = ref({ val: '', opts: [{ value: 'a', label: 'Alpha' }, { value: 'b', label: 'Beta' }, { value: 'c', label: 'Gamma' }] })
 const tabs = ref({ active: 'tab1', items: [{ key: 'tab1', label: 'Overview' }, { key: 'tab2', label: 'Details' }, { key: 'tab3', label: 'Settings' }] })
 const morphTabs = ref({ active: 'm1', items: [{ key: 'm1', label: 'Read' }, { key: 'm2', label: 'Write' }, { key: 'm3', label: 'Preview' }] })
 
-const tableCols = [{ key: 'name', label: 'Name' }, { key: 'role', label: 'Role' }]
+const tableCols = [{ key: 'name', title: 'Name' }, { key: 'role', title: 'Role' }]
 const tableRows = [{ name: 'Alice', role: 'Admin' }, { name: 'Bob', role: 'Editor' }, { name: 'Charlie', role: 'Viewer' }]
-const timelineItems = [
-  { title: 'v1.0 Released', description: 'Initial release', time: '2024-01' },
-  { title: 'v1.1', description: 'Added dark mode', time: '2024-03' },
-  { title: 'v2.0', description: 'Major rewrite', time: '2025-06' },
+const timelineSteps = [
+  { key: 'v1', label: 'v1.0 Released' },
+  { key: 'v11', label: 'v1.1' },
+  { key: 'v2', label: 'v2.0' },
 ]
 </script>
 


### PR DESCRIPTION
## Summary

Fixes two master-branch build failure groups:

1. **Rust (hikari-i18n):** `include_dir!("$CARGO_MANIFEST_DIR/../../../res/i18n/locales")` had one `../` too many (introduced by d275e9f), making `cargo check --workspace --all-targets` fail with a proc-macro panic. Corrected to `$CARGO_MANIFEST_DIR/../../res/i18n/locales`. Grepped the workspace for similar mis-pathed `include_dir!`/`include_str!` references — no other broken paths found (remaining matches are doc snippets and `OUT_DIR`-based includes; `packages/components/src/styles/mod.rs` is not wired into the module tree and never compiled).
2. **Web (packages/vue):** `src/DemoApp.vue` used outdated prop APIs, producing 19 `vue-tsc` errors. Updated the demo only (no component source APIs changed):
   - `HIconButton`: numeric `size` (16/24/40); `variant="outline"` → `secondary` (not in the icon-button variant union)
   - `HTag`: `variant="error"` → `danger`
   - `HProgressBar`/`HProgressRing`: `:model-value` → `:value`
   - `HGaugeRing`: pass required `rings` (`RingData[]`) + `center-label` instead of `model-value`/`label`
   - `HRadio`: single group with required `options` instead of per-option `value`/`label`
   - `HAlert`: pass required `message`
   - `HTabs`/`HMorphingTabs`: `:items` → `:tabs`
   - `HTable`: column `label` → `title`
   - `HTimeline`: `:items` → required `steps` + `current-key`
   - `HTextarea` `rows` as number; `HSkeleton` width/height as CSS strings; `HSkeletonList` `rows` → `count`; removed non-existent `HDivider` `label`; `HEmptyState` icon attr → `#icon` slot
3. **Version bumps (same PR, per repo convention):** workspace `Cargo.toml` 0.3.14 → 0.3.15; `packages/vue/package.json` 0.4.0 → 0.4.1 (demo footer text synced).

Also fixed 3 pre-existing clippy lints in `packages/i18n/src/lib.rs` (`collapsible_if` ×2, `unnecessary_map_or`) that were hidden while the crate failed to compile and would now fail CI's `cargo clippy --all-targets --all-features -- -D warnings`.

## Verification (3-round verify cycle, all rounds green)

| Command | Exit |
|---|---|
| `cargo check --workspace --all-targets` | 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | 0 |
| `cargo fmt --all -- --check` | 0 |
| `cd packages/vue && pnpm install --frozen-lockfile && pnpm build` (vue-tsc --noEmit, 19 errors → 0) | 0 |
| `cargo test -p hikari-i18n` | 0 |

## Out of scope (not addressed)

- Non-fatal SCSS `@use '../../../../theme/styles/variables'` warnings emitted by the hikari-components build script when consumed from the cargo registry (observed downstream in lagrange builds) — still present.