### PR TITLE
🔧 Publish the hikari vue package with npm instead of the OIDC pnpm path.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Publish
         run: |
           cd packages/vue
-          pnpm publish --access public --provenance --no-git-checks
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
pnpm publish tried OIDC token exchange and failed with 404 before falling back; npm publish uses NODE_AUTH_TOKEN directly.