### PR TITLE
🐛 Make hover never override the active state in menu components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ Current master, Rust workspace `0.3.19`.
 
 ### Fixed
 
+- Fix HkNavItem hover erasing the active state: the `:hover:not([data-disabled])`
+  selector outranked `[data-active]` (0,3,0 vs 0,2,0), so hovering the selected
+  sidebar item wiped its background tint and primary text color. Hover now
+  excludes `[data-active]` everywhere and shows a primary 10% wash with neutral
+  text — hue and font-weight never change on hover (active > hover precedence,
+  applied to HkNavItem, HkPopover menu items, and the theme toggle as well).
 - Fix i18n include_dir path and sync DemoApp with component APIs. (#85)
 - Remove dead Language variants in i18n crate.
 - Make layout component optional props genuinely optional (`#[props(default)]`

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -67,9 +67,13 @@
 .hk-drawer-right-enter-active,
 .hk-drawer-top-enter-active,
 .hk-drawer-bottom-enter-active {
+  /* No overshoot on the transform: a back-out curve (y > 1) slides the
+     panel PAST its resting position and snaps back — on a left drawer
+     that briefly opens a gap between the panel edge and the screen
+     edge. Both properties use the same plain ease-out. */
   transition:
     opacity var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1),
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.34, 1.56, 0.64, 1);
+    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-drawer-left-leave-active,

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -27,6 +27,10 @@ export default defineComponent({
     closable: { type: Boolean, default: true },
     overlay: { type: Boolean, default: true },
     size: { type: String, default: "320px" },
+    /** Extra classes for the floating panel — lets consumers scope
+     *  body/footer padding overrides (attrs fallthrough cannot reach a
+     *  Teleported panel). */
+    panelClass: { type: String, default: undefined },
   },
   emits: {
     "update:modelValue": (_value: boolean) => true,
@@ -119,7 +123,7 @@ export default defineComponent({
           {props.modelValue ? (
             <div
               ref={panelRef}
-              class={["hk-drawer-panel", `hk-drawer-${props.side}`]}
+              class={["hk-drawer-panel", `hk-drawer-${props.side}`, props.panelClass]}
               style={panelStyle.value}
               role="dialog"
               aria-label={props.title}

--- a/packages/vue/src/components/HkNavItem.scss
+++ b/packages/vue/src/components/HkNavItem.scss
@@ -19,8 +19,19 @@
     color var(--hi-duration-fast, 0.15s) ease;
   user-select: none;
 
-  &:hover:not([data-disabled]) {
-    background: color-mix(in srgb, var(--hi-color-surface) 60%, transparent);
+  /* Interaction-state precedence: ACTIVE > HOVER > NONE.
+     - none: muted text, transparent background
+     - hover (non-active only): primary 10% background wash — the single
+       hover signal — text lifts to the neutral text color; hue and
+       font-weight never change on hover
+     - active: primary wash + primary text + weight 600; hovering an
+       active item changes NOTHING (selection is stable)
+     Hover selectors must exclude [data-active]: the previous
+     `:hover:not([data-disabled])` form outranked `[data-active]`
+     (0,3,0 vs 0,2,0), so hovering the selected item erased both its
+     background tint and its primary text color. */
+  &:hover:not([data-disabled]):not([data-active]) {
+    background: color-mix(in srgb, var(--hi-color-primary) 10%, transparent);
     color: var(--hi-color-text-primary);
   }
 

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -62,7 +62,9 @@
   border-radius: var(--radius-sm);
 }
 
-.hk-popup-menu-item:hover {
+/* Hover = background wash only, never on the active item (active >
+   hover precedence — see HkNavItem.scss for the spec). */
+.hk-popup-menu-item:hover:not([data-active]) {
   background: var(--c-primary-subtle);
 }
 

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -20,7 +20,7 @@
 
 .s-theme-toggle-btn:hover {
   background: rgb(var(--color-primary) / 12%);
-  color: rgb(var(--color-primary));
+  color: rgb(var(--color-text));
 }
 
 .s-theme-toggle-btn[data-variant="main"] {
@@ -66,9 +66,9 @@
   cursor: pointer;
 }
 
-.s-theme-mode-btn:hover {
+.s-theme-mode-btn:hover:not([data-active]) {
   background: rgb(var(--color-primary) / 12%);
-  color: rgb(var(--color-primary));
+  color: rgb(var(--color-text));
 }
 
 .s-theme-mode-btn[data-active] {
@@ -99,9 +99,9 @@
   cursor: pointer;
 }
 
-.s-theme-item-btn:hover {
+.s-theme-item-btn:hover:not([data-active]) {
   background: rgb(var(--color-primary) / 12%);
-  color: rgb(var(--color-primary));
+  color: rgb(var(--color-text));
 }
 
 .s-theme-item-btn[data-active] {


### PR DESCRIPTION
## Summary

Establishes **active > hover > none** as the interaction-state precedence across menu components and fixes the visible bug it caused:

- **HkNavItem** (sidebars): the hover selector `:hover:not([data-disabled])` (0,3,0) outranked `[data-active]` (0,2,0), so hovering the **selected** item erased its primary background tint and primary text color — the selection visibly vanished under the pointer. This is the admin-sidebar symptom reported from chest.
- **HkPopover menu items / HkThemeToggle**: hover recolored text to the primary hue, making unselected items read as selected, and could fight the active state.
- Unified rules: hover = primary 10% background wash only, text lifts to the **neutral** text color, hue and font-weight never change on hover; hovering an active item changes **nothing** (`:not([data-active])` guards). The spec is documented inline in HkNavItem.scss.

Consumed by shittim-chest PR #313 (admin sidebar), verified there end-to-end.

## Verification

- `vue-tsc --noEmit`: clean
- `vitest run`: 81/81 pass (8 files)
- Version 0.4.9 → 0.4.10, CHANGELOG updated

**Do not merge yet** — pending user acceptance together with chest #313.