### PR TITLE
🔧 Resolve the theme partials via a legacy symlink instead of an exports wildcard.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,8 +26,7 @@
     },
     "./styles": {
       "import": "./src/styles/index.scss"
-    },
-    "./theme/*": "./src/theme/*"
+    }
   },
   "files": [
     "src/",

--- a/packages/vue/theme
+++ b/packages/vue/theme
@@ -1,0 +1,1 @@
+src/theme


### PR DESCRIPTION
The #119 exports mapping ("./theme/*" wildcard) is not honored by the sass/vite resolver in use (sass 1.102 fails with `Can't find stylesheet to import` even with a plain-string or "sass"-conditional mapping; physical files resolve fine). Replace it with a committed symlink packages/vue/theme -> src/theme so legacy `@use "@celestia-island/hikari/theme/field"` consumers resolve through classic node_modules lookup. Verified: chest webui vite build passes.