### PR TITLE
🔧 Map the legacy theme/* exports to the migrated src/theme layout.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.5",
   "private": false,
   "type": "module",
-  "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",
+  "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
   "license": "SySL-1.0",
   "repository": {
     "type": "git",
@@ -26,7 +26,8 @@
     },
     "./styles": {
       "import": "./src/styles/index.scss"
-    }
+    },
+    "./theme/*": "./src/theme/*"
   },
   "files": [
     "src/",


### PR DESCRIPTION
hikari#118 moved the theme partials from packages/vue/theme/ into packages/vue/src/theme/ but left the package.json exports untouched. Downstream sass files that @use \@celestia-island/hikari/theme/field\ now fail with `Can't find stylesheet to import` (chest webui vite build). Map the legacy ./theme/* exports to ./src/theme/* so existing consumers keep resolving.