### PR TITLE
✨ Upstream zoom-pan interaction and file-type utilities.

### DIFF
--- a/packages/vue/src/composables/useZoomPan.ts
+++ b/packages/vue/src/composables/useZoomPan.ts
@@ -1,0 +1,192 @@
+import { computed, onUnmounted, ref, type Ref } from "vue";
+
+import { useReportedTransition } from "@celestia-island/hikari";
+
+/** Duration of the transform settle transition (see `style` below) AND the
+ *  window reported to the unified animation bus. JS == CSS so the bus
+ *  timeline tracks the CSS timeline exactly (SGaugeRing convention). */
+const SETTLE_ANIM_MS = 150;
+
+export interface ZoomPanOptions {
+  minZoom?: number;
+  maxZoom?: number;
+  zoomStep?: number;
+  containerRef: Ref<HTMLElement | null>;
+  contentRef: Ref<HTMLElement | null>;
+}
+
+export interface ZoomPanState {
+  zoom: Ref<number>;
+  panX: Ref<number>;
+  panY: Ref<number>;
+  isZoomed: Ref<boolean>;
+  canZoomIn: Ref<boolean>;
+  canZoomOut: Ref<boolean>;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetView: () => void;
+  style: Ref<Record<string, string>>;
+}
+
+export function useZoomPan(options: ZoomPanOptions): ZoomPanState {
+  const {
+    minZoom = 0.5,
+    maxZoom = 1,
+    zoomStep = 0.1,
+    containerRef,
+    contentRef,
+  } = options;
+
+  const zoom = ref(1);
+  const panX = ref(0);
+  const panY = ref(0);
+  const isPanning = ref(false);
+  const lastPointerX = ref(0);
+  const lastPointerY = ref(0);
+  const contentOverflow = ref(false);
+
+  // Reports the 150ms transform settle to the animation bus whenever a
+  // value change starts a non-panning transition (zoom step, reset, or the
+  // pointer-up that ends a drag). Panning itself sets transition:none so
+  // there's nothing to report during an active drag.
+  const settleAnim = useReportedTransition(SETTLE_ANIM_MS);
+
+  const isZoomed = computed(() => zoom.value < 1);
+  const canZoomIn = computed(() => zoom.value < maxZoom);
+  const canZoomOut = computed(() => {
+    if (zoom.value <= minZoom) return false;
+    return contentOverflow.value;
+  });
+
+  function checkOverflow() {
+    const container = containerRef.value;
+    const content = contentRef.value;
+    if (!container || !content) {
+      contentOverflow.value = false;
+      return;
+    }
+    contentOverflow.value =
+      content.scrollHeight > container.clientHeight ||
+      content.scrollWidth > container.clientWidth;
+  }
+
+  function clampPan() {
+    if (!containerRef.value || !contentRef.value) return;
+    const cw = containerRef.value.clientWidth;
+    const ch = containerRef.value.clientHeight;
+    const sw = contentRef.value.scrollWidth * zoom.value;
+    const sh = contentRef.value.scrollHeight * zoom.value;
+    const maxX = Math.max(0, (sw - cw) / 2);
+    const maxY = Math.max(0, (sh - ch) / 2);
+    panX.value = Math.max(-maxX, Math.min(maxX, panX.value));
+    panY.value = Math.max(-maxY, Math.min(maxY, panY.value));
+  }
+
+  function zoomIn() {
+    if (!canZoomIn.value) return;
+    zoom.value = Math.min(maxZoom, +(zoom.value + zoomStep).toFixed(2));
+    if (zoom.value >= 1) {
+      panX.value = 0;
+      panY.value = 0;
+    }
+    checkOverflow();
+    clampPan();
+    settleAnim.run();
+  }
+
+  function zoomOut() {
+    if (!canZoomOut.value) return;
+    zoom.value = Math.max(minZoom, +(zoom.value - zoomStep).toFixed(2));
+    checkOverflow();
+    clampPan();
+    settleAnim.run();
+  }
+
+  function resetView() {
+    zoom.value = 1;
+    panX.value = 0;
+    panY.value = 0;
+    settleAnim.run();
+  }
+
+  function onWheel(e: WheelEvent) {
+    if (zoom.value >= 1) return;
+    if (!contentOverflow.value && e.deltaY > 0) return;
+    if (e.deltaY > 0) zoomOut();
+    else if (e.deltaY < 0) zoomIn();
+    e.preventDefault();
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (zoom.value >= 1) return;
+    isPanning.value = true;
+    lastPointerX.value = e.clientX;
+    lastPointerY.value = e.clientY;
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+    e.preventDefault();
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!isPanning.value) return;
+    const dx = e.clientX - lastPointerX.value;
+    const dy = e.clientY - lastPointerY.value;
+    lastPointerX.value = e.clientX;
+    lastPointerY.value = e.clientY;
+    panX.value += dx;
+    panY.value += dy;
+    clampPan();
+  }
+
+  function onPointerUp() {
+    if (!isPanning.value) return;
+    isPanning.value = false;
+    // Drag just ended → the transform now switches from transition:none
+    // to the 0.15s settle, so report it to the bus.
+    settleAnim.run();
+  }
+
+  let detach: (() => void) | null = null;
+  if (typeof window !== "undefined") {
+    const el = containerRef.value;
+    if (el) {
+      const wheelOpts = { passive: false } as AddEventListenerOptions;
+      el.addEventListener("wheel", onWheel, wheelOpts);
+      el.addEventListener("pointerdown", onPointerDown);
+      el.addEventListener("pointermove", onPointerMove);
+      el.addEventListener("pointerup", onPointerUp);
+      el.addEventListener("pointercancel", onPointerUp);
+      detach = () => {
+        el.removeEventListener("wheel", onWheel, wheelOpts);
+        el.removeEventListener("pointerdown", onPointerDown);
+        el.removeEventListener("pointermove", onPointerMove);
+        el.removeEventListener("pointerup", onPointerUp);
+        el.removeEventListener("pointercancel", onPointerUp);
+      };
+    }
+  }
+
+  const style = computed(() => ({
+    transform: `scale(${zoom.value}) translate(${panX.value / zoom.value}px, ${panY.value / zoom.value}px)`,
+    transformOrigin: "top left",
+    // 0.15s mirrors SETTLE_ANIM_MS above — see the comment there.
+    transition: isPanning.value ? "none" : `transform ${SETTLE_ANIM_MS}ms ease-out`,
+  }));
+
+  onUnmounted(() => {
+    detach?.();
+    resetView();
+  });
+
+  return {
+    zoom,
+    panX,
+    panY,
+    isZoomed,
+    canZoomIn,
+    canZoomOut,
+    zoomIn,
+    zoomOut,
+    resetView,
+    style,
+  };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -149,3 +149,7 @@ export type { PasswordValidationResult, PasswordLevel } from "./utils/password";
 
 export { FOCUSABLE_SELECTOR, getFocusableElements, focusFirst, trapFocus, scrollToElement } from "./utils/dom";
 export { useDeferredTransition } from "./composables/useDeferredTransition";
+
+export { useZoomPan } from "./composables/useZoomPan";
+export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";
+export { extOf, isImageFile, isAudioFile, codeLanguage, isCodeFile, isArchiveFile, fileIcon } from "./utils/fileType";

--- a/packages/vue/src/utils/fileType.ts
+++ b/packages/vue/src/utils/fileType.ts
@@ -1,0 +1,108 @@
+import { FileArchive, FileAudio, FileCode, FileImage, FileText, FileVideo, type LucideIcon } from "lucide-vue-next";
+
+const CODE_EXT: Record<string, string> = {
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  ts: "typescript",
+  tsx: "typescript",
+  json: "json",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  rs: "rust",
+  py: "python",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  hpp: "cpp",
+  cc: "cpp",
+  cxx: "cpp",
+  cs: "csharp",
+  rb: "ruby",
+  php: "php",
+  swift: "swift",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  sql: "sql",
+  vue: "xml",
+  dart: "dart",
+  lua: "lua",
+  r: "r",
+  scala: "scala",
+  clj: "clojure",
+  ex: "elixir",
+  exs: "elixir",
+  gradle: "groovy",
+  groovy: "groovy",
+};
+
+const ARCHIVE_EXT = new Set([
+  "zip", "gz", "tar", "tgz", "rar", "7z", "bz2", "xz", "iso", "dmg", "lz",
+]);
+
+const TEXT_EXT = new Set([
+  "txt", "log", "csv", "tsv", "md", "markdown", "rst", "cfg", "conf",
+  "env", "props", "gitignore", "npmignore", "editorconfig",
+]);
+
+export function extOf(name: string): string {
+  const base = name.split("/").pop() ?? name;
+  const i = base.lastIndexOf(".");
+  if (i < 0) return "";
+  return base.slice(i + 1).toLowerCase();
+}
+
+export function isImageFile(type: string): boolean {
+  return type.startsWith("image/");
+}
+
+export function isAudioFile(type: string): boolean {
+  return type.startsWith("audio/");
+}
+
+export function codeLanguage(name: string): string | undefined {
+  const base = name.split("/").pop()?.toLowerCase() ?? "";
+  if (base === "dockerfile") return "dockerfile";
+  if (base === "makefile") return "makefile";
+  return CODE_EXT[extOf(name)];
+}
+
+export function isCodeFile(name: string): boolean {
+  return codeLanguage(name) !== undefined;
+}
+
+export function isArchiveFile(name: string): boolean {
+  return ARCHIVE_EXT.has(extOf(name));
+}
+
+export function isTextFile(name: string, type: string): boolean {
+  if (type.startsWith("text/")) return true;
+  if (type === "application/json" || type === "application/xml") return true;
+  if (type === "image/svg+xml") return true;
+  if (isCodeFile(name)) return true;
+  if (type === "" && TEXT_EXT.has(extOf(name))) return true;
+  return false;
+}
+
+export function fileIcon(type: string, name: string): LucideIcon {
+  if (type.startsWith("image/")) return FileImage;
+  if (type.startsWith("video/")) return FileVideo;
+  if (type.startsWith("audio/")) return FileAudio;
+  if (isCodeFile(name)) return FileCode;
+  if (isArchiveFile(name)) return FileArchive;
+  return FileText;
+}


### PR DESCRIPTION
## Summary

- `useZoomPan` — pointer zoom/pan/clamp interaction composable (vueuse-free native listeners; settles via the animation bus).
- `extOf`/`isImageFile`/`isAudioFile`/`codeLanguage`/`isCodeFile`/`isArchiveFile`/`fileIcon` — file-type/MIME helpers.

Both were chest-only; now generic hikari utils.

## Verification

- `vue-tsc --noEmit` (packages/vue): clean.