### PR TITLE
✨ Port media, zoom and chart components to Vue.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.17"
+version = "0.3.18"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Hikari Contributors"]

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "dompurify": "^*",
+    "echarts": "^*",
     "lucide-vue-next": "^*",
     "marked": "^*"
   },

--- a/packages/vue/pnpm-lock.yaml
+++ b/packages/vue/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dompurify:
         specifier: ^*
         version: 3.4.12
+      echarts:
+        specifier: ^*
+        version: 6.1.0
       lucide-vue-next:
         specifier: ^*
         version: 1.0.0(vue@3.5.40(typescript@6.0.3))
@@ -496,6 +499,9 @@ packages:
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
+
   electron-to-chromium@1.5.398:
     resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
 
@@ -705,6 +711,9 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -781,6 +790,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
 snapshots:
 
@@ -1266,6 +1278,11 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  echarts@6.1.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.1.0
+
   electron-to-chromium@1.5.398: {}
 
   entities@7.0.1: {}
@@ -1431,6 +1448,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -1472,3 +1491,7 @@ snapshots:
       typescript: 6.0.3
 
   yallist@3.1.1: {}
+
+  zrender@6.1.0:
+    dependencies:
+      tslib: 2.3.0

--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -193,8 +193,64 @@
       <HTimeline :steps="timelineSteps" current-key="v2" />
     </section>
 
+    <section>
+      <h2>HMediaSlider</h2>
+      <div class="row" style="width:min(420px,100%)">
+        <HMediaSlider v-model:ratio="mediaSliderRatio" :buffered="0.85" />
+        <span style="font-size:0.7rem;opacity:0.6">{{ Math.round(mediaSliderRatio * 100) }}%</span>
+      </div>
+    </section>
+
+    <section>
+      <h2>HMediaPlayer (audio)</h2>
+      <HMediaPlayer type="audio" :src="demoAudioSrc" style="max-width:560px" />
+    </section>
+
+    <section>
+      <h2>HImageViewer</h2>
+      <HImageViewer :src="demoImageSrc" alt="Hikari demo image" />
+    </section>
+
+    <section>
+      <h2>HZoomToolbar / HMinimap</h2>
+      <div style="position:relative;height:200px;border-radius:8px;overflow:hidden;background:rgba(0,0,0,0.35)">
+        <div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:0.75rem;opacity:0.5">
+          Host surface — zoom {{ zoomState.zoom.toFixed(2) }}x, pan ({{ Math.round(zoomState.panX) }}, {{ Math.round(zoomState.panY) }})
+        </div>
+        <HZoomToolbar
+          :zoom="zoomState.zoom"
+          :can-zoom-in="zoomState.canIn"
+          :can-zoom-out="zoomState.canOut"
+          :is-zoomed="zoomState.zoomed"
+          @zoom-in="zoomIn"
+          @zoom-out="zoomOut"
+          @reset="zoomReset"
+        />
+        <HMinimap
+          :boxes="zoomBoxes"
+          :hub-pos="zoomHub"
+          :zoom="zoomState.zoom"
+          :pan-x="zoomState.panX"
+          :pan-y="zoomState.panY"
+          :viewport-width="800"
+          :viewport-height="200"
+          :content-bounds="zoomContent"
+          :zoom-percent="Math.round(zoomState.zoom * 100)"
+          :can-zoom-in="zoomState.canIn"
+          :can-zoom-out="zoomState.canOut"
+          show-reset
+          @pan-delta="panBy"
+        />
+      </div>
+    </section>
+
+    <section>
+      <h2>HTrendChart</h2>
+      <HTrendChart :pens="trendPens" height="260px" style="max-width:760px" />
+    </section>
+
     <section class="demo-footer">
-      <p>Hikari v0.4.3 — Powered by celestia-island</p>
+      <p>Hikari v0.4.4 — Powered by celestia-island</p>
     </section>
   </div>
 </template>
@@ -209,9 +265,12 @@ import {
   HSkeleton, HSkeletonList, HAvatar, HKbd, HDivider,
   HAlert, HEmptyState, HCollapse,
   HTabs, HMorphingTabs, HCard, HTable, HTimeline,
+  HMediaSlider, HMediaPlayer, HImageViewer,
+  HZoomToolbar, HMinimap, HTrendChart,
+  type TrendPen, type MinimapBox,
 } from '@celestia-island/hikari'
 
-const totalComponents = 56
+const totalComponents = 64
 
 const icons = ['home', 'settings', 'user', 'search', 'bell', 'heart', 'star', 'mail', 'download', 'upload', 'trash', 'edit', 'plus', 'check', 'x']
 
@@ -230,6 +289,98 @@ const timelineSteps = [
   { key: 'v1', label: 'v1.0 Released' },
   { key: 'v11', label: 'v1.1' },
   { key: 'v2', label: 'v2.0' },
+]
+
+const mediaSliderRatio = ref(0.42)
+
+function makeSilentWav(seconds = 2, sampleRate = 8000): string {
+  const frames = seconds * sampleRate
+  const bytes = 44 + frames
+  const buf = new Uint8Array(bytes)
+  const v = new DataView(buf.buffer)
+  v.setUint32(0, 0x52494646, false) // "RIFF"
+  v.setUint32(4, bytes - 8, true)
+  v.setUint32(8, 0x57415645, false) // "WAVE"
+  v.setUint32(12, 0x666d7420, false) // "fmt "
+  v.setUint32(16, 16, true)
+  v.setUint16(20, 1, true)
+  v.setUint16(22, 1, true)
+  v.setUint32(24, sampleRate, true)
+  v.setUint32(28, sampleRate, true)
+  v.setUint16(32, 1, true)
+  v.setUint16(34, 8, true)
+  v.setUint32(36, 0x64617461, false) // "data"
+  v.setUint32(40, frames, true)
+  return 'data:audio/wav;base64,' + btoa(String.fromCharCode(...buf))
+}
+const demoAudioSrc = makeSilentWav()
+
+const demoImageSrc =
+  'data:image/svg+xml;base64,' +
+  btoa(`<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900">
+    <rect width="1600" height="900" fill="#1b2333"/>
+    <g stroke="#2c3a55" stroke-width="1">
+      ${Array.from({ length: 15 }, (_, i) => `<line x1="${i * 110}" y1="0" x2="${i * 110}" y2="900"/>`).join('')}
+      ${Array.from({ length: 9 }, (_, i) => `<line x1="0" y1="${i * 110}" x2="1600" y2="${i * 110}"/>`).join('')}
+    </g>
+    <circle cx="800" cy="450" r="180" fill="rgba(122,162,247,0.35)" stroke="#7aa2f7" stroke-width="3"/>
+    <circle cx="800" cy="450" r="90" fill="rgba(122,162,247,0.2)" stroke="#7aa2f7" stroke-width="2" stroke-dasharray="6 4"/>
+    <circle cx="800" cy="450" r="12" fill="#f7768e"/>
+    <text x="800" y="700" fill="#9aa5ce" font-family="monospace" font-size="28" text-anchor="middle">Hikari — zoom / pan demo</text>
+  </svg>`)
+
+const zoomState = ref({ zoom: 1.6, panX: -40, panY: -18, canIn: true, canOut: true, zoomed: true })
+const zoomBoxes: MinimapBox[] = [
+  { id: 'a', bounds: { x: 60, y: 40, w: 200, h: 90 }, color: 'rgb(var(--color-info, 59 130 246))' },
+  { id: 'b', bounds: { x: 340, y: 40, w: 200, h: 90 }, color: 'rgb(var(--color-success, 34 197 94))' },
+  { id: 'c', bounds: { x: 200, y: 160, w: 200, h: 90 }, color: 'rgb(var(--color-warning, 245 158 11))' },
+]
+const zoomHub = { x: 300, y: 210 }
+const zoomContent = { x: 0, y: 0, w: 600, h: 300 }
+function zoomIn() {
+  zoomState.value.zoom = Math.min(8, zoomState.value.zoom * 1.2)
+  syncZoom()
+}
+function zoomOut() {
+  zoomState.value.zoom = Math.max(1, zoomState.value.zoom / 1.2)
+  syncZoom()
+}
+function zoomReset() {
+  zoomState.value.zoom = 1
+  zoomState.value.panX = 0
+  zoomState.value.panY = 0
+  syncZoom()
+}
+function panBy(dx: number, dy: number) {
+  zoomState.value.panX += dx
+  zoomState.value.panY += dy
+  syncZoom()
+}
+function syncZoom() {
+  const z = zoomState.value
+  z.zoomed = z.zoom > 1
+  z.canIn = z.zoom < 8
+  z.canOut = z.zoom > 1
+}
+
+const now = Date.now()
+const trendPens: TrendPen[] = [
+  {
+    label: 'CPU',
+    thresholds: { h: 70, l: 15 },
+    data: Array.from({ length: 40 }, (_, i) => ({
+      time: now - (40 - i) * 15_000,
+      value: 30 + Math.sin(i / 3) * 18 + (i % 7) * 2,
+    })),
+  },
+  {
+    label: 'Memory',
+    thresholds: { hh: 90 },
+    data: Array.from({ length: 40 }, (_, i) => ({
+      time: now - (40 - i) * 15_000,
+      value: 48 + Math.cos(i / 4) * 10,
+    })),
+  },
 ]
 </script>
 

--- a/packages/vue/src/components/HkImageViewer.scss
+++ b/packages/vue/src/components/HkImageViewer.scss
@@ -1,0 +1,33 @@
+.hk-image-viewer {
+  position: relative;
+  width: 100%;
+  height: 60vh;
+  min-height: 18rem;
+  overflow: hidden;
+  background: rgb(0 0 0 / 45%);
+  border-radius: var(--radius-sm);
+  touch-action: none;
+  user-select: none;
+}
+
+.hk-image-viewer-img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  max-width: none;
+  max-height: none;
+  will-change: transform;
+  transition: transform 0.12s ease-out;
+
+  &.is-loading {
+    opacity: 0;
+  }
+}
+
+.hk-image-viewer-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/packages/vue/src/components/HkImageViewer.tsx
+++ b/packages/vue/src/components/HkImageViewer.tsx
@@ -1,0 +1,250 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, watch } from "vue";
+
+import HSpinner from "./HkSpinner";
+import HMinimap from "./HkMinimap";
+import "./HkImageViewer.scss";
+
+/**
+ * Zoomable / pannable image viewer.
+ *
+ * The image is laid out at its natural pixel size and transformed with
+ * `translate(panX, panY) scale(zoom)` (transform-origin 0 0). That keeps it
+ * compatible with HMinimap's viewport-rect math, which assumes exactly this
+ * transform model. Default state is fit-to-container + centred; wheel and
+ * double-click zoom (cursor-anchored), drag pans. The minimap reuses the
+ * generic HMinimap (rendered with the image as its background).
+ */
+export default defineComponent({
+  name: "HkImageViewer",
+  props: {
+    src: { type: String, required: true },
+    alt: { type: String, default: "" },
+  },
+  setup(props) {
+    const containerRef = ref<HTMLElement | null>(null);
+    const imgRef = ref<HTMLImageElement | null>(null);
+
+    const zoom = ref(1);
+    const panX = ref(0);
+    const panY = ref(0);
+    const fit = ref(1);
+    const imgW = ref(0);
+    const imgH = ref(0);
+    const loaded = ref(false);
+
+    const dragging = ref(false);
+    const lastPt = ref({ x: 0, y: 0 });
+
+    const MAX_ZOOM = 8;
+
+    const isZoomed = computed(() => loaded.value && zoom.value > fit.value + 0.001);
+    const canZoomIn = computed(() => zoom.value < MAX_ZOOM);
+    const canZoomOut = computed(() => zoom.value > fit.value + 0.001);
+
+    function dims() {
+      const c = containerRef.value;
+      return c ? { cw: c.clientWidth, ch: c.clientHeight } : { cw: 0, ch: 0 };
+    }
+
+    function recomputeFit() {
+      const { cw, ch } = dims();
+      if (!imgW.value || !imgH.value || !cw || !ch) return;
+      fit.value = Math.min(1, cw / imgW.value, ch / imgH.value);
+    }
+
+    function center() {
+      const { cw, ch } = dims();
+      const dw = imgW.value * zoom.value;
+      const dh = imgH.value * zoom.value;
+      panX.value = (cw - dw) / 2;
+      panY.value = (ch - dh) / 2;
+    }
+
+    function clampPan() {
+      const { cw, ch } = dims();
+      const dw = imgW.value * zoom.value;
+      const dh = imgH.value * zoom.value;
+      if (dw <= cw) panX.value = (cw - dw) / 2;
+      else panX.value = Math.max(cw - dw, Math.min(0, panX.value));
+      if (dh <= ch) panY.value = (ch - dh) / 2;
+      else panY.value = Math.max(ch - dh, Math.min(0, panY.value));
+    }
+
+    function setZoom(next: number, cx?: number, cy?: number) {
+      const { cw, ch } = dims();
+      const target = Math.max(fit.value, Math.min(MAX_ZOOM, next));
+      if (target === zoom.value) return;
+      const anchorX = cx ?? cw / 2;
+      const anchorY = cy ?? ch / 2;
+      const wx = (anchorX - panX.value) / zoom.value;
+      const wy = (anchorY - panY.value) / zoom.value;
+      zoom.value = target;
+      panX.value = anchorX - wx * target;
+      panY.value = anchorY - wy * target;
+      clampPan();
+    }
+
+    function resetView() {
+      recomputeFit();
+      zoom.value = fit.value;
+      center();
+    }
+
+    function onImgLoad() {
+      const img = imgRef.value;
+      if (!img) return;
+      imgW.value = img.naturalWidth;
+      imgH.value = img.naturalHeight;
+      loaded.value = true;
+      resetView();
+    }
+
+    function onWheel(e: WheelEvent) {
+      if (!loaded.value) return;
+      e.preventDefault();
+      const el = containerRef.value;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      const factor = e.deltaY < 0 ? 1.15 : 1 / 1.15;
+      setZoom(zoom.value * factor, cx, cy);
+    }
+
+    function onPointerDown(e: PointerEvent) {
+      if (!loaded.value) return;
+      dragging.value = true;
+      lastPt.value = { x: e.clientX, y: e.clientY };
+      (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+    }
+
+    function onPointerMove(e: PointerEvent) {
+      if (!dragging.value) return;
+      const dx = e.clientX - lastPt.value.x;
+      const dy = e.clientY - lastPt.value.y;
+      lastPt.value = { x: e.clientX, y: e.clientY };
+      panX.value += dx;
+      panY.value += dy;
+      clampPan();
+    }
+
+    function onPointerUp() {
+      dragging.value = false;
+    }
+
+    function onDblClick(e: MouseEvent) {
+      if (!loaded.value) return;
+      const el = containerRef.value;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const cx = e.clientX - rect.left;
+      const cy = e.clientY - rect.top;
+      setZoom(isZoomed.value ? fit.value : Math.min(MAX_ZOOM, fit.value * 3), cx, cy);
+    }
+
+    function onPanDelta(dx: number, dy: number) {
+      panX.value += dx;
+      panY.value += dy;
+      clampPan();
+    }
+
+    let ro: ResizeObserver | null = null;
+
+    onMounted(() => {
+      const c = containerRef.value;
+      if (!c) return;
+      ro = new ResizeObserver(() => {
+        const wasFit = !isZoomed.value;
+        recomputeFit();
+        if (wasFit) {
+          zoom.value = fit.value;
+          center();
+        } else {
+          clampPan();
+        }
+      });
+      ro.observe(c);
+      c.addEventListener("wheel", onWheel, { passive: false });
+      c.addEventListener("pointerdown", onPointerDown);
+      c.addEventListener("pointermove", onPointerMove);
+      c.addEventListener("pointerup", onPointerUp);
+      c.addEventListener("pointercancel", onPointerUp);
+      c.addEventListener("dblclick", onDblClick);
+    });
+
+    onBeforeUnmount(() => {
+      const c = containerRef.value;
+      if (!c) return;
+      ro?.disconnect();
+      ro = null;
+      c.removeEventListener("wheel", onWheel);
+      c.removeEventListener("pointerdown", onPointerDown);
+      c.removeEventListener("pointermove", onPointerMove);
+      c.removeEventListener("pointerup", onPointerUp);
+      c.removeEventListener("pointercancel", onPointerUp);
+      c.removeEventListener("dblclick", onDblClick);
+    });
+
+    watch(
+      () => props.src,
+      () => {
+        loaded.value = false;
+        imgW.value = 0;
+        imgH.value = 0;
+        zoom.value = 1;
+        fit.value = 1;
+        panX.value = 0;
+        panY.value = 0;
+      },
+    );
+
+    const imgStyle = computed(() => ({
+      transform: `translate(${panX.value}px, ${panY.value}px) scale(${zoom.value})`,
+      transformOrigin: "0 0",
+      cursor: isZoomed.value ? (dragging.value ? "grabbing" : "grab") : "zoom-in",
+    }));
+
+    const contentBounds = computed(() => ({ x: 0, y: 0, w: imgW.value, h: imgH.value }));
+    const zoomPercent = computed(() => Math.round(zoom.value * 100));
+
+    return () => (
+      <div ref={containerRef} class="hk-image-viewer">
+        <img
+          ref={imgRef}
+          src={props.src}
+          alt={props.alt}
+          class={["hk-image-viewer-img", !loaded.value && "is-loading"].filter(Boolean).join(" ")}
+          style={imgStyle.value}
+          draggable={false}
+          onLoad={onImgLoad}
+        />
+        {!loaded.value && (
+          <div class="hk-image-viewer-loading">
+            <HSpinner size="md" />
+          </div>
+        )}
+
+        {loaded.value && isZoomed.value && (
+          <HMinimap
+            imageSrc={props.src}
+            imageBounds={contentBounds.value}
+            zoom={zoom.value}
+            panX={panX.value}
+            panY={panY.value}
+            viewportWidth={dims().cw}
+            viewportHeight={dims().ch}
+            contentBounds={contentBounds.value}
+            zoomPercent={zoomPercent.value}
+            canZoomIn={canZoomIn.value}
+            canZoomOut={canZoomOut.value}
+            showReset
+            onZoomIn={() => setZoom(zoom.value * 1.2)}
+            onZoomOut={() => setZoom(zoom.value / 1.2)}
+            onReset={resetView}
+            onPanDelta={onPanDelta}
+          />
+        )}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkMediaControlBar.scss
+++ b/packages/vue/src/components/HkMediaControlBar.scss
@@ -1,0 +1,65 @@
+.hk-media-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-6) var(--space-10);
+  background: rgb(var(--color-surface) / 0.85);
+  backdrop-filter: blur(var(--blur-sm));
+  border-top: 1px solid var(--border-faint);
+  color: rgb(var(--color-text));
+}
+
+.hk-media-btn.hk-btn {
+  min-width: 28px;
+  height: 28px;
+  padding: 0 var(--space-6);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.hk-media-play.hk-btn {
+  background: rgb(var(--color-primary) / 0.14);
+  color: rgb(var(--color-primary));
+
+  &:hover:not(:disabled) {
+    background: rgb(var(--color-primary) / 0.24);
+  }
+}
+
+.hk-media-controls-seek {
+  flex: 1;
+  min-width: 0;
+}
+
+.hk-media-time {
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--color-muted));
+  white-space: nowrap;
+  user-select: none;
+}
+
+.hk-media-volume {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.hk-media-controls-vol {
+  width: 64px;
+}
+
+.hk-media-rate {
+  font-variant-numeric: tabular-nums;
+}
+
+// ── Mobile responsive ─────────────────────────────────────────────
+// On a phone the play button + time labels + 64px volume slider leave
+// almost no room for the seek bar to be usable. Phone volume is set via
+// hardware keys, so hide the volume control on narrow screens and let
+// the seek bar reclaim that width.
+@media (max-width: 600px) {
+  .hk-media-volume {
+    display: none;
+  }
+}

--- a/packages/vue/src/components/HkMediaControlBar.tsx
+++ b/packages/vue/src/components/HkMediaControlBar.tsx
@@ -1,0 +1,115 @@
+import { defineComponent } from "vue";
+import { Maximize, Minimize, Pause, Play, Volume2, VolumeX } from "lucide-vue-next";
+
+import HButton from "./HkButton";
+import { useI18n } from "../i18n/context";
+import HMediaSlider from "./HkMediaSlider";
+import "./HkMediaControlBar.scss";
+
+export function formatMediaTime(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) sec = 0;
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Shared transport controls for any media controller — the same bar is used
+ * under the audio and video players. Purely presentational: it reflects
+ * controller state via props and forwards intents via events. `HMediaSlider`
+ * backs both the seek track and the volume track.
+ */
+export default defineComponent({
+  name: "HkMediaControlBar",
+  props: {
+    playing: { type: Boolean, default: false },
+    current: { type: Number, default: 0 },
+    duration: { type: Number, default: 0 },
+    progress: { type: Number, default: 0 },
+    bufferedPct: { type: Number, default: 0 },
+    volume: { type: Number, default: 1 },
+    muted: { type: Boolean, default: false },
+    rate: { type: Number, default: 1 },
+    isFullscreen: { type: Boolean, default: false },
+    showFullscreen: { type: Boolean, default: false },
+    disabled: { type: Boolean, default: false },
+  },
+  emits: {
+    togglePlay: () => true,
+    seek: (_ratio: number) => true,
+    setVolume: (_v: number) => true,
+    toggleMute: () => true,
+    cycleRate: () => true,
+    toggleFullscreen: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    return () => (
+      <div class="hk-media-controls">
+        <HButton
+          variant="ghost"
+          size="sm"
+          class="hk-media-btn hk-media-play"
+          ariaLabel={props.playing ? t("hk.mediaPlayer.pause", "Pause") : t("hk.mediaPlayer.play", "Play")}
+          onClick={() => emit("togglePlay")}
+        >
+          {props.playing ? <Pause size={16} /> : <Play size={16} />}
+        </HButton>
+
+        <HMediaSlider
+          class="hk-media-controls-seek"
+          ratio={props.progress / 100}
+          buffered={props.bufferedPct / 100}
+          disabled={props.disabled || props.duration <= 0}
+          ariaLabel={t("hk.mediaPlayer.seek", "Seek")}
+          onUpdate:ratio={(r) => emit("seek", r)}
+        />
+
+        <span class="hk-media-time">
+          {formatMediaTime(props.current)} / {formatMediaTime(props.duration)}
+        </span>
+
+        <div class="hk-media-volume">
+          <HButton
+            variant="ghost"
+            size="sm"
+            class="hk-media-btn"
+            ariaLabel={props.muted ? t("hk.mediaPlayer.unmute", "Unmute") : t("hk.mediaPlayer.mute", "Mute")}
+            onClick={() => emit("toggleMute")}
+          >
+            {props.muted || props.volume === 0 ? <VolumeX size={15} /> : <Volume2 size={15} />}
+          </HButton>
+          <HMediaSlider
+            class="hk-media-controls-vol"
+            size="sm"
+            ratio={props.muted ? 0 : props.volume}
+            ariaLabel={t("hk.mediaPlayer.volume", "Volume")}
+            onUpdate:ratio={(v) => emit("setVolume", v)}
+          />
+        </div>
+
+        <HButton
+          variant="ghost"
+          size="sm"
+          class="hk-media-btn hk-media-rate"
+          ariaLabel={t("hk.mediaPlayer.speed", "Playback speed")}
+          onClick={() => emit("cycleRate")}
+        >
+          {props.rate}x
+        </HButton>
+
+        {props.showFullscreen && (
+          <HButton
+            variant="ghost"
+            size="sm"
+            class="hk-media-btn"
+            ariaLabel={props.isFullscreen ? t("hk.mediaPlayer.exitFullscreen", "Exit fullscreen") : t("hk.mediaPlayer.fullscreen", "Fullscreen")}
+            onClick={() => emit("toggleFullscreen")}
+          >
+            {props.isFullscreen ? <Minimize size={15} /> : <Maximize size={15} />}
+          </HButton>
+        )}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkMediaPlayer.scss
+++ b/packages/vue/src/components/HkMediaPlayer.scss
@@ -1,0 +1,29 @@
+.hk-media-player {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  width: 100%;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: rgb(0 0 0 / 0.2);
+}
+
+.hk-media-player.is-fullscreen {
+  width: 100%;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.hk-media-player-video {
+  width: 100%;
+  max-height: 60vh;
+  display: block;
+  background: #000;
+  cursor: pointer;
+}
+
+.hk-media-player.is-fullscreen .hk-media-player-video {
+  max-height: none;
+  height: 100%;
+  object-fit: contain;
+}

--- a/packages/vue/src/components/HkMediaPlayer.tsx
+++ b/packages/vue/src/components/HkMediaPlayer.tsx
@@ -1,0 +1,210 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue";
+
+import HMediaControlBar from "./HkMediaControlBar";
+import HMediaVisualizer from "./HkMediaVisualizer";
+import "./HkMediaPlayer.scss";
+
+type MediaKind = "video" | "audio";
+
+/** Playback rate presets cycled by the control bar's rate button. */
+export const MEDIA_RATES = [0.5, 1, 1.25, 1.5, 2] as const;
+
+/**
+ * Thin media player orchestrator. Owns the `<video>` / `<audio>` element,
+ * wires the raw media element events into reactive playback state, and
+ * composes the pluggable pieces: `HMediaVisualizer` (audio only) + the
+ * shared `HMediaControlBar`. Everything interactive lives in the control
+ * bar / slider, so this stays a small shell that's easy to swap or embed.
+ */
+export default defineComponent({
+  name: "HkMediaPlayer",
+  props: {
+    src: { type: String, required: true },
+    type: { type: String as PropType<MediaKind>, required: true },
+    poster: { type: String, default: undefined },
+  },
+  setup(props) {
+    const rootRef = ref<HTMLElement | null>(null);
+    const mediaRef = ref<HTMLMediaElement | null>(null);
+
+    const playing = ref(false);
+    const current = ref(0);
+    const duration = ref(0);
+    const buffered = ref(0);
+    const volume = ref(1);
+    const muted = ref(false);
+    const rateIdx = ref(1);
+    const isFullscreen = ref(false);
+
+    const rate = computed(() => MEDIA_RATES[rateIdx.value]);
+    const progress = computed(() =>
+      duration.value > 0 ? (current.value / duration.value) * 100 : 0,
+    );
+    const bufferedPct = computed(() =>
+      duration.value > 0 ? (buffered.value / duration.value) * 100 : 0,
+    );
+
+    function applyVolume() {
+      const m = mediaRef.value;
+      if (m) {
+        m.volume = volume.value;
+        m.muted = muted.value;
+      }
+    }
+    function applyRate() {
+      const m = mediaRef.value;
+      if (m) m.playbackRate = rate.value;
+    }
+
+    function onTimeUpdate() {
+      const m = mediaRef.value;
+      if (!m) return;
+      current.value = m.currentTime;
+      if (m.buffered.length) buffered.value = m.buffered.end(m.buffered.length - 1);
+    }
+    function onDurationChange() {
+      const m = mediaRef.value;
+      if (m) duration.value = m.duration || 0;
+    }
+    function onLoadedMetadata() {
+      const m = mediaRef.value;
+      if (!m) return;
+      duration.value = m.duration || 0;
+      volume.value = m.volume;
+      muted.value = m.muted;
+      applyRate();
+    }
+    function onVolumeChange() {
+      const m = mediaRef.value;
+      if (!m) return;
+      volume.value = m.volume;
+      muted.value = m.muted;
+    }
+    function onPlay() {
+      playing.value = true;
+    }
+    function onPause() {
+      playing.value = false;
+    }
+    function onEnded() {
+      playing.value = false;
+    }
+
+    let cleanupMedia: (() => void) | null = null;
+    function attachMedia(media: HTMLMediaElement | null) {
+      cleanupMedia?.();
+      cleanupMedia = null;
+      if (!media) return;
+      media.addEventListener("timeupdate", onTimeUpdate);
+      media.addEventListener("durationchange", onDurationChange);
+      media.addEventListener("loadedmetadata", onLoadedMetadata);
+      media.addEventListener("volumechange", onVolumeChange);
+      media.addEventListener("play", onPlay);
+      media.addEventListener("pause", onPause);
+      media.addEventListener("ended", onEnded);
+      cleanupMedia = () => {
+        media.removeEventListener("timeupdate", onTimeUpdate);
+        media.removeEventListener("durationchange", onDurationChange);
+        media.removeEventListener("loadedmetadata", onLoadedMetadata);
+        media.removeEventListener("volumechange", onVolumeChange);
+        media.removeEventListener("play", onPlay);
+        media.removeEventListener("pause", onPause);
+        media.removeEventListener("ended", onEnded);
+      };
+    }
+
+    function onFullscreenChange() {
+      isFullscreen.value = !!document.fullscreenElement;
+    }
+
+    onMounted(() => {
+      document.addEventListener("fullscreenchange", onFullscreenChange);
+    });
+
+    onBeforeUnmount(() => {
+      cleanupMedia?.();
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+    });
+
+    watch(mediaRef, attachMedia, { flush: "post" });
+
+    function togglePlay() {
+      const m = mediaRef.value;
+      if (!m) return;
+      if (m.paused) void m.play();
+      else m.pause();
+    }
+    function seekToRatio(ratio: number) {
+      const m = mediaRef.value;
+      if (!m || !duration.value) return;
+      const r = Math.max(0, Math.min(1, ratio));
+      m.currentTime = r * duration.value;
+      current.value = m.currentTime;
+    }
+    function setVolume(v: number) {
+      const val = Math.max(0, Math.min(1, v));
+      volume.value = val;
+      muted.value = val === 0;
+      applyVolume();
+    }
+    function toggleMute() {
+      muted.value = !muted.value;
+      applyVolume();
+    }
+    function cycleRate() {
+      rateIdx.value = (rateIdx.value + 1) % MEDIA_RATES.length;
+      applyRate();
+    }
+    function toggleFullscreen() {
+      const el = rootRef.value;
+      if (!el) return;
+      if (document.fullscreenElement) void document.exitFullscreen();
+      else void el.requestFullscreen?.();
+    }
+
+    return () => (
+      <div
+        ref={rootRef}
+        class={[
+          "hk-media-player",
+          `hk-media-player--${props.type}`,
+          isFullscreen.value && "is-fullscreen",
+        ].filter(Boolean).join(" ")}
+      >
+        {props.type === "audio" ? (
+          <>
+            <HMediaVisualizer mediaRef={mediaRef} />
+            <audio ref={mediaRef} src={props.src} />
+          </>
+        ) : (
+          <video
+            ref={mediaRef}
+            src={props.src}
+            poster={props.poster}
+            class="hk-media-player-video"
+            onClick={togglePlay}
+          />
+        )}
+
+        <HMediaControlBar
+          playing={playing.value}
+          current={current.value}
+          duration={duration.value}
+          progress={progress.value}
+          bufferedPct={bufferedPct.value}
+          volume={volume.value}
+          muted={muted.value}
+          rate={rate.value}
+          isFullscreen={isFullscreen.value}
+          showFullscreen={props.type === "video"}
+          onTogglePlay={togglePlay}
+          onSeek={seekToRatio}
+          onSetVolume={setVolume}
+          onToggleMute={toggleMute}
+          onCycleRate={cycleRate}
+          onToggleFullscreen={toggleFullscreen}
+        />
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkMediaSlider.scss
+++ b/packages/vue/src/components/HkMediaSlider.scss
@@ -1,0 +1,54 @@
+.hk-media-slider {
+  position: relative;
+  height: 6px;
+  border-radius: var(--radius-sm);
+  background: rgb(var(--color-muted) / 22%);
+  cursor: pointer;
+  touch-action: none;
+  user-select: none;
+}
+
+.hk-media-slider[data-size="sm"] {
+  height: 5px;
+}
+
+.hk-media-slider.is-disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.hk-media-slider-buffered {
+  position: absolute;
+  inset: 0 auto 0 0;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: rgb(var(--color-muted) / 40%);
+}
+
+.hk-media-slider-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  height: 100%;
+  border-radius: var(--radius-sm);
+  background: rgb(var(--color-primary));
+}
+
+.hk-media-slider-thumb {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+  border-radius: 50%;
+  background: rgb(var(--color-primary));
+  box-shadow: 0 1px 3px rgb(0 0 0 / 35%);
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity var(--hi-duration-short, 0.15s);
+  pointer-events: none;
+}
+
+.hk-media-slider:hover .hk-media-slider-thumb,
+.hk-media-slider:active .hk-media-slider-thumb {
+  opacity: 1;
+}

--- a/packages/vue/src/components/HkMediaSlider.tsx
+++ b/packages/vue/src/components/HkMediaSlider.tsx
@@ -1,0 +1,81 @@
+import { defineComponent, onBeforeUnmount, onMounted, ref } from "vue";
+
+import "./HkMediaSlider.scss";
+
+/**
+ * Generic draggable 0..1 track — the one primitive both the seek bar and the
+ * volume slider are built on. Pointer-drag (with capture) emits the ratio
+ * continuously so consumers can scrub live. An optional secondary `buffered`
+ * fill renders behind the played fill.
+ */
+export default defineComponent({
+  name: "HkMediaSlider",
+  props: {
+    ratio: { type: Number, required: true },
+    buffered: { type: Number, default: 0 },
+    disabled: { type: Boolean, default: false },
+    ariaLabel: { type: String, default: undefined },
+    size: { type: String as () => "md" | "sm", default: "md" },
+  },
+  emits: {
+    "update:ratio": (_ratio: number) => true,
+  },
+  setup(props, { emit }) {
+    const trackRef = ref<HTMLElement | null>(null);
+    let dragging = false;
+
+    function ratioFrom(clientX: number): number {
+      const el = trackRef.value;
+      if (!el) return 0;
+      const rect = el.getBoundingClientRect();
+      return Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    }
+    function onDown(e: PointerEvent) {
+      if (props.disabled) return;
+      dragging = true;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      emit("update:ratio", ratioFrom(e.clientX));
+    }
+    function onMove(e: PointerEvent) {
+      if (dragging) emit("update:ratio", ratioFrom(e.clientX));
+    }
+    function onUp() {
+      dragging = false;
+    }
+
+    onMounted(() => {
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    });
+    onBeforeUnmount(() => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    });
+
+    return () => (
+      <div
+        ref={trackRef}
+        class={[
+          "hk-media-slider",
+          props.disabled && "is-disabled",
+        ].filter(Boolean).join(" ")}
+        data-size={props.size}
+        role="slider"
+        tabindex={-1}
+        aria-label={props.ariaLabel}
+        aria-valuenow={Math.round(props.ratio * 100)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        onPointerdown={onDown}
+      >
+        {props.buffered > 0 && (
+          <div class="hk-media-slider-buffered" style={{ width: `${props.buffered * 100}%` }} />
+        )}
+        <div class="hk-media-slider-fill" style={{ width: `${props.ratio * 100}%` }} />
+        <div class="hk-media-slider-thumb" style={{ left: `${props.ratio * 100}%` }} />
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkMediaVisualizer.scss
+++ b/packages/vue/src/components/HkMediaVisualizer.scss
@@ -1,0 +1,7 @@
+.hk-media-visualizer {
+  width: 100%;
+  height: 8rem;
+  display: block;
+  background: rgb(var(--color-muted) / 6%);
+  border-radius: var(--radius-sm);
+}

--- a/packages/vue/src/components/HkMediaVisualizer.tsx
+++ b/packages/vue/src/components/HkMediaVisualizer.tsx
@@ -1,0 +1,119 @@
+import { defineComponent, onBeforeUnmount, ref, watch, type PropType, type Ref } from "vue";
+
+import { onFrame, type AnimationHandle } from "../runtime/animationBus";
+import "./HkMediaVisualizer.scss";
+
+/**
+ * Pluggable audio spectrum visualiser. Point it at any media element ref and
+ * it draws an analyser-driven frequency bar chart while that element plays
+ * (and stops otherwise). Self-contained WebAudio wiring — the
+ * `MediaElementAudioSourceNode` is created lazily and only once per element.
+ *
+ * The draw loop registers with the unified animation bus via `onFrame`
+ * (sync priority) rather than a private rAF, so it shares the same loop
+ * lifecycle as every other per-frame consumer and the bus's
+ * idle-auto-shutdown applies to it too.
+ */
+export default defineComponent({
+  name: "HkMediaVisualizer",
+  props: {
+    mediaRef: {
+      type: Object as PropType<Ref<HTMLMediaElement | null>>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const canvasRef = ref<HTMLCanvasElement | null>(null);
+    let audioCtx: AudioContext | null = null;
+    let analyser: AnalyserNode | null = null;
+    let source: MediaElementAudioSourceNode | null = null;
+    let frameHandle: AnimationHandle | null = null;
+
+    function start() {
+      const media = props.mediaRef.value;
+      const canvas = canvasRef.value;
+      if (!media || !canvas) return;
+      try {
+        if (!audioCtx) {
+          audioCtx = new (window.AudioContext ||
+            (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext)();
+          analyser = audioCtx.createAnalyser();
+          analyser.fftSize = 128;
+          source = audioCtx.createMediaElementSource(media);
+          source.connect(analyser);
+          analyser.connect(audioCtx.destination);
+        }
+        if (audioCtx.state === "suspended") void audioCtx.resume();
+      } catch {
+        return;
+      }
+      const ctx2d = canvas.getContext("2d");
+      if (!ctx2d || !analyser) return;
+      canvas.width = canvas.clientWidth * 2;
+      canvas.height = canvas.clientHeight * 2;
+      const data = new Uint8Array(analyser.frequencyBinCount);
+
+      function draw() {
+        if (!analyser || !ctx2d || !canvas) return;
+        analyser.getByteFrequencyData(data);
+        const w = canvas.width;
+        const h = canvas.height;
+        ctx2d.clearRect(0, 0, w, h);
+        const n = data.length;
+        const bw = w / n;
+        for (let i = 0; i < n; i++) {
+          const v = data[i] / 255;
+          const bh = v * h * 0.85;
+          const hue = 200 + (i / n) * 80;
+          ctx2d.fillStyle = `hsl(${hue}, 70%, 55%)`;
+          ctx2d.fillRect(i * bw, h - bh, bw - 1, bh);
+        }
+        // No self-reschedule — onFrame keeps firing until disconnect().
+      }
+
+      // Drop any prior handle (e.g. a replay after pause) before subscribing.
+      if (frameHandle) {
+        frameHandle.disconnect();
+        frameHandle = null;
+      }
+      frameHandle = onFrame(draw, "sync");
+    }
+
+    function stop() {
+      if (frameHandle) {
+        frameHandle.disconnect();
+        frameHandle = null;
+      }
+    }
+
+    let cleanupListeners: (() => void) | null = null;
+    function attach(media: HTMLMediaElement | null) {
+      cleanupListeners?.();
+      cleanupListeners = null;
+      if (!media) return;
+      media.addEventListener("play", start);
+      media.addEventListener("pause", stop);
+      media.addEventListener("ended", stop);
+      cleanupListeners = () => {
+        media.removeEventListener("play", start);
+        media.removeEventListener("pause", stop);
+        media.removeEventListener("ended", stop);
+      };
+    }
+
+    watch(() => props.mediaRef.value, attach, { immediate: true });
+
+    onBeforeUnmount(() => {
+      stop();
+      cleanupListeners?.();
+      source?.disconnect();
+      analyser?.disconnect();
+      audioCtx?.close().catch(() => {});
+      audioCtx = null;
+      analyser = null;
+      source = null;
+    });
+
+    return () => <canvas ref={canvasRef} class="hk-media-visualizer" />;
+  },
+});

--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -1,0 +1,76 @@
+.hk-minimap {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 50;
+  width: 160px;
+  background: rgb(var(--color-surface) / 0.82);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-sm);
+  backdrop-filter: blur(var(--blur-md));
+  cursor: pointer;
+  overflow: hidden;
+  pointer-events: auto;
+
+  &:hover {
+    border-color: rgb(var(--color-primary) / 0.3);
+  }
+
+  &[data-dragging] {
+    cursor: grabbing;
+  }
+}
+
+.hk-minimap-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.hk-mm-zoom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 3px 8px;
+  border-top: 1px solid var(--border-faint);
+  pointer-events: auto;
+}
+
+.hk-mm-zoom-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--color-text));
+  cursor: pointer;
+  transition: background 0.1s ease, color 0.1s ease;
+
+  &:hover:not(:disabled) {
+    background: rgb(var(--color-primary) / 0.1);
+    color: rgb(var(--color-primary));
+  }
+
+  &:disabled {
+    color: rgb(var(--color-muted) / 40%);
+    cursor: not-allowed;
+  }
+}
+
+.hk-mm-zoom-reset-btn svg {
+  stroke-width: 2px;
+}
+
+.hk-mm-zoom-label {
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: rgb(var(--color-muted));
+  min-width: 30px;
+  text-align: center;
+  user-select: none;
+}

--- a/packages/vue/src/components/HkMinimap.tsx
+++ b/packages/vue/src/components/HkMinimap.tsx
@@ -1,0 +1,255 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, type PropType } from "vue";
+import { Maximize2, ZoomIn, ZoomOut } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+import "./HkMinimap.scss";
+
+export interface MinimapBox {
+  id: string;
+  bounds: { x: number; y: number; w: number; h: number };
+  color: string;
+}
+
+export interface MinimapRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/**
+ * Generic minimap / overview overlay for pannable+zoomable surfaces.
+ *
+ * Renders an optionally-zoomed content area as an SVG scaled to fit, with
+ * coloured boxes (or an image background for an image navigator), a hub
+ * marker, the current viewport rectangle, and a small zoom bar. Dragging
+ * inside the map pans the viewport via the `panDelta` event. The math
+ * assumes the main surface uses `translate(panX, panY) scale(zoom)` with
+ * `transform-origin: 0 0` — the same model HImageViewer uses.
+ */
+export default defineComponent({
+  name: "HkMinimap",
+  props: {
+    boxes: { type: Array as PropType<MinimapBox[]>, default: () => [] },
+    hubPos: { type: Object as PropType<{ x: number; y: number } | null>, default: null },
+    /** Optional image rendered as the minimap background (image navigator).
+     *  When set, the minimap renders even with no boxes. */
+    imageSrc: { type: String, default: undefined },
+    imageBounds: { type: Object as PropType<MinimapRect>, default: undefined },
+    zoom: { type: Number, default: 1 },
+    panX: { type: Number, default: 0 },
+    panY: { type: Number, default: 0 },
+    viewportWidth: { type: Number, default: 800 },
+    viewportHeight: { type: Number, default: 600 },
+    contentBounds: {
+      type: Object as PropType<MinimapRect>,
+      default: () => ({ x: 0, y: 0, w: 1200, h: 800 }),
+    },
+    zoomPercent: { type: Number, default: 100 },
+    canZoomIn: { type: Boolean, default: true },
+    canZoomOut: { type: Boolean, default: true },
+    /** Show the reset/fit button in the zoom bar (chest only rendered it
+     *  when a reset handler was wired up). */
+    showReset: { type: Boolean, default: false },
+  },
+  emits: {
+    zoomIn: () => true,
+    zoomOut: () => true,
+    reset: () => true,
+    panDelta: (_dx: number, _dy: number) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const svgW = 160;
+    const svgH = 110;
+    const rootRef = ref<HTMLElement | null>(null);
+    const dragging = ref(false);
+    const dragStart = ref({ x: 0, y: 0 });
+
+    const cb = computed(() => props.contentBounds);
+    const overpanW = computed(() => Math.max(props.contentBounds.w * 0.5, props.viewportWidth * 0.3));
+    const overpanH = computed(() => Math.max(props.contentBounds.h * 0.5, props.viewportHeight * 0.3));
+
+    const mapRect = computed(() => ({
+      x: cb.value.x - overpanW.value,
+      y: cb.value.y - overpanH.value,
+      w: cb.value.w + overpanW.value * 2,
+      h: cb.value.h + overpanH.value * 2,
+    }));
+
+    const scale = computed(() => {
+      const sx = svgW / mapRect.value.w;
+      const sy = svgH / mapRect.value.h;
+      return Math.min(sx, sy);
+    });
+
+    const contentOffset = computed(() => {
+      const sw = mapRect.value.w * scale.value;
+      const sh = mapRect.value.h * scale.value;
+      return { ox: (svgW - sw) / 2, oy: (svgH - sh) / 2 };
+    });
+
+    function toMap(wx: number, wy: number): [number, number] {
+      const s = scale.value;
+      const { ox, oy } = contentOffset.value;
+      return [(wx - mapRect.value.x) * s + ox, (wy - mapRect.value.y) * s + oy];
+    }
+
+    const viewportRect = computed(() => {
+      const z = props.zoom;
+      const tl = toMap(-props.panX / z, -props.panY / z);
+      const br = toMap(-props.panX / z + props.viewportWidth / z, -props.panY / z + props.viewportHeight / z);
+      return { x: tl[0], y: tl[1], w: Math.max(1, br[0] - tl[0]), h: Math.max(1, br[1] - tl[1]) };
+    });
+
+    function onDown(e: PointerEvent) {
+      if ((e.target as HTMLElement).closest(".hk-mm-zoom-bar")) return;
+      e.stopPropagation();
+      e.preventDefault();
+      dragging.value = true;
+      dragStart.value = { x: e.clientX, y: e.clientY };
+      rootRef.value?.setPointerCapture(e.pointerId);
+    }
+    function onMove(e: PointerEvent) {
+      if (!dragging.value) return;
+      e.stopPropagation();
+      const dx = e.clientX - dragStart.value.x;
+      const dy = e.clientY - dragStart.value.y;
+      dragStart.value = { x: e.clientX, y: e.clientY };
+      if (scale.value > 0) {
+        emit("panDelta", (-dx / scale.value) * props.zoom, (-dy / scale.value) * props.zoom);
+      }
+    }
+    function onUp(e: PointerEvent) {
+      if (!dragging.value) return;
+      e.stopPropagation();
+      dragging.value = false;
+      rootRef.value?.releasePointerCapture(e.pointerId);
+    }
+
+    onMounted(() => {
+      const el = rootRef.value;
+      if (!el) return;
+      el.addEventListener("pointerdown", onDown);
+      el.addEventListener("pointermove", onMove);
+      el.addEventListener("pointerup", onUp);
+      el.addEventListener("pointercancel", onUp);
+    });
+    onBeforeUnmount(() => {
+      const el = rootRef.value;
+      if (!el) return;
+      el.removeEventListener("pointerdown", onDown);
+      el.removeEventListener("pointermove", onMove);
+      el.removeEventListener("pointerup", onUp);
+      el.removeEventListener("pointercancel", onUp);
+    });
+
+    return () => {
+      if (props.boxes.length === 0 && !props.imageSrc) return null;
+
+      const s = scale.value;
+      const vr = viewportRect.value;
+
+      const ib = props.imageBounds ?? props.contentBounds;
+      const imgPos = props.imageSrc ? toMap(ib.x, ib.y) : null;
+
+      const boxRects = props.boxes.map((b) => {
+        const p = toMap(b.bounds.x, b.bounds.y);
+        return (
+          <rect
+            key={`mm-${b.id}`}
+            x={p[0]}
+            y={p[1]}
+            width={b.bounds.w * s}
+            height={b.bounds.h * s}
+            rx={2}
+            fill={b.color}
+            opacity="0.28"
+            stroke={b.color}
+            stroke-width="0.6"
+          />
+        );
+      });
+
+      const hubP = props.hubPos ? toMap(props.hubPos.x, props.hubPos.y) : null;
+
+      return (
+        <div
+          ref={rootRef}
+          class="hk-minimap"
+          data-dragging={dragging.value ? "" : undefined}
+        >
+          <svg viewBox={`0 0 ${svgW} ${svgH}`} width={svgW} height={svgH} class="hk-minimap-svg">
+            {imgPos && (
+              <image
+                href={props.imageSrc}
+                x={imgPos[0]}
+                y={imgPos[1]}
+                width={ib.w * s}
+                height={ib.h * s}
+                preserveAspectRatio="none"
+                class="hk-mm-image"
+              />
+            )}
+            {boxRects}
+            {hubP && (
+              <circle
+                cx={hubP[0]}
+                cy={hubP[1]}
+                r={3}
+                fill="rgb(var(--color-primary))"
+                filter="drop-shadow(0 0 2px rgb(var(--color-primary) / 0.6))"
+              />
+            )}
+            <rect
+              x={vr.x}
+              y={vr.y}
+              width={Math.max(1, vr.w)}
+              height={Math.max(1, vr.h)}
+              fill="none"
+              stroke="rgb(var(--color-primary))"
+              stroke-width="1"
+              stroke-dasharray="3 2"
+              rx="2"
+              opacity="0.85"
+            />
+          </svg>
+          <div class="hk-mm-zoom-bar">
+            <button
+              class="hk-mm-zoom-btn"
+              type="button"
+              onClick={() => emit("zoomOut")}
+              disabled={!props.canZoomOut}
+              aria-label={t("hk.zoomToolbar.zoomOut", "Zoom out")}
+              title={t("hk.zoomToolbar.zoomOut", "Zoom out")}
+            >
+              <ZoomOut size={12} />
+            </button>
+            <span class="hk-mm-zoom-label">{props.zoomPercent}%</span>
+            <button
+              class="hk-mm-zoom-btn"
+              type="button"
+              onClick={() => emit("zoomIn")}
+              disabled={!props.canZoomIn}
+              aria-label={t("hk.zoomToolbar.zoomIn", "Zoom in")}
+              title={t("hk.zoomToolbar.zoomIn", "Zoom in")}
+            >
+              <ZoomIn size={12} />
+            </button>
+            {props.showReset && (
+              <button
+                class="hk-mm-zoom-btn hk-mm-zoom-reset-btn"
+                type="button"
+                onClick={() => emit("reset")}
+                aria-label={t("hk.zoomToolbar.reset", "Reset zoom")}
+                title={t("hk.zoomToolbar.reset", "Reset zoom")}
+              >
+                <Maximize2 size={11} />
+              </button>
+            )}
+          </div>
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkTrendChart.tsx
+++ b/packages/vue/src/components/HkTrendChart.tsx
@@ -1,0 +1,180 @@
+import { defineComponent, onMounted, onUnmounted, ref, watch, type PropType } from "vue";
+
+import { LineChart } from "echarts/charts";
+import { DataZoomComponent, GridComponent, LegendComponent, MarkLineComponent, TooltipComponent } from "echarts/components";
+import * as echarts from "echarts/core";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([
+  LineChart,
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+  DataZoomComponent,
+  MarkLineComponent,
+  CanvasRenderer,
+]);
+
+export interface TrendPoint {
+  time: number;
+  value: number;
+}
+
+export interface AlarmThresholds {
+  hh?: number;
+  h?: number;
+  l?: number;
+  ll?: number;
+}
+
+export interface TrendPen {
+  label: string;
+  data: TrendPoint[];
+  thresholds?: AlarmThresholds;
+}
+
+/**
+ * Streaming line-chart wrapper around echarts. Takes any number of
+ * "pens" (labelled time-series) and renders them against a rolling
+ * time window, with optional alarm threshold lines (hh/h/l/ll) per pen.
+ * Pure echarts plumbing — no domain logic, so any consumer can feed it
+ * metrics, telemetry or analytics series.
+ */
+export default defineComponent({
+  name: "HkTrendChart",
+  props: {
+    pens: { type: Array as PropType<TrendPen[]>, default: () => [] },
+    height: { type: String, default: "240px" },
+    showThresholds: { type: Boolean, default: true },
+    timeWindowMs: { type: Number, default: 300_000 }, // 5 minutes
+  },
+  setup(props) {
+    const chartEl = ref<HTMLElement>();
+    let chart: echarts.ECharts | null = null;
+    let resizeCleanup: (() => void) | undefined;
+
+    function renderChart() {
+      if (!chart || props.pens.length === 0) return;
+
+      const now = Date.now();
+      const minTime = now - props.timeWindowMs;
+
+      const series = props.pens.map((pen) => ({
+        name: pen.label,
+        type: "line" as const,
+        data: pen.data
+          .filter((p) => p.time >= minTime)
+          .map((p) => [p.time, p.value]),
+        smooth: true,
+        symbol: "none",
+        lineStyle: { width: 2 },
+      }));
+
+      const markLines: Record<string, unknown>[] = [];
+      if (props.showThresholds) {
+        for (const pen of props.pens) {
+          if (pen.thresholds) {
+            const t = pen.thresholds;
+            if (t.hh != null)
+              markLines.push({
+                yAxis: t.hh,
+                lineStyle: { color: "#FF1744", type: "dashed", width: 1 },
+                label: { show: false },
+              });
+            if (t.h != null)
+              markLines.push({
+                yAxis: t.h,
+                lineStyle: { color: "#FF6D00", type: "dotted", width: 1 },
+                label: { show: false },
+              });
+            if (t.l != null)
+              markLines.push({
+                yAxis: t.l,
+                lineStyle: { color: "#FFD600", type: "dotted", width: 1 },
+                label: { show: false },
+              });
+            if (t.ll != null)
+              markLines.push({
+                yAxis: t.ll,
+                lineStyle: { color: "#FF1744", type: "dashed", width: 1 },
+                label: { show: false },
+              });
+          }
+        }
+      }
+
+      chart.setOption(
+        {
+          tooltip: {
+            trigger: "axis",
+            axisPointer: { type: "cross" },
+          },
+          legend: {
+            top: 0,
+            textStyle: { fontSize: 11 },
+          },
+          grid: { left: 50, right: 20, top: 30, bottom: 40 },
+          xAxis: {
+            type: "time",
+            min: minTime,
+            max: now,
+          },
+          yAxis: { type: "value", scale: true },
+          dataZoom: [{ type: "inside" }],
+          series:
+            markLines.length > 0
+              ? series.map((s) => ({
+                  ...s,
+                  markLine: { silent: true, data: markLines.map((m) => [{ ...m }, { ...m }]) },
+                }))
+              : series,
+        },
+        // Merge (not notMerge): this fires on every streaming tick (deep watch
+        // on pens). notMerge:true replaced the whole option each tick, which
+        // reset the user's dataZoom pan/zoom on every update and rebuilt every
+        // series. Merge updates data incrementally and — because we never
+        // specify dataZoom start/end here — preserves the user's current zoom.
+      );
+    }
+
+    function onResize() {
+      chart?.resize();
+    }
+
+    onMounted(() => {
+      if (chartEl.value) {
+        chart = echarts.init(chartEl.value);
+        renderChart();
+        // Keep the canvas in sync with its container. echarts doesn't
+        // observe its own element, so without this the chart keeps its
+        // initial pixel size when the column narrows (mobile rotation,
+        // sidebar collapse, container resize) and renders off-canvas or
+        // leaves dead space. ResizeObserver covers container-driven
+        // changes; the window listener catches the cases where the
+        // observer isn't supported / doesn't fire (older WebViews).
+        const el = chartEl.value;
+        window.addEventListener("resize", onResize);
+        let ro: ResizeObserver | undefined;
+        if (typeof ResizeObserver !== "undefined") {
+          ro = new ResizeObserver(onResize);
+          ro.observe(el);
+        }
+        resizeCleanup = () => {
+          window.removeEventListener("resize", onResize);
+          ro?.disconnect();
+        };
+      }
+    });
+
+    onUnmounted(() => {
+      resizeCleanup?.();
+      resizeCleanup = undefined;
+      chart?.dispose();
+      chart = null;
+    });
+
+    watch(() => props.pens, renderChart, { deep: true });
+
+    return () => <div ref={chartEl} style={{ width: "100%", height: props.height }} />;
+  },
+});

--- a/packages/vue/src/components/HkZoomToolbar.scss
+++ b/packages/vue/src/components/HkZoomToolbar.scss
@@ -1,0 +1,35 @@
+.hk-zoom-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  border-radius: var(--radius-md);
+  background: rgb(var(--color-surface) / 85%);
+  border: 1px solid rgb(var(--color-border) / 8%);
+  padding: 2px 4px;
+  backdrop-filter: blur(var(--blur-sm));
+}
+
+.hk-zoom-btn.hk-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
+
+.hk-zoom-label {
+  font-size: var(--text-2xs);
+  font-family: var(--font-mono, monospace);
+  color: rgb(var(--color-muted));
+  min-width: 32px;
+  text-align: center;
+  user-select: none;
+}
+
+.hk-zoom-reset-btn {
+  margin-left: 2px;
+  border-left: 1px solid rgb(var(--color-border) / 8%);
+  padding-left: 4px;
+}

--- a/packages/vue/src/components/HkZoomToolbar.tsx
+++ b/packages/vue/src/components/HkZoomToolbar.tsx
@@ -1,0 +1,69 @@
+import { defineComponent } from "vue";
+import { Maximize2, ZoomIn, ZoomOut } from "lucide-vue-next";
+
+import HButton from "./HkButton";
+import { useI18n } from "../i18n/context";
+import "./HkZoomToolbar.scss";
+
+/**
+ * Floating zoom control cluster for image/pan viewers. Reflects viewer state
+ * via props and forwards intents via events; renders nothing when the view
+ * is fully zoomed out (nothing to undo).
+ */
+export default defineComponent({
+  name: "HkZoomToolbar",
+  props: {
+    zoom: { type: Number, required: true },
+    canZoomIn: { type: Boolean, required: true },
+    canZoomOut: { type: Boolean, required: true },
+    isZoomed: { type: Boolean, required: true },
+  },
+  emits: {
+    zoomIn: () => true,
+    zoomOut: () => true,
+    reset: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    return () => {
+      if (!props.isZoomed && !props.canZoomOut) return null;
+
+      return (
+        <div class="hk-zoom-toolbar">
+          <HButton
+            variant="ghost"
+            size="sm"
+            class="hk-zoom-btn"
+            disabled={!props.canZoomOut}
+            ariaLabel={t("hk.zoomToolbar.zoomOut", "Zoom out")}
+            onClick={() => emit("zoomOut")}
+          >
+            <ZoomOut size={14} />
+          </HButton>
+          <span class="hk-zoom-label">{Math.round(props.zoom * 100)}%</span>
+          <HButton
+            variant="ghost"
+            size="sm"
+            class="hk-zoom-btn"
+            disabled={!props.canZoomIn}
+            ariaLabel={t("hk.zoomToolbar.zoomIn", "Zoom in")}
+            onClick={() => emit("zoomIn")}
+          >
+            <ZoomIn size={14} />
+          </HButton>
+          {props.isZoomed && (
+            <HButton
+              variant="ghost"
+              size="sm"
+              class={["hk-zoom-btn", "hk-zoom-reset-btn"]}
+              ariaLabel={t("hk.zoomToolbar.reset", "Reset zoom")}
+              onClick={() => emit("reset")}
+            >
+              <Maximize2 size={14} />
+            </HButton>
+          )}
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -56,6 +56,20 @@ export { default as HWindowedItem } from "./components/HkWindowedItem";
 export { default as HDateTimePicker } from "./components/HkDateTimePicker";
 export { default as HTimeline } from "./components/HkTimeline";
 
+// Media player kit
+export { default as HMediaPlayer, MEDIA_RATES } from "./components/HkMediaPlayer";
+export { default as HMediaControlBar, formatMediaTime } from "./components/HkMediaControlBar";
+export { default as HMediaSlider } from "./components/HkMediaSlider";
+export { default as HMediaVisualizer } from "./components/HkMediaVisualizer";
+
+// Image viewer kit
+export { default as HImageViewer } from "./components/HkImageViewer";
+export { default as HZoomToolbar } from "./components/HkZoomToolbar";
+export { default as HMinimap } from "./components/HkMinimap";
+
+// Charts
+export { default as HTrendChart } from "./components/HkTrendChart";
+
 export { default as HErrorBoundary } from "./components/HkErrorBoundary";
 export { default as HDraggableList } from "./components/HkDraggableList";
 export { default as HDraggableGrid } from "./components/HkDraggableGrid";
@@ -70,6 +84,8 @@ export { type ModalAction } from "./components/HkModal";
 export { type TreeNode, type TreeSize, type TreeRowScope } from "./components/HkTree";
 export { type DragListItem } from "./components/HkDraggableList";
 export { type GridItem } from "./components/HkDraggableGrid";
+export { type MinimapBox, type MinimapRect } from "./components/HkMinimap";
+export { type TrendPen, type TrendPoint, type AlarmThresholds } from "./components/HkTrendChart";
 
 // Theme system
 export {


### PR DESCRIPTION
## Summary

Ports the chest media/zoom/chart Vue components into hikari (P0#2 P2 batch), following the `Hk*.tsx` / `H*` export convention.

### New components (packages/vue/src/components/)

**Media player kit** (from chest `components/media/`):
- `HMediaPlayer` (+ `MEDIA_RATES`) — orchestrator owning the `<video>`/`<audio>` element; wires raw media-element events into reactive state (no business logic, no chest stores)
- `HMediaControlBar` (+ `formatMediaTime`) — presentational transport controls, props in / events out
- `HMediaSlider` — generic draggable 0..1 track primitive (seek + volume)
- `HMediaVisualizer` — WebAudio spectrum analyser drawing on hikari's `onFrame` animation bus

**Image viewer kit** (from chest `chat/ImageViewer.tsx`, `chat/ZoomToolbar.tsx`, `shared/RadialMinimap.tsx`; cross-referenced Rust `node_graph/minimap.rs`):
- `HImageViewer` — fit-to-container zoom/pan viewer, wheel + double-click + drag, minimap overlay
- `HZoomToolbar` — floating zoom controls (converted to emits)
- `HMinimap` (+ `MinimapBox`, `MinimapRect` types) — generic minimap with boxes / image background / hub / viewport rect / zoom bar; drag-to-pan via `panDelta` event

**Chart** (from chest `charts/TrendChart.tsx`):
- `HTrendChart` (+ `TrendPen`, `TrendPoint`, `AlarmThresholds`) — generic echarts line wrapper: streaming pens + optional hh/h/l/ll threshold mark-lines + tooltip

### Conventions
- Chest-specific deps stripped: `@vueuse/core` and vue-i18n replaced with native listeners + hikari's own `useI18n`/`onFrame`; `HButton`/`HSpinner` reused
- Function props (`onZoomIn` etc.) converted to emits per hikari convention; minimap `showReset` prop replaces the "handler wired" check
- echarts declared as `^*` dependency (workspace convention, chest-compatible), lockfile committed
- Demo app showcases all new components; version bump 0.4.3 → 0.4.4 (vue) and 0.3.17 → 0.3.18 (Cargo workspace)

## Verification
- `cargo check --workspace --all-targets` — exit 0
- `cargo clippy --workspace --all-targets` — exit 0
- `pnpm install --frozen-lockfile && pnpm build` (vue-tsc) — exit 0, zero errors
- `pnpm build:docs` (vite build) — exit 0
- `node demo/ssr-verify.mjs` — 42 FAIL before and after (delta 0; all are the known pre-existing vite8 SSR `__moduleId` errors)
- All 8 components additionally SSR-rendered via renderToString with a `__moduleId`-dedupe harness — 10/10 OK, no new failure signatures