### PR TITLE
🔧 Upgrade vulnerable dependency from cargo audit scan.

### DIFF
--- a/packages/builder/Cargo.toml
+++ b/packages/builder/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = "^1.0"
 anyhow = "^1.0"
 lightningcss = "^1.0.0-alpha.68"
-quick-xml = { version = "^0.35", features = ["serialize"] }
+quick-xml = { version = "^0.41", features = ["serialize"] }
 regex = "^1"
 flate2 = "^1"
 


### PR DESCRIPTION
## P2 D1 家族安全扫描（cargo audit）
- 修复本仓可修复项；其余上游未修复项（rsa 0.9.10 无修复版、russh 需大版本 API 重写、rustls-webpki 经 rumqttc 等）已在 PLAN.md 登记