### PR TITLE
✨ Scroll overflowing input placeholders like a storefront sign.

### DIFF
--- a/packages/vue/node_modules
+++ b/packages/vue/node_modules
@@ -1,0 +1,1 @@
+/mnt/codespace/hikari/packages/vue/node_modules

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -1,4 +1,5 @@
 @use "../tokens";
+@use "./HkPlaceholderMarquee" as placeholder-marquee;
 
 .hk-input-wrapper {
   display: block;

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -3,6 +3,7 @@ import { computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, u
 
 import { useI18n } from "../i18n/context";
 
+import { HkPlaceholderMarquee } from "./HkPlaceholderMarquee";
 import "./HkInput.scss";
 
 export default defineComponent({
@@ -33,6 +34,18 @@ export default defineComponent({
       type: String as () => "text" | "password" | "number",
       default: "text",
     },
+    /**
+     * Overflow strategy for a placeholder longer than the input line:
+     * `marquee` (default) scrolls it like a storefront sign — the text is
+     * rendered three times inside a clipping window and the strip is
+     * translated through the hikari animation bus; `truncate` hard-cuts it
+     * with an ellipsis. The marquee parks while the input is focused or
+     * holds a value, and under reduced-motion the strip stays parked.
+     */
+    placeholderVariant: {
+      type: String as () => "marquee" | "truncate",
+      default: "marquee",
+    },
   },
   emits: {
     "update:modelValue": (_value: string) => true,
@@ -46,6 +59,16 @@ export default defineComponent({
     const inputRef = ref<HTMLElement>();
 
     const revealing = ref(false);
+    const marqueeRef = ref<{
+      setActive(active: boolean): void;
+      measure(): void;
+    }>();
+    const isEmpty = computed(() => String(props.modelValue ?? "") === "");
+
+    const forwardFocus = (active: boolean) => {
+      marqueeRef.value?.setActive(active);
+    };
+
     const resolvedType = computed(() => {
       if (props.variant === "password") {
         return revealing.value ? "text" : "password";
@@ -139,7 +162,7 @@ export default defineComponent({
               ref={inputRef}
               type={resolvedType.value}
               value={props.modelValue}
-              placeholder={props.placeholder}
+              placeholder={props.placeholderVariant === "truncate" ? props.placeholder : ""}
               disabled={props.disabled}
               readonly={props.readonly}
               name={props.name}
@@ -149,15 +172,15 @@ export default defineComponent({
               class="hk-input-element"
               {...filteredAttrs.value}
               onInput={onInput}
-              onFocus={(e) => emit("focus", e)}
-              onBlur={(e) => emit("blur", e)}
+              onFocus={(e) => { forwardFocus(true); emit("focus", e); }}
+              onBlur={(e) => { forwardFocus(false); emit("blur", e); }}
               onKeydown={(e) => emit("keydown", e)}
             />
           ) : (
             <textarea
               ref={inputRef}
               value={props.modelValue}
-              placeholder={props.placeholder}
+              placeholder={props.placeholderVariant === "truncate" ? props.placeholder : ""}
               disabled={props.disabled}
               readonly={props.readonly}
               rows={props.rows}
@@ -172,11 +195,21 @@ export default defineComponent({
               ]}
               {...filteredAttrs.value}
               onInput={onInput}
-              onFocus={(e) => emit("focus", e)}
-              onBlur={(e) => emit("blur", e)}
+              onFocus={(e) => { forwardFocus(true); emit("focus", e); }}
+              onBlur={(e) => { forwardFocus(false); emit("blur", e); }}
               onKeydown={(e) => emit("keydown", e)}
             />
           )}
+          {props.placeholder &&
+            props.placeholderVariant === "marquee" &&
+            isEmpty.value &&
+            !props.disabled && (
+              <HkPlaceholderMarquee
+                ref={marqueeRef}
+                text={props.placeholder}
+                variant={props.placeholderVariant}
+              />
+            )}
           {slots.suffix && (
             <span class="hk-input-affix hk-input-suffix">
               {slots.suffix()}

--- a/packages/vue/src/components/HkPlaceholderMarquee.scss
+++ b/packages/vue/src/components/HkPlaceholderMarquee.scss
@@ -1,0 +1,54 @@
+@use "../tokens";
+
+/**
+ * Placeholder overflow layer shared by text inputs.
+ *
+ * The marquee variant is a clipping window: the strip (three identical text
+ * copies, laid out in a row) translates leftward through it, so the sign
+ * scrolls seamlessly. The real <input> keeps its native placeholder hidden
+ * and sits on top; this layer only renders when the text overflows and the
+ * input is empty.
+ */
+.hk-placeholder-marquee {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  pointer-events: none;
+  // Same typography as the input element so measurements match.
+  font-family: inherit;
+  font-size: var(--text-base);
+  line-height: 1.5;
+  color: rgb(var(--color-muted));
+  white-space: nowrap;
+  // The strip is wider than the window; the JS offset drives translateX.
+  will-change: transform;
+
+  &__strip {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  &__copy {
+    padding-right: 24px;
+  }
+
+  &--truncate &__text {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: center;
+  }
+}
+
+// Reduced motion: the bus is parked by setReducedMotion(true); park the
+// strip at its natural position too so no transform jumps remain.
+@media (prefers-reduced-motion: reduce) {
+  .hk-placeholder-marquee__strip {
+    transform: none !important;
+  }
+}

--- a/packages/vue/src/components/HkPlaceholderMarquee.test.ts
+++ b/packages/vue/src/components/HkPlaceholderMarquee.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+
+import { HkPlaceholderMarquee } from "./HkPlaceholderMarquee";
+import HkInput from "./HkInput";
+
+interface Mounted<T> {
+  app: ReturnType<typeof createApp>;
+  container: HTMLElement;
+  vm: T;
+}
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountMarquee(props: Record<string, unknown> = {}): Mounted<InstanceType<typeof HkPlaceholderMarquee>> & { container: HTMLElement } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkPlaceholderMarquee, { ...props }) });
+  app.mount(container);
+  mounts.push({ app, container });
+  const root = app._container.firstElementChild
+    ? (app as unknown as { _instance?: { proxy?: InstanceType<typeof HkPlaceholderMarquee> } })._instance?.proxy
+    : undefined;
+  void root;
+  // The component root instance: mount() renders a single root node owned by
+  // HkPlaceholderMarquee, so the app's root proxy IS the marquee instance.
+  const vm = (app._instance as unknown as { proxy: InstanceType<typeof HkPlaceholderMarquee> } | undefined)?.proxy;
+  return { app, container, vm: vm! };
+}
+
+function mountInput(props: Record<string, unknown> = {}) {
+  const model = ref("");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render() {
+      return h(HkInput, {
+        ...props,
+        modelValue: model.value,
+        "onUpdate:modelValue": (v: string) => {
+          model.value = v;
+        },
+      });
+    },
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { model, app, container };
+}
+
+afterEach(() => {
+  for (const m of mounts.splice(0)) {
+    m.app.unmount();
+    m.container.remove();
+  }
+});
+
+describe("HkPlaceholderMarquee", () => {
+  it("renders three identical copies for the seamless wrap", () => {
+    const { container } = mountMarquee({ text: "a very long placeholder" });
+    const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
+    expect(copies).toHaveLength(3);
+    expect(copies.map((c) => c.textContent)).toEqual([
+      "a very long placeholder",
+      "a very long placeholder",
+      "a very long placeholder",
+    ]);
+  });
+
+  it("renders a single ellipsis copy in truncate variant", () => {
+    const { container } = mountMarquee({ text: "too long", variant: "truncate" });
+    expect(container.querySelector(".hk-placeholder-marquee--truncate")).toBeTruthy();
+    expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(0);
+  });
+
+  it("renders nothing for empty text", () => {
+    const { container } = mountMarquee({ text: "" });
+    expect(container.querySelector(".hk-placeholder-marquee")).toBeNull();
+  });
+
+  it("exposes setActive without throwing in both directions", async () => {
+    const { container } = mountMarquee({ text: "scrolls" });
+    await nextTick();
+    // The exposed API lives on the component's setup result; reach it through
+    // the root element's __vueParentComponent wiring jsdom provides.
+    const el = container.querySelector(".hk-placeholder-marquee") as HTMLElement & {
+      __vueParentComponent?: { exposed?: { setActive?(a: boolean): void } };
+    };
+    const exposed = el?.__vueParentComponent?.exposed;
+    expect(exposed).toBeTruthy();
+    expect(typeof exposed!.setActive).toBe("function");
+    expect(() => exposed!.setActive!(true)).not.toThrow();
+    expect(() => exposed!.setActive!(false)).not.toThrow();
+  });
+
+  it("re-renders the copies when the text prop changes", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const textRef = ref("first");
+    const app = createApp({
+      render: () => h(HkPlaceholderMarquee, { text: textRef.value }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    textRef.value = "second";
+    await nextTick();
+    const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
+    expect(copies.map((c) => c.textContent?.trim())).toEqual(["second", "second", "second"]);
+  });
+});
+
+describe("HkInput placeholder-variant", () => {
+  it("keeps the native placeholder in truncate mode and mounts no marquee", () => {
+    const { container } = mountInput({
+      placeholder: "truncation keeps the native placeholder",
+      placeholderVariant: "truncate",
+    });
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("placeholder")).toBe("truncation keeps the native placeholder");
+    expect(container.querySelector(".hk-placeholder-marquee")).toBeNull();
+  });
+
+  it("hides the native placeholder and mounts the marquee overlay by default", () => {
+    const { container } = mountInput({
+      placeholder: "marquee is the default overflow behavior",
+    });
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("placeholder")).toBe("");
+    expect(container.querySelector(".hk-placeholder-marquee")).toBeTruthy();
+    const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
+    expect(copies).toHaveLength(3);
+  });
+
+  it("drops the overlay once the input holds a value", async () => {
+    const mounted = mountInput({ placeholder: "typing hides the layer" });
+    expect(mounted.container.querySelector(".hk-placeholder-marquee")).toBeTruthy();
+    mounted.model.value = "typed";
+    await nextTick();
+    expect(mounted.container.querySelector(".hk-placeholder-marquee")).toBeNull();
+  });
+
+  it("never mounts the overlay when disabled", () => {
+    const { container } = mountInput({
+      placeholder: "disabled inputs show nothing",
+      disabled: true,
+    });
+    expect(container.querySelector(".hk-placeholder-marquee")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -1,0 +1,113 @@
+import { defineComponent, ref, computed, onMounted, onBeforeUnmount, watch, type PropType } from "vue";
+import { onFrame } from "../runtime/animationBus";
+
+/**
+ * Overflow strategy for a placeholder that does not fit its input.
+ *
+ * - `marquee` (default): render the text three times side by side inside a
+ *   clipping window and translate the strip leftward in a loop — the classic
+ *   scrolling storefront sign. The strip content is identical in all three
+ *   copies so the wrap-around is seamless. Animation runs through the hikari
+ *   animation bus, so it participates in the unified frame scheduling, pauses
+ *   under reduced-motion, and parks the strip at the natural position when
+ *   the host input is focused or the text fits.
+ * - `truncate`: hard-cut the text at the container edge with an ellipsis.
+ */
+export type PlaceholderVariant = "marquee" | "truncate";
+
+export const HkPlaceholderMarquee = defineComponent({
+  name: "HkPlaceholderMarquee",
+  props: {
+    text: { type: String, default: "" },
+    variant: { type: String as PropType<PlaceholderVariant>, default: "marquee" },
+    /** Pixels per second of strip travel. Negative scrolls rightward. */
+    speed: { type: Number, default: 24 },
+    /** Extra horizontal padding (px) between the repeated copies. */
+    gap: { type: Number, default: 24 },
+    /** Park offset (px) while focused — small lead-in before scrolling. */
+    focusHoldMs: { type: Number, default: 600 },
+  },
+  setup(props, { expose }) {
+    const hostEl = ref<HTMLElement | null>(null);
+    const stripEl = ref<HTMLElement | null>(null);
+    const offset = ref(0);
+    const overflowing = ref(false);
+    const focused = ref(false);
+
+    let handle: { disconnect(): void } | null = null;
+    let holdUntil = 0;
+    let copyWidth = 0;
+
+    const measure = () => {
+      const host = hostEl.value;
+      const strip = stripEl.value;
+      if (!host || !strip) return;
+      // One copy = a third of the strip (three identical spans + gaps).
+      const total = strip.scrollWidth;
+      copyWidth = total / 3;
+      overflowing.value = copyWidth - props.gap > host.clientWidth;
+      if (!overflowing.value) offset.value = 0;
+    };
+
+    const frame = (ctx: { now: number }) => {
+      if (!overflowing.value || focused.value || copyWidth <= 0) return;
+      if (ctx.now < holdUntil) return;
+      offset.value = (offset.value - props.speed * (16 / 1000)) % copyWidth;
+    };
+
+    onMounted(() => {
+      measure();
+      handle = onFrame(frame, "normal");
+      if (typeof ResizeObserver !== "undefined" && hostEl.value) {
+        ro = new ResizeObserver(() => measure());
+        ro.observe(hostEl.value);
+      }
+    });
+
+    let ro: ResizeObserver | null = null;
+    watch(() => props.text, () => {
+      // Re-measure after the DOM paints the new strip.
+      requestAnimationFrame(() => measure());
+    });
+
+    onBeforeUnmount(() => {
+      handle?.disconnect();
+      ro?.disconnect();
+    });
+
+    expose({
+      /** Called by the host input: focus parks the strip, blur resumes. */
+      setActive(active: boolean) {
+        focused.value = active;
+        if (active) holdUntil = performance.now() + props.focusHoldMs;
+      },
+      measure,
+    });
+
+    const stripStyle = computed(() => ({
+      transform: `translateX(${offset.value}px)`,
+    }));
+
+    return () => {
+      if (!props.text) return null;
+      if (props.variant === "truncate") {
+        return (
+          <span ref={hostEl} class="hk-placeholder-marquee hk-placeholder-marquee--truncate">
+            <span class="hk-placeholder-marquee__text">{props.text}</span>
+          </span>
+        );
+      }
+      return (
+        <span ref={hostEl} class="hk-placeholder-marquee" aria-hidden="true">
+          <span ref={stripEl} class="hk-placeholder-marquee__strip" style={stripStyle.value}>
+            <span class="hk-placeholder-marquee__copy">{props.text}</span>
+            <span class="hk-placeholder-marquee__copy">{props.text}</span>
+            <span class="hk-placeholder-marquee__copy">{props.text}</span>
+          </span>
+        </span>
+      );
+    };
+  },
+});
+
+export default HkPlaceholderMarquee;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -15,6 +15,7 @@ export { default as HEmptyState } from "./components/HkEmptyState";
 export { default as HIcon } from "./components/HkIcon";
 export { default as HIconButton } from "./components/HkIconButton";
 export { default as HInput } from "./components/HkInput";
+export { default as HPlaceholderMarquee, type PlaceholderVariant } from "./components/HkPlaceholderMarquee";
 export { default as HKbd } from "./components/HkKbd";
 export { default as HListTransition } from "./components/HkListTransition";
 export { default as HMarkdownRenderer } from "./components/HkMarkdownRenderer";


### PR DESCRIPTION
## Summary
Input placeholders had no overflow handling — text longer than the input line simply clipped. This PR adds two overflow strategies to `HkInput` (+ the shared `HkPlaceholderMarquee` layer):

- `placeholder-variant="marquee"` (default): the placeholder is rendered **three times** in a strip inside a clipping window and translated leftward through the hikari **animation bus** (`onFrame`, unified frame scheduling) — the classic scrolling storefront LED sign, with a seamless wrap because the strip loops modulo one copy. The strip parks when the input is focused (short hold before resuming) or holds a value, and under `prefers-reduced-motion`.
- `placeholder-variant="truncate"`: hard-cut at the container edge with an ellipsis (native placeholder kept).

The overlay only mounts when needed (non-empty placeholder, empty value, enabled); native placeholder attribute is cleared in marquee mode so the two never double-render. Textarea path treated identically. Exported `HPlaceholderMarquee` + `PlaceholderVariant` for reuse.

## Tests
- 9 new tests: 3-copy seam, truncate single copy, empty text, exposed `setActive` API, text-change re-render, HkInput truncate/native-placeholder interplay, default overlay mount, value-gated unmount, disabled guard.
- Full suite 66/66, vue-tsc clean, vite build green.