### PR TITLE
🐛 Restore the neutral grey border on regular input fields.

### DIFF
--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -27,7 +27,7 @@
   min-height: 2.5rem;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   
-  border: none;
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--radius-sm);
   overflow: hidden;
   transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) var(--ease-standard);

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -28,7 +28,7 @@
   min-height: 2.5rem;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   
-  border: none;
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--radius-md);
   font-family: inherit;
   font-size: var(--text-base);

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -28,7 +28,7 @@
   min-height: 2.5rem;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   
-  border: none;
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--radius-md);
   font-family: inherit;
   font-size: var(--text-base);

--- a/packages/vue/src/theme/_field.scss
+++ b/packages/vue/src/theme/_field.scss
@@ -24,7 +24,7 @@
   padding: var(--space-8) var(--space-12);
   min-height: 2.5rem;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
-  border: none;
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--radius-sm);
   overflow: hidden;
   transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) var(--ease-standard);


### PR DESCRIPTION
#150 over-deleted the neutral grey border from regular input fields, removing it from HkInput, HkSelect, HkPopupSelect and the shared field mixin. This restores the 1px color-mix grey border on those controls; the password field (HkPasswordInput) and card inputs stay borderless as originally requested in #150.