### PR TITLE
🔧 Replace dev paths in docker docs and e2e tests.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ This directory contains Docker configurations for running Hikari E2E tests with 
 ### Start Testing Environment
 
 ```bash
-cd /mnt/sdb1/hikari
+cd /opt/hikari
 
 # Build and start all services
 docker-compose up --build
@@ -28,7 +28,7 @@ docker-compose logs -f
 
 ```bash
 # In a new terminal, run E2E tests
-cd /mnt/sdb1/hikari/packages/e2e
+cd /opt/hikari/packages/e2e
 
 # Set Chrome remote address
 export CHROME_REMOTE_ADDRESS=chrome:4444

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   # Hikari Website
   website:
     build:
-      context: /mnt/sdb1/hikari
+      context: /opt/hikari
       dockerfile: docker/website.Dockerfile
     container_name: hikari-website
     ports:

--- a/docs/en/guides/DEBUG_GUIDE.md
+++ b/docs/en/guides/DEBUG_GUIDE.md
@@ -13,7 +13,7 @@
 persistent-terminal_startService(
     name="hikari-dev",
     command="just dev",
-    cwd="/mnt/sdb1/hikari",
+    cwd="/opt/hikari",
     readyPatterns=["Server running", "listening on"]
 )
 ```
@@ -45,13 +45,13 @@ just debug-generate "/" "/components" "/components/layer1/basic"
 
 ```
 zai-mcp-server_ui_to_artifact(
-    image_source="/mnt/sdb1/hikari/scripts/dev/screenshots/components.png",
+    image_source="/opt/hikari/scripts/dev/screenshots/components.png",
     output_type="description",
     prompt="分析这个 UI 组件页面的布局和样式是否正确"
 )
 
 zai-mcp-server_diagnose_error_screenshot(
-    image_source="/mnt/sdb1/hikari/scripts/dev/screenshots/error_page.png",
+    image_source="/opt/hikari/scripts/dev/screenshots/error_page.png",
     prompt="分析这个错误截图，识别可能的问题"
 )
 ```

--- a/packages/e2e/src/bin/test_ssr_direct.rs
+++ b/packages/e2e/src/bin/test_ssr_direct.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     info!("==========================================\n");
 
     // Read the WASM file
-    let wasm_path = "/mnt/sdb1/hikari/public/website.wasm";
+    let wasm_path = "/opt/hikari/public/website.wasm";
     let wasm_bytes = fs::read(wasm_path)?;
     info!("Loaded {} bytes from {}", wasm_bytes.len(), wasm_path);
 

--- a/packages/e2e/test_ssr_standalone.rs
+++ b/packages/e2e/test_ssr_standalone.rs
@@ -13,11 +13,11 @@ fn main() -> Result<()> {
     info!("===========================\n");
 
     // Read WASM file
-    let wasm_bytes = fs::read("/mnt/sdb1/hikari/public/website.wasm")?;
+    let wasm_bytes = fs::read("/opt/hikari/public/website.wasm")?;
     info!("Loaded {} bytes of WASM", wasm_bytes.len());
 
     // Try to load tairitsu_ssr dynamically
-    let dynamic_lib = std::ffi::CString::new("/mnt/sdb1/tairitsu/target/debug/libtairitsu_ssr-1e71b4c225e205fd.rlib")?;
+    let dynamic_lib = std::ffi::CString::new("/opt/tairitsu/target/debug/libtairitsu_ssr-1e71b4c225e205fd.rlib")?;
     info!("Looking for library: {}", dynamic_lib.to_string_lossy());
 
     Ok(())


### PR DESCRIPTION
Replaces /mnt/sdb1 dev paths in docker docs, debug guide and e2e test files with generic /opt paths.