### PR TITLE
🔧 Set typescript ~6.0 as the direct dev dependency.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -53,7 +53,7 @@
     "@vitejs/plugin-vue-jsx": "^*",
     "@vue/server-renderer": "^*",
     "sass": "^*",
-    "typescript": "^*",
+    "typescript": "~6.0",
     "vite": "^*",
     "vue-tsc": "^*"
   }


### PR DESCRIPTION
## npm 发布修复（round 2）
- #95 的 override 与直接依赖 ^* 冲突（EOVERRIDE）→ 直接改 devDependencies 为 ~6.0，移除 override