### PR TITLE
🔧 Provide static color defaults and close the remaining token gaps.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -42,6 +42,7 @@
   --space-96: 6rem;
 
   // ── Border radius scale ─
+  --radius-xs: 2px;
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
@@ -84,6 +85,7 @@
   --border-subtle: rgb(var(--color-border) / 12%);
 
   // ── Duration / easing ─
+  --duration-fast: 0.15s;
   --duration-short: 0.15s;
   --duration-normal: 0.3s;
   --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
@@ -95,4 +97,7 @@
   --c-primary-light: rgb(var(--color-primary) / 15%);
   --c-primary-subtle: rgb(var(--color-primary) / 8%);
   --c-primary-overlay: rgb(var(--color-primary) / 15%);
+
+  // ── Shadow scale ─
+  --shadow-modal: 0 12px 40px rgb(0 0 0 / 20%), 0 0 0 1px rgb(255 255 255 / 4%);
 }

--- a/packages/theme/styles/foundation.scss
+++ b/packages/theme/styles/foundation.scss
@@ -41,6 +41,8 @@
   // Shadow Colors
   --hi-shadow-color: rgba(0, 0, 0, 0.1);
   --hi-glow-color: rgba(255, 79, 0, 0.5);
+  --hi-color-primary-dark: #d97f83;
+  --hi-color-secondary-dark: #3f7a5b;
 
   // ------
   // 2. Border Radius System

--- a/packages/vue/src/render.ts
+++ b/packages/vue/src/render.ts
@@ -6,7 +6,7 @@ import './demo.scss'
 localStorage.setItem('hikari-theme', 'tokyonight')
 initTheme()
 
-const tpl = new URLSearchParams(location.search).get('tpl') || (window as any).__TEMPLATE__ || '<div style="padding:1rem;color:var(--fg-sec)">No template provided</div>'
+const tpl = new URLSearchParams(location.search).get('tpl') || (window as any).__TEMPLATE__ || '<div style="padding:1rem;color:var(--color-text-secondary)">No template provided</div>'
 
 const app = createApp({ template: tpl })
 // Register all hikari components globally

--- a/packages/vue/src/theme/presets.ts
+++ b/packages/vue/src/theme/presets.ts
@@ -265,6 +265,7 @@ export function tokensToCSSVars(
 ): Record<string, string> {
   const onPrimary = contrastColor(tokens.primary);
   const textSecondary = mixToken(tokens.text, tokens.muted, 0.25);
+  const textTertiary = mixToken(tokens.text, tokens.muted, 0.5);
   return {
     "--color-primary": `${tokens.primary.r} ${tokens.primary.g} ${tokens.primary.b}`,
     "--color-on-primary": `${onPrimary.r} ${onPrimary.g} ${onPrimary.b}`,
@@ -273,6 +274,7 @@ export function tokensToCSSVars(
     "--color-accent": `${tokens.accent.r} ${tokens.accent.g} ${tokens.accent.b}`,
     "--color-text": `${tokens.text.r} ${tokens.text.g} ${tokens.text.b}`,
     "--color-text-secondary": `${textSecondary.r} ${textSecondary.g} ${textSecondary.b}`,
+    "--color-text-tertiary": `${textTertiary.r} ${textTertiary.g} ${textTertiary.b}`,
     "--color-muted": `${tokens.muted.r} ${tokens.muted.g} ${tokens.muted.b}`,
     "--color-border": `${tokens.border.r} ${tokens.border.g} ${tokens.border.b}`,
     "--color-focused-border": `${tokens.focusedBorder.r} ${tokens.focusedBorder.g} ${tokens.focusedBorder.b}`,

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -24,3 +24,41 @@
   --border-faint: rgb(var(--color-border, 100 100 100) / 10%);
   --border-subtle: rgb(var(--color-border, 100 100 100) / 12%);
 }
+
+/* Static default light theme — renders correctly even without initTheme().
+   initTheme() overrides these at runtime via inline styles on
+   documentElement, which beat stylesheet :root declarations. */
+:root {
+  --color-primary: 122 162 247;
+  --color-on-primary: 255 255 255;
+  --color-on-solid: 255 255 255;
+  --color-secondary: 81 154 115;
+  --color-accent: 247 181 0;
+  --color-text: 30 30 30;
+  --color-text-secondary: 102 102 102;
+  --color-text-tertiary: 140 140 140;
+  --color-muted: 108 108 108;
+  --color-border: 100 100 100;
+  --color-focused-border: 122 162 247;
+  --color-background: 214 236 240;
+  --color-surface: 240 244 248;
+  --color-success: 14 184 64;
+  --color-error: 247 118 142;
+  --color-warning: 238 214 119;
+  --color-info: 106 190 214;
+
+  --hi-color-primary: rgb(var(--color-primary));
+  --hi-color-secondary: rgb(var(--color-secondary));
+  --hi-color-surface: rgb(var(--color-surface));
+  --hi-color-background: rgb(var(--color-background));
+  --hi-color-border: rgb(var(--color-border));
+  --hi-color-text-primary: rgb(var(--color-text));
+  --hi-color-text-secondary: rgb(var(--color-text-secondary));
+  --hi-color-muted: rgb(var(--color-muted));
+  --hi-color-on-primary: rgb(var(--color-on-primary));
+  --hi-color-text-on-primary: rgb(var(--color-on-primary));
+  --hi-color-success: rgb(var(--color-success));
+  --hi-color-error: rgb(var(--color-error));
+  --hi-color-warning: rgb(var(--color-warning));
+  --hi-color-info: rgb(var(--color-info));
+}


### PR DESCRIPTION
## Summary

Components reference `--color-*` / `--hi-*` CSS variables that were only injected at runtime by `initTheme()` (200+ no-fallback references), plus a handful of tokens referenced with no fallback and never defined. This adds static defaults so components render with a sane light theme out of the box; `initTheme()` still overrides via inline styles.

## Changes

- `packages/vue/src/tokens.scss`: static `:root` block with `--color-*` RGB-triplet defaults + `--hi-color-*` aliases (mirrors the runtime set from `presets.ts`).
- `packages/theme/styles/_layout.scss`: adds `--radius-xs`, `--duration-fast`, `--shadow-modal`.
- `packages/theme/styles/foundation.scss`: defines `--hi-color-primary-dark` / `--hi-color-secondary-dark` (referenced by the gradient tokens but never defined).
- `packages/vue/src/theme/presets.ts`: `tokensToCSSVars` now emits `--color-text-tertiary` (referenced by plana-ui but missing from the runtime set).
- `packages/vue/src/render.ts`: replaces the stale `var(--fg-sec)` with `var(--color-text-secondary)`.

## Verification

- Corrected CSS-variable audit: `UNDEFINED_NO_FALLBACK: 0` in `packages/vue/src` + `packages/theme/styles` (was 15 on master, excluding runtime-only vars).
- `pnpm build` introduces no new errors (only the 3 pre-existing vitest TS2307s present on master).