### PR TITLE
✨ Upstream a bytesToBase64 helper.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -165,3 +165,4 @@ export type { MessagePayload, MessageSeverity, MessageTransport, NotifyOptions, 
 export { useResourceListModal } from "./composables/useResourceListModal";
 
 export { downloadBlob, downloadTextAsFile } from "./utils/download";
+export { bytesToBase64 } from "./utils/base64";

--- a/packages/vue/src/utils/base64.ts
+++ b/packages/vue/src/utils/base64.ts
@@ -1,0 +1,10 @@
+/** Encode a binary buffer as a base64 string. */
+export function bytesToBase64(bytes: ArrayBuffer | Uint8Array): string {
+  const buf = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < buf.length; i += chunk) {
+    binary += String.fromCharCode(...buf.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}


### PR DESCRIPTION
AdminLayout and the realtime-audio path hand-rolled the same ArrayBuffer chunk loop; the encoding now lives in hikari.