### PR TITLE
✨ Upstream DOM focus utilities and the deferred-transition gate.

### DIFF
--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -13,6 +13,7 @@ import {
 
 import { useI18n } from "../i18n/context";
 import "./HkModal.scss";
+import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import HButton from "./HkButton";
@@ -29,28 +30,6 @@ export interface ModalAction {
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-function trapFocus(container: HTMLElement, e: KeyboardEvent): void {
-  const focusable = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-  if (focusable.length === 0) return;
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
-  if (e.shiftKey) {
-    if (document.activeElement === first) {
-      e.preventDefault();
-      last.focus();
-    }
-  } else {
-    if (document.activeElement === last) {
-      e.preventDefault();
-      first.focus();
-    }
-  }
-}
-
-function focusFirst(container: HTMLElement): void {
-  const el = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-  if (el) el.focus();
-}
 
 export default defineComponent({
   name: "HkModal",

--- a/packages/vue/src/composables/useDeferredTransition.ts
+++ b/packages/vue/src/composables/useDeferredTransition.ts
@@ -1,0 +1,16 @@
+import { nextTick, onMounted, ref } from "vue";
+
+/** Mount-then-double-nextTick animation gate (upstreamed from shittim-chest). */
+export function useDeferredTransition() {
+  const animated = ref(false);
+
+  onMounted(() => {
+    nextTick(() => {
+      nextTick(() => {
+        animated.value = true;
+      });
+    });
+  });
+
+  return { animated };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -141,3 +141,6 @@ export { fuzzyScore, fuzzyScoreFields, fuzzySearch } from "./utils/fuzzy";
 export type { FuzzyMatch } from "./utils/fuzzy";
 export { validatePassword, passwordLevel } from "./utils/password";
 export type { PasswordValidationResult, PasswordLevel } from "./utils/password";
+
+export { FOCUSABLE_SELECTOR, getFocusableElements, focusFirst, trapFocus, scrollToElement } from "./utils/dom";
+export { useDeferredTransition } from "./composables/useDeferredTransition";

--- a/packages/vue/src/utils/dom.ts
+++ b/packages/vue/src/utils/dom.ts
@@ -1,0 +1,39 @@
+export const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/** All focusable elements inside a container (excluding tabindex=-1). */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/** Focus the first autofocus/focusable element, falling back to the container. */
+export function focusFirst(container: HTMLElement): void {
+  const autofocus = container.querySelector<HTMLElement>("[autofocus]");
+  const focusable = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+  (autofocus || focusable || container).focus();
+}
+
+/** Keep Tab/Shift+Tab cycling inside the container (modal focus trap). */
+export function trapFocus(container: HTMLElement, event: KeyboardEvent): void {
+  const focusable = getFocusableElements(container);
+  if (focusable.length === 0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (event.shiftKey) {
+    if (document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    }
+  } else {
+    if (document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+}
+
+/** Scroll an element into view by selector (optional options). */
+export function scrollToElement(selector: string, opts?: ScrollIntoViewOptions): void {
+  const el = document.querySelector(selector) as HTMLElement | null;
+  el?.scrollIntoView(opts ?? { block: "nearest" });
+}


### PR DESCRIPTION
## Summary

- `trapFocus`/`focusFirst`/`getFocusableElements`/`scrollToElement` — chest-only DOM focus utilities, hand-duplicated inside `HkModal`; now shared hikari utils with `HkModal` reusing them.
- `useDeferredTransition` — mount + double-nextTick animation gate.

## Verification

- `vue-tsc --noEmit` (packages/vue): clean.