### PR TITLE
🔧 Fix cargo cache path in CI workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-
@@ -86,7 +86,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            ${{ env.CARGO_HOME }}
+            ~/.cargo
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: ${{ runner.os }}-cargo-


### PR DESCRIPTION
The workflows referenced `${{ env.CARGO_HOME }}`, but `CARGO_HOME` is never defined in the workflow YAML, so the actions/cache path was empty and the cache never restored. Use the standard `~/.cargo` path (resolves to the runner's CARGO_HOME on both self-hosted and GitHub-hosted runners).