### PR TITLE
✨ Give the password field the same placeholder overflow strategies.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -115,6 +115,8 @@
   pointer-events: none;
 }
 
+@use "./HkPlaceholderMarquee" as placeholder-marquee;
+
 .hk-pwd-placeholder {
   position: absolute;
   inset: 0;
@@ -126,6 +128,11 @@
   font-size: 0.875rem;
   color: var(--hi-color-primary, rgba(88, 166, 255, 0.7));
   animation: hk-pwd-breathe 3s ease-in-out infinite;
+  /* Default overflow strategy: hard-cut with an ellipsis (the marquee
+   * variant layers its own clipping window inside this element). */
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .hk-pwd-box[data-focused] .hk-pwd-placeholder {

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -11,6 +11,7 @@ import {
 import { useI18n } from "../i18n/context";
 
 import HListTransition from "./HkListTransition";
+import { HkPlaceholderMarquee, type PlaceholderVariant } from "./HkPlaceholderMarquee";
 import "./HkPasswordInput.scss";
 
 interface Ripple {
@@ -34,6 +35,18 @@ export default defineComponent({
      * `:placeholder="t('auth.register.confirmPassword')"`.
      */
     placeholder: { type: String, default: "" },
+    /**
+     * Overflow strategy when the placeholder text is longer than the field:
+     * `marquee` scrolls it like a storefront sign (three copies through a
+     * clipping window, driven by the animation bus — same semantics as
+     * HkInput); `truncate` hard-cuts it with an ellipsis. Defaults to
+     * `truncate` because the password field already renders a custom
+     * centered placeholder layer with its own focus states.
+     */
+    placeholderVariant: {
+      type: String as () => PlaceholderVariant,
+      default: "truncate",
+    },
     /**
      * Selects the default placeholder text and default icon. Only a
      * fallback: an explicit `placeholder` or `icon` prop overrides the
@@ -642,6 +655,16 @@ export default defineComponent({
                 : focused.value
                   ? t("hikari::passwordInput.focusedPlaceholder")
                   : props.placeholder || t(variantPlaceholderKey.value)}
+              {props.placeholderVariant === "marquee" && (
+                <HkPlaceholderMarquee
+                  text={
+                    pendingClear.value && props.modelValue
+                      ? t("hikari::passwordInput.focusedHasValuePlaceholder")
+                      : props.placeholder || t(variantPlaceholderKey.value)
+                  }
+                  variant={props.placeholderVariant}
+                />
+              )}
             </span>
           ) : null}
           {props.modelValue &&


### PR DESCRIPTION
#174/#175 gave HkInput the placeholder overflow layer (marquee / truncate). HkPasswordInput renders its own custom centered placeholder (focus states, breathe animation) with **no overflow handling** — long text was hard-clipped by the box.

This PR:
- Adds `placeholder-variant` prop (default `truncate`): the centered custom placeholder now ellipsizes cleanly by default.
- `marquee` variant layers the shared HkPlaceholderMarquee clipping window inside the placeholder element (same animation-bus-driven scrolling as HkInput).
- Chains the marquee styles.

## Verification
vue-tsc clean, vitest 66/66, version 0.4.6.