### PR TITLE
🐛 Stop the blur reclaim from hijacking Tab navigation.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick, ref } from "vue";
 
 import HkPasswordInput from "./HkPasswordInput";
@@ -154,5 +154,31 @@ describe("HkPasswordInput refocus", () => {
     input.dispatchEvent(new FocusEvent("focus"));
     await nextTick();
     expect(placeholderText(container)).toBe("Focused, enter your password");
+  });
+
+  it("reclaims focus on a stray blur right after input", async () => {
+    const { input } = mountPasswordInput("");
+    fireInput(input, "a");
+    const focusSpy = vi.spyOn(input, "focus");
+
+    input.dispatchEvent(new FocusEvent("blur", { relatedTarget: null }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it("lets Tab navigation hand focus to another element", async () => {
+    const { input } = mountPasswordInput("");
+    const next = document.createElement("input");
+    document.body.appendChild(next);
+
+    fireInput(input, "a");
+    const focusSpy = vi.spyOn(input, "focus");
+
+    input.dispatchEvent(new FocusEvent("blur", { relatedTarget: next }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(focusSpy).not.toHaveBeenCalled();
+    next.remove();
   });
 });

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -398,12 +398,14 @@ export default defineComponent({
       pendingClear.value = false;
       // If the blur lands within a short window after the last input
       // event (e.g. an extension/IME yanks focus when the field is
-      // cleared to empty), reclaim focus — a deliberate user click away
-      // never follows an input this tightly.
+      // cleared to empty), reclaim focus. A blur that hands focus to
+      // another element (Tab navigation or a click on a focusable
+      // control) is deliberate and must not be reclaimed.
       if (
         performance.now() - lastInputAt < 300 &&
         !props.disabled &&
-        !props.readonly
+        !props.readonly &&
+        !e.relatedTarget
       ) {
         const el = inputRef.value;
         if (el) setTimeout(() => el.focus(), 0);


### PR DESCRIPTION
## What

The focus reclaim (added to fight extensions stealing focus after input) treated every blur inside its 300ms window as stolen, so pressing Tab right after typing a password pulled focus straight back — the next password field was unreachable.

A blur event that hands focus to another element (`e.relatedTarget` non-null, e.g. Tab navigation or clicking another control) is now considered deliberate and skips the reclaim. Blurs with no related target (browser UI / extension bubble stealing focus) still reclaim as before.

Two new tests cover the reclaim and the Tab hand-off.

Local verification: vitest 48/48, vue-tsc 0 errors.