### PR TITLE
🛡️ Pin cargo install tool versions in CI.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,7 +52,9 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.8.7
 
       - name: Generate coverage report (HTML + lcov)
         run: |


### PR DESCRIPTION
## P9#D5 — pin cargo-llvm-cov install (`.github/workflows/coverage.yml`)

- Line 55: `uses: taiki-e/install-action@cargo-llvm-cov` (tag = tool name, resolves to latest release, mutable) → `uses: taiki-e/install-action@v2` with `tool: cargo-llvm-cov@0.8.7`.
- install-action v2 supports the `name@version` tool syntax, pinning the exact release (0.8.7 = crates.io max_stable_version, checked 2026-08-08).
- The action itself is now pinned to the v2 major tag (was a floating tool-name tag).

Validation: `python3 -c yaml.safe_load` passed; diff limited to the workflow file.