### PR TITLE
✨ Add safe centering overflow sensing and scrollable tabs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ hikari currently carries two version lines, plus one stale tag:
   `v0.3.0`–`v0.3.2` and `v0.3.4` were published to crates.io without git
   tags, and `v0.3.15`–`v0.3.19` are unpublished master changes.
 - **Vue port (`@celestia-island/hikari`)** — the `0.4.x` line. The npm
-  package is at `0.4.5` on master but has **never been published** to npm;
+  package is at `0.4.7` on master but has **never been published** to npm;
   publication is pending (A3).
 - **Tag `v0.4.0` is a stale tag.** It was created on an early Vue-port
   commit (2026-07-21) before the npm package version line was established,
@@ -28,6 +28,13 @@ Current master, Rust workspace `0.3.19`.
 
 ### Added
 
+- Add safe centering and overflow sensing to HkScrollContainer (`align="center"`
+  wraps the slot in an auto-margin aligner; `data-h-overflow` /
+  `data-v-overflow` mirror sensed overflow; optional `fade` masks the edges
+  with hidden content; `refresh()` / `getOverflow()` join the exposed API).
+- Add `scrollable` mode to HkTabs — the tab list rides a centered horizontal
+  HkScrollContainer, keeps center alignment while it fits, scrolls when it
+  overflows, fades its hidden edges and scrolls the active tab into view.
 - Port media, zoom and chart components to Vue. (#89)
 - Add Phase 6 theme bridge — CSS variable bridge for hikari components. (#83)
 - Migrate PopupSelect component from shittim-chest to hikari.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkHoverRevealAction.scss
+++ b/packages/vue/src/components/HkHoverRevealAction.scss
@@ -2,12 +2,18 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  /* Let the reveal chain shrink inside width-constrained flex parents
+     (mobile status bars / header centres) so a scrollable main slot
+     can take over the overflow instead of the wrapper clipping it. */
+  min-width: 0;
+  max-width: 100%;
 }
 
 .hk-hover-reveal-main {
   display: inline-flex;
   align-items: center;
   min-width: 0;
+  max-width: 100%;
 }
 
 .hk-hover-reveal-extension {

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -21,6 +21,60 @@
   overflow-y: hidden;
 }
 
+/* ── Safe centering (align="center") ─────────────────────────────
+   The viewport becomes a row flex container whose single item is the
+   aligner wrapper. Auto inline margins absorb free space (content
+   centered) and collapse to zero when the content overflows, so the
+   content falls back to the inline-start edge and stays fully
+   reachable by scrolling — unlike justify-content: center, which
+   clips the overflowing start. Horizontal axis only (axis="both"
+   would re-introduce cross-axis center-clipping, so it is excluded). */
+.hk-scroll-container[data-align="center"][data-axis="horizontal"] > .hk-scroll-container-viewport {
+  display: flex;
+  flex-direction: row;
+}
+
+.hk-scroll-container-aligner {
+  flex: none;
+  margin-inline: auto;
+}
+
+/* ── Optional edge fades (fade=true) ──────────────────────────────
+   Pure CSS driven by the sensed overflow state the component mirrors
+   onto the root (data-h-overflow). Only the sides with hidden
+   content fade. The fade size custom property is declared on the
+   root so consumers can override it from the container element. */
+.hk-scroll-container[data-fade="true"] {
+  --hk-scroll-fade-size: 24px;
+}
+
+.hk-scroll-container[data-fade="true"][data-h-overflow="end"] > .hk-scroll-container-viewport {
+  -webkit-mask-image: linear-gradient(to left, transparent 0, #000 var(--hk-scroll-fade-size));
+  mask-image: linear-gradient(to left, transparent 0, #000 var(--hk-scroll-fade-size));
+}
+
+.hk-scroll-container[data-fade="true"][data-h-overflow="start"] > .hk-scroll-container-viewport {
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
+  mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
+}
+
+.hk-scroll-container[data-fade="true"][data-h-overflow="both"] > .hk-scroll-container-viewport {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--hk-scroll-fade-size),
+    #000 calc(100% - var(--hk-scroll-fade-size)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--hk-scroll-fade-size),
+    #000 calc(100% - var(--hk-scroll-fade-size)),
+    transparent 100%
+  );
+}
+
 .hk-scroll-container-autofollow-content {
   display: block;
   flex-shrink: 0;

--- a/packages/vue/src/components/HkScrollContainer.test.ts
+++ b/packages/vue/src/components/HkScrollContainer.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, ref } from "vue";
+
+import HkScrollContainer from "./HkScrollContainer";
+
+interface Mounted {
+  app: ReturnType<typeof createApp>;
+  container: HTMLElement;
+  root: HTMLElement;
+  viewport: HTMLElement;
+  instance: {
+    refresh: () => void;
+    getOverflow: () => { horizontal: string; vertical: string };
+  } | null;
+}
+
+const mounts: Mounted["app"][] = [];
+const containers: HTMLElement[] = [];
+
+/** Mount a HkScrollContainer with a default slot and capture its
+ *  exposed instance (refresh / getOverflow) through a wrapper ref. */
+function mountScroller(props: Record<string, unknown> = {}, slotText = "content"): Mounted {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const instance = ref<Mounted["instance"] | null>(null);
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkScrollContainer, { ref: instance as never, ...props }, {
+          default: () => h("span", { class: "slot-marker" }, slotText),
+        });
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+
+  const root = container.querySelector<HTMLElement>(".hk-scroll-container");
+  const viewport = container.querySelector<HTMLElement>(".hk-scroll-container-viewport");
+  if (!root || !viewport) throw new Error("HkScrollContainer did not render its shell");
+  return { app, container, root, viewport, instance: instance.value };
+}
+
+/** happy-dom performs no layout, so scroll geometry is stubbed on the
+ *  viewport instance (shadowing the prototype getters) before a
+ *  refresh() pass re-senses the overflow. */
+function stubGeometry(el: HTMLElement, geom: { scrollWidth?: number; clientWidth?: number; scrollLeft?: number }) {
+  const desc: PropertyDescriptorMap = {};
+  for (const [key, value] of Object.entries(geom)) {
+    desc[key] = { configurable: true, get: () => value };
+  }
+  Object.defineProperties(el, desc);
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("HkScrollContainer alignment", () => {
+  it("renders the slot bare without an align prop", () => {
+    const m = mountScroller();
+    expect(m.root.hasAttribute("data-align")).toBe(false);
+    expect(m.root.querySelector(".hk-scroll-container-aligner")).toBeNull();
+    expect(m.viewport.querySelector(".slot-marker")).not.toBeNull();
+  });
+
+  it("wraps the slot in an auto-margin aligner with align=center", () => {
+    const m = mountScroller({ axis: "horizontal", align: "center" });
+    expect(m.root.getAttribute("data-align")).toBe("center");
+    const aligner = m.root.querySelector<HTMLElement>(".hk-scroll-container-aligner");
+    expect(aligner).not.toBeNull();
+    expect(aligner?.querySelector(".slot-marker")).not.toBeNull();
+  });
+
+  it("ignores align=center on non-horizontal containers", () => {
+    const vertical = mountScroller({ axis: "vertical", align: "center" });
+    expect(vertical.root.hasAttribute("data-align")).toBe(false);
+    expect(vertical.root.querySelector(".hk-scroll-container-aligner")).toBeNull();
+    const both = mountScroller({ axis: "both", align: "center" });
+    expect(both.root.hasAttribute("data-align")).toBe(false);
+    expect(both.root.querySelector(".hk-scroll-container-aligner")).toBeNull();
+  });
+
+  it("mirrors the fade prop as data-fade", () => {
+    const plain = mountScroller({ axis: "horizontal" });
+    expect(plain.root.hasAttribute("data-fade")).toBe(false);
+    const faded = mountScroller({ axis: "horizontal", fade: true });
+    expect(faded.root.getAttribute("data-fade")).toBe("true");
+  });
+});
+
+describe("HkScrollContainer overflow sensing", () => {
+  it("reports none while the content fits", () => {
+    const m = mountScroller({ axis: "horizontal" });
+    expect(m.root.getAttribute("data-h-overflow")).toBe("none");
+    expect(m.instance?.getOverflow()).toEqual({ horizontal: "none", vertical: "none" });
+  });
+
+  it("senses hidden content towards the end at the start edge", () => {
+    const m = mountScroller({ axis: "horizontal" });
+    stubGeometry(m.viewport, { scrollWidth: 300, clientWidth: 100, scrollLeft: 0 });
+    m.instance?.refresh();
+    expect(m.root.getAttribute("data-h-overflow")).toBe("end");
+  });
+
+  it("senses hidden content towards the start at the end edge", () => {
+    const m = mountScroller({ axis: "horizontal" });
+    stubGeometry(m.viewport, { scrollWidth: 300, clientWidth: 100, scrollLeft: 200 });
+    m.instance?.refresh();
+    expect(m.root.getAttribute("data-h-overflow")).toBe("start");
+  });
+
+  it("senses both edges mid-scroll", () => {
+    const m = mountScroller({ axis: "horizontal" });
+    stubGeometry(m.viewport, { scrollWidth: 300, clientWidth: 100, scrollLeft: 100 });
+    m.instance?.refresh();
+    expect(m.root.getAttribute("data-h-overflow")).toBe("both");
+  });
+
+  it("keeps the horizontal axis at none for vertical-only containers", () => {
+    const m = mountScroller({ axis: "vertical" });
+    stubGeometry(m.viewport, { scrollWidth: 300, clientWidth: 100, scrollLeft: 0 });
+    m.instance?.refresh();
+    expect(m.root.getAttribute("data-h-overflow")).toBe("none");
+  });
+});

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -5,6 +5,7 @@ import {
   onMounted,
   ref,
   shallowRef,
+  watch,
   type PropType,
 } from "vue";
 
@@ -16,6 +17,8 @@ import { notifyScrollStart, onceFrame, scheduleFrame, type AnimationHandle } fro
 
 type ScrollAxis = "vertical" | "horizontal" | "both";
 type ScrollMode = "traditional" | "windowed";
+type ScrollAlign = "start" | "center";
+type OverflowSense = "none" | "start" | "end" | "both";
 
 interface AxisState {
   track: HTMLElement;
@@ -35,6 +38,21 @@ interface DragHandlers {
   onLeave: () => void;
 }
 
+/** Which edges of an axis still hide content, derived from live scroll
+ *  geometry. "end" = content continues past the end edge (can scroll
+ *  towards larger offsets), "start" = content hides before the start
+ *  edge, "both" = either side, "none" = everything fits. */
+function computeOverflow(scrollSize: number, clientSize: number, scrollPos: number): OverflowSense {
+  if (scrollSize <= clientSize + 1) return "none";
+  const max = scrollSize - clientSize;
+  const atStart = scrollPos <= 1;
+  const atEnd = scrollPos >= max - 1;
+  if (atStart && atEnd) return "none";
+  if (atStart) return "end";
+  if (atEnd) return "start";
+  return "both";
+}
+
 export default defineComponent({
   name: "HkScrollContainer",
   props: {
@@ -44,6 +62,18 @@ export default defineComponent({
     scrollbar: { type: Boolean, default: true },
     autoFollow: { type: Boolean, default: false },
     overscanScreens: { type: Number, default: 1 },
+    /** Inline-axis alignment of the content when it fits the viewport.
+     *  "center" wraps the slot in an auto-margin aligner: content that
+     *  fits stays centered while overflowing content falls back to the
+     *  inline-start edge (scrollable, never clipped) — the safe
+     *  centering `justify-content: center` cannot provide. Applies to
+     *  horizontal-axis containers (toggling at runtime is supported);
+     *  ignored for vertical-only and axis="both" containers (the
+     *  latter would re-introduce cross-axis center-clipping). */
+    align: { type: String as PropType<ScrollAlign>, default: "start" },
+    /** Fade the viewport's inline edges (CSS mask) on the sides where
+     *  the sensed overflow (`data-h-overflow`) reports hidden content. */
+    fade: { type: Boolean, default: false },
   },
   setup(props, { slots, expose }) {
     const { t } = useI18n();
@@ -54,6 +84,15 @@ export default defineComponent({
     let hState: AxisState | null = null;
     let vDrag: DragHandlers | null = null;
     let hDrag: DragHandlers | null = null;
+
+    // Sensed overflow mirrored onto the root as data-h-overflow /
+    // data-v-overflow so consumers can style edge affordances in pure
+    // CSS. Attributes are only touched on change to avoid DOM churn.
+    let lastHOverflow: OverflowSense | null = null;
+    let lastVOverflow: OverflowSense | null = null;
+
+    const alignerRef = shallowRef<HTMLElement | null>(null);
+    let alignRO: ResizeObserver | null = null;
 
     const pinned = ref(true);
     const FOLLOW_THRESHOLD = 24;
@@ -67,6 +106,41 @@ export default defineComponent({
 
     const hasV = () => props.axis !== "horizontal";
     const hasH = () => props.axis !== "vertical";
+    // Safe centering applies to horizontal-axis containers only; the
+    // rendered aligner + flex overlay are both gated on this.
+    const alignCenter = () => props.align === "center" && props.axis === "horizontal";
+
+    function setAligner(el: unknown) {
+      const prev = alignerRef.value;
+      if (prev && alignRO) alignRO.unobserve(prev);
+      alignerRef.value = el instanceof HTMLElement ? el : null;
+      // Content growth changes the sensed overflow but not the
+      // viewport box, so the viewport-only ResizeObserver never fires
+      // for it — observe the aligner as the content-size proxy.
+      if (alignerRef.value && alignRO) alignRO.observe(alignerRef.value);
+      // A render that just created the aligner (align toggled on after
+      // mount) needs the observer created lazily here.
+      syncAlignObserver();
+    }
+
+    /** (Re)create or drop the content-size observer so runtime toggles
+     *  of the align/axis props keep sensing accurate (a container that
+     *  switches to align="center" after mount still gets an aligner
+     *  observer; switching back stops it). */
+    function syncAlignObserver() {
+      if (alignCenter() && !alignRO && alignerRef.value) {
+        alignRO = new ResizeObserver(scheduleUpdate);
+        alignRO.observe(alignerRef.value);
+      } else if (!alignCenter() && alignRO) {
+        alignRO.disconnect();
+        alignRO = null;
+      }
+    }
+
+    watch(() => [props.align, props.axis] as const, () => {
+      syncAlignObserver();
+      scheduleUpdate();
+    }, { flush: "post" });
 
     function recomputePinned() {
       const vp = viewportRef.value;
@@ -129,6 +203,25 @@ export default defineComponent({
       if (!vp) return;
       if (vState) updateAxis(vp, vState, false);
       if (hState) updateAxis(vp, hState, true);
+      senseOverflow(vp);
+    }
+
+    /** Mirror the live scroll geometry onto the root element as
+     *  data-h-overflow / data-v-overflow. Runs on every scheduled
+     *  update (scroll, resize, content resize via the aligner). */
+    function senseOverflow(vp: HTMLElement) {
+      const root = vp.parentElement;
+      if (!root) return;
+      const h = hasH() ? computeOverflow(vp.scrollWidth, vp.clientWidth, vp.scrollLeft) : "none";
+      const v = hasV() ? computeOverflow(vp.scrollHeight, vp.clientHeight, vp.scrollTop) : "none";
+      if (h !== lastHOverflow) {
+        lastHOverflow = h;
+        root.setAttribute("data-h-overflow", h);
+      }
+      if (v !== lastVOverflow) {
+        lastVOverflow = v;
+        root.setAttribute("data-v-overflow", v);
+      }
     }
 
     function updateAxis(vp: HTMLElement, s: AxisState, horizontal: boolean) {
@@ -279,6 +372,8 @@ export default defineComponent({
       ro = new ResizeObserver(scheduleUpdate);
       ro.observe(vp);
 
+      syncAlignObserver();
+
       if (props.autoFollow && autoFollowContent.value) {
         pinned.value = true;
         onceFrame(() => {
@@ -309,6 +404,8 @@ export default defineComponent({
       ro?.disconnect();
       followRO?.disconnect();
       followRO = null;
+      alignRO?.disconnect();
+      alignRO = null;
     });
 
     function scrollTo(top: number, behavior: ScrollBehavior = "auto") {
@@ -336,19 +433,47 @@ export default defineComponent({
       return viewportRef.value?.scrollTop ?? 0;
     }
 
-    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop });
+    /** Re-run the scrollbar + overflow sensing pass. Public escape
+     *  hatch for content mutations the observers cannot see (e.g. the
+     *  slot's own children resizing without the aligner box changing,
+     *  or non-align consumers swapping content). */
+    function refresh(): void {
+      update();
+    }
+
+    /** Current sensed overflow per axis, same values as the mirrored
+     *  data attributes. */
+    function getOverflow(): { horizontal: OverflowSense; vertical: OverflowSense } {
+      return {
+        horizontal: lastHOverflow ?? "none",
+        vertical: lastVOverflow ?? "none",
+      };
+    }
+
+    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop, refresh, getOverflow });
 
     return () => {
       const Tag = props.as as "div" | "section" | "nav" | "main" | "aside";
-      const content = props.autoFollow ? (
+      let content = props.autoFollow ? (
         <div ref={autoFollowContent} class="hk-scroll-container-autofollow-content">
           {slots.default?.()}
         </div>
       ) : (
         slots.default?.()
       );
+      // The aligner is the single flex item of the (row) viewport; its
+      // auto inline margins center it when it fits and collapse to
+      // zero when it overflows — see HkScrollContainer.scss.
+      if (alignCenter()) {
+        content = <div ref={setAligner} class="hk-scroll-container-aligner">{content}</div>;
+      }
       return (
-        <Tag class="hk-scroll-container" data-axis={props.axis}>
+        <Tag
+          class="hk-scroll-container"
+          data-axis={props.axis}
+          data-align={alignCenter() ? "center" : undefined}
+          data-fade={props.fade ? "true" : undefined}
+        >
           <div ref={viewportRef} class="hk-scroll-container-viewport">
             {content}
           </div>

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -4,6 +4,23 @@
   width: 100%;
 }
 
+/* === Scrollable variant === */
+
+/* The scroller (a horizontal HkScrollContainer) bounds the list: it
+   sizes to the content up to the available width, then the list
+   scrolls inside with safe centering. min-width: 0 lets the whole
+   chain shrink inside constrained flex parents (status bars, header
+   centres). */
+.hk-tabs[data-scrollable] {
+  width: auto;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.hk-tabs-scroller {
+  width: 100%;
+}
+
 /* === Shared list === */
 
 .hk-tabs-list {

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkTabs from "./HkTabs";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+interface TabsHarness {
+  container: HTMLElement;
+  setActive: (key: string) => void;
+}
+
+function mountTabs(props: Record<string, unknown> = {}): TabsHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const active = ref(props.modelValue as string ?? "a");
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkTabs, {
+          ...props,
+          modelValue: active.value,
+          "onUpdate:modelValue": (v: string) => { active.value = v; },
+          tabs: [
+            { key: "a", label: "Alpha" },
+            { key: "b", label: "Beta" },
+            { key: "c", label: "Gamma" },
+          ],
+          renderPanels: false,
+        });
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { container, setActive: (key) => { active.value = key; } };
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("HkTabs scrollable", () => {
+  it("renders a bare list without scrollable", () => {
+    const t = mountTabs();
+    expect(t.container.querySelector(".hk-tabs[data-scrollable]")).toBeNull();
+    expect(t.container.querySelector(".hk-tabs-scroller")).toBeNull();
+    const list = t.container.querySelector(".hk-tabs-list");
+    expect(list?.parentElement?.classList.contains("hk-scroll-container-viewport")).toBe(false);
+  });
+
+  it("wraps the list in a centered horizontal scroller with scrollable", () => {
+    const t = mountTabs({ scrollable: true });
+    const tabs = t.container.querySelector<HTMLElement>(".hk-tabs[data-scrollable]");
+    expect(tabs).not.toBeNull();
+    const scroller = t.container.querySelector<HTMLElement>(".hk-tabs-scroller");
+    expect(scroller).not.toBeNull();
+    expect(scroller?.getAttribute("data-axis")).toBe("horizontal");
+    expect(scroller?.getAttribute("data-align")).toBe("center");
+    expect(scroller?.getAttribute("data-fade")).toBe("true");
+    const aligner = scroller?.querySelector(".hk-scroll-container-aligner");
+    expect(aligner).not.toBeNull();
+    expect(aligner?.querySelector(".hk-tabs-list")).not.toBeNull();
+  });
+
+  it("keeps the pill indicator tracking the active tab inside the scroller", async () => {
+    const t = mountTabs({ scrollable: true, variant: "pill" });
+    const indicator = () => t.container.querySelector<HTMLElement>(".hk-tabs-indicator");
+    expect(indicator()).not.toBeNull();
+    t.setActive("c");
+    await nextTick();
+    await nextTick();
+    const activeBtn = t.container.querySelector<HTMLElement>('.hk-tabs-trigger[data-active]');
+    expect(activeBtn?.textContent).toContain("Gamma");
+    // offsetLeft/offsetWidth are 0 in happy-dom, so the indicator stays
+    // at its last concrete values — the contract under test is that a
+    // modelValue change does not break the indicator update pass.
+    expect(indicator()).not.toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -1,11 +1,19 @@
-import { defineComponent, nextTick, onMounted, ref, watch, type ComponentPublicInstance, type PropType } from "vue";
+import { defineComponent, nextTick, onBeforeUnmount, onMounted, ref, watch, type ComponentPublicInstance, type PropType } from "vue";
 
 import "./HkTabs.scss";
+import HkScrollContainer from "./HkScrollContainer";
 
 interface TabItem {
   key: string;
   label: string;
   disabled?: boolean;
+}
+
+/** Structural stand-in for HkScrollContainer's exposed surface —
+ *  imperative expose() types don't flow through render-function
+ *  setups, so declare just the method we consume. */
+interface ScrollerExpose {
+  getScrollElement?: () => HTMLElement | undefined;
 }
 
 export default defineComponent({
@@ -15,6 +23,12 @@ export default defineComponent({
     tabs: { type: Array as PropType<TabItem[]>, required: true },
     variant: { type: String as PropType<"underline" | "pill">, default: "underline" },
     renderPanels: { type: Boolean, default: true },
+    /** Wrap the tab list in a horizontal HkScrollContainer. The list
+     *  stays centered while it fits and becomes swipe/scroll-driven
+     *  once it overflows (safe centering — the overflowing start is
+     *  never clipped), with edge fades hinting at hidden tabs and the
+     *  active tab scrolled into view on change. */
+    scrollable: { type: Boolean, default: false },
   },
   emits: {
     "update:modelValue": (_value: string) => true,
@@ -22,6 +36,7 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const triggerRefs = ref<Map<number, HTMLElement>>(new Map());
     const indicatorStyle = ref<Record<string, string>>({});
+    const scrollerRef = ref<ScrollerExpose | null>(null);
 
     function setTriggerRef(el: Element | ComponentPublicInstance | null, idx: number) {
       if (el instanceof HTMLElement) {
@@ -42,10 +57,36 @@ export default defineComponent({
       indicatorStyle.value = { left, width };
     }
 
+    /** Nudge the scroller so the active trigger is fully visible with
+     *  a small breathing margin on either side. Manual scroll math (not
+     *  scrollIntoView) so only the scroller's own axis moves — the
+     *  surrounding page never scrolls. */
+    function scrollActiveIntoView() {
+      const vp = scrollerRef.value?.getScrollElement?.();
+      if (!vp) return;
+      const idx = props.tabs.findIndex((t) => t.key === props.modelValue);
+      const el = triggerRefs.value.get(idx >= 0 ? idx : 0);
+      if (!el) return;
+      const left = el.offsetLeft;
+      const right = left + el.offsetWidth;
+      const pad = 24;
+      if (left - pad < vp.scrollLeft) {
+        vp.scrollLeft = Math.max(0, left - pad);
+      } else if (right + pad > vp.scrollLeft + vp.clientWidth) {
+        vp.scrollLeft = right + pad - vp.clientWidth;
+      }
+    }
+
+    function refreshGeometry() {
+      updateIndicator();
+      if (props.scrollable) scrollActiveIntoView();
+    }
+
     let resizeObserver: ResizeObserver | null = null;
+    let scrollerResizeObserver: ResizeObserver | null = null;
 
     onMounted(() => {
-      nextTick(updateIndicator);
+      nextTick(refreshGeometry);
       if (props.variant === "pill") {
         resizeObserver = new ResizeObserver(() => updateIndicator());
         const firstEl = triggerRefs.value.get(0);
@@ -53,17 +94,35 @@ export default defineComponent({
           resizeObserver.observe(firstEl.parentElement);
         }
       }
+      if (props.scrollable) {
+        // The pill observer watches the content-sized list, so a
+        // viewport-only resize (container narrowing) never re-runs the
+        // active-tab nudge — observe the scroller viewport itself.
+        nextTick(() => {
+          const vp = scrollerRef.value?.getScrollElement?.();
+          if (!vp) return;
+          scrollerResizeObserver = new ResizeObserver(() => scrollActiveIntoView());
+          scrollerResizeObserver.observe(vp);
+        });
+      }
     });
 
-    watch(() => props.modelValue, () => nextTick(updateIndicator));
+    onBeforeUnmount(() => {
+      resizeObserver?.disconnect();
+      resizeObserver = null;
+      scrollerResizeObserver?.disconnect();
+      scrollerResizeObserver = null;
+    });
+
+    watch(() => props.modelValue, () => nextTick(refreshGeometry));
 
     watch(() => props.tabs, () => {
       triggerRefs.value.clear();
-      nextTick(updateIndicator);
+      nextTick(refreshGeometry);
     }, { deep: true });
 
-    return () => (
-      <div class="hk-tabs" data-variant={props.variant}>
+    return () => {
+      const list = (
         <div
           class="hk-tabs-list"
           data-variant={props.variant === "pill" ? "pill" : undefined}
@@ -94,18 +153,35 @@ export default defineComponent({
             );
           })}
         </div>
+      );
 
-        {props.renderPanels && props.tabs.map((tab) => (
-          <div
-            key={tab.key}
-            role="tabpanel"
-            class="hk-tabs-panel"
-            data-active={(tab.key === props.modelValue) || undefined}
-          >
-            {tab.key === props.modelValue && slots[tab.key]?.()}
-          </div>
-        ))}
-      </div>
-    );
+      return (
+        <div class="hk-tabs" data-variant={props.variant} data-scrollable={props.scrollable || undefined}>
+          {props.scrollable ? (
+            <HkScrollContainer
+              ref={scrollerRef}
+              class="hk-tabs-scroller"
+              axis="horizontal"
+              scrollbar={false}
+              align="center"
+              fade
+            >
+              {list}
+            </HkScrollContainer>
+          ) : list}
+
+          {props.renderPanels && props.tabs.map((tab) => (
+            <div
+              key={tab.key}
+              role="tabpanel"
+              class="hk-tabs-panel"
+              data-active={(tab.key === props.modelValue) || undefined}
+            >
+              {tab.key === props.modelValue && slots[tab.key]?.()}
+            </div>
+          ))}
+        </div>
+      );
+    };
   },
 });


### PR DESCRIPTION
## Summary

- **HkScrollContainer `align="center"`** — safe centering: content that fits the viewport is centered via an auto-margin aligner wrapper; overflowing content falls back to the inline-start edge and stays fully reachable by scrolling (unlike `justify-content: center`, which clips the overflowing start). Horizontal axis only; runtime prop toggles supported.
- **Overflow sensing** — the container senses per-axis overflow (`none/start/end/both`) and mirrors it onto the root as `data-h-overflow` / `data-v-overflow` with change-only writes, so consumers can build pure-CSS edge affordances.
- **Optional `fade`** — CSS mask fades only the viewport edges that still hide content, driven by the sensed overflow state; `--hk-scroll-fade-size` is overridable from the root.
- **Exposed API** — `refresh()` (manual re-sense for invisible mutations) and `getOverflow()` join the exposed surface.
- **HkTabs `scrollable`** — wraps the tab list in a centered horizontal HkScrollContainer: centered while it fits, swipe/scroll when it overflows, edge fades hint at hidden tabs, active tab nudged into view on change and on container resize. Consumed next by shittim-chest P25 (mobile status bar + top/bottom tab strips).
- **HkHoverRevealAction** — the reveal chain can now shrink inside width-constrained flex parents (`min-width: 0; max-width: 100%`).
- Version 0.4.5 → **0.4.7** (0.4.6 was taken by #177 on master; rebase kept the bump monotonic).

## Verification

- 3-round subagent verify cycle: R1 PASS (2 should-fix applied), R2 PASS (fixes deep-reviewed), R3 PASS (release readiness). Local: `vitest run` 69/69 green, `vue-tsc --noEmit` clean — re-confirmed after the 0.4.7 re-bump and after rebasing onto master 6f57a98.
- New tests: HkScrollContainer.test.ts (9: aligner rendering, axis gating, fade attr, all four overflow branches via stubbed geometry), HkTabs.test.ts (3: bare list unchanged, scroller wiring, indicator stability).
- Regression audit: default-props DOM delta vs master is exactly two inert `data-*-overflow` attributes; non-scrollable HkTabs markup byte-identical; only internal HScrollContainer consumers (HkPopupSelect, HkErrorBoundary) are vertical/default-align and unaffected; no selector collisions across hikari/chest.
- Noted nits (non-blocking): `scrollable` is mount-static; `fade` is horizontal-only by design.