### PR TITLE
⬆️ Migrate the package build and release to pnpm 11.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -26,10 +26,15 @@ jobs:
           node-version: "22"
           registry-url: https://registry.npmjs.org/
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11
+
       - name: Install dependencies
         run: |
           cd packages/vue
-          npm install
+          pnpm install --frozen-lockfile
 
       - name: Resolve version
         id: ver
@@ -52,6 +57,6 @@ jobs:
       - name: Publish
         run: |
           cd packages/vue
-          npm publish --access public --provenance
+          pnpm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,13 +56,8 @@
     "sass": "^*",
     "typescript": "^*",
     "vite": "^*",
-    "vue-tsc": "^*"
-  },
-  "pnpm": {
-    "overrides": {
-      "typescript": "~6.0",
-      "vue-tsc": "~3.3.9"
-    }
+    "vue-tsc": "^*",
+    "vitest": "^*"
   },
   "sideEffects": [
     "**/*.scss",

--- a/packages/vue/pnpm-lock.yaml
+++ b/packages/vue/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
       vite:
         specifier: ^*
         version: 8.2.0(sass@1.102.0)
+      vitest:
+        specifier: ^*
+        version: 4.1.10(vite@8.2.0(sass@1.102.0))
       vue-tsc:
         specifier: ~3.3.9
         version: 3.3.9(typescript@6.0.3)
@@ -236,36 +239,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.6.0':
     resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.6.0':
     resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.6.0':
     resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.6.0':
     resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.6.0':
     resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.6.0':
     resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
@@ -318,36 +327,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.2.1':
     resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.2.1':
     resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.2.1':
     resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.2.1':
     resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
@@ -374,8 +389,20 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -393,6 +420,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -452,6 +508,10 @@ packages:
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   baseline-browser-mapping@2.11.8:
     resolution: {integrity: sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==}
     engines: {node: '>=6.0.0'}
@@ -464,6 +524,10 @@ packages:
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
@@ -501,12 +565,22 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -589,24 +663,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.33.0:
     resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.33.0:
     resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
@@ -659,8 +737,15 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -695,13 +780,33 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.3.0:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
@@ -763,6 +868,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -779,6 +925,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1107,10 +1258,21 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -1132,6 +1294,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.0(sass@1.102.0)
       vue: 3.5.40(typescript@6.0.3)
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.0(sass@1.102.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(sass@1.102.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -1240,6 +1443,8 @@ snapshots:
 
   alien-signals@3.2.1: {}
 
+  assertion-error@2.0.1: {}
+
   baseline-browser-mapping@2.11.8: {}
 
   browserslist@4.28.7:
@@ -1251,6 +1456,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   caniuse-lite@1.0.30001806: {}
+
+  chai@6.2.2: {}
 
   chokidar@5.0.0:
     dependencies:
@@ -1279,9 +1486,17 @@ snapshots:
 
   entities@7.0.1: {}
 
+  es-module-lexer@2.3.1: {}
+
   escalade@3.2.0: {}
 
   estree-walker@2.0.2: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -1384,7 +1599,11 @@ snapshots:
 
   node-releases@2.0.51: {}
 
+  obug@2.1.4: {}
+
   path-browserify@1.0.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -1435,12 +1654,24 @@ snapshots:
 
   semver@6.3.1: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tslib@2.3.0: {}
 
@@ -1466,6 +1697,31 @@ snapshots:
       fsevents: 2.3.3
       sass: 1.102.0
 
+  vitest@4.1.10(vite@8.2.0(sass@1.102.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(sass@1.102.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(sass@1.102.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-tsc@3.3.9(typescript@6.0.3):
@@ -1483,6 +1739,11 @@ snapshots:
       '@vue/shared': 3.5.40
     optionalDependencies:
       typescript: 6.0.3
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   yallist@3.1.1: {}
 

--- a/packages/vue/pnpm-workspace.yaml
+++ b/packages/vue/pnpm-workspace.yaml
@@ -6,3 +6,6 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - '@vue/language-core@3.3.9'
   - vue-tsc@3.3.9
+overrides:
+  typescript: ~6.0
+  vue-tsc: ~3.3.9

--- a/packages/vue/src/components/HkAlert.tsx
+++ b/packages/vue/src/components/HkAlert.tsx
@@ -1,9 +1,6 @@
 import { computed, defineComponent, ref, type PropType } from "vue";
 import { useI18n } from "../i18n/context";
-import AlertTriangle from "lucide-vue-next/dist/esm/icons/triangle-alert";
-import CheckCircle from "lucide-vue-next/dist/esm/icons/circle-check";
-import Info from "lucide-vue-next/dist/esm/icons/info";
-import X from "lucide-vue-next/dist/esm/icons/x";
+import { AlertTriangle, CheckCircle, Info, X } from "lucide-vue-next";
 
 import "./HkAlert.scss";
 

--- a/packages/vue/src/components/HkCheckbox.tsx
+++ b/packages/vue/src/components/HkCheckbox.tsx
@@ -1,5 +1,6 @@
+import { Check } from "lucide-vue-next";
 import { defineComponent, ref, type PropType } from "vue";
-import Check from "lucide-vue-next/dist/esm/icons/check";
+
 import "./HkCheckbox.scss";
 
 export default defineComponent({

--- a/packages/vue/src/components/HkDateTimePicker.tsx
+++ b/packages/vue/src/components/HkDateTimePicker.tsx
@@ -1,10 +1,11 @@
+import { ArrowLeft, Calendar, ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from "lucide-vue-next";
 import { computed, defineComponent, onBeforeUnmount, ref, Transition, watch, type PropType } from "vue";
-import ArrowLeft from "lucide-vue-next/dist/esm/icons/arrow-left";
-import Calendar from "lucide-vue-next/dist/esm/icons/calendar";
-import ChevronDown from "lucide-vue-next/dist/esm/icons/chevron-down";
-import ChevronLeft from "lucide-vue-next/dist/esm/icons/chevron-left";
-import ChevronRight from "lucide-vue-next/dist/esm/icons/chevron-right";
-import ChevronUp from "lucide-vue-next/dist/esm/icons/chevron-up";
+
+
+
+
+
+
 
 import { useI18n } from "../i18n/context";
 import "./HkDateTimePicker.scss";

--- a/packages/vue/src/components/HkErrorBoundary.tsx
+++ b/packages/vue/src/components/HkErrorBoundary.tsx
@@ -1,7 +1,8 @@
+import { Copy, RefreshCw, TriangleAlert as AlertTriangle } from "lucide-vue-next";
 import { defineComponent, onErrorCaptured, ref, type PropType, type VNode } from "vue";
-import AlertTriangle from "lucide-vue-next/dist/esm/icons/triangle-alert";
-import Copy from "lucide-vue-next/dist/esm/icons/copy";
-import RefreshCw from "lucide-vue-next/dist/esm/icons/refresh-cw";
+
+
+
 import { useClipboard } from "../runtime/useClipboard";
 import { useI18n } from "../i18n/context";
 import HButton from "./HkButton";

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -1,6 +1,7 @@
+import { Eye, EyeOff } from "lucide-vue-next";
 import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, useAttrs, watch } from "vue";
-import Eye from "lucide-vue-next/dist/esm/icons/eye";
-import EyeOff from "lucide-vue-next/dist/esm/icons/eye-off";
+
+
 import "./HkInput.scss";
 
 export default defineComponent({

--- a/packages/vue/src/components/HkMediaControlBar.tsx
+++ b/packages/vue/src/components/HkMediaControlBar.tsx
@@ -1,10 +1,11 @@
+import { Maximize, Minimize, Pause, Play, Volume2, VolumeX } from "lucide-vue-next";
 import { defineComponent } from "vue";
-import Maximize from "lucide-vue-next/dist/esm/icons/maximize";
-import Minimize from "lucide-vue-next/dist/esm/icons/minimize";
-import Pause from "lucide-vue-next/dist/esm/icons/pause";
-import Play from "lucide-vue-next/dist/esm/icons/play";
-import Volume2 from "lucide-vue-next/dist/esm/icons/volume-2";
-import VolumeX from "lucide-vue-next/dist/esm/icons/volume-x";
+
+
+
+
+
+
 
 import HButton from "./HkButton";
 import { useI18n } from "../i18n/context";

--- a/packages/vue/src/components/HkMinimap.tsx
+++ b/packages/vue/src/components/HkMinimap.tsx
@@ -1,7 +1,8 @@
+import { Maximize2, ZoomIn, ZoomOut } from "lucide-vue-next";
 import { computed, defineComponent, onBeforeUnmount, onMounted, ref, type PropType } from "vue";
-import Maximize2 from "lucide-vue-next/dist/esm/icons/maximize-2";
-import ZoomIn from "lucide-vue-next/dist/esm/icons/zoom-in";
-import ZoomOut from "lucide-vue-next/dist/esm/icons/zoom-out";
+
+
+
 
 import { useI18n } from "../i18n/context";
 import "./HkMinimap.scss";

--- a/packages/vue/src/components/HkNavItem.tsx
+++ b/packages/vue/src/components/HkNavItem.tsx
@@ -1,6 +1,7 @@
+import { ChevronRight } from "lucide-vue-next";
 import { defineComponent, computed, ref, type PropType } from "vue";
 import type { Component } from "vue";
-import ChevronRight from "lucide-vue-next/dist/esm/icons/chevron-right";
+
 import "./HkNavItem.scss";
 
 interface NavItemChild {

--- a/packages/vue/src/components/HkPopupSelect.tsx
+++ b/packages/vue/src/components/HkPopupSelect.tsx
@@ -1,5 +1,6 @@
+import { ChevronDown } from "lucide-vue-next";
 import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch, type PropType } from "vue";
-import ChevronDown from "lucide-vue-next/dist/esm/icons/chevron-down";
+
 import HkPopover from "./HkPopover";
 import HkScrollContainer from "./HkScrollContainer";
 import "./HkPopupSelect.scss";

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -8,8 +8,9 @@ import {
   type PropType,
   Teleport,
 } from "vue";
-import ChevronDown from "lucide-vue-next/dist/esm/icons/chevron-down";
-import Search from "lucide-vue-next/dist/esm/icons/search";
+
+
+import { ChevronDown, Search } from "lucide-vue-next";
 import "./HkSelect.scss";
 
 export interface HkSelectOption {

--- a/packages/vue/src/components/HkSelectionGrid.tsx
+++ b/packages/vue/src/components/HkSelectionGrid.tsx
@@ -1,5 +1,6 @@
+import { Check } from "lucide-vue-next";
 import { defineComponent, type PropType } from "vue";
-import Check from "lucide-vue-next/dist/esm/icons/check";
+
 import "./HkSelectionGrid.scss";
 
 export interface SelectionGridItem {

--- a/packages/vue/src/components/HkSelectionWaterfall.tsx
+++ b/packages/vue/src/components/HkSelectionWaterfall.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, type PropType } from "vue";
-import Check from "lucide-vue-next/dist/esm/icons/check";
+import { Check } from "lucide-vue-next";
 import "./HkSelectionWaterfall.scss";
 
 export interface WaterfallItem {

--- a/packages/vue/src/components/HkTag.tsx
+++ b/packages/vue/src/components/HkTag.tsx
@@ -1,5 +1,6 @@
+import { X } from "lucide-vue-next";
 import { computed, defineComponent, type PropType } from "vue";
-import X from "lucide-vue-next/dist/esm/icons/x";
+
 import "./HkTag.scss";
 
 export type TagVariant = "default" | "primary" | "success" | "warning" | "danger" | "info";

--- a/packages/vue/src/components/HkTimeline.tsx
+++ b/packages/vue/src/components/HkTimeline.tsx
@@ -1,5 +1,6 @@
+import { Check } from "lucide-vue-next";
 import { defineComponent, type PropType } from "vue";
-import Check from "lucide-vue-next/dist/esm/icons/check";
+
 
 import "./HkTimeline.scss";
 

--- a/packages/vue/src/components/HkToast.tsx
+++ b/packages/vue/src/components/HkToast.tsx
@@ -1,10 +1,8 @@
+import { CircleX as XCircle, X } from "lucide-vue-next";
 import { computed, defineComponent, ref, Teleport, Transition, TransitionGroup, watch } from "vue";
-import AlertTriangle from "lucide-vue-next/dist/esm/icons/triangle-alert";
-import CheckCircle from "lucide-vue-next/dist/esm/icons/circle-check";
-import Copy from "lucide-vue-next/dist/esm/icons/copy";
-import Info from "lucide-vue-next/dist/esm/icons/info";
-import X from "lucide-vue-next/dist/esm/icons/x";
-import XCircle from "lucide-vue-next/dist/esm/icons/circle-x";
+import { AlertTriangle, CheckCircle, Copy, Info } from "lucide-vue-next";
+
+
 import { useToast, type ToastItem, type ToastMessage, type ToastType } from "../runtime/useToast";
 import { useClipboard } from "../runtime/useClipboard";
 import { useI18n } from "../i18n/context";

--- a/packages/vue/src/components/HkZoomToolbar.tsx
+++ b/packages/vue/src/components/HkZoomToolbar.tsx
@@ -1,7 +1,8 @@
+import { Maximize2, ZoomIn, ZoomOut } from "lucide-vue-next";
 import { defineComponent } from "vue";
-import Maximize2 from "lucide-vue-next/dist/esm/icons/maximize-2";
-import ZoomIn from "lucide-vue-next/dist/esm/icons/zoom-in";
-import ZoomOut from "lucide-vue-next/dist/esm/icons/zoom-out";
+
+
+
 
 import HButton from "./HkButton";
 import { useI18n } from "../i18n/context";

--- a/packages/vue/src/composables/iconRegistry.ts
+++ b/packages/vue/src/composables/iconRegistry.ts
@@ -8,92 +8,93 @@
 // badges, nav tags) resolve without the wildcard import. Unknown names fall
 // back to `Info`, matching the previous `|| LucideIcons.Info` behavior.
 
+import { Activity, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Battery, Bell, Bot, Box, Brain, Cable, Calendar, ChartBarBig as BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Circle, CircleAlert as AlertCircle, CircleCheck as CheckCircle, CircleCheckBig as CheckCircle2, CircleDot, Clock, Cpu, Database, Dot, Ellipsis as MoreHorizontal, ExternalLink, Eye, FileArchive, FileCode, FileImage, FileText, Flame, FolderOpen, Gauge, Globe, HardDrive, Info, Kanban, Key, Layers, LayoutDashboard, LoaderCircle as Loader2, Lock, Maximize, Maximize2, MessageSquare, Mic, MicOff, Minimize, Monitor, Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, Search, Send, Server, Settings, Share2, Shield, Star, Table, Tag, Thermometer, Trash2, TriangleAlert as AlertTriangle, Volume2, VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut } from "lucide-vue-next";
 import type { Component } from "vue";
 
-import Activity from "lucide-vue-next/dist/esm/icons/activity";
-import AlertCircle from "lucide-vue-next/dist/esm/icons/circle-alert";
-import AlertTriangle from "lucide-vue-next/dist/esm/icons/triangle-alert";
-import ArrowDown from "lucide-vue-next/dist/esm/icons/arrow-down";
-import ArrowLeft from "lucide-vue-next/dist/esm/icons/arrow-left";
-import ArrowRight from "lucide-vue-next/dist/esm/icons/arrow-right";
-import ArrowUp from "lucide-vue-next/dist/esm/icons/arrow-up";
-import BarChart3 from "lucide-vue-next/dist/esm/icons/chart-bar-big";
-import Battery from "lucide-vue-next/dist/esm/icons/battery";
-import Bell from "lucide-vue-next/dist/esm/icons/bell";
-import Bot from "lucide-vue-next/dist/esm/icons/bot";
-import Box from "lucide-vue-next/dist/esm/icons/box";
-import Brain from "lucide-vue-next/dist/esm/icons/brain";
-import Cable from "lucide-vue-next/dist/esm/icons/cable";
-import Calendar from "lucide-vue-next/dist/esm/icons/calendar";
-import Check from "lucide-vue-next/dist/esm/icons/check";
-import CheckCircle from "lucide-vue-next/dist/esm/icons/circle-check";
-import CheckCircle2 from "lucide-vue-next/dist/esm/icons/circle-check-big";
-import ChevronDown from "lucide-vue-next/dist/esm/icons/chevron-down";
-import ChevronLeft from "lucide-vue-next/dist/esm/icons/chevron-left";
-import ChevronRight from "lucide-vue-next/dist/esm/icons/chevron-right";
-import ChevronUp from "lucide-vue-next/dist/esm/icons/chevron-up";
-import Circle from "lucide-vue-next/dist/esm/icons/circle";
-import CircleDot from "lucide-vue-next/dist/esm/icons/circle-dot";
-import Clock from "lucide-vue-next/dist/esm/icons/clock";
-import Cpu from "lucide-vue-next/dist/esm/icons/cpu";
-import Database from "lucide-vue-next/dist/esm/icons/database";
-import Dot from "lucide-vue-next/dist/esm/icons/dot";
-import ExternalLink from "lucide-vue-next/dist/esm/icons/external-link";
-import Eye from "lucide-vue-next/dist/esm/icons/eye";
-import FileArchive from "lucide-vue-next/dist/esm/icons/file-archive";
-import FileCode from "lucide-vue-next/dist/esm/icons/file-code";
-import FileImage from "lucide-vue-next/dist/esm/icons/file-image";
-import FileText from "lucide-vue-next/dist/esm/icons/file-text";
-import Flame from "lucide-vue-next/dist/esm/icons/flame";
-import FolderOpen from "lucide-vue-next/dist/esm/icons/folder-open";
-import Gauge from "lucide-vue-next/dist/esm/icons/gauge";
-import Globe from "lucide-vue-next/dist/esm/icons/globe";
-import HardDrive from "lucide-vue-next/dist/esm/icons/hard-drive";
-import Info from "lucide-vue-next/dist/esm/icons/info";
-import Kanban from "lucide-vue-next/dist/esm/icons/kanban";
-import Key from "lucide-vue-next/dist/esm/icons/key";
-import Layers from "lucide-vue-next/dist/esm/icons/layers";
-import LayoutDashboard from "lucide-vue-next/dist/esm/icons/layout-dashboard";
-import Loader2 from "lucide-vue-next/dist/esm/icons/loader-circle";
-import Lock from "lucide-vue-next/dist/esm/icons/lock";
-import Maximize from "lucide-vue-next/dist/esm/icons/maximize";
-import Maximize2 from "lucide-vue-next/dist/esm/icons/maximize-2";
-import MessageSquare from "lucide-vue-next/dist/esm/icons/message-square";
-import Mic from "lucide-vue-next/dist/esm/icons/mic";
-import MicOff from "lucide-vue-next/dist/esm/icons/mic-off";
-import Minimize from "lucide-vue-next/dist/esm/icons/minimize";
-import Monitor from "lucide-vue-next/dist/esm/icons/monitor";
-import MoreHorizontal from "lucide-vue-next/dist/esm/icons/ellipsis";
-import Network from "lucide-vue-next/dist/esm/icons/network";
-import Package from "lucide-vue-next/dist/esm/icons/package";
-import Pause from "lucide-vue-next/dist/esm/icons/pause";
-import Pencil from "lucide-vue-next/dist/esm/icons/pencil";
-import Play from "lucide-vue-next/dist/esm/icons/play";
-import Plug from "lucide-vue-next/dist/esm/icons/plug";
-import Plus from "lucide-vue-next/dist/esm/icons/plus";
-import Radio from "lucide-vue-next/dist/esm/icons/radio";
-import RefreshCw from "lucide-vue-next/dist/esm/icons/refresh-cw";
-import Search from "lucide-vue-next/dist/esm/icons/search";
-import Send from "lucide-vue-next/dist/esm/icons/send";
-import Server from "lucide-vue-next/dist/esm/icons/server";
-import Settings from "lucide-vue-next/dist/esm/icons/settings";
-import Share2 from "lucide-vue-next/dist/esm/icons/share-2";
-import Shield from "lucide-vue-next/dist/esm/icons/shield";
-import Star from "lucide-vue-next/dist/esm/icons/star";
-import Table from "lucide-vue-next/dist/esm/icons/table";
-import Tag from "lucide-vue-next/dist/esm/icons/tag";
-import Thermometer from "lucide-vue-next/dist/esm/icons/thermometer";
-import Trash2 from "lucide-vue-next/dist/esm/icons/trash-2";
-import Volume2 from "lucide-vue-next/dist/esm/icons/volume-2";
-import VolumeX from "lucide-vue-next/dist/esm/icons/volume-x";
-import Webhook from "lucide-vue-next/dist/esm/icons/webhook";
-import Wind from "lucide-vue-next/dist/esm/icons/wind";
-import Workflow from "lucide-vue-next/dist/esm/icons/workflow";
-import Wrench from "lucide-vue-next/dist/esm/icons/wrench";
-import X from "lucide-vue-next/dist/esm/icons/x";
-import Zap from "lucide-vue-next/dist/esm/icons/zap";
-import ZoomIn from "lucide-vue-next/dist/esm/icons/zoom-in";
-import ZoomOut from "lucide-vue-next/dist/esm/icons/zoom-out";
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 const REGISTRY: Record<string, Component> = {
   Activity, AlertCircle, AlertTriangle, ArrowDown, ArrowLeft, ArrowRight,

--- a/packages/vue/src/composables/useResourceListModal.tsx
+++ b/packages/vue/src/composables/useResourceListModal.tsx
@@ -1,10 +1,11 @@
+import { Search } from "lucide-vue-next";
 import { computed, ref, shallowRef, watch } from "vue";
 import { useI18n } from "../i18n/context";
 // @ts-ignore JSX namespace
 
 
 import { HEmptyState, HInput, HListTransition, HModal, HScrollContainer, HSpinner } from "../index";
-import Search from "lucide-vue-next/dist/esm/icons/search";
+
 
 interface ResourceItem {
   name: string;

--- a/packages/vue/src/utils/fileType.ts
+++ b/packages/vue/src/utils/fileType.ts
@@ -1,7 +1,8 @@
-import FileArchive from "lucide-vue-next/dist/esm/icons/file-archive";
-import FileCode from "lucide-vue-next/dist/esm/icons/file-code";
-import FileImage from "lucide-vue-next/dist/esm/icons/file-image";
-import FileText from "lucide-vue-next/dist/esm/icons/file-text";
+
+
+
+
+import { FileArchive, FileCode, FileImage, FileText } from "lucide-vue-next";
 import type { LucideIcon } from "lucide-vue-next";
 
 const CODE_EXT: Record<string, string> = {


### PR DESCRIPTION
## 目的

统一全体前端仓库到 pnpm 11。hikari 的发布流程一直用 `npm install`（无视 pnpm-lock.yaml），
且 lockfile 是 pnpm 9 产物——双不一致。

## 改动

- `npm-release.yml`：npm install → `pnpm/action-setup@v6 (version: 11)` + `pnpm install --frozen-lockfile`；
  `npm publish` → `pnpm publish --provenance`
- `packages/vue/pnpm-lock.yaml`：pnpm 11 重生成
- `packages/vue/package.json`：`pnpm.overrides` 块迁移到 `pnpm-workspace.yaml`（pnpm 11 要求）；
  补 `vitest` 到 devDependencies（#130 加测试但从未声明依赖，vue-tsc 编译 test 文件必需）
- `packages/vue/src/` 17 个文件：`lucide-vue-next/dist/esm/icons/*` deep imports 改为主入口命名导入——
  lucide-vue-next 1.0.0 的 deep 路径无类型声明（TS7016），master 的 build 一直坏（CI 从不跑 vue-tsc）；
  新命名体系用 `as` 别名保持代码原标识符（AlertTriangle/TriangleAlert 等）

## 验证

- `pnpm 11 install --frozen-lockfile` ✓
- `pnpm run build`（vue-tsc --noEmit）✓ —— master 本身 TS7016 全红，本 PR 修好
- `vitest run`：25 tests 过（messaging.test.ts 的 localStorage 环境失败是既有独立问题，未在本 PR 修）
- 遗留债务：messaging.test.ts 需 jsdom/happy-dom 环境配置（独立立项）