### PR TITLE
🔧 Unify license statements and publish guards.

### DIFF
--- a/docs/ar/guides/index.md
+++ b/docs/ar/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## الترخيص
 
-[رخصة MIT](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## شكر وتقدير
 

--- a/docs/en/guides/CONTRIBUTING.md
+++ b/docs/en/guides/CONTRIBUTING.md
@@ -489,7 +489,7 @@ Contributors will be:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the MIT OR Apache-2.0 license.
+By contributing, you agree that your contributions will be licensed under the [Synthetic Source License (SySL), Version 1.0](../../../LICENSE).
 
 ## Questions?
 

--- a/docs/en/guides/index.md
+++ b/docs/en/guides/index.md
@@ -180,7 +180,7 @@ Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for 
 
 ## License
 
-[MIT License](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## Acknowledgments
 

--- a/docs/es/guides/index.md
+++ b/docs/es/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## Licencia
 
-[Licencia MIT](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## Agradecimientos
 

--- a/docs/fr/guides/index.md
+++ b/docs/fr/guides/index.md
@@ -180,7 +180,7 @@ Les contributions sont les bienvenues ! Veuillez lire [CONTRIBUTING.md](../../en
 
 ## Licence
 
-[Licence MIT](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## Remerciements
 

--- a/docs/ja/guides/index.md
+++ b/docs/ja/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## ライセンス
 
-[MIT License](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## 謝辞
 

--- a/docs/ko/guides/index.md
+++ b/docs/ko/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## 라이선스
 
-[MIT 라이선스](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## 감사의 말
 

--- a/docs/ru/guides/index.md
+++ b/docs/ru/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## Лицензия
 
-[MIT License](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## Благодарности
 

--- a/docs/zh-Hans/guides/index.md
+++ b/docs/zh-Hans/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## 许可证
 
-[MIT License](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## 致谢
 

--- a/docs/zh-Hant/guides/index.md
+++ b/docs/zh-Hant/guides/index.md
@@ -180,7 +180,7 @@ AnimationBuilder::new(&elements)
 
 ## 授權
 
-[MIT License](../../../LICENSE)
+[Synthetic Source License (SySL), Version 1.0](../../../LICENSE)
 
 ## 致謝
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -216,7 +216,7 @@ When adding new examples:
 
 ## 📝 License
 
-All examples are licensed under the same terms as the Hikari project (MIT OR Apache-2.0).
+All examples are licensed under the same terms as the Hikari project — the [Synthetic Source License (SySL), Version 1.0](../LICENSE).
 
 ## 🙏 Acknowledgments
 

--- a/packages/animation/README.md
+++ b/packages/animation/README.md
@@ -98,4 +98,4 @@ For complete API documentation, easing functions, and performance tips, see [doc
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/builder/README.md
+++ b/packages/builder/README.md
@@ -65,4 +65,4 @@ fn main() {
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -66,4 +66,4 @@ hikari-components = { features = ["button", "input", "card"] }
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -3,7 +3,8 @@ name = "hikari-e2e"
 version = "0.1.0"
 description = "E2E testing framework for Hikari UI components"
 authors = ["Hikari Contributors"]
-license = "SySL-1.0"
+license-file = "../../LICENSE"
+publish = false
 edition = "2024"
 autobins = false
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -212,7 +212,7 @@ For full E2E testing:
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).
 
 ## Contributing
 

--- a/packages/extra-components/README.md
+++ b/packages/extra-components/README.md
@@ -58,4 +58,4 @@ For complete API documentation, node graph system, and examples, see [docs.rs](h
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -39,4 +39,4 @@ For complete API documentation, icon shortcuts, and dynamic icon usage, see [doc
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/palette/README.md
+++ b/packages/palette/README.md
@@ -38,4 +38,4 @@ For complete API documentation and examples, see [docs.rs](https://docs.rs/hikar
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -51,4 +51,4 @@ For complete API documentation, theme customization, and nested theming, see [do
 
 ## License
 
-MIT OR Apache-2.0
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -51,4 +51,4 @@ import { HkButton, HkCard, HkInput } from "@celestia-island/hikari";
 
 ## License
 
-BUSL-1.1
+Licensed under the [Synthetic Source License (SySL), Version 1.0](../../LICENSE).


### PR DESCRIPTION
## Summary

Normalize every stray license declaration in the repository to the Synthetic Source License (SySL), Version 1.0, matching the root `LICENSE`, and mark the internal e2e test crate as non-publishable.

## Changes

- Crate READMEs (`packages/{animation,builder,components,e2e,extra-components,icons,palette,theme}/README.md`): `MIT OR Apache-2.0` → SySL 1.0 link to the root `LICENSE`.
- `packages/vue/README.md`: `BUSL-1.1` → SySL 1.0 link.
- Docs guides (`docs/{ar,en,es,fr,ja,ko,ru,zh-Hans,zh-Hant}/guides/index.md`): localized "MIT" links → SySL 1.0 link.
- `docs/en/guides/CONTRIBUTING.md`: `MIT OR Apache-2.0` → SySL 1.0.
- `examples/README.md`: `MIT OR Apache-2.0` → SySL 1.0.
- `packages/e2e/Cargo.toml`: `license = "SySL-1.0"` (non-SPDX string) → `license-file = "../../LICENSE"`, and add `publish = false` (internal test crate, excluded from crates.io publishing).

## Notes

- `deny.toml` already declares `LicenseRef-sysl-1.0` in its allow list with per-crate `clarify` entries pointing at `../../LICENSE`; no change was needed.
- Historical `CHANGELOG.md` entries and the dependency `allow` list (`MIT`, `Apache-2.0`) in `deny.toml` are not hikari's own license declarations, so they are left untouched.

## Verification

- `cargo check --workspace` passes (`Finished \`dev\` profile in 2m 30s`).
