### PR TITLE
✨ Upstream download helpers, media-kind classification and a body-capturing probe.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -149,10 +149,10 @@ export { useDeferredTransition } from "./composables/useDeferredTransition";
 
 export { useZoomPan } from "./composables/useZoomPan";
 export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";
-export { extOf, isImageFile, isAudioFile, codeLanguage, isCodeFile, isArchiveFile, isTextFile, fileIcon } from "./utils/fileType";
+export { extOf, isImageFile, isAudioFile, codeLanguage, isCodeFile, isArchiveFile, isTextFile, fileIcon, mediaKindOf } from "./utils/fileType";
 
 export { useReducedMotion } from "./composables/useReducedMotion";
-export { probeOrigin } from "./utils/connectivity";
+export { probeOrigin, probeOriginWithBody } from "./utils/connectivity";
 export type { OriginProbe } from "./utils/connectivity";
 
 export { highlight, useHighlight } from "./composables/useHighlight";
@@ -162,3 +162,5 @@ export { useMessaging, registerTransport, registerNativeBridge } from "./composa
 export type { MessagePayload, MessageSeverity, MessageTransport, NotifyOptions, TransportName } from "./composables/messaging";
 
 export { useResourceListModal } from "./composables/useResourceListModal";
+
+export { downloadBlob, downloadTextAsFile } from "./utils/download";

--- a/packages/vue/src/utils/connectivity.ts
+++ b/packages/vue/src/utils/connectivity.ts
@@ -31,3 +31,21 @@ export async function probeOrigin(
     }
   }
 }
+
+/**
+ * Like `probeOrigin` but captures the response body when the credentialed
+ * fetch succeeds — for identity assertions (e.g. checking a product field)
+ * without re-implementing the probe ladder.
+ */
+export async function probeOriginWithBody(
+  url: string,
+  opts?: { fetchFn?: typeof fetch },
+): Promise<{ ok: boolean; body?: string }> {
+  const fetchFn = opts?.fetchFn ?? fetch;
+  try {
+    const resp = await fetchFn(url, { credentials: "include", mode: "cors" });
+    return { ok: true, body: await resp.text().catch(() => undefined) };
+  } catch {
+    return { ok: false };
+  }
+}

--- a/packages/vue/src/utils/download.ts
+++ b/packages/vue/src/utils/download.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser file download helpers (upstreamed from shittim-chest).
+ */
+export function downloadBlob(filename: string, blob: Blob): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Download a text payload (CSV/TOML/JSON…) as a file. */
+export function downloadTextAsFile(
+  filename: string,
+  text: string,
+  mime = "text/plain",
+): void {
+  downloadBlob(filename, new Blob([text], { type: mime }));
+}

--- a/packages/vue/src/utils/fileType.ts
+++ b/packages/vue/src/utils/fileType.ts
@@ -106,3 +106,17 @@ export function fileIcon(type: string, name: string): LucideIcon {
   if (isArchiveFile(name)) return FileArchive;
   return FileText;
 }
+
+const IMG_EXT = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".avif"]);
+const VID_EXT = new Set([".mp4", ".webm", ".mov", ".mkv", ".avi", ".ogv"]);
+const AUD_EXT = new Set([".mp3", ".wav", ".ogg", ".flac", ".m4a", ".opus", ".aac"]);
+
+/** Media kind by file extension (no MIME available). */
+export function mediaKindOf(name: string): "image" | "video" | "audio" | "text" | "other" {
+  const ext = extOf(name).toLowerCase();
+  if (IMG_EXT.has(ext)) return "image";
+  if (VID_EXT.has(ext)) return "video";
+  if (AUD_EXT.has(ext)) return "audio";
+  if (isTextFile(name, "")) return "text";
+  return "other";
+}


### PR DESCRIPTION
downloadBlob/downloadTextAsFile (four chest views hand-rolled the Blob download ladder), mediaKindOf (extension-based media classification) and probeOriginWithBody (identity assertions without re-implementing the probe ladder) are now generic hikari utils.