### PR TITLE
🐛 Keep the entered password on refocus and clear it on first input.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -83,9 +83,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition:
-    color 0.3s ease,
-    filter 0.3s ease;
+  transition: color 0.3s ease;
 }
 
 .hk-pwd-lock-empty {
@@ -102,12 +100,10 @@
 .hk-pwd-box:focus-within .hk-pwd-lock,
 .hk-pwd-box[data-focused] .hk-pwd-lock {
   color: var(--hi-color-primary, #58a6ff);
-  filter: drop-shadow(0 0 5px currentColor);
 }
 
 .hk-pwd-lock[data-revealing] {
   color: var(--hi-color-primary, #58a6ff);
-  filter: drop-shadow(0 0 6px currentColor);
 }
 
 .hk-pwd-dots {

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -148,11 +148,12 @@
   justify-content: center;
   z-index: 1;
   user-select: none;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-style: italic;
   color: var(--hi-color-text-secondary, #666);
   cursor: pointer;
   transition: color 0.3s ease;
+  animation: hk-pwd-breathe 3s ease-in-out infinite;
 }
 
 .hk-pwd-blur-hint:hover {
@@ -171,10 +172,11 @@
   justify-content: center;
   z-index: 1;
   user-select: none;
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-style: italic;
   color: var(--hi-color-text-secondary, #666);
   pointer-events: none;
+  animation: hk-pwd-breathe 3s ease-in-out infinite;
 }
 
 .hk-pwd-reveal-text {

--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+
+import HkPasswordInput from "./HkPasswordInput";
+
+interface Mounted {
+  model: ReturnType<typeof ref<string>>;
+  app: ReturnType<typeof createApp>;
+  container: HTMLElement;
+  input: HTMLInputElement;
+}
+
+const mounts: Mounted[] = [];
+
+function mountPasswordInput(initial = ""): Mounted {
+  const model = ref(initial);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render() {
+      return h(HkPasswordInput, {
+        modelValue: model.value,
+        placeholder: "Enter password",
+        "onUpdate:modelValue": (v: string) => {
+          model.value = v;
+        },
+      });
+    },
+  });
+  app.mount(container);
+  const input = container.querySelector(".hk-pwd-input") as HTMLInputElement;
+  const mounted = { model, app, container, input };
+  mounts.push(mounted);
+  return mounted;
+}
+
+function placeholderText(container: HTMLElement): string | null {
+  return container.querySelector(".hk-pwd-placeholder")?.textContent ?? null;
+}
+
+function blurHintText(container: HTMLElement): string | null {
+  return container.querySelector(".hk-pwd-blur-hint")?.textContent ?? null;
+}
+
+function fireInput(input: HTMLInputElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function fireBeforeinput(input: HTMLInputElement, inputType: string) {
+  const event = new InputEvent("beforeinput", {
+    inputType,
+    bubbles: true,
+    cancelable: true,
+  });
+  input.dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkPasswordInput refocus", () => {
+  it("keeps the entered password and shows the refocus placeholder on focus", async () => {
+    const { container, input, model } = mountPasswordInput("secret");
+    expect(placeholderText(container)).toBeNull();
+
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    expect(model.value).toBe("secret");
+    expect(placeholderText(container)).toBe(
+      "Focused, typing will clear the current password",
+    );
+    expect(blurHintText(container)).toBeNull();
+  });
+
+  it("restores the blur hint when the field loses focus again", async () => {
+    const { container, input } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    input.dispatchEvent(new FocusEvent("blur"));
+    await nextTick();
+
+    expect(placeholderText(container)).toBeNull();
+    expect(blurHintText(container)).toBe("Password entered");
+  });
+
+  it("starts the next input from an empty field after beforeinput", async () => {
+    const { input, model } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    fireBeforeinput(input, "insertText");
+    fireInput(input, "x");
+    await nextTick();
+
+    expect(model.value).toBe("x");
+  });
+
+  it("clears the whole field on delete instead of nibbling the old value", async () => {
+    const { container, input, model } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    const event = fireBeforeinput(input, "deleteContentBackward");
+    await nextTick();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(model.value).toBe("");
+    expect(input.value).toBe("");
+    expect(placeholderText(container)).toBe("Focused, enter your password");
+  });
+
+  it("keeps only the newly typed tail when beforeinput is unavailable", async () => {
+    const { input, model } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    fireInput(input, "secretx");
+    await nextTick();
+
+    expect(model.value).toBe("x");
+  });
+
+  it("starts over when an edit lands mid-value without beforeinput", async () => {
+    const { input, model } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    fireInput(input, "secxret");
+    await nextTick();
+
+    expect(model.value).toBe("");
+  });
+
+  it("shows the waiting placeholder again on refocus after clearing", async () => {
+    const { container, input } = mountPasswordInput("secret");
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+
+    fireBeforeinput(input, "deleteContentBackward");
+    await nextTick();
+
+    input.dispatchEvent(new FocusEvent("blur"));
+    await nextTick();
+    expect(blurHintText(container)).toBeNull();
+
+    input.dispatchEvent(new FocusEvent("focus"));
+    await nextTick();
+    expect(placeholderText(container)).toBe("Focused, enter your password");
+  });
+});

--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -86,7 +86,9 @@ describe("HkPasswordInput refocus", () => {
     await nextTick();
 
     expect(placeholderText(container)).toBeNull();
-    expect(blurHintText(container)).toBe("Password entered");
+    expect(blurHintText(container)).toBe(
+      "Entered, click to clear the existing password",
+    );
   });
 
   it("starts the next input from an empty field after beforeinput", async () => {

--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -87,7 +87,7 @@ describe("HkPasswordInput refocus", () => {
 
     expect(placeholderText(container)).toBeNull();
     expect(blurHintText(container)).toBe(
-      "Entered, click to clear the existing password",
+      "Entered, click to focus and clear the existing password",
     );
   });
 

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -54,6 +54,7 @@ export default defineComponent({
     const composing = ref(false);
     const preComposeValue = ref("");
     const revealing = ref(false);
+    const pendingClear = ref(false);
     let lastInputAt = 0;
 
     const level = computed(() => {
@@ -307,6 +308,17 @@ export default defineComponent({
       const t = e.target as HTMLInputElement;
       lastInputAt = performance.now();
       if (composing.value) return;
+      if (pendingClear.value) {
+        // Fallback for engines without beforeinput: keep only the part
+        // typed beyond the old password, or start over on any other edit.
+        pendingClear.value = false;
+        const old = props.modelValue;
+        if (old && t.value.startsWith(old) && t.value.length > old.length) {
+          t.value = t.value.slice(old.length);
+        } else {
+          t.value = "";
+        }
+      }
       const v = t.value;
       if (FW_RE.test(v)) {
         const clean = v.replace(FW_RE, "");
@@ -347,13 +359,35 @@ export default defineComponent({
       checkSelection();
     }
 
+    function onBeforeinput(e: InputEvent) {
+      if (!pendingClear.value) return;
+      const inputType = e.inputType || "";
+      if (!inputType.startsWith("insert") && !inputType.startsWith("delete")) {
+        return;
+      }
+      const el = inputRef.value;
+      if (!el) return;
+      pendingClear.value = false;
+      // The old password is only a placeholder for the next input: typing
+      // (or pasting) starts from an empty field, and deleting clears the
+      // whole field instead of nibbling one dot of the old value.
+      el.value = "";
+      emit("update:modelValue", "");
+      if (inputType.startsWith("delete")) {
+        e.preventDefault();
+        kickRipple();
+      }
+    }
+
     function onFocus(e: FocusEvent) {
       focused.value = true;
-      if (props.modelValue && !props.readonly) {
-        emit("update:modelValue", "");
-        if (inputRef.value) inputRef.value.value = "";
-        kickRipple();
+      if (props.modelValue && !props.readonly && !props.disabled) {
+        // Keep the entered password on refocus instead of wiping it: the
+        // field now shows a focused placeholder and clears the old value
+        // only once the user actually starts typing.
+        pendingClear.value = true;
       } else {
+        pendingClear.value = false;
         checkAutofill();
       }
       emit("focus", e);
@@ -361,6 +395,7 @@ export default defineComponent({
 
     function onBlur(e: FocusEvent) {
       focused.value = false;
+      pendingClear.value = false;
       // If the blur lands within a short window after the last input
       // event (e.g. an extension/IME yanks focus when the field is
       // cleared to empty), reclaim focus — a deliberate user click away
@@ -410,7 +445,19 @@ export default defineComponent({
 
     function onCompositionEnd() {
       composing.value = false;
-      const v = inputRef.value?.value ?? "";
+      let v = inputRef.value?.value ?? "";
+      if (pendingClear.value) {
+        // Same fallback as onInput for engines without beforeinput.
+        pendingClear.value = false;
+        const old = props.modelValue;
+        if (old && v.startsWith(old) && v.length > old.length) {
+          v = v.slice(old.length);
+          if (inputRef.value) inputRef.value.value = v;
+        } else if (old) {
+          v = "";
+          if (inputRef.value) inputRef.value.value = "";
+        }
+      }
       if (FW_RE.test(v.slice(preComposeValue.value.length))) {
         if (inputRef.value) inputRef.value.value = preComposeValue.value;
         emit("update:modelValue", preComposeValue.value);
@@ -455,8 +502,11 @@ export default defineComponent({
 
     let autofillInterval: ReturnType<typeof setInterval> | null = null;
 
-    watch([() => props.modelValue, focused, revealing], () => {
-      // kick a draw on state change
+    watch(() => props.modelValue, (v) => {
+      // An external clear (or the blur hint's clear-and-focus) must drop
+      // the pending-clear state so the placeholder falls back to the
+      // waiting-for-input message.
+      if (!v) pendingClear.value = false;
     });
 
     onMounted(() => {
@@ -519,7 +569,8 @@ export default defineComponent({
             </svg>
           </div>
           <canvas ref={dotCanvasRef} class="hk-pwd-dots" />
-          {!props.modelValue && !revealing.value ? (
+          {(!props.modelValue || (pendingClear.value && focused.value)) &&
+          !revealing.value ? (
             <span
               class="hk-pwd-placeholder"
               onPointerdown={(e: PointerEvent) => {
@@ -530,12 +581,17 @@ export default defineComponent({
                 inputRef.value?.focus();
               }}
             >
-              {focused.value
-                ? t("hikari::passwordInput.focusedPlaceholder")
-                : props.placeholder}
+              {pendingClear.value && props.modelValue
+                ? t("hikari::passwordInput.focusedHasValuePlaceholder")
+                : focused.value
+                  ? t("hikari::passwordInput.focusedPlaceholder")
+                  : props.placeholder}
             </span>
           ) : null}
-          {props.modelValue && !focused.value && !revealing.value ? (
+          {props.modelValue &&
+          !focused.value &&
+          !revealing.value &&
+          !pendingClear.value ? (
             <span
               class="hk-pwd-blur-hint"
               onPointerdown={(e: PointerEvent) => {
@@ -568,6 +624,7 @@ export default defineComponent({
             required={props.required}
             class="hk-pwd-input"
             onInput={onInput}
+            onBeforeinput={onBeforeinput}
             onFocus={onFocus}
             onBlur={onBlur}
             onKeydown={onKeydown}

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "تم الإدخال، انقر لمسح كلمة المرور الحالية",
+    "hikari::passwordInput.passwordEntered": "تم الإدخال، انقر للتركيز ومسح كلمة المرور الحالية",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "تم التركيز، أدخل كلمة المرور"
+    "hikari::passwordInput.focusedPlaceholder": "تم التركيز، أدخل كلمة المرور",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "تم التركيز، ستؤدي الكتابة إلى مسح كلمة المرور الحالية"
   }
 }

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "تم الإدخال، انقر لمسح كلمة المرور الحالية",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "Fokussiert, Passwort eingeben"
+    "hikari::passwordInput.focusedPlaceholder": "Fokussiert, Passwort eingeben",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Fokussiert, weitere Eingaben löschen das bisherige Passwort"
   }
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Eingegeben, zum Löschen des vorhandenen Passworts klicken",
+    "hikari::passwordInput.passwordEntered": "Eingegeben, Klicken fokussiert und löscht das vorhandene Passwort",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Eingegeben, zum Löschen des vorhandenen Passworts klicken",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "Focused, enter your password"
+    "hikari::passwordInput.focusedPlaceholder": "Focused, enter your password",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Focused, typing will clear the current password"
   }
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Entered, click to clear the existing password",
+    "hikari::passwordInput.passwordEntered": "Entered, click to focus and clear the existing password",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Entered, click to clear the existing password",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "Enfocado, introduzca su contraseña"
+    "hikari::passwordInput.focusedPlaceholder": "Enfocado, introduzca su contraseña",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Enfocado, escribir borrará la contraseña actual"
   }
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Introducida, haga clic para borrar la contraseña existente",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Introducida, haga clic para borrar la contraseña existente",
+    "hikari::passwordInput.passwordEntered": "Introducida, al hacer clic se enfoca y borra la contraseña existente",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "Champ actif, saisissez votre mot de passe"
+    "hikari::passwordInput.focusedPlaceholder": "Champ actif, saisissez votre mot de passe",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Champ actif, la saisie effacera le mot de passe actuel"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Saisi, cliquez pour effacer le mot de passe existant",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Saisi, cliquez pour effacer le mot de passe existant",
+    "hikari::passwordInput.passwordEntered": "Saisi, un clic active le champ et efface le mot de passe existant",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "データなし",
     "hikari::confirmDialog.cancel": "キャンセル",
     "hikari::confirmDialog.confirm": "確認",
-    "hikari::passwordInput.passwordEntered": "パスワード入力済み",
+    "hikari::passwordInput.passwordEntered": "入力済み、クリックで既存のパスワードを消去します",
     "hikari::passwordInput.allSelected": "全選択",
     "hikari::passwordInput.capsLock": "CapsLock オン",
     "hikari::passwordInput.fullWidth": "全角文字不可",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "データなし",
     "hikari::confirmDialog.cancel": "キャンセル",
     "hikari::confirmDialog.confirm": "確認",
-    "hikari::passwordInput.passwordEntered": "入力済み、クリックで既存のパスワードを消去します",
+    "hikari::passwordInput.passwordEntered": "入力済み、クリックでフォーカスし既存のパスワードを消去します",
     "hikari::passwordInput.allSelected": "全選択",
     "hikari::passwordInput.capsLock": "CapsLock オン",
     "hikari::passwordInput.fullWidth": "全角文字不可",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "？",
-    "hikari::passwordInput.focusedPlaceholder": "フォーカス中、パスワードを入力してください"
+    "hikari::passwordInput.focusedPlaceholder": "フォーカス中、パスワードを入力してください",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "フォーカス中、入力を続けると現在のパスワードは消去されます"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "자동",
     "hikari::scrollContainer.auto": "자동",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "포커스됨, 비밀번호를 입력하세요"
+    "hikari::passwordInput.focusedPlaceholder": "포커스됨, 비밀번호를 입력하세요",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "포커스됨, 입력을 계속하면 현재 비밀번호가 지워집니다"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "데이터 없음",
     "hikari::confirmDialog.cancel": "취소",
     "hikari::confirmDialog.confirm": "확인",
-    "hikari::passwordInput.passwordEntered": "입력됨, 클릭하여 기존 비밀번호를 지우세요",
+    "hikari::passwordInput.passwordEntered": "입력됨, 클릭하여 포커스하면 기존 비밀번호가 지워집니다",
     "hikari::passwordInput.allSelected": "전체 선택",
     "hikari::passwordInput.capsLock": "CapsLock 켜짐",
     "hikari::passwordInput.fullWidth": "전각 문자 불가",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "데이터 없음",
     "hikari::confirmDialog.cancel": "취소",
     "hikari::confirmDialog.confirm": "확인",
-    "hikari::passwordInput.passwordEntered": "비밀번호 입력됨",
+    "hikari::passwordInput.passwordEntered": "입력됨, 클릭하여 기존 비밀번호를 지우세요",
     "hikari::passwordInput.allSelected": "전체 선택",
     "hikari::passwordInput.capsLock": "CapsLock 켜짐",
     "hikari::passwordInput.fullWidth": "전각 문자 불가",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Inserida, clique para apagar a senha existente",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Inserida, clique para apagar a senha existente",
+    "hikari::passwordInput.passwordEntered": "Inserida, clique para focar e apagar a senha existente",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "Focado, digite sua senha"
+    "hikari::passwordInput.focusedPlaceholder": "Focado, digite sua senha",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Focado, digitar apagará a senha atual"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Введён, нажмите, чтобы очистить текущий пароль",
+    "hikari::passwordInput.passwordEntered": "Введён, клик сфокусирует и очистит текущий пароль",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "В фокусе, введите пароль"
+    "hikari::passwordInput.focusedPlaceholder": "В фокусе, введите пароль",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "В фокусе, ввод очистит текущий пароль"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
-    "hikari::passwordInput.passwordEntered": "Password entered",
+    "hikari::passwordInput.passwordEntered": "Введён, нажмите, чтобы очистить текущий пароль",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",
     "hikari::passwordInput.fullWidth": "Full-width characters not allowed",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "暂无数据",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "确认",
-    "hikari::passwordInput.passwordEntered": "已输入密码",
+    "hikari::passwordInput.passwordEntered": "已输入，点击以消除现有密码",
     "hikari::passwordInput.allSelected": "已全选",
     "hikari::passwordInput.capsLock": "大写锁定已开启",
     "hikari::passwordInput.fullWidth": "全角字符不可用",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "暂无数据",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "确认",
-    "hikari::passwordInput.passwordEntered": "已输入，点击以消除现有密码",
+    "hikari::passwordInput.passwordEntered": "已输入，点击聚焦将清空已有密码",
     "hikari::passwordInput.allSelected": "已全选",
     "hikari::passwordInput.capsLock": "大写锁定已开启",
     "hikari::passwordInput.fullWidth": "全角字符不可用",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "自动",
     "hikari::scrollContainer.auto": "自动",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "已聚焦，请输入密码"
+    "hikari::passwordInput.focusedPlaceholder": "已聚焦，请输入密码",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，继续输入将清空原密码"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "暫無數據",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "確認",
-    "hikari::passwordInput.passwordEntered": "已輸入密碼",
+    "hikari::passwordInput.passwordEntered": "已輸入，點擊以消除現有密碼",
     "hikari::passwordInput.allSelected": "已全選",
     "hikari::passwordInput.capsLock": "大寫鎖定已開啟",
     "hikari::passwordInput.fullWidth": "全形字元不可用",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -44,6 +44,7 @@
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "?",
-    "hikari::passwordInput.focusedPlaceholder": "已聚焦，請輸入密碼"
+    "hikari::passwordInput.focusedPlaceholder": "已聚焦，請輸入密碼",
+    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，繼續輸入將清除原密碼"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -30,7 +30,7 @@
     "hikari::table.noData": "暫無數據",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "確認",
-    "hikari::passwordInput.passwordEntered": "已輸入，點擊以消除現有密碼",
+    "hikari::passwordInput.passwordEntered": "已輸入，點擊聚焦將清空已有密碼",
     "hikari::passwordInput.allSelected": "已全選",
     "hikari::passwordInput.capsLock": "大寫鎖定已開啟",
     "hikari::passwordInput.fullWidth": "全形字元不可用",


### PR DESCRIPTION
## What

The password input wiped the entered password the moment the field regained focus, which was too aggressive. This PR changes the semantics:

- On refocus with an existing value the password is **kept**; the placeholder shows the new localized message `hikari::passwordInput.focusedHasValuePlaceholder` (已聚焦，继续输入将清空原密码 / "Focused, typing will clear the current password").
- The old password is cleared only on the **first edit**: typing/pasting starts from an empty field (`beforeinput` handler clears first), delete/backspace clears the whole field, with an `onInput`/`onCompositionEnd` fallback for engines without `beforeinput`.
- Removed the glow (`drop-shadow`) on the left lock icon in focus and reveal states; the placeholder text breathe animation is kept.

Also adds the first component test for `HkPasswordInput` covering the refocus flows.

Local verification: `vitest run` 46/46, `vue-tsc --noEmit` clean.

Not merging yet — pending user verification.