### PR TITLE
🛡️ Ignore the rkyv advisory pinned by parcel_sourcemap.

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+# cargo-audit configuration — mirrors the advisory ignore in deny.toml.
+#
+# RUSTSEC-2026-0235 (rkyv 0.7.x): fix exists only in the 0.8 line, but the
+# sole consumer parcel_sourcemap 2.1.1 (max stable, transitively via
+# lazy_static) pins ^0.7. rkyv is internal to parcel_sourcemap; hikari never
+# deserializes attacker-controlled archives. Upgrade tracked with the
+# parcel_sourcemap dependency refresh.
+[advisories]
+ignore = [
+    "RUSTSEC-2026-0235",
+]

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,15 @@
 [advisories]
 unmaintained = "workspace"
 unsound = "workspace"
+# RUSTSEC-2026-0235 (rkyv 0.7.x): out-of-bounds read in archives containing
+# Rc/Arc with forged slice metadata. Fix exists only in the 0.8 line, but the
+# sole consumer in this graph — parcel_sourcemap 2.1.1 (max stable, pulled in
+# transitively by lazy_static) — pins rkyv ^0.7. rkyv is an internal
+# implementation detail of parcel_sourcemap; hikari never deserializes
+# attacker-controlled archives through it.
+ignore = [
+    "RUSTSEC-2026-0235",
+]
 
 [licenses]
 allow = [


### PR DESCRIPTION
The master Security Audit gate fails on RUSTSEC-2026-0235 (rkyv 0.7.x out-of-bounds read). The fix exists only in the rkyv 0.8 line, but parcel_sourcemap 2.1.1 (max stable, pulled in transitively via lazy_static) pins ^0.7. rkyv is internal to parcel_sourcemap; hikari never deserializes attacker-controlled archives, so the advisory is not reachable. Ignored in both deny.toml and .cargo/audit.toml (force-added, .cargo/ is gitignored like watch.toml) with rationale. Verified: cargo audit exit 0, cargo-deny check advisories ok.