### PR TITLE
🔧 Inline the remaining cross-package component styles for npm consumers.

### DIFF
--- a/packages/vue/src/components/HkAvatar.scss
+++ b/packages/vue/src/components/HkAvatar.scss
@@ -1,0 +1,93 @@
+// ------
+// Hikari Avatar Component
+// ------
+
+.hk-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background-color: var(--hi-color-gray-200, #E5E7EB);
+  color: var(--hi-color-gray-600, #4B5563);
+  font-weight: 500;
+  transition: all 0.2s ease;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.hk-avatar-xs {
+  width: 24px;
+  height: 24px;
+  font-size: 0.625rem;
+}
+
+.hk-avatar-sm {
+  width: 32px;
+  height: 32px;
+  font-size: 0.75rem;
+}
+
+.hk-avatar-md {
+  width: 40px;
+  height: 40px;
+  font-size: 0.875rem;
+}
+
+.hk-avatar-lg {
+  width: 48px;
+  height: 48px;
+  font-size: 1rem;
+}
+
+.hk-avatar-xl {
+  width: 64px;
+  height: 64px;
+  font-size: 1.25rem;
+}
+
+.hk-avatar-circular {
+  border-radius: 50%;
+}
+
+.hk-avatar-rounded {
+  border-radius: 8px;
+}
+
+.hk-avatar-square {
+  border-radius: 0;
+}
+
+.hk-avatar-fallback {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+  font-weight: 600;
+}
+
+.hk-avatar-icon {
+  color: var(--hi-color-text-secondary);
+  opacity: 0.8;
+}
+
+.hk-avatar-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+[data-theme="dark"] .hk-avatar {
+  background-color: var(--hi-surface);
+  color: var(--hi-color-text-secondary);
+}
+
+[data-theme="dark"] .hk-avatar-icon {
+  color: var(--hi-color-text-secondary);
+  opacity: 0.6;
+}

--- a/packages/vue/src/components/HkAvatar.tsx
+++ b/packages/vue/src/components/HkAvatar.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, type PropType } from "vue";
 import { useI18n } from "../i18n/context";
-import "../../../components/src/styles/components/avatar.scss";
+import "./HkAvatar.scss";
 
 export default defineComponent({
   name: "HkAvatar",

--- a/packages/vue/src/components/HkBreadcrumb.scss
+++ b/packages/vue/src/components/HkBreadcrumb.scss
@@ -1,0 +1,624 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
+// ------
+// Hikari Breadcrumb Component
+// Features: Glowing separators, smooth transitions, hover effects
+// ------
+
+// ------
+// Base Breadcrumb Styles
+// ------
+
+.hk-breadcrumb {
+  // Layout
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+
+  // Reset
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  // Typography
+  font-family: vars.$hikari-font-family-sans;
+  font-size: vars.$hikari-font-size-sm;
+  line-height: 1.5;
+
+  // Gap
+  gap: 0.5rem;
+}
+
+// ------
+// Breadcrumb Item
+// ------
+
+.hk-breadcrumb-item {
+  // Layout
+  display: flex;
+  align-items: center;
+
+  // Spacing
+  margin: 0;
+
+  // Position
+  position: relative;
+
+  // Not the last item
+  &:not(:last-child) {
+    // Separator
+    .hk-breadcrumb-separator {
+      margin-left: 0.5rem;
+      color: var(--hi-color-text-secondary);
+      opacity: 0.5;
+      // DISABLED - migrated to JS animation
+
+      // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+      // Glow effect on separator
+      filter: drop-shadow(0 0 4px var(--hi-primary));
+
+      svg {
+        width: 1rem;
+        height: 1rem;
+      }
+    }
+  }
+
+  // Last item (current page)
+  &:last-child {
+    .hk-breadcrumb-link {
+      color: var(--hi-color-text-primary);
+      font-weight: 500;
+      cursor: default;
+      pointer-events: none;
+
+      // Subtle glow on current item
+      text-shadow: 0 0 8px var(--hi-primary);
+    }
+  }
+}
+
+// ------
+// Breadcrumb Link
+// ------
+
+.hk-breadcrumb-link {
+  // Typography
+  color: var(--hi-color-text-secondary);
+  text-decoration: none;
+  white-space: nowrap;
+
+  // Cursor
+  cursor: pointer;
+
+  // Transitions
+  // DISABLED - migrated to JS animation
+
+  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+  // Padding
+  padding: 0.25rem 0.5rem;
+  margin: -0.25rem -0.5rem;
+  border-radius: vars.$hikari-radius-fui-sm;
+
+  // Display
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+
+  // Icon
+  .hk-breadcrumb-icon {
+    flex-shrink: 0;
+    width: 1rem;
+    height: 1rem;
+    // DISABLED - migrated to JS animation
+
+    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  // Hover state
+  &:hover {
+    color: var(--hi-color-text-primary);
+    background: var(--hi-primary);
+
+    .hk-breadcrumb-icon {
+      color: var(--hi-color-primary);
+      filter: drop-shadow(0 0 4px var(--hi-primary));
+    }
+
+    // Glow effect on text
+    text-shadow: 0 0 8px var(--hi-primary);
+  }
+
+  // Active/focus state
+  &:focus-visible {
+    outline: none;
+    background: var(--hi-primary);
+    box-shadow:
+      0 0 0 2px var(--hi-primary),
+      0 0 12px var(--hi-primary);
+  }
+
+  // Active state (for non-last items)
+  &.hk-breadcrumb-link-active {
+    color: var(--hi-color-text-primary);
+    font-weight: 500;
+  }
+}
+
+// ------
+// Breadcrumb Separator
+// ------
+
+.hk-breadcrumb-separator {
+  // Layout
+  display: inline-flex;
+  align-items: center;
+
+  // Typography
+  font-size: 0.875rem;
+
+  // Transitions
+  // DISABLED - migrated to JS animation
+
+  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+  // Custom separator glow
+  &.hk-breadcrumb-separator-glow {
+    color: var(--hi-color-primary);
+    opacity: 0.8;
+    filter: drop-shadow(0 0 6px var(--hi-primary));
+  }
+}
+
+// ------
+// Separator Variants
+// ------
+
+// Slash separator
+.hk-breadcrumb-separator-slash {
+  &::before {
+    content: '/';
+  }
+}
+
+// Arrow separator
+.hk-breadcrumb-separator-arrow {
+  &::before {
+    content: '›';
+    font-size: 1.1em;
+  }
+}
+
+// Double arrow separator
+.hk-breadcrumb-separator-double-arrow {
+  &::before {
+    content: '»';
+    font-size: 0.9em;
+  }
+}
+
+// Chevron separator (default with icon)
+.hk-breadcrumb-separator-chevron {
+  // Uses chevron-right icon
+}
+
+// Dot separator
+.hk-breadcrumb-separator-dot {
+  &::before {
+    content: '•';
+    font-size: 1.2em;
+  }
+}
+
+// ------
+// Breadcrumb Dropdown (for nested paths)
+// ------
+
+.hk-breadcrumb-dropdown {
+  // Layout
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  // Trigger
+  .hk-breadcrumb-dropdown-trigger {
+    // Layout
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+
+    // Arrow icon
+    .hk-breadcrumb-dropdown-arrow {
+      width: 0.75rem;
+      height: 0.75rem;
+      // DISABLED - migrated to JS animation
+
+      // transition: transform vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+      svg {
+        width: 100%;
+        height: 100%;
+      }
+    }
+
+    // Open state
+    &.hk-breadcrumb-dropdown-open {
+      .hk-breadcrumb-dropdown-arrow {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  // Dropdown menu
+  .hk-breadcrumb-dropdown-menu {
+    // Layout
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    min-width: 200px;
+    z-index: 100;
+
+    // Appearance
+    border-radius: vars.$hikari-radius-fui-md;
+    border: 1px solid var(--hi-color-border);
+    background: var(--hi-surface);
+    backdrop-filter: blur(4px);
+    box-shadow:
+      0 8px 16px var(--hi-black-30, rgba(0, 0, 0, 0.3)),
+      0 0 0 1px var(--hi-white-5, rgba(255, 255, 255, 0.05)) inset;
+
+    // Padding
+    padding: 0.5rem;
+
+    // Transitions
+    // DISABLED - migrated to JS animation
+
+    // transition: all vars.$hikari-duration-normal vars.$hikari-ease-smooth;
+
+    // Animation
+    opacity: 0;
+    transform: translateY(-8px);
+    pointer-events: none;
+
+    // Open state
+    &.hk-breadcrumb-dropdown-menu-open {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
+
+    // Menu items
+    .hk-breadcrumb-dropdown-item {
+      // Layout
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+
+      // Spacing
+      padding: 0.5rem 0.75rem;
+      margin: 0.125rem 0;
+
+      // Typography
+      font-size: vars.$hikari-font-size-sm;
+      color: var(--hi-color-text-primary);
+      text-decoration: none;
+      white-space: nowrap;
+
+      // Appearance
+      border-radius: vars.$hikari-radius-fui-sm;
+
+      // Cursor
+      cursor: pointer;
+
+      // Transitions
+      // DISABLED - migrated to JS animation
+
+      // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+      // Hover state
+      &:hover {
+        background: var(--hi-primary);
+        color: var(--hi-color-text-primary);
+        box-shadow:
+          0 0 12px var(--hi-primary),
+          inset 0 0 8px var(--hi-primary);
+      }
+    }
+  }
+}
+
+// ------
+// Icon Styles
+// ------
+
+.hk-breadcrumb-icon {
+  // Layout
+  display: inline-flex;
+  align-items: center;
+
+  // Size
+  width: 1rem;
+  height: 1rem;
+
+  // Color
+  color: var(--hi-color-text-secondary);
+
+  // Transitions
+  // DISABLED - migrated to JS animation
+
+  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+// ------
+// Size Variants
+// ------
+
+.hk-breadcrumb-sm {
+  font-size: 0.75rem;
+  gap: 0.375rem;
+
+  .hk-breadcrumb-link {
+    padding: 0.125rem 0.375rem;
+    margin: -0.125rem -0.375rem;
+
+    .hk-breadcrumb-icon {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  .hk-breadcrumb-separator {
+    margin-left: 0.375rem;
+    font-size: 0.75rem;
+
+    svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+}
+
+.hk-breadcrumb-md {
+  font-size: vars.$hikari-font-size-sm;
+  gap: 0.5rem;
+}
+
+.hk-breadcrumb-lg {
+  font-size: 1rem;
+  gap: 0.625rem;
+
+  .hk-breadcrumb-link {
+    padding: 0.375rem 0.625rem;
+    margin: -0.375rem -0.625rem;
+
+    .hk-breadcrumb-icon {
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+
+  .hk-breadcrumb-separator {
+    margin-left: 0.625rem;
+    font-size: 1rem;
+
+    svg {
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+}
+
+// ------
+// Theme Variants
+// ------
+
+// With background
+.hk-breadcrumb-background {
+  gap: 0;
+
+  .hk-breadcrumb-item {
+    background: var(--hi-card-bg);
+    padding: 0.375rem 0.75rem;
+    border-radius: vars.$hikari-radius-fui-sm;
+    // DISABLED - migrated to JS animation
+
+    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+    &:not(:last-child):hover {
+      background: var(--hi-primary);
+    }
+
+    &:last-child {
+      background: var(--hi-primary);
+      box-shadow:
+        0 0 12px var(--hi-primary),
+        inset 0 0 8px var(--hi-primary);
+    }
+  }
+}
+
+// Pill style
+.hk-breadcrumb-pill {
+  .hk-breadcrumb-item {
+    background: var(--hi-card-bg);
+    padding: 0.375rem 0.875rem;
+    border-radius: 999px;
+    border: 1px solid var(--hi-color-border);
+    // DISABLED - migrated to JS animation
+
+    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+
+    &:not(:last-child) {
+      &:hover {
+        background: var(--hi-primary);
+        border-color: var(--hi-primary);
+      }
+    }
+
+    &:last-child {
+      background: linear-gradient(135deg, var(--hi-primary), var(--hi-primary));
+      border-color: var(--hi-primary);
+      box-shadow:
+        0 0 12px var(--hi-primary),
+        inset 0 0 8px var(--hi-primary);
+    }
+  }
+}
+
+// ------
+// Separator Animations
+// ------
+
+// Animated separator (pulsing glow)
+.hk-breadcrumb-separator-animated {
+  // DISABLED - migrated to JS animation
+
+  // animation: breadcrumb-separator-pulse 2s ease-in-out infinite;
+}
+
+// DISABLED - migrated to JS animation
+// @keyframes breadcrumb-separator-pulse {
+//   0%, 100% {
+//     opacity: 0.5;
+//     filter: drop-shadow(0 0 4px var(--hi-primary));
+//   }
+//   50% {
+//     opacity: 1;
+//     filter: drop-shadow(0 0 8px var(--hi-primary));
+//   }
+// }
+
+// ------
+// Collapsible Breadcrumb (for mobile)
+// ------
+
+.hk-breadcrumb-collapsible {
+  // Hide middle items on small screens
+  .hk-breadcrumb-item {
+    &:nth-child(n+2):nth-last-child(n+3) {
+      @media (max-width: 768px) {
+        display: none;
+      }
+    }
+
+    // Show ellipsis
+    &.hk-breadcrumb-ellipsis {
+      @media (max-width: 768px) {
+        display: flex;
+      }
+    }
+  }
+}
+
+// ------
+// Animations
+// ------
+
+// Fade-in animation
+.hk-breadcrumb-animate-in {
+  .hk-breadcrumb-item {
+    opacity: 0;
+    // DISABLED - migrated to JS animation
+
+    // animation: breadcrumb-fade-in vars.$hikari-duration-normal vars.$hikari-ease-smooth forwards;
+
+    @for $i from 1 through 10 {
+      &:nth-child(#{$i}) {
+        animation-delay: #{$i * 0.1s};
+      }
+    }
+  }
+}
+
+// DISABLED - migrated to JS animation
+// @keyframes breadcrumb-fade-in {
+//   from {
+//     opacity: 0;
+//     transform: translateY(-4px);
+//   }
+//   to {
+//     opacity: 1;
+//     transform: translateY(0);
+//   }
+// }
+
+// Slide-in animation
+.hk-breadcrumb-slide-in {
+  .hk-breadcrumb-item {
+    opacity: 0;
+    // DISABLED - migrated to JS animation
+
+    // animation: breadcrumb-slide-in vars.$hikari-duration-normal vars.$hikari-ease-smooth forwards;
+
+    @for $i from 1 through 10 {
+      &:nth-child(#{$i}) {
+        animation-delay: #{$i * 0.08s};
+      }
+    }
+  }
+}
+
+// DISABLED - migrated to JS animation
+// @keyframes breadcrumb-slide-in {
+//   from {
+//     opacity: 0;
+//     transform: translateX(-8px);
+//   }
+//   to {
+//     opacity: 1;
+//     transform: translateX(0);
+//   }
+// }
+
+// ------
+// Custom Colors
+// ------
+
+.hk-breadcrumb-primary {
+  .hk-breadcrumb-link {
+    &:hover {
+      color: var(--hi-color-primary);
+      text-shadow: 0 0 8px var(--hi-color-primary);
+    }
+  }
+}
+
+.hk-breadcrumb-success {
+  .hk-breadcrumb-link {
+    &:hover {
+      color: var(--hi-color-success);
+      text-shadow: 0 0 8px var(--hi-color-success);
+    }
+  }
+}
+
+.hk-breadcrumb-warning {
+  .hk-breadcrumb-link {
+    &:hover {
+      color: var(--hi-color-warning);
+      text-shadow: 0 0 8px var(--hi-color-warning);
+    }
+  }
+}
+
+.hk-breadcrumb-danger {
+  .hk-breadcrumb-link {
+    &:hover {
+      color: var(--hi-color-danger);
+      text-shadow: 0 0 8px var(--hi-color-danger);
+    }
+  }
+}

--- a/packages/vue/src/components/HkBreadcrumb.tsx
+++ b/packages/vue/src/components/HkBreadcrumb.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, type PropType } from "vue";
 import { useI18n } from "../i18n/context";
-import "../../../components/src/styles/components/breadcrumb.scss";
+import "./HkBreadcrumb.scss";
 
 export default defineComponent({
   name: "HkBreadcrumb",

--- a/packages/vue/src/components/HkCollapse.scss
+++ b/packages/vue/src/components/HkCollapse.scss
@@ -1,0 +1,50 @@
+// Collapse component styles
+// Animated collapse/expand for tree nodes
+
+.hk-collapse {
+  display: flex;
+  flex-direction: column;
+}
+
+.hk-collapse-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s ease;
+
+  &:hover {
+    background: var(--hi-color-background-light, #f9fafb);
+  }
+
+  &:active {
+    background: var(--hi-color-primary-light, rgba(0, 160, 233, 0.1));
+  }
+}
+
+.hk-collapse-arrow {
+  display: inline-block;
+  transition: transform 0.2s ease;
+  color: var(--hi-color-text-secondary, #666666);
+  font-size: 16px;
+}
+
+.hk-collapse-header-content {
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.hk-collapse-content {
+  overflow: hidden;
+  transition: max-height 0.2s ease-in-out, opacity 0.2s ease-in-out;
+  opacity: 0;
+  max-height: 0;
+}
+
+.hk-collapse-content.hk-collapse-expanded {
+  opacity: 1;
+  max-height: none;
+}

--- a/packages/vue/src/components/HkCollapse.tsx
+++ b/packages/vue/src/components/HkCollapse.tsx
@@ -1,5 +1,5 @@
 import { computed, defineComponent, ref, watch, type PropType } from "vue";
-import "../../../components/src/styles/components/collapse.scss";
+import "./HkCollapse.scss";
 
 export default defineComponent({
   name: "HkCollapse",

--- a/packages/vue/src/components/HkIcon.scss
+++ b/packages/vue/src/components/HkIcon.scss
@@ -1,0 +1,123 @@
+// Icon component styles
+//
+// These styles enable icons to inherit theme colors and support
+// custom color overrides.
+
+// ------
+// Base Icon Styles
+// ------
+
+.hk-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  // Default: inherit color from parent element
+  // This allows buttons and other containers to control icon color
+  color: inherit;
+
+  // SVG inherits color; fill/stroke controlled by each icon's inline attributes
+  svg {
+    width: 100%;
+    height: 100%;
+    // MDI fill-based icons set fill="currentColor" in their SVG data
+    // Lucide/Feather stroke-based icons set stroke="currentColor" + fill="none"
+    // We must NOT override these here
+  }
+}
+
+// ------
+// Icon Size Variants
+// ------
+
+.hk-icon-16 {
+  width: 1rem;
+  height: 1rem;
+}
+
+.hk-icon-20 {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.hk-icon-24 {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.hk-icon-32 {
+  width: 2rem;
+  height: 2rem;
+}
+
+.hk-icon-40 {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.hk-icon-48 {
+  width: 3rem;
+  height: 3rem;
+}
+
+.hk-icon-64 {
+  width: 4rem;
+  height: 4rem;
+}
+
+// ------
+// Icon Color Variants
+// ------
+
+// Use theme primary color
+.hk-icon-primary {
+  color: var(--hi-color-primary);
+}
+
+// Use theme secondary color
+.hk-icon-secondary {
+  color: var(--hi-color-secondary);
+}
+
+// Use theme accent color
+.hk-icon-accent {
+  color: var(--hi-color-accent);
+}
+
+// Use theme success color
+.hk-icon-success {
+  color: var(--hi-color-success);
+}
+
+// Use theme warning color
+.hk-icon-warning {
+  color: var(--hi-color-warning);
+}
+
+// Use theme danger color
+.hk-icon-danger {
+  color: var(--hi-color-danger);
+}
+
+// Use secondary text color
+.hk-icon-muted {
+  color: var(--hi-color-text-secondary);
+}
+
+// ------
+// Transitions
+// ------
+
+.hk-icon-transition {
+  transition: color 150ms ease-in-out;
+
+  svg path,
+  svg circle,
+  svg rect,
+  svg ellipse,
+  svg polygon,
+  svg polyline,
+  svg line {
+    transition: fill 150ms ease-in-out, stroke 150ms ease-in-out;
+  }
+}

--- a/packages/vue/src/components/HkIcon.tsx
+++ b/packages/vue/src/components/HkIcon.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, type PropType } from "vue";
 import * as LucideIcons from "lucide-vue-next";
-import "../../../components/src/styles/components/icon.scss";
+import "./HkIcon.scss";
 
 function pascalCase(str: string): string {
   const camel = str.replace(/-([a-z])/g, (_: string, c: string) => c.toUpperCase());

--- a/packages/vue/src/components/HkIconButton.scss
+++ b/packages/vue/src/components/HkIconButton.scss
@@ -1,0 +1,170 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+@use "./HkIconButtonVars.scss";
+
+// ------
+// Hikari IconButton Component - FUI Styling
+// Three-layer CSS variable system:
+// - Layer1: Foundation variables (foundation.scss)
+// - Layer2: Component variables (icon-button-vars.scss)
+// - Custom: Runtime overrides via AnimationBuilder
+//
+// NOTE: Hover effects are handled by Glow wrapper, not here
+// ------
+
+.hk-icon-button {
+  // Layer2 variables are defined in icon-button-vars.scss
+
+  // Layout
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  line-height: 0;
+  gap: 0;
+
+  // Size - use CSS variables
+  width: var(--hi-icon-button-size);
+  height: var(--hi-icon-button-size);
+  min-width: var(--hi-icon-button-size);
+  max-width: var(--hi-icon-button-size);
+  min-height: var(--hi-icon-button-size);
+  max-height: var(--hi-icon-button-size);
+
+  // Allow glow effect to show
+  overflow: visible;
+
+  // Remove default button styling
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  // Background - use CSS variables
+  background: var(--hi-icon-button-bg);
+  border: none;
+  border-radius: var(--hi-icon-button-radius);
+
+  // Typography
+  font-family: vars.$hikari-font-family-sans;
+  font-size: vars.$hikari-font-size-sm;
+  font-weight: 400;
+  color: var(--hi-icon-button-icon-color);
+
+  // Transitions - use CSS variables
+  transition: var(--hi-icon-button-transition);
+
+  // No transform - controlled by AnimationBuilder via Glow wrapper
+
+  // Cursor
+  cursor: pointer;
+
+  // Focus state - only outline, no color changes
+  &:focus-visible {
+    outline: 2px solid var(--hi-icon-button-border-color-focus);
+    outline-offset: 2px;
+    color: var(--hi-icon-button-icon-color);
+
+    .hk-icon-button-icon {
+      color: var(--hi-icon-button-icon-color);
+    }
+  }
+
+  // Disabled state
+  &:disabled {
+    background: var(--hi-icon-button-bg-disabled);
+    color: var(--hi-icon-button-icon-color-disabled);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  // No active state - controlled by AnimationBuilder via Glow wrapper
+
+  // ------
+  // Size Variants - Variables defined in icon-button-vars.scss
+  // ------
+
+  &.hk-icon-button-16,
+  &.hk-icon-button-24,
+  &.hk-icon-button-32,
+  &.hk-icon-button-36,
+  &.hk-icon-button-40 {
+    // Size variables are already set by the classes in icon-button-vars.scss
+  }
+
+  // ------
+  // Variant: Ghost (default - transparent)
+  // ------
+
+  &.hk-icon-button-ghost,
+  &.hk-icon-button-borderless {
+    // Variables defined in icon-button-vars.scss
+  }
+
+  // ------
+  // Variant: Primary (solid primary color)
+  // ------
+
+  &.hk-icon-button-primary {
+    // Variables defined in icon-button-vars.scss
+  }
+
+  // ------
+  // Variant: Secondary (solid secondary color)
+  // ------
+
+  &.hk-icon-button-secondary {
+    // Variables defined in icon-button-vars.scss
+  }
+
+  // ------
+  // Variant: Danger (solid danger color)
+  // ------
+
+  &.hk-icon-button-danger {
+    // Variables defined in icon-button-vars.scss
+  }
+
+  // ------
+  // Variant: Success (solid success color)
+  // ------
+
+  &.hk-icon-button-success {
+    // Variables defined in icon-button-vars.scss
+  }
+
+  // ------
+  // Icon Styles - Use CSS Variables
+  // ------
+
+  .hk-icon-button-icon {
+    width: var(--hi-icon-button-icon-size);
+    height: var(--hi-icon-button-icon-size);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    color: var(--hi-icon-button-icon-color);
+
+    svg {
+      width: var(--hi-icon-button-icon-size);
+      height: var(--hi-icon-button-icon-size);
+      display: block;
+      fill: currentColor;
+    }
+  }
+
+  // Active state for icon
+  &:active:not(:disabled) .hk-icon-button-icon {
+    color: var(--hi-icon-button-icon-color-active);
+  }
+
+  // Disabled state for icon
+  &:disabled .hk-icon-button-icon {
+    color: var(--hi-icon-button-icon-color-disabled);
+  }
+
+  .hk-icon-button-disabled {
+    opacity: 0.3;
+  }
+}

--- a/packages/vue/src/components/HkIconButton.tsx
+++ b/packages/vue/src/components/HkIconButton.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, type PropType } from "vue";
-import "../../../components/src/styles/components/icon_button.scss";
-import "../../../components/src/styles/components/icon-button-vars.scss";
+import "./HkIconButton.scss";
+import "./HkIconButtonVars.scss";
 
 export default defineComponent({
   name: "HkIconButton",

--- a/packages/vue/src/components/HkIconButtonVars.scss
+++ b/packages/vue/src/components/HkIconButtonVars.scss
@@ -1,0 +1,176 @@
+// HkIconButtonVars.scss
+// Layer2 - IconButton Component Variables
+//
+// This file defines component-level CSS variables for the IconButton component.
+// These variables can be overridden at runtime via AnimationBuilder.
+//
+// NOTE: Hover effects are handled by Glow wrapper, not here.
+// Only base, active, and disabled states are defined.
+
+// ------
+// Base IconButton Variables
+// ------
+
+.hk-icon-button {
+  // ------
+  // 1. Color System
+  // ------
+
+  // Icon Colors
+  --hi-icon-button-icon-color: var(--hi-icon-color);
+  --hi-icon-button-icon-color-active: var(--hi-icon-color);
+  --hi-icon-button-icon-color-disabled: rgba(128, 128, 128, 0.5);
+
+  // Background Colors
+  --hi-icon-button-bg: transparent;
+  --hi-icon-button-bg-active: var(--hi-bg-surface-dark);
+  --hi-icon-button-bg-disabled: rgba(128, 128, 128, 0.1);
+
+  // Border Colors
+  --hi-icon-button-border-color: transparent;
+  --hi-icon-button-border-color-focus: var(--hi-border-color-focus);
+
+  // Shadow & Glow (used by Glow wrapper)
+  --hi-icon-button-glow: var(--hi-glow-color);
+
+  // ------
+  // 2. Border Radius System
+  // ------
+
+  --hi-icon-button-radius: 4px;
+
+  // ------
+  // 3. Animation System
+  // ------
+
+  // Duration
+  --hi-icon-button-duration: var(--hi-duration-fast);
+  --hi-icon-button-duration-active: var(--hi-duration-instant);
+
+  // Easing
+  --hi-icon-button-easing: var(--hi-ease-default);
+
+  // Transition
+  --hi-icon-button-transition:
+    background-color var(--hi-icon-button-duration) var(--hi-icon-button-easing),
+    transform var(--hi-icon-button-duration-active) var(--hi-icon-button-easing);
+
+  // ------
+  // 4. Size System
+  // ------
+
+  --hi-icon-button-size: 40px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-sm);
+
+  // ------
+  // 5. Transform System
+  // ------
+
+  --hi-icon-button-transform: none;
+  --hi-icon-button-transform-active: scale(0.95);
+}
+
+// ------
+// Size Variants
+// ------
+
+.hk-icon-button-16 {
+  --hi-icon-button-size: 16px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-xs);
+}
+
+.hk-icon-button-24 {
+  --hi-icon-button-size: 24px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-xs);
+}
+
+.hk-icon-button-32 {
+  --hi-icon-button-size: 32px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-sm);
+}
+
+.hk-icon-button-36 {
+  --hi-icon-button-size: 36px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-sm);
+}
+
+.hk-icon-button-40 {
+  --hi-icon-button-size: 40px;
+  --hi-icon-button-icon-size: var(--hi-icon-size-sm);
+}
+
+// ------
+// Ghost Variant Variables
+// ------
+
+.hk-icon-button-ghost,
+.hk-icon-button-borderless {
+  --hi-icon-button-icon-color: var(--hi-color-text-secondary);
+  --hi-icon-button-icon-color-active: var(--hi-color-text-secondary);
+
+  --hi-icon-button-bg: transparent;
+  --hi-icon-button-bg-active: var(--hi-color-gray-20, rgba(128, 128, 128, 0.2));
+
+  --hi-icon-button-border-color: transparent;
+  --hi-icon-button-glow: var(--hi-glow-color);
+}
+
+// ------
+// Primary Variant Variables
+// ------
+
+.hk-icon-button-primary {
+  --hi-icon-button-icon-color: var(--hi-color-text-on-primary);
+  --hi-icon-button-icon-color-active: var(--hi-color-text-on-primary);
+
+  --hi-icon-button-bg: var(--hi-color-primary);
+  --hi-icon-button-bg-active: var(--hi-color-primary-dark);
+
+  --hi-icon-button-border-color-focus: var(--hi-color-primary);
+  --hi-icon-button-glow: var(--hi-glow-color);
+}
+
+// ------
+// Secondary Variant Variables
+// ------
+
+.hk-icon-button-secondary {
+  --hi-icon-button-icon-color: var(--hi-color-text-on-secondary);
+  --hi-icon-button-icon-color-active: var(--hi-color-text-on-secondary);
+
+  --hi-icon-button-bg: var(--hi-color-secondary);
+  --hi-icon-button-bg-active: var(--hi-color-secondary-dark);
+
+  --hi-icon-button-border-color-focus: var(--hi-color-secondary);
+  --hi-icon-button-glow: var(--hi-glow-color);
+}
+
+// ------
+// Danger Variant Variables
+// ------
+
+.hk-icon-button-danger {
+  --hi-icon-button-icon-color: var(--hi-color-text-on-danger, #ffffff);
+  --hi-icon-button-icon-color-active: var(--hi-color-text-on-danger, #ffffff);
+
+  --hi-icon-button-bg: var(--hi-color-danger);
+  --hi-icon-button-bg-active: var(--hi-color-danger-dark);
+
+  --hi-icon-button-border-color-focus: var(--hi-color-danger);
+  --hi-icon-button-glow: var(--hi-glow-color);
+}
+
+// ------
+// Success Variant Variables
+// ------
+
+.hk-icon-button-success {
+  --hi-icon-button-icon-color: var(--hi-color-text-on-success, #ffffff);
+  --hi-icon-button-icon-color-active: var(--hi-color-text-on-success, #ffffff);
+
+  --hi-icon-button-bg: var(--hi-color-success);
+  --hi-icon-button-bg-active: var(--hi-color-success-dark);
+
+  --hi-icon-button-border-color-focus: var(--hi-color-success);
+  --hi-icon-button-glow: var(--hi-glow-color);
+}

--- a/packages/vue/src/components/_hikari-vars.scss
+++ b/packages/vue/src/components/_hikari-vars.scss
@@ -1,0 +1,4 @@
+$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+$hikari-font-size-sm: 0.875rem;
+$hikari-radius-fui-sm: 4px;
+$hikari-radius-fui-md: 6px;


### PR DESCRIPTION
## Summary

Five vue components imported SCSS from `packages/components/src/styles` via monorepo-relative paths (`../../../components/...`). The npm package publishes only `packages/vue/src`, so consuming `@celestia-island/hikari` from npm failed to build on these components. Their styles are now vendored next to the components, following the existing `HkButton.scss` pattern.

## Changes

- New local scss in `packages/vue/src/components/`: `HkAvatar.scss`, `HkIcon.scss`, `HkBreadcrumb.scss`, `HkCollapse.scss`, `HkIconButton.scss`, `HkIconButtonVars.scss`, plus the shared `_hikari-vars.scss` partial with the only sass variables the copies use.
- All five tsx files import `./Hk*.scss`; zero `components/src/styles` references remain in the vue components.
- `packages/components/src/styles` untouched (still consumed by the Rust crate and the monorepo-only `styles/index.scss` entry, which is documented as such).

## Verification

- Each vendored scss compiles standalone with `sass` (proves no cross-package `@use` remains).
- `pnpm build` introduces no new errors (only the 3 pre-existing vitest TS2307s present on master).