### PR TITLE
🔧 Isolate CI cargo caches per runner via CARGO_HOME.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
           components: rustfmt, clippy
 
       - name: Restore Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run cargo fmt -- --check
         run: cargo +nightly fmt --all -- --check --unstable-features
@@ -42,7 +48,13 @@ jobs:
           targets: wasm32-wasip2
 
       - name: Restore Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run cargo clippy
         run: cargo clippy --all --all-features
@@ -71,7 +83,13 @@ jobs:
           targets: wasm32-wasip2
 
       - name: Restore Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run cargo test
         run: cargo test --all-features --all

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -42,7 +42,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Run clippy
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,14 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Generate icon data
         run: cargo build -p hikari-icons

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,14 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.CARGO_HOME }}
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install just
         run: |


### PR DESCRIPTION
Point all workflow cargo-cache paths at $CARGO_HOME (injected per-runner via the self-hosted runner .env, defaulting to ~/.cargo on hosted runners) and replace Swatinem/rust-cache with plain actions/cache (v4/v6 per repo convention) so concurrent runners no longer share ~/.cargo and Swatinem's restore no longer deletes shared registry files.