### PR TITLE
✨ Add GitHub-hosted CI fallback to remove the self-hosted single point.

### DIFF
--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -1,0 +1,28 @@
+name: CI (GitHub-hosted fallback)
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test:
+    name: fmt + clippy + test (hosted)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Check
+        run: cargo check --workspace
+      - name: Test
+        run: cargo test --workspace


### PR DESCRIPTION
## P2 D4
- 新增 ci-hosted.yml（ubuntu-latest：fmt/clippy/check/test）——自托管 runner 挂时仍有兜底
- 本仓依赖全公开（无私有 git 依赖），hosted 可完整构建