### PR TITLE
🔧 Publish hikari through npm trusted publishing without a token override.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -58,5 +58,3 @@ jobs:
         run: |
           cd packages/vue
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The NODE_AUTH_TOKEN override may be shadowing the GitHub OIDC trusted publisher with an invalid repo token. Remove the env override so npm can use trusted publishing.