### PR TITLE
✨ Upstream an isTauri environment check.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -168,3 +168,5 @@ export { downloadBlob, downloadTextAsFile } from "./utils/download";
 export { bytesToBase64 } from "./utils/base64";
 
 export { THEME_MODE_STORAGE_KEY } from "./theme/useTheme";
+
+export { isTauri } from "./runtime/env";

--- a/packages/vue/src/runtime/env.ts
+++ b/packages/vue/src/runtime/env.ts
@@ -1,0 +1,4 @@
+/** True when running inside a Tauri webview. */
+export function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}


### PR DESCRIPTION
Four files across both WebUIs hand-rolled the same __TAURI_INTERNALS__ probe; the check now lives in hikari's runtime.