### PR TITLE
✨ Add the admin KPI widgets stat card, status pill, and share bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ Current master, Rust workspace `0.3.19`.
 
 ### Fixed
 
+- Add admin KPI widgets: HkStatCard (label/value/hint with a tone DOT —
+  text hue never changes, per the interaction-state precedence), HkStatusPill
+  (compact ok/warn/error/unknown pill with optional latency + version, gentle
+  pulse on live state, reduced-motion aware), and HkShareBar (label + share
+  bar + caption row for usage/quota breakdowns).
 - Fix HkNavItem hover erasing the active state: the `:hover:not([data-disabled])`
   selector outranked `[data-active]` (0,3,0 vs 0,2,0), so hovering the selected
   sidebar item wiped its background tint and primary text color. Hover now

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAdminWidgets.test.ts
+++ b/packages/vue/src/components/HkAdminWidgets.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import { HkStatCard } from "./HkStatCard";
+import { HkStatusPill } from "./HkStatusPill";
+import { HkShareBar } from "./HkShareBar";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkStatCard", () => {
+  it("renders label, value, hint and a tone dot", () => {
+    const c = mount(h(HkStatCard, { label: "Hub health", value: "2/2", tone: "success", hint: "hubs" }));
+    expect(c.querySelector(".hk-stat-card-label")?.textContent).toBe("Hub health");
+    expect(c.querySelector(".hk-stat-card-value")?.textContent).toBe("2/2");
+    expect(c.querySelector(".hk-stat-card-hint")?.textContent).toBe("hubs");
+    expect(c.querySelector(".hk-stat-card-dot-success")).toBeTruthy();
+    expect(c.querySelector(".hk-stat-card-clickable")).toBeNull();
+  });
+
+  it("marks clickable cards and emits role=button", () => {
+    const c = mount(h(HkStatCard, { label: "L", value: 1, clickable: true }));
+    const el = c.querySelector(".hk-stat-card") as HTMLElement;
+    expect(el.getAttribute("role")).toBe("button");
+    expect(el.className).toContain("hk-stat-card-clickable");
+  });
+
+  it("omits the hint node when absent", () => {
+    const c = mount(h(HkStatCard, { label: "L", value: 1 }));
+    expect(c.querySelector(".hk-stat-card-hint")).toBeNull();
+  });
+});
+
+describe("HkStatusPill", () => {
+  it("renders state dot with label, latency and version", () => {
+    const c = mount(h(HkStatusPill, { state: "ok", label: "online", latencyMs: 34, version: "0.2.0" }));
+    expect(c.querySelector(".hk-status-pill-ok")).toBeTruthy();
+    expect(c.querySelector(".hk-status-pill-label")?.textContent).toBe("online");
+    expect(c.querySelector(".hk-status-pill-latency")?.textContent).toBe("34 ms");
+    expect(c.querySelector(".hk-status-pill-version")?.textContent).toBe("0.2.0");
+  });
+
+  it("defaults to unknown state with no extras", () => {
+    const c = mount(h(HkStatusPill));
+    expect(c.querySelector(".hk-status-pill-unknown")).toBeTruthy();
+    expect(c.querySelector(".hk-status-pill-latency")).toBeNull();
+    expect(c.querySelector(".hk-status-pill-version")).toBeNull();
+  });
+});
+
+describe("HkShareBar", () => {
+  it("computes percent from value/total and clamps to 100", () => {
+    const c = mount(h(HkShareBar, { label: "a", value: 25, total: 100 }));
+    const fill = c.querySelector(".hk-share-bar-fill") as HTMLElement;
+    expect(fill.style.width).toBe("25%");
+
+    const over = mount(h(HkShareBar, { label: "b", value: 300, total: 100 }));
+    const fill2 = over.querySelector(".hk-share-bar-fill") as HTMLElement;
+    expect(fill2.style.width).toBe("100%");
+  });
+
+  it("renders zero-width for zero totals and honors captions", () => {
+    const c = mount(h(HkShareBar, { label: "a", value: 5, total: 0, caption: "5 tok" }));
+    const fill = c.querySelector(".hk-share-bar-fill") as HTMLElement;
+    expect(fill.style.width).toBe("0%");
+    expect(c.querySelector(".hk-share-bar-caption")?.textContent).toBe("5 tok");
+  });
+
+  it("applies the percent override", () => {
+    const c = mount(h(HkShareBar, { label: "a", value: 1, total: 100, percentOverride: 60 }));
+    const fill = c.querySelector(".hk-share-bar-fill") as HTMLElement;
+    expect(fill.style.width).toBe("60%");
+  });
+});

--- a/packages/vue/src/components/HkShareBar.scss
+++ b/packages/vue/src/components/HkShareBar.scss
@@ -1,0 +1,40 @@
+.hk-share-bar {
+  display: grid;
+  grid-template-columns: minmax(6rem, 1fr) minmax(4rem, 2fr) auto;
+  align-items: center;
+  gap: var(--space-10, 0.625rem);
+  min-width: 0;
+}
+
+.hk-share-bar-label {
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-text));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-share-bar-track {
+  position: relative;
+  height: 6px;
+  border-radius: 3px;
+  background: rgb(var(--color-border) / 15%);
+  overflow: hidden;
+  min-width: 4rem;
+}
+
+.hk-share-bar-fill {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  border-radius: 3px;
+  background: rgb(var(--color-primary) / 70%);
+  transition: width var(--duration-normal, 0.2s) ease;
+}
+
+.hk-share-bar-caption {
+  font-size: var(--text-2xs, 0.6875rem);
+  color: rgb(var(--color-muted));
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}

--- a/packages/vue/src/components/HkShareBar.tsx
+++ b/packages/vue/src/components/HkShareBar.tsx
@@ -1,0 +1,50 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkShareBar.scss";
+
+/**
+ * HkShareBar — a horizontal share/proportion bar (label + bar + value).
+ * Used in usage tables (share of total tokens), quota panels, and any
+ * "X of Y" breakdown row.
+ *
+ * ```tsx
+ * <HShareBar label="glm-5.2" value={8_231} total={20_000} caption="41%" />
+ * ```
+ */
+export const HkShareBar = defineComponent({
+  name: "HkShareBar",
+  props: {
+    label: { type: String, required: true },
+    value: { type: Number, required: true },
+    total: { type: Number, required: true },
+    /** Pre-formatted value text (defaults to the raw number). */
+    caption: { type: String, default: undefined },
+    /** 0–100 override for the bar width; defaults to value/total. */
+    percentOverride: { type: Number, default: undefined },
+    /** Bar fill color (any CSS color); defaults to primary. */
+    color: { type: String, default: undefined },
+  },
+  setup(props) {
+    return () => {
+      const pct = props.percentOverride ?? (props.total > 0 ? (props.value / props.total) * 100 : 0);
+      const clamped = Math.max(0, Math.min(100, pct));
+      return (
+        <div class="hk-share-bar" role="img" aria-label={`${props.label}: ${clamped.toFixed(1)}%`}>
+          <span class="hk-share-bar-label" title={props.label}>{props.label}</span>
+          <span class="hk-share-bar-track">
+            <span
+              class="hk-share-bar-fill"
+              style={{
+                width: `${clamped}%`,
+                ...(props.color ? { background: props.color } : {}),
+              }}
+            />
+          </span>
+          <span class="hk-share-bar-caption">
+            {props.caption ?? props.value.toLocaleString()}
+          </span>
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkStatCard.scss
+++ b/packages/vue/src/components/HkStatCard.scss
@@ -1,0 +1,73 @@
+.hk-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: var(--space-12, 0.75rem) var(--space-16, 1rem);
+  border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
+  border-radius: var(--radius-md, 0.5rem);
+  background: rgb(var(--color-surface));
+  min-width: 0;
+}
+
+.hk-stat-card-clickable {
+  cursor: pointer;
+  transition: border-color var(--duration-normal, 0.2s) ease;
+
+  &:hover {
+    border-color: rgb(var(--color-primary) / 35%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
+}
+
+.hk-stat-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-8, 0.5rem);
+}
+
+.hk-stat-card-label {
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-muted));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Tone lives on the dot ONLY — the value text stays neutral so tone
+   never reads as selection (interaction-state precedence). */
+.hk-stat-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.hk-stat-card-dot-success { background: rgb(var(--color-success)); }
+.hk-stat-card-dot-warning { background: rgb(var(--color-warning)); }
+.hk-stat-card-dot-error { background: rgb(var(--color-error)); }
+.hk-stat-card-dot-info { background: rgb(var(--color-info, rgb(var(--color-primary)))); }
+.hk-stat-card-dot-primary { background: rgb(var(--color-primary)); }
+.hk-stat-card-dot-muted { background: rgb(var(--color-muted)); }
+
+.hk-stat-card-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: rgb(var(--color-text));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-stat-card-hint {
+  font-size: var(--text-2xs, 0.6875rem);
+  color: rgb(var(--color-muted) / 70%);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/vue/src/components/HkStatCard.tsx
+++ b/packages/vue/src/components/HkStatCard.tsx
@@ -1,0 +1,46 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkStatCard.scss";
+
+export type StatTone = "success" | "warning" | "error" | "info" | "primary" | "muted";
+
+/**
+ * HkStatCard — one KPI cell for the admin stat grids.
+ *
+ * Anatomy: label + value + optional hint, with a tone dot carrying the
+ * health semantics (the text hue never changes — tone is expressed by
+ * the dot alone, matching the interaction-state precedence rules).
+ *
+ * ```tsx
+ * <HStatCard label="Hub health" value="2/2" tone="success" hint="entelecheia / arona" />
+ * ```
+ */
+export const HkStatCard = defineComponent({
+  name: "HkStatCard",
+  props: {
+    label: { type: String, required: true },
+    value: { type: [String, Number], required: true },
+    tone: { type: String as PropType<StatTone>, default: "muted" },
+    hint: { type: String, default: undefined },
+    /** Whole-card click (drill-through to the owning page). */
+    clickable: { type: Boolean, default: false },
+  },
+  emits: { click: (_e: MouseEvent) => true },
+  setup(props, { emit }) {
+    return () => (
+      <div
+        class={["hk-stat-card", props.clickable && "hk-stat-card-clickable"]}
+        role={props.clickable ? "button" : undefined}
+        tabindex={props.clickable ? 0 : undefined}
+        onClick={props.clickable ? (e: MouseEvent) => emit("click", e) : undefined}
+      >
+        <div class="hk-stat-card-head">
+          <span class="hk-stat-card-label">{props.label}</span>
+          <span class={`hk-stat-card-dot hk-stat-card-dot-${props.tone}`} aria-hidden="true" />
+        </div>
+        <div class="hk-stat-card-value">{props.value}</div>
+        {props.hint && <div class="hk-stat-card-hint" title={props.hint}>{props.hint}</div>}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkStatusPill.scss
+++ b/packages/vue/src/components/HkStatusPill.scss
@@ -1,0 +1,70 @@
+.hk-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-6, 0.375rem);
+  padding: 2px var(--space-8, 0.5rem);
+  border-radius: 999px;
+  font-size: var(--text-2xs, 0.6875rem);
+  line-height: 1.4;
+  color: rgb(var(--color-text));
+  background: rgb(var(--color-surface) / 60%);
+  border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
+  max-width: 100%;
+  min-width: 0;
+}
+
+.hk-status-pill-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: rgb(var(--color-muted));
+}
+
+.hk-status-pill-ok .hk-status-pill-dot {
+  background: rgb(var(--color-success));
+}
+
+.hk-status-pill-warn .hk-status-pill-dot {
+  background: rgb(var(--color-warning));
+}
+
+.hk-status-pill-error .hk-status-pill-dot {
+  background: rgb(var(--color-error));
+}
+
+/* Gentle pulse for the live/ok state so liveness reads at a glance. */
+.hk-status-pill-ok .hk-status-pill-dot {
+  animation: hk-status-pill-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes hk-status-pill-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgb(var(--color-success) / 35%); }
+  50%      { box-shadow: 0 0 0 3px rgb(var(--color-success) / 0%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-status-pill-ok .hk-status-pill-dot {
+    animation: none;
+  }
+}
+
+.hk-status-pill-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-status-pill-latency {
+  color: rgb(var(--color-muted));
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+.hk-status-pill-version {
+  color: rgb(var(--color-muted) / 80%);
+  font-family: var(--font-mono, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/packages/vue/src/components/HkStatusPill.tsx
+++ b/packages/vue/src/components/HkStatusPill.tsx
@@ -1,0 +1,39 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkStatusPill.scss";
+
+export type PillState = "ok" | "warn" | "error" | "unknown";
+
+/**
+ * HkStatusPill — compact health indicator with optional latency and
+ * version readouts. Used for hub connections, edge nodes, stations:
+ * anywhere a service's liveness is summarized inline.
+ *
+ * ```tsx
+ * <HStatusPill state="ok" label="online" latencyMs={34} version="0.2.0" />
+ * ```
+ */
+export const HkStatusPill = defineComponent({
+  name: "HkStatusPill",
+  props: {
+    state: { type: String as PropType<PillState>, default: "unknown" },
+    /** Text beside the dot (e.g. "online" / a service name). */
+    label: { type: String, default: "" },
+    /** Round-trip latency in milliseconds; omitted when unknown. */
+    latencyMs: { type: Number, default: undefined },
+    /** Service version string; omitted when unknown. */
+    version: { type: String, default: undefined },
+  },
+  setup(props) {
+    return () => (
+      <span class={["hk-status-pill", `hk-status-pill-${props.state}`]} role="status">
+        <span class="hk-status-pill-dot" aria-hidden="true" />
+        {props.label && <span class="hk-status-pill-label">{props.label}</span>}
+        {props.latencyMs != null && (
+          <span class="hk-status-pill-latency">{props.latencyMs} ms</span>
+        )}
+        {props.version && <span class="hk-status-pill-version">{props.version}</span>}
+      </span>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -198,4 +198,7 @@ export type { ChallengeDescriptor } from "./utils/powNonce";
 export { HkAdminTablePage as HAdminTablePage } from "./components/HkAdminTablePage";
 export type { HTableColumn } from "./components/HkAdminTablePage";
 export { HkPageHeader as HPageHeader } from "./components/HkPageHeader";
+export { HkStatCard as HStatCard, type StatTone } from "./components/HkStatCard";
+export { HkStatusPill as HStatusPill, type PillState } from "./components/HkStatusPill";
+export { HkShareBar as HShareBar } from "./components/HkShareBar";
 export { HkSecretRevealModal as HSecretRevealModal } from "./components/HkSecretRevealModal";


### PR DESCRIPTION
## Summary

Three primitives extracted from the chest admin redesign's repeated inline patterns:

- **HStatCard** — KPI cell (label / value / hint) with tone expressed by a **dot only**; the value text hue never changes, honoring the interaction-state precedence rules established in #182.
- **HStatusPill** — inline liveness pill (ok / warn / error / unknown) with optional latency and version readouts; gentle pulse on live state, `prefers-reduced-motion` aware.
- **HShareBar** — label + proportional bar + caption row for usage / quota breakdowns, with percent override and 0–100 clamping.

## Verification

- vue-tsc --noEmit clean; vitest 93/93 (8 new tests across the three widgets)
- Version 0.4.11 → 0.4.12; CHANGELOG updated

Consumed next by chest PR #316 (dashboard stat grid → HStatCard, connection/edge pills → HStatusPill, usage table → HShareBar).