### PR TITLE
🐛 Move the marquee style import to the top of the password stylesheet.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -1,3 +1,4 @@
+@use "./HkPlaceholderMarquee" as placeholder-marquee;
 .hk-pwd-wrapper {
   display: block;
   width: 100%;
@@ -115,7 +116,6 @@
   pointer-events: none;
 }
 
-@use "./HkPlaceholderMarquee" as placeholder-marquee;
 
 .hk-pwd-placeholder {
   position: absolute;


### PR DESCRIPTION
#177 inserted the `@use "./HkPlaceholderMarquee"` statement mid-file; Sass requires @use before any rules, so any downstream vite build consuming hikari source failed with a stylesheet parse error. Move it to line 1.

Verified: chest webui vite build now succeeds against this hikari.