### PR TITLE
🔥 Drop the dead useToast pass-through shim.

### DIFF
--- a/packages/vue/src/composables/useToast.ts
+++ b/packages/vue/src/composables/useToast.ts
@@ -1,2 +1,0 @@
-export { useToast } from "../runtime/useToast";
-export type { ToastItem, ToastMessage, ToastType } from "../runtime/useToast";


### PR DESCRIPTION
composables/useToast only re-exported runtime/useToast with zero importers; the runtime export is the single source.