### PR TITLE
🐛 Fix the theme export surface: luminance sampler names, ThemeTokens, reportTransition.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -91,10 +91,10 @@ export { type TrendPen, type TrendPoint, type AlarmThresholds } from "./componen
 export {
   initTheme, useTheme, themePresets, tokensToCSSVars, getThemeTokens,
   loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme,
-  useBackgroundLuminance,
+  startLuminanceSampler, stopLuminanceSampler, sampleLuminanceNow, invalidateLuminanceCache,
   getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION,
   type ThemeTokenRGB, type ThemeSchemeTokens, type ThemePreset, type ThemeMode,
-  type ThemeId, type CustomThemePreset, type TimePeriod,
+  type ThemeId, type ThemeTokens, type CustomThemePreset, type TimePeriod,
 } from "./theme";
 
 // Runtime systems
@@ -106,6 +106,7 @@ export {
   scheduleAfter,
   scheduleCron,
   scheduleCronAfter,
+  reportTransition,
   setReducedMotion,
   notifyScrollStart,
   useOverlay,

--- a/packages/vue/src/theme/index.ts
+++ b/packages/vue/src/theme/index.ts
@@ -1,6 +1,7 @@
 export { initTheme, useTheme } from "./useTheme";
 export { themePresets, tokensToCSSVars, getThemeTokens, loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme } from "./presets";
 export type { ThemeTokenRGB, ThemeSchemeTokens, ThemePreset, CustomThemePreset, ThemeId, ThemeMode } from "./presets";
+export type { ThemeTokens } from "./presets";
 export { getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION } from "./useSolarTime";
-export { useBackgroundLuminance } from "./useBackgroundLuminance";
+export { startLuminanceSampler, stopLuminanceSampler, sampleLuminanceNow, invalidateLuminanceCache } from "./useBackgroundLuminance";
 export type { TimePeriod } from "./useSolarTime";


### PR DESCRIPTION
The luminance sampler was exported under a nonexistent name; `ThemeTokens` alias and runtime `reportTransition` were missing from the package entry.