### PR TITLE
🔥 Remove the accidentally committed self-referential node_modules symlink.

### DIFF
--- a/packages/vue/node_modules
+++ b/packages/vue/node_modules
@@ -1,1 +1,0 @@
-/mnt/codespace/hikari/packages/vue/node_modules


### PR DESCRIPTION
#174 的合并快照意外把 `packages/vue/node_modules`（指向自身的绝对路径 symlink）带进了 master。任何 checkout master 的全新 clone 都会得到一个坏链接，pnpm 安装与构建全部失败。

本 PR 删除该条目（磁盘上真实 node_modules 由 pnpm install 提供，且被 ignore）。

验证：删除后 `pnpm install --frozen-lockfile` 正常、vite/vitest 可用。