### PR TITLE
🐛 Treat any successful credentialed fetch as reachable.

### DIFF
--- a/packages/vue/src/utils/connectivity.ts
+++ b/packages/vue/src/utils/connectivity.ts
@@ -16,8 +16,10 @@ export async function probeOrigin(
 ): Promise<OriginProbe> {
   const fetchFn = opts?.fetchFn ?? fetch;
   try {
-    const resp = await fetchFn(url, { credentials: "include", mode: "cors" });
-    return { ok: resp.ok };
+    // A successful credentialed fetch means reachable + CORS-whitelisted,
+    // regardless of the HTTP status code (4xx/5xx still prove the origin).
+    await fetchFn(url, { credentials: "include", mode: "cors" });
+    return { ok: true };
   } catch {
     // no-cors probe: still reports success if the server is reachable,
     // just without reading the response.


### PR DESCRIPTION
HTTP 4xx/5xx still prove the origin is up and CORS-whitelisted; only the `{ ok: true }` branch is used for reachability.