### PR TITLE
🛡️ Keep the spinner status text out of text selection.

### DIFF
--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -58,6 +58,14 @@
 .hk-spinner-text {
   font-size: var(--text-base);
   color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
+  /* Transient status, not content: selecting it mid-drag produces
+     accidental clipboard noise. The circle itself stays selectable-free
+     via the wrapper below. */
+  user-select: none;
+}
+
+.hk-spinner-wrapper {
+  user-select: none;
 }
 
 @keyframes hk-spinner-rotate {


### PR DESCRIPTION
## What
`.hk-spinner-text` (and the wrapper) now set `user-select: none` — the label beside a spinner is transient status, not content; drag-selecting across it mid-interaction produced accidental clipboard noise.

## Verification
- packages/vue: vue-tsc 0, vitest 93/93 (CSS-only change).