### PR TITLE
🔧 Route compute CI to local self-hosted runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 ---
 name: Run Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   rustfmt:
     name: Check Formatting
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4
@@ -85,7 +85,7 @@ jobs:
 
   website-build:
     name: Build website with tairitsu-packager
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,6 +1,7 @@
 name: Clippy
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/clippy.yml'
@@ -13,7 +14,7 @@ on:
 jobs:
   clippy:
     name: Clippy
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: Coverage
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
   pull_request:
@@ -18,7 +19,7 @@ concurrency:
 jobs:
   coverage:
     name: Test Coverage
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,5 +1,6 @@
 name: Format
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/fmt.yml'
@@ -12,7 +13,7 @@ on:
 jobs:
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 name: Security Audit
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/security.yml'
@@ -14,7 +15,7 @@ on:
 jobs:
   audit:
     name: cargo audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - uses: actions/checkout@v4
 
@@ -26,7 +27,7 @@ jobs:
 
   deny:
     name: cargo deny
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - '.github/workflows/test.yml'
@@ -14,7 +15,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   visual-regression:
     name: Visual Regression Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     timeout-minutes: 45
 
     steps:


### PR DESCRIPTION
Route compute-heavy Linux CI jobs to the org-level local self-hosted runner (labels: self-hosted, linux, x64, local).

- Linux compute jobs: keep auto-triggering on push/PR, now execute on the local runner.
- macOS/Windows matrix legs: manual `workflow_dispatch` only.
- Merge hooks (commit-msg-lint / pr-title-check / squash-msg-clean), tag/release workflows, and Pages deploys stay on GitHub-hosted runners.
- evernight: re-enables workflows previously paused via __billing-paused__.
- entelecheia: fixes a pre-existing YAML block-scalar bug in install-test.yml.