### PR TITLE
✅ Move the fuzzy-search and password tests next to their implementations.

### DIFF
--- a/packages/vue/src/utils/fuzzySearch.test.ts
+++ b/packages/vue/src/utils/fuzzySearch.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { fuzzyScore, fuzzyScoreFields, fuzzySearch } from "./fuzzy";
+
+describe("fuzzyScore", () => {
+  it("treats an empty query as a (zero-score) match", () => {
+    expect(fuzzyScore("", "anything")).toEqual({ matched: true, score: 0 });
+  });
+
+  it("scores an exact substring highest, with a boundary bonus", () => {
+    const mid = fuzzyScore("err", "terrors"); // substring, but mid-word (prev = 't')
+    const start = fuzzyScore("err", "error log"); // substring at a word edge
+    expect(mid.matched).toBe(true);
+    expect(start.matched).toBe(true);
+    // Substring at a word boundary should beat a mid-word substring.
+    expect(start.score).toBeGreaterThan(mid.score);
+  });
+
+  it("matches as a subsequence with run + boundary bonuses", () => {
+    const res = fuzzyScore("rep", "report");
+    expect(res.matched).toBe(true);
+    expect(res.score).toBeGreaterThan(0);
+  });
+
+  it("does not match when characters are out of order / missing", () => {
+    expect(fuzzyScore("xyz", "report").matched).toBe(false);
+    expect(fuzzyScore("rp", "par").matched).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyScore("REP", "report").matched).toBe(true);
+    expect(fuzzyScore("rep", "REPORT").matched).toBe(true);
+  });
+});
+
+describe("fuzzyScoreFields", () => {
+  it("returns the best weighted score across fields", () => {
+    const res = fuzzyScoreFields("err", [
+      { text: "Report: execution error", weight: 3 },
+      { text: "ferry crossing", weight: 1 },
+    ]);
+    expect(res.matched).toBe(true);
+    expect(res.score).toBeGreaterThan(0);
+  });
+
+  it("reports no match when no field matches", () => {
+    expect(fuzzyScoreFields("zzz", [{ text: "report" }]).matched).toBe(false);
+  });
+});
+
+describe("fuzzySearch", () => {
+  interface Rec { title: string; body: string }
+  const records: Rec[] = [
+    { title: "Execution error", body: "fuel cell tripped" },
+    { title: "Daily summary", body: "all systems nominal" },
+    { title: "ferry schedule", body: "crossing at noon" },
+  ];
+  const fieldsOf = (r: Rec) => [
+    { text: r.title, weight: 3 },
+    { text: r.body, weight: 1 },
+  ];
+
+  it("returns all records (score 0) for an empty query", () => {
+    const out = fuzzySearch("", records, fieldsOf);
+    expect(out).toHaveLength(records.length);
+  });
+
+  it("requires every whitespace-separated term to match some field", () => {
+    const out = fuzzySearch("error fuel", records, fieldsOf);
+    expect(out).toHaveLength(1);
+    expect(out[0].record.title).toBe("Execution error");
+  });
+
+  it("drops records where any term is absent", () => {
+    const out = fuzzySearch("error nominal", records, fieldsOf);
+    expect(out).toHaveLength(0);
+  });
+
+  it("ranks higher-scoring matches first", () => {
+    const pool: Rec[] = [
+      { title: "error", body: "" },            // title-only exact
+      { title: "misc", body: "an error ocurred" }, // body subsequence
+    ];
+    const out = fuzzySearch("error", pool, fieldsOf);
+    expect(out[0].record.title).toBe("error");
+  });
+});

--- a/packages/vue/src/utils/validation.test.ts
+++ b/packages/vue/src/utils/validation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { passwordLevel, validatePassword } from "./password";
+
+describe("validatePassword", () => {
+  it("returns valid for matching passwords >= 8 chars with letters and digits", () => {
+    const result = validatePassword("password123", "password123");
+    expect(result.valid).toBe(true);
+    expect(result.errorKey).toBeNull();
+  });
+
+  it("returns mismatch when passwords differ", () => {
+    const result = validatePassword("password1", "password2");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.passwordMismatch");
+  });
+
+  it("returns minLength when password < 8 chars", () => {
+    const result = validatePassword("short", "short");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.minLength");
+  });
+
+  it("prioritises mismatch over minLength", () => {
+    const result = validatePassword("abc", "xyz");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.passwordMismatch");
+  });
+
+  it("accepts an exactly 8-char password with letters and digits", () => {
+    const result = validatePassword("pass1234", "pass1234");
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects digits-only password as needing variety", () => {
+    const result = validatePassword("12345678", "12345678");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.passwordNeedsVariety");
+  });
+
+  it("rejects letters-only password as needing variety", () => {
+    const result = validatePassword("password", "password");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.passwordNeedsVariety");
+  });
+
+  it("rejects empty passwords with minLength", () => {
+    const result = validatePassword("", "");
+    expect(result.valid).toBe(false);
+    expect(result.errorKey).toBe("common.validation.minLength");
+  });
+});
+
+describe("passwordLevel", () => {
+  it("returns null for empty password", () => {
+    expect(passwordLevel("")).toBeNull();
+  });
+
+  it("returns weak when below 8 chars", () => {
+    expect(passwordLevel("Ab1")).toBe("weak");
+  });
+
+  it("returns weak for 8 chars without digits", () => {
+    expect(passwordLevel("password")).toBe("weak");
+  });
+
+  it("returns fair for 8 chars with letters and digits", () => {
+    expect(passwordLevel("pass1234")).toBe("fair");
+  });
+
+  it("returns strong for 10+ chars with upper, lower, and special", () => {
+    expect(passwordLevel("Pass1234!x")).toBe("strong");
+  });
+
+  it("returns fair (not strong) when missing special char", () => {
+    expect(passwordLevel("Password1234")).toBe("fair");
+  });
+});


### PR DESCRIPTION
The consumer-side copies in shittim-chest tested upstream code; the tests now live with fuzzy.ts and password.ts.