### PR TITLE
🔧 Restrict pull_request CI triggers to PR lifecycle events.

### DIFF
--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -1,9 +1,11 @@
 name: CI (GitHub-hosted fallback)
 
 on:
+  workflow_dispatch:
   push:
-    branches: [master, main]
+    branches: [ master ]
   pull_request:
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 ---
 name: Run Tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  workflow_dispatch:
 
 jobs:
   rustfmt:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,6 +3,7 @@ name: Clippy
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/clippy.yml'
       - 'packages/**/*'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [master, dev]
   pull_request:
+    types: [opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/coverage.yml'
       - 'packages/**/*'

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -2,6 +2,7 @@ name: Format
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/fmt.yml'
       - 'packages/**/*'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,7 @@ name: Security Audit
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/security.yml'
       - '**/Cargo.toml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Tests
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, reopened, ready_for_review]
     paths:
       - '.github/workflows/test.yml'
       - 'packages/**/*'


### PR DESCRIPTION
Same as entelecheia #114: self-hosted runners flooded by per-push CI on every PR branch. Restrict `pull_request` triggers to `types: [opened, reopened, ready_for_review]`, keep workflow_dispatch + push master. ci.yml converted from legacy array form to keyed triggers. commit-msg-lint/pr-title-check untouched (per-commit gates). 7 workflows, YAML validated.