### PR TITLE
🔧 Use node 24 for the hikari npm trusted publishing flow.

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: https://registry.npmjs.org/
 
       - name: Set up pnpm


### PR DESCRIPTION
npm trusted publishing requires npm CLI 11.5.1+ and Node 22.14+; Node 24 is the supported host for the npm 11 CLI. Align setup-node.