### PR TITLE
🔧 Allow the hikari npm release to publish with a dirty working tree.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Publish
         run: |
           cd packages/vue
-          pnpm publish --access public --provenance
+          pnpm publish --access public --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The workflow bumps package.json before pnpm publish, which then rejects the unclean tree with ERR_PNPM_GIT_UNCLEAN. Add --no-git-checks.