### PR TITLE
✨ Upstream fuzzy search and password validation as generic utils.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -135,3 +135,9 @@ export {
   setLocale,
   mergeMessages,
 } from "./i18n/context";
+
+// ── Generic utils ───────────────────────────────────────────────
+export { fuzzyScore, fuzzyScoreFields, fuzzySearch } from "./utils/fuzzy";
+export type { FuzzyMatch } from "./utils/fuzzy";
+export { validatePassword, passwordLevel } from "./utils/password";
+export type { PasswordValidationResult, PasswordLevel } from "./utils/password";

--- a/packages/vue/src/utils/fuzzy.ts
+++ b/packages/vue/src/utils/fuzzy.ts
@@ -1,0 +1,67 @@
+export interface FuzzyMatch {
+  matched: boolean;
+  /** Higher is better. 0 when not matched. */
+  score: number;
+}
+
+/**
+ * Lightweight subsequence fuzzy matcher with word-boundary scoring
+ * (upstreamed from shittim-chest). A query "matches" a haystack if the
+ * query characters appear in order; the score rewards consecutive runs
+ * and matches at word boundaries (spaces, camelCase transitions,
+ * punctuation), so typing "rep err" surfaces "Report: execution error"
+ * over a stray "repairs ferry".
+ */
+export function fuzzyScore(query: string, haystack: string): FuzzyMatch {
+  if (!query) return { matched: true, score: 0 };
+  const q = query.toLowerCase();
+  const h = haystack.toLowerCase();
+  let qi = 0;
+  let score = 0;
+  let run = 0;
+  let prevBoundary = true;
+  for (let hi = 0; hi < h.length && qi < q.length; hi++) {
+    if (h[hi] !== q[qi]) {
+      run = 0;
+      prevBoundary = /[\s\-_.,/()[\]]/.test(h[hi]) || (hi > 0 && /[a-z0-9]/.test(h[hi - 1]) && /[A-Z]/.test(h[hi]));
+      continue;
+    }
+    qi++;
+    run++;
+    score += 1 + (prevBoundary ? 2 : 0) + (run > 1 ? 1 : 0);
+    prevBoundary = false;
+  }
+  if (qi < q.length) return { matched: false, score: 0 };
+  return { matched: true, score };
+}
+
+/** Score an object across several string fields (weighted sum). */
+export function fuzzyScoreFields(
+  query: string,
+  fields: Array<[string, number]>,
+): FuzzyMatch {
+  let total = 0;
+  let any = false;
+  for (const [field, weight] of fields) {
+    const m = fuzzyScore(query, field);
+    if (m.matched) {
+      any = true;
+      total += m.score * weight;
+    }
+  }
+  return any ? { matched: true, score: total } : { matched: false, score: 0 };
+}
+
+/** Filter + rank a list by fuzzy query over the given field getters. */
+export function fuzzySearch<T>(
+  query: string,
+  items: T[],
+  getFields: (item: T) => Array<[string, number]>,
+): T[] {
+  if (!query.trim()) return items;
+  return items
+    .map((item) => ({ item, m: fuzzyScoreFields(query, getFields(item)) }))
+    .filter(({ m }) => m.matched)
+    .sort((a, b) => b.m.score - a.m.score)
+    .map(({ item }) => item);
+}

--- a/packages/vue/src/utils/password.ts
+++ b/packages/vue/src/utils/password.ts
@@ -1,0 +1,53 @@
+export interface PasswordValidationResult {
+  valid: boolean;
+  errorKey: string | null;
+}
+
+/**
+ * Password policy validation (upstreamed from shittim-chest).
+ *
+ * Rules: match with the confirmation, ≥ 8 chars, letters + digits.
+ * `errorKey` is an i18n key the caller resolves with its own catalog
+ * (override the prefix via the second arg if your catalog differs).
+ */
+export function validatePassword(
+  password: string,
+  confirmPassword: string,
+  keyPrefix = "common.validation",
+): PasswordValidationResult {
+  if (password !== confirmPassword) {
+    return { valid: false, errorKey: `${keyPrefix}.passwordMismatch` };
+  }
+  if (password.length < 8) {
+    return { valid: false, errorKey: `${keyPrefix}.minLength` };
+  }
+  if (!/[a-zA-Z]/.test(password) || !/\d/.test(password)) {
+    return { valid: false, errorKey: `${keyPrefix}.passwordNeedsVariety` };
+  }
+  return { valid: true, errorKey: null };
+}
+
+export type PasswordLevel = "weak" | "fair" | "strong";
+
+/**
+ * Password strength level for a traffic-light indicator:
+ * - "strong": ≥ 10 chars + upper + lower + special (green)
+ * - "fair":   ≥ 8 chars + letters + digits (yellow)
+ * - "weak":   below fair (red)
+ * - null:     empty (no indicator)
+ */
+export function passwordLevel(password: string): PasswordLevel | null {
+  if (!password) return null;
+  const hasLetter = /[a-zA-Z]/.test(password);
+  const hasDigit = /\d/.test(password);
+  const hasUpper = /[A-Z]/.test(password);
+  const hasLower = /[a-z]/.test(password);
+  const hasSpecial = /[^a-zA-Z0-9]/.test(password);
+  if (password.length >= 10 && hasUpper && hasLower && hasSpecial) {
+    return "strong";
+  }
+  if (password.length >= 8 && hasLetter && hasDigit) {
+    return "fair";
+  }
+  return "weak";
+}


### PR DESCRIPTION
## Summary

- `fuzzyScore`/`fuzzyScoreFields`/`fuzzySearch` — subsequence matcher with word-boundary scoring (report/node keyword search).
- `validatePassword`/`passwordLevel` — password policy validation + strength traffic-light (injectable i18n key prefix).

Both were chest-only; now generic hikari utils for every webui.

## Verification

- `vue-tsc --noEmit` (packages/vue): clean.