### PR TITLE
🔧 Pin typescript to ~6.0 for vue-tsc compatibility in the npm package.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,5 +56,8 @@
     "typescript": "^*",
     "vite": "^*",
     "vue-tsc": "^*"
+  },
+  "overrides": {
+    "typescript": "~6.0"
   }
 }


### PR DESCRIPTION
## npm 发布阻断修复（8-03 实测）
- packages/vue 的 typescript ^* 在独立 npm install 时解析到 TS 7（Go 原生编译器，无 ./lib/tsc）→ vue-tsc 崩溃 → npm publish 失败
- 补上 PLAN.md §2.4 强制 typescript override（npm overrides ~6.0，与 pnpm 家族一致）