### PR TITLE
🐛 Include undefined in the optional HMinimap imageBounds prop type.

### DIFF
--- a/packages/vue/src/components/HkMinimap.tsx
+++ b/packages/vue/src/components/HkMinimap.tsx
@@ -35,7 +35,7 @@ export default defineComponent({
     /** Optional image rendered as the minimap background (image navigator).
      *  When set, the minimap renders even with no boxes. */
     imageSrc: { type: String, default: undefined },
-    imageBounds: { type: Object as PropType<MinimapRect>, default: undefined },
+    imageBounds: { type: Object as PropType<MinimapRect | undefined>, default: undefined },
     zoom: { type: Number, default: 1 },
     panX: { type: Number, default: 0 },
     panY: { type: Number, default: 0 },


### PR DESCRIPTION
HkMinimap declares imageBounds with PropType<MinimapRect> and default: undefined — consumers that pass undefined (e.g. plana-ui PlanaMinimap) fail vue-tsc with TS2322. Widen the prop type to MinimapRect | undefined (the value already defaults to undefined and the setup code handles it via ?? contentBounds).