### PR TITLE
✨ Export the full theme surface (custom themes, solar time, luminance).

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -89,8 +89,12 @@ export { type TrendPen, type TrendPoint, type AlarmThresholds } from "./componen
 
 // Theme system
 export {
-  initTheme, useTheme, themePresets, tokensToCSSVars,
-  type ThemeTokenRGB, type ThemeSchemeTokens, type ThemePreset, type ThemeMode, type ThemeId,
+  initTheme, useTheme, themePresets, tokensToCSSVars, getThemeTokens,
+  loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme,
+  useBackgroundLuminance,
+  getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION,
+  type ThemeTokenRGB, type ThemeSchemeTokens, type ThemePreset, type ThemeMode,
+  type ThemeId, type CustomThemePreset, type TimePeriod,
 } from "./theme";
 
 // Runtime systems

--- a/packages/vue/src/theme/index.ts
+++ b/packages/vue/src/theme/index.ts
@@ -2,4 +2,5 @@ export { initTheme, useTheme } from "./useTheme";
 export { themePresets, tokensToCSSVars, getThemeTokens, loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme } from "./presets";
 export type { ThemeTokenRGB, ThemeSchemeTokens, ThemePreset, CustomThemePreset, ThemeId, ThemeMode } from "./presets";
 export { getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION } from "./useSolarTime";
+export { useBackgroundLuminance } from "./useBackgroundLuminance";
 export type { TimePeriod } from "./useSolarTime";


### PR DESCRIPTION
getThemeTokens/loadCustomThemes/saveCustomThemes/addCustomTheme/removeCustomTheme, `useBackgroundLuminance` and the solar-time helpers were implemented but not re-exported from the package entry — the downstream theme migration (chest) needs them.