### PR TITLE
🐛 Drive the placeholder marquee from the real frame delta.

### DIFF
--- a/packages/vue/src/components/HkPlaceholderMarquee.scss
+++ b/packages/vue/src/components/HkPlaceholderMarquee.scss
@@ -22,6 +22,9 @@
   line-height: 1.5;
   color: rgb(var(--color-muted));
   white-space: nowrap;
+  // Match the native placeholder's centered posture (HkInput's element is
+  // text-align: center) so the two modes do not shift horizontally.
+  text-align: center;
   // The strip is wider than the window; the JS offset drives translateX.
   will-change: transform;
 

--- a/packages/vue/src/components/HkPlaceholderMarquee.test.ts
+++ b/packages/vue/src/components/HkPlaceholderMarquee.test.ts
@@ -18,13 +18,9 @@ function mountMarquee(props: Record<string, unknown> = {}): Mounted<InstanceType
   const app = createApp({ render: () => h(HkPlaceholderMarquee, { ...props }) });
   app.mount(container);
   mounts.push({ app, container });
-  const root = app._container.firstElementChild
-    ? (app as unknown as { _instance?: { proxy?: InstanceType<typeof HkPlaceholderMarquee> } })._instance?.proxy
-    : undefined;
-  void root;
-  // The component root instance: mount() renders a single root node owned by
-  // HkPlaceholderMarquee, so the app's root proxy IS the marquee instance.
-  const vm = (app._instance as unknown as { proxy: InstanceType<typeof HkPlaceholderMarquee> } | undefined)?.proxy;
+  // mount() renders a single root node owned by HkPlaceholderMarquee, so
+  // the app's root proxy IS the marquee instance.
+  const vm = (app._instance as unknown as { proxy?: InstanceType<typeof HkPlaceholderMarquee> } | undefined)?.proxy;
   return { app, container, vm: vm! };
 }
 

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -15,6 +15,10 @@ import { onFrame } from "../runtime/animationBus";
  */
 export type PlaceholderVariant = "marquee" | "truncate";
 
+/** Horizontal spacing between repeated copies — mirrors the scss copy
+ * padding-right; kept in sync so overflow detection measures reality. */
+const COPY_SPACING = 24;
+
 export const HkPlaceholderMarquee = defineComponent({
   name: "HkPlaceholderMarquee",
   props: {
@@ -22,9 +26,7 @@ export const HkPlaceholderMarquee = defineComponent({
     variant: { type: String as PropType<PlaceholderVariant>, default: "marquee" },
     /** Pixels per second of strip travel. Negative scrolls rightward. */
     speed: { type: Number, default: 24 },
-    /** Extra horizontal padding (px) between the repeated copies. */
-    gap: { type: Number, default: 24 },
-    /** Park offset (px) while focused — small lead-in before scrolling. */
+    /** Park delay (ms) while focused — small hold before scrolling resumes. */
     focusHoldMs: { type: Number, default: 600 },
   },
   setup(props, { expose }) {
@@ -42,17 +44,21 @@ export const HkPlaceholderMarquee = defineComponent({
       const host = hostEl.value;
       const strip = stripEl.value;
       if (!host || !strip) return;
-      // One copy = a third of the strip (three identical spans + gaps).
+      // One copy = a third of the strip (three identical spans + the CSS
+      // copy spacing), so copyWidth already includes the 24px gap.
       const total = strip.scrollWidth;
       copyWidth = total / 3;
-      overflowing.value = copyWidth - props.gap > host.clientWidth;
+      overflowing.value = copyWidth - COPY_SPACING > host.clientWidth;
       if (!overflowing.value) offset.value = 0;
     };
 
-    const frame = (ctx: { now: number }) => {
+    const frame = (ctx: { now: number; delta: number }) => {
       if (!overflowing.value || focused.value || copyWidth <= 0) return;
       if (ctx.now < holdUntil) return;
-      offset.value = (offset.value - props.speed * (16 / 1000)) % copyWidth;
+      // delta is in seconds, matching the animation bus FrameContext —
+      // nominal speed holds regardless of the bus's normal-priority frame
+      // budget (33ms) or the display's refresh rate.
+      offset.value = (offset.value - props.speed * ctx.delta) % copyWidth;
     };
 
     onMounted(() => {


### PR DESCRIPTION
Follow-up to #174 (post-merge review findings).

## Fixes
- **Speed correctness (major)**: the frame callback hardcoded `16ms` per tick, but the animation bus throttles normal-priority entries to a 33ms budget — effective scroll speed was ~48% of the declared `speed` and drifted with frame rate. Now uses `ctx.delta` (seconds) from the bus `FrameContext`, so nominal speed holds at any budget or refresh rate.
- **Test TS18047**: nullable `app._instance` access in the test helper now typechecks clean.
- **Alignment (minor)**: marquee overlay gets `text-align: center` to match the native placeholder posture (HkInput's element is centered) — no horizontal shift between variants.
- **Dead `gap` prop removed**: overflow detection now measures against a `COPY_SPACING` constant kept in sync with the scss copy padding, instead of a prop that never reached the CSS.

## Verification
vue-tsc 0 errors, vitest 66/66, gates unchanged.