### PR TITLE
🐛 Restore the dialog-style useConfirm shadow copy with live downstream consumers.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -112,6 +112,7 @@ export {
   useOverlay,
   usePopupManager,
   useToast,
+  useConfirm,
   useBreakpoint,
   useClipboard,
   closeAll,

--- a/packages/vue/src/runtime/index.ts
+++ b/packages/vue/src/runtime/index.ts
@@ -3,6 +3,7 @@ export * from "./cronBus";
 export { useOverlay, closeAll, isOverlayOpen, type OverlayHandle, type UseOverlayOptions } from "./useOverlay";
 export { usePopupManager, type PopupHandle, type PopupKind } from "./usePopupManager";
 export { useToast, TOAST_DURATION, type ToastItem, type ToastMessage, type ToastType } from "./useToast";
+export { useConfirm } from "./useConfirm";
 export { useBreakpoint } from "./useBreakpoint";
 export { useClipboard } from "./useClipboard";
 export { provideScrollWindow, useScrollWindow, type ScrollWindowContext } from "../composables/useScrollWindow";

--- a/packages/vue/src/runtime/useConfirm.ts
+++ b/packages/vue/src/runtime/useConfirm.ts
@@ -1,0 +1,35 @@
+import { ref } from "vue";
+
+export function useConfirm() {
+  const resolveRef = ref<((value: boolean) => void) | null>(null);
+  const open = ref(false);
+  const message = ref("");
+  const title = ref("Confirm");
+  const confirmText = ref("Confirm");
+  const cancelText = ref("Cancel");
+
+  function confirm(text: string, opts?: { title?: string; confirmText?: string; cancelText?: string }): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      resolveRef.value = resolve;
+      message.value = text;
+      title.value = opts?.title ?? "Confirm";
+      confirmText.value = opts?.confirmText ?? "Confirm";
+      cancelText.value = opts?.cancelText ?? "Cancel";
+      open.value = true;
+    });
+  }
+
+  function onConfirm() {
+    open.value = false;
+    resolveRef.value?.(true);
+    resolveRef.value = null;
+  }
+
+  function onCancel() {
+    open.value = false;
+    resolveRef.value?.(false);
+    resolveRef.value = null;
+  }
+
+  return { open, title, message, confirmText, cancelText, confirm, onConfirm, onCancel };
+}


### PR DESCRIPTION
hikari#116 dropped runtime/useConfirm (and its exports) assuming plana-ui owned the API — but arona's admin views use the dialog-style surface (open/confirmText/cancelText/onConfirm/onCancel), which differs from plana-ui's function-style confirm(title, message). Restore the runtime copy and re-export it from both the runtime barrel and the top-level entry. Verified: arona webui vue-tsc 0 errors.