### PR TITLE
✨ Add base64ToBytes and blobToBase64 next to bytesToBase64.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -165,7 +165,7 @@ export type { MessagePayload, MessageSeverity, MessageTransport, NotifyOptions, 
 export { useResourceListModal } from "./composables/useResourceListModal";
 
 export { downloadBlob, downloadTextAsFile } from "./utils/download";
-export { bytesToBase64 } from "./utils/base64";
+export { bytesToBase64, base64ToBytes, blobToBase64 } from "./utils/base64";
 
 export { THEME_MODE_STORAGE_KEY } from "./theme/useTheme";
 

--- a/packages/vue/src/utils/base64.ts
+++ b/packages/vue/src/utils/base64.ts
@@ -8,3 +8,24 @@ export function bytesToBase64(bytes: ArrayBuffer | Uint8Array): string {
   }
   return btoa(binary);
 }
+
+/** Decode a base64 string into raw bytes. */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Read a Blob/File and return its base64 payload (no data: prefix). */
+export function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result ?? "");
+      resolve(result.includes(",") ? result.slice(result.indexOf(",") + 1) : result);
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}


### PR DESCRIPTION
Chest's device terminal (decodeChunk) and voice transcriber (blobToBase64) hand-rolled the same conversions; the base64 family is now complete in hikari.