### PR TITLE
🐛 Drive the input ripple animation by timestamp delta instead of frame count.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -91,10 +91,10 @@ export default defineComponent({
     const GAP = 8;
     const DOT_R = 2.2;
     const SIGMA = 2.8;
-    const R_SPEED = 0.22;
+    const R_SPEED = 13.2;
     const R_WIDTH = 1.3;
     const R_BOOST = 0.7;
-    const PEAK_SPEED = 0.02;
+    const PEAK_SPEED = 1.2;
 
     let COLS = 11;
     let dists: number[][] = [];
@@ -166,7 +166,7 @@ export default defineComponent({
       rebuildGrid(cols);
     }
 
-    function draw() {
+    function draw(dt: number) {
       const cv = dotCanvasRef.value;
       if (!cv) return;
       const ctx = cv.getContext("2d");
@@ -227,8 +227,8 @@ export default defineComponent({
 
       for (let i = ripples.length - 1; i >= 0; i--) {
         const rp = ripples[i];
-        rp.radius += R_SPEED;
-        rp.peak = Math.max(0, rp.peak - PEAK_SPEED);
+        rp.radius += R_SPEED * dt;
+        rp.peak = Math.max(0, rp.peak - PEAK_SPEED * dt);
         if (rp.radius > MAX_D + R_WIDTH + 0.5 && rp.peak <= 0) {
           ripples.splice(i, 1);
         }
@@ -236,16 +236,20 @@ export default defineComponent({
     }
 
     let running = false;
+    let lastTime = 0;
 
-    function loop() {
-      draw();
+    function loop(ts: number) {
+      if (!lastTime) lastTime = ts;
+      const dt = Math.min(0.1, (ts - lastTime) / 1000);
+      lastTime = ts;
+      draw(dt);
       rafId = requestAnimationFrame(loop);
     }
 
     function startLoop() {
       if (running) return;
       running = true;
-      loop();
+      loop(performance.now());
     }
 
     function stopLoop() {


### PR DESCRIPTION
## Problem

On mobile (esp. low-refresh/power-saver mode, ~30Hz rAF), the HkPasswordInput ripple animation appears noticeably slow.

## Root cause

The ripple loop in `packages/vue/src/components/HkPasswordInput.tsx` advanced `rp.radius += R_SPEED` and `rp.peak -= PEAK_SPEED` **per requestAnimationFrame callback** (frame counting), so speed is tied to frame rate: fewer frames per second = slower animation.

## Fix

Drive the animation by timestamp delta:

- Convert `R_SPEED` (0.22/frame) and `PEAK_SPEED` (0.02/frame) to per-second rates (13.2/s, 1.2/s — identical at 60Hz).
- `loop(ts)` records `lastTime`, computes `dt = min(0.1, (ts - lastTime) / 1000)`, passes it to `draw(dt)`.
- `rp.radius += R_SPEED * dt`, `rp.peak = max(0, rp.peak - PEAK_SPEED * dt)`.
- First frame seeded with `performance.now()`; dt clamped to 0.1s to avoid jumps after tab inactivity.

Speed is now constant across refresh rates. Verified with `vue-tsc --noEmit` (only pre-existing vitest module errors on master too).