### PR TITLE
🔧 Pass NODE_AUTH_TOKEN to the npm publish step.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -53,3 +53,5 @@ jobs:
         run: |
           cd packages/vue
           npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

P2 A3: the publish step never set `NODE_AUTH_TOKEN`, so publishing would fail authentication even once the `NPM_TOKEN` secret is configured. Publishes the existing `@celestia-island/hikari` package (packages/vue, current 0.4.4) — no new package names.