### PR TITLE
🐛 Render the placeholder marquee copies only while the text overflows.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -64,10 +64,28 @@ export default defineComponent({
       measure(): void;
     }>();
     const isEmpty = computed(() => String(props.modelValue ?? "") === "");
+    // Flipped by the marquee overlay once it measures the placeholder
+    // actually overflowing the input line. While false, the native
+    // placeholder does the showing and the overlay stays a hidden probe.
+    const placeholderOverflows = ref(false);
+    watch([isEmpty, () => props.disabled], ([empty, disabled]) => {
+      // The overlay unmounts on these flips — drop the stale overflow flag
+      // so the native placeholder returns the moment the field is cleared.
+      if (!empty || disabled) placeholderOverflows.value = false;
+    });
 
     const forwardFocus = (active: boolean) => {
       marqueeRef.value?.setActive(active);
     };
+
+    // In marquee mode the native placeholder is suppressed only while the
+    // scrolling overlay is actually needed (overflowing); the truncate
+    // variant always keeps it native.
+    const nativePlaceholder = computed(() =>
+      props.placeholderVariant === "truncate" || !placeholderOverflows.value
+        ? props.placeholder
+        : "",
+    );
 
     const resolvedType = computed(() => {
       if (props.variant === "password") {
@@ -162,7 +180,7 @@ export default defineComponent({
               ref={inputRef}
               type={resolvedType.value}
               value={props.modelValue}
-              placeholder={props.placeholderVariant === "truncate" ? props.placeholder : ""}
+              placeholder={nativePlaceholder.value}
               disabled={props.disabled}
               readonly={props.readonly}
               name={props.name}
@@ -180,7 +198,7 @@ export default defineComponent({
             <textarea
               ref={inputRef}
               value={props.modelValue}
-              placeholder={props.placeholderVariant === "truncate" ? props.placeholder : ""}
+              placeholder={nativePlaceholder.value}
               disabled={props.disabled}
               readonly={props.readonly}
               rows={props.rows}
@@ -208,6 +226,9 @@ export default defineComponent({
                 ref={marqueeRef}
                 text={props.placeholder}
                 variant={props.placeholderVariant}
+                onOverflowChange={(v: boolean) => {
+                  placeholderOverflows.value = v;
+                }}
               />
             )}
           {slots.suffix && (

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -93,6 +93,10 @@ export default defineComponent({
     const preComposeValue = ref("");
     const revealing = ref(false);
     const pendingClear = ref(false);
+    // Flipped by the opt-in marquee overlay when the placeholder actually
+    // overflows — the static text below is then hidden so the scrolling
+    // copies do not overprint it.
+    const marqueeOverflow = ref(false);
     let lastInputAt = 0;
 
     const level = computed(() => {
@@ -650,11 +654,20 @@ export default defineComponent({
                 inputRef.value?.focus();
               }}
             >
-              {pendingClear.value && props.modelValue
-                ? t("hikari::passwordInput.focusedHasValuePlaceholder")
-                : focused.value
-                  ? t("hikari::passwordInput.focusedPlaceholder")
-                  : props.placeholder || t(variantPlaceholderKey.value)}
+              <span
+                class="hk-pwd-placeholder-text"
+                style={
+                  props.placeholderVariant === "marquee" && marqueeOverflow.value
+                    ? { visibility: "hidden" }
+                    : undefined
+                }
+              >
+                {pendingClear.value && props.modelValue
+                  ? t("hikari::passwordInput.focusedHasValuePlaceholder")
+                  : focused.value
+                    ? t("hikari::passwordInput.focusedPlaceholder")
+                    : props.placeholder || t(variantPlaceholderKey.value)}
+              </span>
               {props.placeholderVariant === "marquee" && (
                 <HkPlaceholderMarquee
                   text={
@@ -663,6 +676,9 @@ export default defineComponent({
                       : props.placeholder || t(variantPlaceholderKey.value)
                   }
                   variant={props.placeholderVariant}
+                  onOverflowChange={(v: boolean) => {
+                    marqueeOverflow.value = v;
+                  }}
                 />
               )}
             </span>

--- a/packages/vue/src/components/HkPlaceholderMarquee.scss
+++ b/packages/vue/src/components/HkPlaceholderMarquee.scss
@@ -3,11 +3,11 @@
 /**
  * Placeholder overflow layer shared by text inputs.
  *
- * The marquee variant is a clipping window: the strip (three identical text
- * copies, laid out in a row) translates leftward through it, so the sign
- * scrolls seamlessly. The real <input> keeps its native placeholder hidden
- * and sits on top; this layer only renders when the text overflows and the
- * input is empty.
+ * The marquee variant is a clipping window: while the text overflows, the
+ * strip (three identical text copies, laid out in a row) translates leftward
+ * through it, so the sign scrolls seamlessly. While the text fits, the whole
+ * layer is merely a hidden measuring probe — the host input shows its native
+ * placeholder instead (the component reports the flip via `overflowChange`).
  */
 .hk-placeholder-marquee {
   position: absolute;
@@ -36,6 +36,14 @@
 
   &__copy {
     padding-right: 24px;
+  }
+
+  // Hidden probe mode (text fits): visibility keeps the element laid out —
+  // clientWidth and the copy's bounding rect still measure reality for the
+  // ResizeObserver loop — while the native placeholder of the host input
+  // does the actual showing.
+  &--hidden {
+    visibility: hidden;
   }
 
   &--truncate &__text {

--- a/packages/vue/src/components/HkPlaceholderMarquee.test.ts
+++ b/packages/vue/src/components/HkPlaceholderMarquee.test.ts
@@ -48,7 +48,36 @@ function mountInput(props: Record<string, unknown> = {}) {
   return { model, app, container };
 }
 
+type MarqueeExposed = {
+  setActive?(a: boolean): void;
+  measure?(): void;
+};
+
+function marqueeExposed(container: HTMLElement): MarqueeExposed | undefined {
+  const el = container.querySelector(".hk-placeholder-marquee") as (HTMLElement & {
+    __vueParentComponent?: { exposed?: MarqueeExposed };
+  }) | null;
+  return el?.__vueParentComponent?.exposed;
+}
+
+/** Simulate real layout for the clipping window and the first copy, then
+ * re-run the component's measurement so the render reflects the geometry. */
+async function forceGeometry(
+  container: HTMLElement,
+  copyWidth: number,
+  hostWidth: number,
+) {
+  const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+  const copy = container.querySelector(".hk-placeholder-marquee__copy") as HTMLElement;
+  expect(host && copy).toBeTruthy();
+  Object.defineProperty(host, "clientWidth", { configurable: true, get: () => hostWidth });
+  vi.spyOn(copy, "getBoundingClientRect").mockReturnValue({ width: copyWidth } as DOMRect);
+  marqueeExposed(container)?.measure?.();
+  await nextTick();
+}
+
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const m of mounts.splice(0)) {
     m.app.unmount();
     m.container.remove();
@@ -56,8 +85,21 @@ afterEach(() => {
 });
 
 describe("HkPlaceholderMarquee", () => {
-  it("renders three identical copies for the seamless wrap", () => {
+  it("stays a hidden single-copy probe while the text fits", () => {
+    const { container } = mountMarquee({ text: "用户名" });
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
+    // No layout in jsdom → nothing overflows → one measuring copy, layer
+    // hidden; the host input's native placeholder does the actual showing.
+    expect(copies).toHaveLength(1);
+    expect(copies[0].textContent).toBe("用户名");
+    expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(true);
+  });
+
+  it("renders three identical copies for the seamless wrap once the text overflows", async () => {
     const { container } = mountMarquee({ text: "a very long placeholder" });
+    await forceGeometry(container, /* copy incl. spacing */ 500, /* window */ 200);
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
     const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
     expect(copies).toHaveLength(3);
     expect(copies.map((c) => c.textContent)).toEqual([
@@ -65,6 +107,17 @@ describe("HkPlaceholderMarquee", () => {
       "a very long placeholder",
       "a very long placeholder",
     ]);
+    expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(false);
+  });
+
+  it("collapses back to a hidden probe when the window grows past the text", async () => {
+    const { container } = mountMarquee({ text: "shrinking story" });
+    await forceGeometry(container, 500, 200);
+    expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(3);
+    await forceGeometry(container, 500, 800);
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(1);
+    expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(true);
   });
 
   it("renders a single ellipsis copy in truncate variant", () => {
@@ -81,19 +134,14 @@ describe("HkPlaceholderMarquee", () => {
   it("exposes setActive without throwing in both directions", async () => {
     const { container } = mountMarquee({ text: "scrolls" });
     await nextTick();
-    // The exposed API lives on the component's setup result; reach it through
-    // the root element's __vueParentComponent wiring jsdom provides.
-    const el = container.querySelector(".hk-placeholder-marquee") as HTMLElement & {
-      __vueParentComponent?: { exposed?: { setActive?(a: boolean): void } };
-    };
-    const exposed = el?.__vueParentComponent?.exposed;
+    const exposed = marqueeExposed(container);
     expect(exposed).toBeTruthy();
     expect(typeof exposed!.setActive).toBe("function");
     expect(() => exposed!.setActive!(true)).not.toThrow();
     expect(() => exposed!.setActive!(false)).not.toThrow();
   });
 
-  it("re-renders the copies when the text prop changes", async () => {
+  it("re-renders the copy when the text prop changes", async () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const textRef = ref("first");
@@ -105,7 +153,7 @@ describe("HkPlaceholderMarquee", () => {
     textRef.value = "second";
     await nextTick();
     const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
-    expect(copies.map((c) => c.textContent?.trim())).toEqual(["second", "second", "second"]);
+    expect(copies.map((c) => c.textContent?.trim())).toEqual(["second"]);
   });
 });
 
@@ -120,15 +168,42 @@ describe("HkInput placeholder-variant", () => {
     expect(container.querySelector(".hk-placeholder-marquee")).toBeNull();
   });
 
-  it("hides the native placeholder and mounts the marquee overlay by default", () => {
+  it("keeps the native placeholder and mounts only a hidden probe while the text fits", () => {
     const { container } = mountInput({
-      placeholder: "marquee is the default overflow behavior",
+      placeholder: "short placeholder that fits",
     });
     const input = container.querySelector("input")!;
+    // Not overflowing → the native placeholder shows; the overlay is a
+    // hidden one-copy measuring probe, never visible.
+    expect(input.getAttribute("placeholder")).toBe("short placeholder that fits");
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    expect(host).toBeTruthy();
+    expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(true);
+    expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(1);
+  });
+
+  it("swaps to the visible marquee and blanks the native placeholder on overflow", async () => {
+    const model = ref("");
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render() {
+        return h(HkInput, {
+          placeholder: "an extremely long placeholder text",
+          modelValue: model.value,
+          "onUpdate:modelValue": (v: string) => {
+            model.value = v;
+          },
+        });
+      },
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.getAttribute("placeholder")).toBe("an extremely long placeholder text");
+    await forceGeometry(container, 500, 200);
     expect(input.getAttribute("placeholder")).toBe("");
-    expect(container.querySelector(".hk-placeholder-marquee")).toBeTruthy();
-    const copies = [...container.querySelectorAll(".hk-placeholder-marquee__copy")];
-    expect(copies).toHaveLength(3);
+    expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(3);
   });
 
   it("drops the overlay once the input holds a value", async () => {

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -4,13 +4,18 @@ import { onFrame } from "../runtime/animationBus";
 /**
  * Overflow strategy for a placeholder that does not fit its input.
  *
- * - `marquee` (default): render the text three times side by side inside a
- *   clipping window and translate the strip leftward in a loop — the classic
- *   scrolling storefront sign. The strip content is identical in all three
- *   copies so the wrap-around is seamless. Animation runs through the hikari
- *   animation bus, so it participates in the unified frame scheduling, pauses
- *   under reduced-motion, and parks the strip at the natural position when
- *   the host input is focused or the text fits.
+ * - `marquee` (default): while the text fits, the overlay stays in the DOM
+ *   only as an invisible measuring probe and the host input shows its NATIVE
+ *   placeholder (crisp, accessible, zero animation). When the text overflows
+ *   the input line, the overlay becomes visible, renders the text three
+ *   times side by side inside a clipping window, and translates the strip
+ *   leftward in a loop — the classic scrolling storefront sign. The strip
+ *   content is identical in all three copies so the wrap-around is seamless.
+ *   Animation runs through the hikari animation bus, so it participates in
+ *   the unified frame scheduling, pauses under reduced-motion, and parks the
+ *   strip at the natural position when the host input is focused. The
+ *   `overflowChange` event tells the host when to swap its native
+ *   placeholder for the scrolling overlay.
  * - `truncate`: hard-cut the text at the container edge with an ellipsis.
  */
 export type PlaceholderVariant = "marquee" | "truncate";
@@ -29,9 +34,12 @@ export const HkPlaceholderMarquee = defineComponent({
     /** Park delay (ms) while focused — small hold before scrolling resumes. */
     focusHoldMs: { type: Number, default: 600 },
   },
-  setup(props, { expose }) {
+  emits: {
+    overflowChange: (_overflowing: boolean) => true,
+  },
+  setup(props, { emit, expose }) {
     const hostEl = ref<HTMLElement | null>(null);
-    const stripEl = ref<HTMLElement | null>(null);
+    const firstCopyEl = ref<HTMLElement | null>(null);
     const offset = ref(0);
     const overflowing = ref(false);
     const focused = ref(false);
@@ -42,14 +50,17 @@ export const HkPlaceholderMarquee = defineComponent({
 
     const measure = () => {
       const host = hostEl.value;
-      const strip = stripEl.value;
-      if (!host || !strip) return;
-      // One copy = a third of the strip (three identical spans + the CSS
-      // copy spacing), so copyWidth already includes the 24px gap.
-      const total = strip.scrollWidth;
-      copyWidth = total / 3;
+      const copy = firstCopyEl.value;
+      if (!host || !copy) return;
+      // Measure ONE copy's laid-out width directly (it includes the 24px
+      // copy spacing as trailing padding). Reading the first copy element —
+      // instead of stripWidth / 3 — stays correct in the fitting case,
+      // where the strip holds a single copy, and through overflow flips,
+      // where the copy count changes under the same strip.
+      copyWidth = copy.getBoundingClientRect().width;
       overflowing.value = copyWidth - COPY_SPACING > host.clientWidth;
       if (!overflowing.value) offset.value = 0;
+      emit("overflowChange", overflowing.value);
     };
 
     const frame = (ctx: { now: number; delta: number }) => {
@@ -104,11 +115,25 @@ export const HkPlaceholderMarquee = defineComponent({
         );
       }
       return (
-        <span ref={hostEl} class="hk-placeholder-marquee" aria-hidden="true">
-          <span ref={stripEl} class="hk-placeholder-marquee__strip" style={stripStyle.value}>
-            <span class="hk-placeholder-marquee__copy">{props.text}</span>
-            <span class="hk-placeholder-marquee__copy">{props.text}</span>
-            <span class="hk-placeholder-marquee__copy">{props.text}</span>
+        <span
+          ref={hostEl}
+          class={[
+            "hk-placeholder-marquee",
+            // While the text fits the overlay stays hidden (but laid out,
+            // so the probe keeps measuring) and the input's NATIVE
+            // placeholder does the showing.
+            overflowing.value ? "" : "hk-placeholder-marquee--hidden",
+          ].filter(Boolean).join(" ")}
+          aria-hidden="true"
+        >
+          <span class="hk-placeholder-marquee__strip" style={stripStyle.value}>
+            <span ref={firstCopyEl} class="hk-placeholder-marquee__copy">{props.text}</span>
+            {overflowing.value && (
+              <>
+                <span class="hk-placeholder-marquee__copy">{props.text}</span>
+                <span class="hk-placeholder-marquee__copy">{props.text}</span>
+              </>
+            )}
           </span>
         </span>
       );


### PR DESCRIPTION
## Bug (user-reported)

The login screen's username input showed its placeholder **three times** (one near the middle, two more on the left). The marquee variant rendered its three wrap-around copies unconditionally and relied solely on the `overflow: hidden` clipping window — for a short placeholder (e.g. 用户名) in a wide input, nothing was clipped and all three copies sat side by side. Introduced with the marquee feature in #174.

## Fix (reworked per review: no overlay at all while the text fits)

While the placeholder **fits**, the overlay exists only as a `visibility: hidden` measuring probe and the input shows its **native placeholder** — crisp, screen-reader-visible, zero animation. The moment the probe measures real overflow it reports the flip via a new `overflowChange` event; the host then blanks the native placeholder and the visible strip (three seamless copies, animation-bus-driven) takes over. Window grows back past the text → collapse to hidden probe + native placeholder again.

- Measure the **first copy element** directly (`getBoundingClientRect().width`) instead of `strip.scrollWidth / 3`, which stayed wrong whenever the strip holds fewer than three copies. `visibility: hidden` keeps layout, so the probe keeps measuring through `ResizeObserver`.
- `HkInput`: native placeholder suppressed only while overflowing (both input and textarea branches); stale overflow flag reset when the overlay unmounts (value typed / disabled).
- `HkPasswordInput` (opt-in marquee): its static placeholder text hides while the marquee scrolls so the copies do not overprint it.
- Animation math untouched (offset modulo copyWidth; parked when not overflowing or focused).

## Verification

- `vitest` 8 files / **81 tests** green, incl. reworked marquee suite: hidden single-copy probe while fitting; three copies + visible layer under mocked overflow geometry (driving the component's real `measure()`); collapse back on window growth; HkInput keeps the **native placeholder** while fitting and blanks it on overflow.
- `vue-tsc --noEmit` exit 0. Independent cross-verification: CLEAN.