### PR TITLE
🐛 Fix the password input placeholder and focus loss on clear.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -133,10 +133,10 @@
 }
 
 .hk-pwd-box[data-focused] .hk-pwd-placeholder {
-  /* Waiting-for-input placeholder turns italic while focused, matching the
-     blur/select hints' style. */
+  /* Waiting-for-input placeholder turns italic + grey while focused,
+     matching the blur/select hints' style. */
   font-style: italic;
-  color: var(--hi-color-primary, rgba(88, 166, 255, 0.85));
+  color: var(--hi-color-text-secondary, #666);
 }
 
 @keyframes hk-pwd-breathe {

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -126,7 +126,6 @@
   align-items: center;
   justify-content: center;
   z-index: 1;
-  pointer-events: none;
   user-select: none;
   font-size: 0.875rem;
   color: var(--hi-color-primary, rgba(88, 166, 255, 0.7));
@@ -134,6 +133,9 @@
 }
 
 .hk-pwd-box[data-focused] .hk-pwd-placeholder {
+  /* Waiting-for-input placeholder turns italic while focused, matching the
+     blur/select hints' style. */
+  font-style: italic;
   color: var(--hi-color-primary, rgba(88, 166, 255, 0.85));
 }
 

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -54,6 +54,7 @@ export default defineComponent({
     const composing = ref(false);
     const preComposeValue = ref("");
     const revealing = ref(false);
+    let lastInputAt = 0;
 
     const level = computed(() => {
       if (!props.strength || !props.modelValue) return null;
@@ -304,6 +305,7 @@ export default defineComponent({
 
     function onInput(e: Event) {
       const t = e.target as HTMLInputElement;
+      lastInputAt = performance.now();
       if (composing.value) return;
       const v = t.value;
       if (FW_RE.test(v)) {
@@ -359,6 +361,18 @@ export default defineComponent({
 
     function onBlur(e: FocusEvent) {
       focused.value = false;
+      // If the blur lands within a short window after the last input
+      // event (e.g. an extension/IME yanks focus when the field is
+      // cleared to empty), reclaim focus — a deliberate user click away
+      // never follows an input this tightly.
+      if (
+        performance.now() - lastInputAt < 300 &&
+        !props.disabled &&
+        !props.readonly
+      ) {
+        const el = inputRef.value;
+        if (el) setTimeout(() => el.focus(), 0);
+      }
       capsLock.value = false;
       fullWidthPaused.value = false;
       allSelected.value = false;

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -469,7 +469,18 @@ export default defineComponent({
           </div>
           <canvas ref={dotCanvasRef} class="hk-pwd-dots" />
           {!props.modelValue && !revealing.value ? (
-            <span class="hk-pwd-placeholder">{props.placeholder}</span>
+            <span
+              class="hk-pwd-placeholder"
+              onPointerdown={(e: PointerEvent) => {
+                // Tapping the placeholder refocuses the field — after a
+                // browser password-manager bubble steals focus the input
+                // otherwise stops responding to typing.
+                e.preventDefault();
+                inputRef.value?.focus();
+              }}
+            >
+              {props.placeholder}
+            </span>
           ) : null}
           {props.modelValue && !focused.value && !revealing.value ? (
             <span

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -318,6 +318,18 @@ export default defineComponent({
       allSelected.value = false;
       emit("update:modelValue", v);
       flash();
+      if (!v) {
+        // Deleting down to empty can lose focus to an extension/IME bubble
+        // in real browsers. Reclaim focus if nothing else has it.
+        const el = inputRef.value;
+        if (el && document.activeElement !== el) {
+          queueMicrotask(() => {
+            if (document.activeElement !== el && !props.disabled) {
+              el.focus();
+            }
+          });
+        }
+      }
     }
 
     function onKeydown(e: KeyboardEvent) {
@@ -383,6 +395,18 @@ export default defineComponent({
       allSelected.value = false;
       emit("update:modelValue", v);
       flash();
+      if (!v) {
+        // Deleting down to empty can lose focus to an extension/IME bubble
+        // in real browsers. Reclaim focus if nothing else has it.
+        const el = inputRef.value;
+        if (el && document.activeElement !== el) {
+          queueMicrotask(() => {
+            if (document.activeElement !== el && !props.disabled) {
+              el.focus();
+            }
+          });
+        }
+      }
     }
 
     function onSelect() {
@@ -472,14 +496,16 @@ export default defineComponent({
             <span
               class="hk-pwd-placeholder"
               onPointerdown={(e: PointerEvent) => {
-                // Tapping the placeholder refocuses the field — after a
-                // browser password-manager bubble steals focus the input
-                // otherwise stops responding to typing.
+                // Tapping the placeholder refocuses the field — after an
+                // extension or IME steals focus the input otherwise stops
+                // responding to typing.
                 e.preventDefault();
                 inputRef.value?.focus();
               }}
             >
-              {props.placeholder}
+              {focused.value
+                ? t("hikari::passwordInput.focusedPlaceholder")
+                : props.placeholder}
             </span>
           ) : null}
           {props.modelValue && !focused.value && !revealing.value ? (

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "تم التركيز، أدخل كلمة المرور"
   }
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "Fokussiert, Passwort eingeben"
   }
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "Focused, enter your password"
   }
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "Enfocado, introduzca su contraseña"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "Champ actif, saisissez votre mot de passe"
   }
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "閉じる",
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
-    "hikari::avatar.fallback": "？"
+    "hikari::avatar.fallback": "？",
+    "hikari::passwordInput.focusedPlaceholder": "フォーカス中、パスワードを入力してください"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "닫기",
     "hikari::modal.auto": "자동",
     "hikari::scrollContainer.auto": "자동",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "포커스됨, 비밀번호를 입력하세요"
   }
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "Focado, digite sua senha"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "В фокусе, введите пароль"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "关闭",
     "hikari::modal.auto": "自动",
     "hikari::scrollContainer.auto": "自动",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "已聚焦，请输入密码"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -43,6 +43,7 @@
     "hikari::toast.close": "關閉",
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
-    "hikari::avatar.fallback": "?"
+    "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.focusedPlaceholder": "已聚焦，請輸入密碼"
   }
 }


### PR DESCRIPTION
The focused placeholder now uses the library's own i18n message (hikari::passwordInput.focusedPlaceholder) in italic grey instead of the consumer label, and clearing the field to empty reclaims focus (microtask + 300ms blur window) when an extension/IME steals it in real browsers. Also makes the placeholder tappable to refocus.