### PR TITLE
✨ Finish the page header shell and scale button heights per size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ Current master, Rust workspace `0.3.19`.
   excludes `[data-active]` everywhere and shows a primary 10% wash with neutral
   text — hue and font-weight never change on hover (active > hover precedence,
   applied to HkNavItem, HkPopover menu items, and the theme toggle as well).
+- Stop HkButton's base min-height from applying to every size: sm buttons were
+  2.5rem (40px) tall regardless of their compact padding — each size variant
+  now carries its own min-height (sm 1.75rem, md 2.5rem, lg 2.75rem).
+- Upgrade HkPageHeader from the inline-styled stub to the full page shell:
+  big title with optional leading icon and subtitle on the left, right-aligned
+  `actions` slot, optional dense variant, and a scoped stylesheet (consumed by
+  the chest admin redesign).
 - Fix i18n include_dir path and sync DemoApp with component APIs. (#85)
 - Remove dead Language variants in i18n crate.
 - Make layout component optional props genuinely optional (`#[props(default)]`

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -17,7 +17,6 @@
   user-select: none;
   outline: none;
   position: relative;
-  min-height: 2.5rem;
 }
 
 .hk-btn:focus-visible {
@@ -32,20 +31,26 @@
 }
 
 /* ---- Size variants ---- */
+/* Height scales WITH the size: a single base min-height made every sm
+   button 2.5rem (40px) tall — comically oversized next to page-header
+   text and toolbar rows. */
 
 .hk-btn-sm {
   padding: var(--space-6) var(--space-12);
   font-size: var(--text-xs);
+  min-height: 1.75rem;
 }
 
 .hk-btn-md {
   padding: var(--space-8) var(--space-16);
   font-size: var(--text-base);
+  min-height: 2.5rem;
 }
 
 .hk-btn-lg {
   padding: var(--space-10) var(--space-24);
   font-size: var(--text-md);
+  min-height: 2.75rem;
 }
 
 /* ---- Primary ---- */

--- a/packages/vue/src/components/HkPageHeader.scss
+++ b/packages/vue/src/components/HkPageHeader.scss
@@ -1,0 +1,79 @@
+.hk-page-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-16, 1rem);
+  /* Breathing room to the page body below; the scroll container above
+     already pads the top. */
+  margin-block-end: var(--space-16, 1rem);
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+.hk-page-header-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 0.25rem);
+  min-width: 0;
+}
+
+.hk-page-header-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
+  margin: 0;
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 700;
+  line-height: 1.3;
+  color: rgb(var(--color-text));
+  min-width: 0;
+}
+
+.hk-page-header-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm, 6px);
+  background: rgb(var(--color-primary) / 10%);
+  color: rgb(var(--color-primary));
+}
+
+.hk-page-header-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-page-header-subtitle {
+  margin: 0;
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-muted));
+  line-height: 1.5;
+}
+
+.hk-page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
+  flex-shrink: 0;
+  /* Align the tool row with the title baseline; wrapped rows (narrow
+     screens) fall back to stretch alignment via flex-wrap. */
+  padding-block-end: var(--space-2, 0.125rem);
+}
+
+/* Dense variant — tighter pages (tables that need every pixel). */
+.hk-page-header-dense {
+  margin-block-end: var(--space-12, 0.75rem);
+
+  .hk-page-header-title {
+    font-size: var(--text-md, 1rem);
+  }
+
+  .hk-page-header-icon {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}

--- a/packages/vue/src/components/HkPageHeader.test.ts
+++ b/packages/vue/src/components/HkPageHeader.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import { HkPageHeader } from "./HkPageHeader";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountHeader(
+  props: { title: string; subtitle?: string; dense?: boolean },
+  slots?: Record<string, () => ReturnType<typeof h>>,
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () => h(HkPageHeader, props, slots),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkPageHeader", () => {
+  it("renders the title and the actions slot on opposite sides", () => {
+    const c = mountHeader(
+      { title: "Channels" },
+      { actions: () => h("button", { class: "tool-mock" }, "TOOL") },
+    );
+    expect(c.querySelector(".hk-page-header-title-text")?.textContent).toBe("Channels");
+    const actions = c.querySelector(".hk-page-header-actions");
+    expect(actions).toBeTruthy();
+    expect(actions?.querySelector(".tool-mock")).toBeTruthy();
+    // The title block precedes the actions row as siblings.
+    expect(c.querySelector(".hk-page-header-main")?.nextElementSibling)
+      .toBe(actions);
+  });
+
+  it("renders an optional subtitle under the title", () => {
+    const c = mountHeader({ title: "Agents", subtitle: "Manage agent runtimes" });
+    expect(c.querySelector(".hk-page-header-subtitle")?.textContent).toBe(
+      "Manage agent runtimes",
+    );
+  });
+
+  it("omits the subtitle node and the actions row when not provided", () => {
+    const c = mountHeader({ title: "System" });
+    expect(c.querySelector(".hk-page-header-subtitle")).toBeNull();
+    expect(c.querySelector(".hk-page-header-actions")).toBeNull();
+  });
+
+  it("carries the dense variant class only when dense is set", () => {
+    const plain = mountHeader({ title: "A" });
+    const dense = mountHeader({ title: "A", dense: true });
+    expect(plain.querySelector(".hk-page-header")?.className).not.toContain(
+      "hk-page-header-dense",
+    );
+    expect(dense.querySelector(".hk-page-header")?.className).toContain(
+      "hk-page-header-dense",
+    );
+  });
+});

--- a/packages/vue/src/components/HkPageHeader.tsx
+++ b/packages/vue/src/components/HkPageHeader.tsx
@@ -1,38 +1,49 @@
-import { defineComponent } from "vue";
+import { defineComponent, h, type Component, type PropType } from "vue";
+
+import "./HkPageHeader.scss";
 
 /**
- * Title + actions page header. Slot `actions` renders on the right.
+ * HkPageHeader — the shared in-page shell header for admin/backend pages.
+ *
+ * One consistent page anatomy across every sub-page: a big title (with
+ * optional icon and subtitle) on the left, and a right-aligned group of
+ * common tool buttons in the `actions` slot. Pages own their actions —
+ * the top app bar carries identity/navigation only.
+ *
+ * ```tsx
+ * <HPageHeader title={t("admin.channels.title")} subtitle={t("...")}>
+ *   {{ actions: () => [<HButton size="sm" onClick={refresh}>…] }}
+ * </HPageHeader>
+ * ```
  */
 export const HkPageHeader = defineComponent({
   name: "HkPageHeader",
   props: {
     title: { type: String, required: true },
+    subtitle: { type: String, default: undefined },
+    /** Leading icon component (rendered before the title text). */
+    icon: { type: Object as PropType<Component>, default: undefined },
+    /** Compact variant for dense pages (smaller title, tighter spacing). */
+    dense: { type: Boolean, default: false },
   },
   setup(props, { slots }) {
     return () => (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "var(--space-12, 0.75rem)",
-          marginBottom: "var(--space-16, 1rem)",
-        }}
-      >
-        <h1
-          style={{
-            margin: 0,
-            fontSize: "var(--text-lg, 1.125rem)",
-            fontWeight: 700,
-            color: "rgb(var(--color-text))",
-          }}
-        >
-          {props.title}
-        </h1>
+      <div class={["hk-page-header", props.dense && "hk-page-header-dense"]}>
+        <div class="hk-page-header-main">
+          <h1 class="hk-page-header-title">
+            {slots.icon
+              ? <span class="hk-page-header-icon">{slots.icon()}</span>
+              : props.icon
+                ? <span class="hk-page-header-icon">{h(props.icon)}</span>
+                : null}
+            <span class="hk-page-header-title-text">{props.title}</span>
+          </h1>
+          {props.subtitle && (
+            <p class="hk-page-header-subtitle">{props.subtitle}</p>
+          )}
+        </div>
         {slots.actions && (
-          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-8, 0.5rem)" }}>
-            {slots.actions()}
-          </div>
+          <div class="hk-page-header-actions">{slots.actions()}</div>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

- **HkPageHeader** completed: big title (+ optional icon chip and subtitle) left, right-aligned `actions` slot, optional `dense` variant, scoped SCSS — the shared in-page shell every chest admin sub-page will use (top app bar keeps identity/navigation only).
- **HkButton height fix**: the base `min-height: 2.5rem` applied to ALL sizes, so sm buttons rendered 40px tall in headers/toolbars. Each size variant now owns its min-height (sm 1.75rem, md 2.5rem, lg 2.75rem).

## Verification

- vue-tsc --noEmit clean; vitest 85/85 (4 new HkPageHeader tests)
- Version 0.4.10 → 0.4.11; CHANGELOG updated

Consumed by the upcoming chest admin redesign PR (联动调试 verified there).