### PR TITLE
✨ Add password and confirm variants with customizable icons and placeholders.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createApp, h, nextTick, ref } from "vue";
+import { createApp, h, nextTick, ref, type Slot } from "vue";
 
 import HkPasswordInput from "./HkPasswordInput";
 
@@ -12,19 +12,27 @@ interface Mounted {
 
 const mounts: Mounted[] = [];
 
-function mountPasswordInput(initial = ""): Mounted {
+function mountPasswordInput(
+  initial = "",
+  props: Record<string, unknown> = {},
+  slots: Record<string, Slot> = {},
+): Mounted {
   const model = ref(initial);
   const container = document.createElement("div");
   document.body.appendChild(container);
   const app = createApp({
     render() {
-      return h(HkPasswordInput, {
-        modelValue: model.value,
-        placeholder: "Enter password",
-        "onUpdate:modelValue": (v: string) => {
-          model.value = v;
+      return h(
+        HkPasswordInput,
+        {
+          ...props,
+          modelValue: model.value,
+          "onUpdate:modelValue": (v: string) => {
+            model.value = v;
+          },
         },
-      });
+        slots,
+      );
     },
   });
   app.mount(container);
@@ -180,5 +188,55 @@ describe("HkPasswordInput refocus", () => {
 
     expect(focusSpy).not.toHaveBeenCalled();
     next.remove();
+  });
+});
+
+describe("HkPasswordInput variants and icons", () => {
+  it("defaults to the password variant with the lock icon and i18n placeholder", () => {
+    const { container } = mountPasswordInput("");
+    expect(placeholderText(container)).toBe("Enter your password");
+    expect(
+      container.querySelector(".hk-pwd-lock")?.getAttribute("data-icon"),
+    ).toBe("password");
+    expect(
+      container
+        .querySelector(".hk-pwd-lock")
+        ?.classList.contains("hk-pwd-lock-empty"),
+    ).toBe(true);
+  });
+
+  it("renders the confirm icon and confirm placeholder for the confirm variant", () => {
+    const { container } = mountPasswordInput("", { variant: "confirm" });
+    expect(placeholderText(container)).toBe("Confirm your password");
+    expect(
+      container.querySelector(".hk-pwd-lock")?.getAttribute("data-icon"),
+    ).toBe("confirm");
+    // The built-in lock icon must not render for the confirm variant.
+    expect(container.querySelector(".hk-pwd-lock rect")).toBeNull();
+  });
+
+  it("renders the icon slot for the custom icon instead of a built-in svg", () => {
+    const { container } = mountPasswordInput(
+      "",
+      { icon: "custom" },
+      {
+        icon: () => [h("span", { class: "custom-icon" }, "custom-✓")],
+      },
+    );
+    expect(
+      container.querySelector(".hk-pwd-lock")?.getAttribute("data-icon"),
+    ).toBe("custom");
+    expect(container.querySelector(".custom-icon")?.textContent).toBe(
+      "custom-✓",
+    );
+    expect(container.querySelector(".hk-pwd-lock svg")).toBeNull();
+  });
+
+  it("lets an explicit placeholder override the variant default", () => {
+    const { container } = mountPasswordInput("", {
+      variant: "confirm",
+      placeholder: "Confirm password (custom)",
+    });
+    expect(placeholderText(container)).toBe("Confirm password (custom)");
   });
 });

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -5,6 +5,7 @@ import {
   onUnmounted,
   ref,
   watch,
+  type PropType,
 } from "vue";
 
 import { useI18n } from "../i18n/context";
@@ -17,11 +18,35 @@ interface Ripple {
   peak: number;
 }
 
+type PasswordVariant = "password" | "confirm";
+type PasswordIcon = PasswordVariant | "custom";
+
 export default defineComponent({
   name: "HkPasswordInput",
   props: {
     modelValue: { type: String, default: "" },
+    /**
+     * Placeholder shown when the field is empty and unfocused. When empty,
+     * the component falls back to the `variant` default from hikari's own
+     * i18n (`hikari::passwordInput.placeholderPassword` /
+     * `hikari::passwordInput.placeholderConfirm`). Custom text is usually
+     * obtained from the caller's i18n `t()` function, e.g.
+     * `:placeholder="t('auth.register.confirmPassword')"`.
+     */
     placeholder: { type: String, default: "" },
+    /**
+     * Selects the default placeholder text and default icon. Only a
+     * fallback: an explicit `placeholder` or `icon` prop overrides the
+     * variant default. `confirm` pairs the confirm placeholder with a
+     * shield-with-check icon so a second field can be visually distinct.
+     */
+    variant: { type: String as PropType<PasswordVariant>, default: "password" },
+    /**
+     * Overrides the leading icon. `password` renders the lock, `confirm`
+     * renders a shield-with-check, and `custom` renders the `#icon` slot so
+     * callers can inject any SVG. Defaults to following `variant`.
+     */
+    icon: { type: String as PropType<PasswordIcon>, default: undefined },
     label: { type: String, default: undefined },
     error: { type: String, default: undefined },
     hint: { type: String, default: undefined },
@@ -42,7 +67,7 @@ export default defineComponent({
     blur: (_e: FocusEvent) => true,
     keydown: (_e: KeyboardEvent) => true,
   },
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     const { t } = useI18n();
     const inputRef = ref<HTMLInputElement>();
     const dotCanvasRef = ref<HTMLCanvasElement>();
@@ -79,6 +104,16 @@ export default defineComponent({
       if (lv === "fair") return t("hikari::passwordInput.strengthFair", "Fair");
       return t("hikari::passwordInput.strengthStrong", "Strong");
     });
+
+    const resolvedIcon = computed<PasswordIcon>(
+      () => props.icon ?? props.variant,
+    );
+
+    const variantPlaceholderKey = computed(() =>
+      props.variant === "confirm"
+        ? "hikari::passwordInput.placeholderConfirm"
+        : "hikari::passwordInput.placeholderPassword",
+    );
 
     function startReveal() {
       if (!props.modelValue || props.disabled) return;
@@ -550,25 +585,44 @@ export default defineComponent({
               "hk-pwd-lock",
               props.modelValue ? "hk-pwd-lock-filled" : "hk-pwd-lock-empty",
             ]}
+            data-icon={resolvedIcon.value}
             data-revealing={revealing.value || undefined}
             onPointerdown={(e: PointerEvent) => {
               e.preventDefault();
               startReveal();
             }}
           >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              width="16"
-              height="16"
-            >
-              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-            </svg>
+            {resolvedIcon.value === "custom" ? (
+              slots.icon?.()
+            ) : resolvedIcon.value === "confirm" ? (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                width="16"
+                height="16"
+              >
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                <path d="m9 12 2 2 4-4" />
+              </svg>
+            ) : (
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                width="16"
+                height="16"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+              </svg>
+            )}
           </div>
           <canvas ref={dotCanvasRef} class="hk-pwd-dots" />
           {(!props.modelValue || (pendingClear.value && focused.value)) &&
@@ -587,7 +641,7 @@ export default defineComponent({
                 ? t("hikari::passwordInput.focusedHasValuePlaceholder")
                 : focused.value
                   ? t("hikari::passwordInput.focusedPlaceholder")
-                  : props.placeholder}
+                  : props.placeholder || t(variantPlaceholderKey.value)}
             </span>
           ) : null}
           {props.modelValue &&

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "أدخل كلمة المرور",
+    "hikari::passwordInput.placeholderConfirm": "تأكيد كلمة المرور",
     "hikari::passwordInput.focusedPlaceholder": "تم التركيز، أدخل كلمة المرور",
     "hikari::passwordInput.focusedHasValuePlaceholder": "تم التركيز، ستؤدي الكتابة إلى مسح كلمة المرور الحالية"
   }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Passwort eingeben",
+    "hikari::passwordInput.placeholderConfirm": "Passwort bestätigen",
     "hikari::passwordInput.focusedPlaceholder": "Fokussiert, Passwort eingeben",
     "hikari::passwordInput.focusedHasValuePlaceholder": "Fokussiert, weitere Eingaben löschen das bisherige Passwort"
   }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Enter your password",
+    "hikari::passwordInput.placeholderConfirm": "Confirm your password",
     "hikari::passwordInput.focusedPlaceholder": "Focused, enter your password",
     "hikari::passwordInput.focusedHasValuePlaceholder": "Focused, typing will clear the current password"
   }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Introduzca la contraseña",
+    "hikari::passwordInput.placeholderConfirm": "Confirme la contraseña",
     "hikari::passwordInput.focusedPlaceholder": "Enfocado, introduzca su contraseña",
     "hikari::passwordInput.focusedHasValuePlaceholder": "Enfocado, escribir borrará la contraseña actual"
   }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Saisissez le mot de passe",
+    "hikari::passwordInput.placeholderConfirm": "Confirmez le mot de passe",
     "hikari::passwordInput.focusedPlaceholder": "Champ actif, saisissez votre mot de passe",
     "hikari::passwordInput.focusedHasValuePlaceholder": "Champ actif, la saisie effacera le mot de passe actuel"
   }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "？",
+    "hikari::passwordInput.placeholderPassword": "パスワードを入力",
+    "hikari::passwordInput.placeholderConfirm": "パスワードを確認",
     "hikari::passwordInput.focusedPlaceholder": "フォーカス中、パスワードを入力してください",
     "hikari::passwordInput.focusedHasValuePlaceholder": "フォーカス中、入力を続けると現在のパスワードは消去されます"
   }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "자동",
     "hikari::scrollContainer.auto": "자동",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "비밀번호 입력",
+    "hikari::passwordInput.placeholderConfirm": "비밀번호 확인",
     "hikari::passwordInput.focusedPlaceholder": "포커스됨, 비밀번호를 입력하세요",
     "hikari::passwordInput.focusedHasValuePlaceholder": "포커스됨, 입력을 계속하면 현재 비밀번호가 지워집니다"
   }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Digite a senha",
+    "hikari::passwordInput.placeholderConfirm": "Confirme a senha",
     "hikari::passwordInput.focusedPlaceholder": "Focado, digite sua senha",
     "hikari::passwordInput.focusedHasValuePlaceholder": "Focado, digitar apagará a senha atual"
   }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "Auto",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "Введите пароль",
+    "hikari::passwordInput.placeholderConfirm": "Подтвердите пароль",
     "hikari::passwordInput.focusedPlaceholder": "В фокусе, введите пароль",
     "hikari::passwordInput.focusedHasValuePlaceholder": "В фокусе, ввод очистит текущий пароль"
   }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "自动",
     "hikari::scrollContainer.auto": "自动",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "输入密码",
+    "hikari::passwordInput.placeholderConfirm": "确认密码",
     "hikari::passwordInput.focusedPlaceholder": "已聚焦，请输入密码",
     "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，继续输入将清空原密码"
   }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -44,6 +44,8 @@
     "hikari::modal.auto": "自動",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "?",
+    "hikari::passwordInput.placeholderPassword": "輸入密碼",
+    "hikari::passwordInput.placeholderConfirm": "確認密碼",
     "hikari::passwordInput.focusedPlaceholder": "已聚焦，請輸入密碼",
     "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，繼續輸入將清除原密碼"
   }


### PR DESCRIPTION
Adds `variant` (password/confirm) and `icon` (password/confirm/custom) props to `HkPasswordInput` so a second password field (e.g. confirm password) can be visually distinct.

- `variant` selects the default placeholder text and default icon; explicit `placeholder`/`icon` props override it.
- `confirm` renders a shield-with-check icon; `custom` renders the new `#icon` slot.
- Empty `placeholder` falls back to `hikari::passwordInput.placeholderPassword` / `placeholderConfirm` per variant.
- Adds the two keys to all 11 locale files.
- Extends HkPasswordInput tests (13 total, all passing); full suite 52 passing; vue-tsc clean.

No new dependencies; existing consumers passing `placeholder` see zero visual change.