### PR TITLE
🔧 Add the missing node types importer to the hikari vue lockfile.

### DIFF
--- a/packages/vue/pnpm-lock.yaml
+++ b/packages/vue/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
         specifier: ^*
         version: 3.5.40(typescript@6.0.3)
     devDependencies:
+      '@types/node':
+        specifier: ^*
+        version: 26.2.0
       '@vitejs/plugin-vue':
         specifier: ^*
         version: 6.0.8(vite@8.2.0(@types/node@26.2.0)(sass@1.102.0))(vue@3.5.40(typescript@6.0.3))


### PR DESCRIPTION
packages/vue/package.json declares @types/node as a dev dependency, but packages/vue/pnpm-lock.yaml had no importer entry, so frozen installs and sibling builds fail with TS2688. Regenerated with pnpm 11.18.0.