### PR TITLE
✨ Export the theme-mode storage key.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -166,3 +166,5 @@ export { useResourceListModal } from "./composables/useResourceListModal";
 
 export { downloadBlob, downloadTextAsFile } from "./utils/download";
 export { bytesToBase64 } from "./utils/base64";
+
+export { THEME_MODE_STORAGE_KEY } from "./theme/useTheme";

--- a/packages/vue/src/theme/useTheme.ts
+++ b/packages/vue/src/theme/useTheme.ts
@@ -7,7 +7,8 @@ import { getTimePeriod, DEFAULT_GEO_LOCATION, type TimePeriod } from "./useSolar
 
 const DEFAULT_THEME = "synthwave84";
 const STORAGE_THEME_KEY = "hikari-theme";
-const STORAGE_MODE_KEY = "hikari-theme-mode";
+export const THEME_MODE_STORAGE_KEY = "hikari-theme-mode";
+const STORAGE_MODE_KEY = THEME_MODE_STORAGE_KEY;
 
 const currentTheme = ref<ThemeId>(
   localStorage.getItem(STORAGE_THEME_KEY) || DEFAULT_THEME,


### PR DESCRIPTION
Chest's wallpaper mode-guess reads the same persisted mode key the theme engine writes; the constant is now shared instead of a stale local copy.