### PR TITLE
✨ Register CSS animations behind a single global switch.

### DIFF
--- a/packages/vue/src/animation/registerAnimations.test.ts
+++ b/packages/vue/src/animation/registerAnimations.test.ts
@@ -1,0 +1,96 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  listCssAnimations,
+  registerCssAnimation,
+  setCssAnimationsEnabled,
+  isCssAnimationsEnabled,
+} from "./registerAnimations";
+import { setReducedMotion } from "../runtime/animationBus";
+
+const srcDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Recursively collect SCSS/TS/TSX sources under src/, skipping the
+ * animation registrar's own directory (it is the thing under test, not
+ * an animation-owning component). */
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (p === path.resolve(srcDir, "animation")) continue;
+      out.push(...collectSourceFiles(p));
+    } else if (/\.(scss|ts|tsx)$/.test(entry.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Names of every `@keyframes` actually declared in the source tree.
+ * Full-line `//` comments are stripped first so commented-out keyframes
+ * (see HkBreadcrumb.scss) are not counted. */
+function declaredKeyframeNames(): string[] {
+  const names = new Set<string>();
+  for (const file of collectSourceFiles(srcDir)) {
+    const stripped = readFileSync(file, "utf-8").replace(/^[ \t]*\/\/.*$/gm, "");
+    for (const m of stripped.matchAll(/@keyframes\s+([A-Za-z0-9_-]+)/g)) {
+      names.add(m[1]);
+    }
+  }
+  return [...names].sort();
+}
+
+describe("registerAnimations", () => {
+  it("registers exactly the keyframes declared in the source tree", () => {
+    const declared = declaredKeyframeNames();
+    expect(declared.length).toBeGreaterThanOrEqual(13);
+    const registered = listCssAnimations().map((a) => a.name);
+    expect([...registered].sort()).toEqual(declared);
+  });
+
+  it("marks looping animations as infinite and one-shots as finite", () => {
+    const byName = new Map(listCssAnimations().map((a) => [a.name, a]));
+    expect(byName.get("hk-spinner-rotate")?.infinite).toBe(true);
+    expect(byName.get("hk-toast-spin")?.infinite).toBe(true);
+    expect(byName.get("hk-skeleton-shimmer")?.infinite).toBe(true);
+    expect(byName.get("hk-progress-indeterminate")?.infinite).toBe(true);
+    expect(byName.get("hk-status-pill-pulse")?.infinite).toBe(true);
+    expect(byName.get("hk-pwd-breathe")?.infinite).toBe(true);
+    expect(byName.get("s-nav-item-badge-pulse")?.infinite).toBe(true);
+    expect(byName.get("s-auth-card-in")?.infinite).toBe(false);
+    expect(byName.get("hk-rolling-number-up")?.infinite).toBe(false);
+    expect(byName.get("hk-modal-breadcrumb-in")?.infinite).toBe(false);
+    expect(byName.get("hk-pwd-flash")?.infinite).toBe(false);
+    expect(byName.get("plana-flip-out")?.infinite).toBe(false);
+    expect(byName.get("plana-flip-in")?.infinite).toBe(false);
+  });
+
+  it("flips the html dataset attribute in both directions", () => {
+    setCssAnimationsEnabled(false);
+    expect(document.documentElement.dataset.cssAnimations).toBe("0");
+    expect(isCssAnimationsEnabled()).toBe(false);
+    setCssAnimationsEnabled(true);
+    expect(document.documentElement.dataset.cssAnimations).toBe("1");
+    expect(isCssAnimationsEnabled()).toBe(true);
+  });
+
+  it("suspends CSS animations together with the reduced-motion bus", () => {
+    setReducedMotion(true);
+    expect(document.documentElement.dataset.cssAnimations).toBe("0");
+    expect(isCssAnimationsEnabled()).toBe(false);
+    setReducedMotion(false);
+    expect(document.documentElement.dataset.cssAnimations).toBe("1");
+    expect(isCssAnimationsEnabled()).toBe(true);
+  });
+
+  it("re-registers idempotently and keeps the list sorted", () => {
+    registerCssAnimation("hk-spinner-rotate", { infinite: true });
+    const names = listCssAnimations().map((a) => a.name);
+    expect(names.indexOf("hk-spinner-rotate")).toBe(names.lastIndexOf("hk-spinner-rotate"));
+    expect(names).toEqual([...names].sort());
+  });
+});

--- a/packages/vue/src/animation/registerAnimations.ts
+++ b/packages/vue/src/animation/registerAnimations.ts
@@ -1,0 +1,90 @@
+// CSS animation registrar (动画注册商).
+//
+// Every keyframes animation shipped by hikari is registered here so a
+// single global switch can suspend them all — e.g. when the animation
+// context detects performance problems — without each component
+// re-implementing reduced-motion handling. The runtime frame scheduler
+// (`runtime/animationBus.ts`) covers JS-driven animation; this registry
+// complements it for pure-CSS animations.
+//
+// The switch works by flipping `html[data-css-animations]` between "0"
+// and "1"; the pause rules live in `theme/theme.scss`.
+
+export interface CssAnimationOptions {
+  /** True for looping animations (`animation-iteration-count: infinite`). */
+  infinite?: boolean;
+}
+
+export interface RegisteredCssAnimation {
+  name: string;
+  infinite: boolean;
+}
+
+const registry = new Map<string, RegisteredCssAnimation>();
+
+/**
+ * Register a CSS keyframes animation. Idempotent: re-registering the
+ * same name overwrites the previous entry.
+ */
+export function registerCssAnimation(name: string, opts?: CssAnimationOptions): RegisteredCssAnimation {
+  const entry: RegisteredCssAnimation = { name, infinite: opts?.infinite ?? false };
+  registry.set(name, entry);
+  return entry;
+}
+
+/** All registered CSS animations, sorted by name for stable output. */
+export function listCssAnimations(): RegisteredCssAnimation[] {
+  return Array.from(registry.values()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Flip the global CSS animation switch. `false` sets
+ * `html[data-css-animations="0"]`, which pauses every registered (and
+ * any unregistered) keyframes animation via `animation-play-state` and
+ * downgrades smooth scrolling — see `theme/theme.scss`.
+ *
+ * No-op on the server (no `document`).
+ */
+export function setCssAnimationsEnabled(enabled: boolean): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.dataset.cssAnimations = enabled ? "1" : "0";
+}
+
+/** Current switch state; `true` when animations are enabled (or unknown). */
+export function isCssAnimationsEnabled(): boolean {
+  if (typeof document === "undefined") return true;
+  return document.documentElement.dataset.cssAnimations !== "0";
+}
+
+// ── Centralized registrations ────────────────────────────────────────
+// One line per keyframes animation declared under packages/vue/src, with
+// the owning component noted. Keep this list in sync with the SCSS
+// sources — `registerAnimations.test.ts` enforces the parity by parsing
+// every `@keyframes` declaration from the source tree.
+
+// styles/admin-tokens.scss — nav badge pulse (loops forever).
+registerCssAnimation("s-nav-item-badge-pulse", { infinite: true });
+// styles/admin-tokens.scss — auth card entrance (plays once).
+registerCssAnimation("s-auth-card-in");
+// components/HkStatusPill.scss — live-dot pulse (loops forever).
+registerCssAnimation("hk-status-pill-pulse", { infinite: true });
+// components/HkRollingNumber.scss — digit roll-up (plays once, forwards).
+registerCssAnimation("hk-rolling-number-up");
+// components/HkSpinner.scss — spinner rotation (loops forever).
+registerCssAnimation("hk-spinner-rotate", { infinite: true });
+// components/HkModalBreadcrumb.scss — breadcrumb entrance (plays once).
+registerCssAnimation("hk-modal-breadcrumb-in");
+// components/HkToast.scss — toast spinner rotation (loops forever).
+registerCssAnimation("hk-toast-spin", { infinite: true });
+// components/HkSkeleton.scss — skeleton shimmer (loops forever).
+registerCssAnimation("hk-skeleton-shimmer", { infinite: true });
+// components/HkProgressBar.scss — indeterminate bar sweep (loops forever).
+registerCssAnimation("hk-progress-indeterminate", { infinite: true });
+// components/HkPasswordInput.scss — caps-lock warning flash (plays once).
+registerCssAnimation("hk-pwd-flash");
+// components/HkPasswordInput.scss — breathing hint glow (loops forever).
+registerCssAnimation("hk-pwd-breathe", { infinite: true });
+// components/HkCountdownDigit.tsx — flip digit out (plays once, both).
+registerCssAnimation("plana-flip-out");
+// components/HkCountdownDigit.tsx — flip digit in (plays once, both).
+registerCssAnimation("plana-flip-in");

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -154,6 +154,13 @@ export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";
 export { extOf, isImageFile, isAudioFile, codeLanguage, isCodeFile, isArchiveFile, isTextFile, fileIcon, mediaKindOf } from "./utils/fileType";
 
 export { useReducedMotion } from "./composables/useReducedMotion";
+export {
+  registerCssAnimation,
+  listCssAnimations,
+  setCssAnimationsEnabled,
+  isCssAnimationsEnabled,
+} from "./animation/registerAnimations";
+export type { CssAnimationOptions, RegisteredCssAnimation } from "./animation/registerAnimations";
 export { probeOrigin, probeOriginWithBody } from "./utils/connectivity";
 export type { OriginProbe } from "./utils/connectivity";
 

--- a/packages/vue/src/runtime/animationBus.ts
+++ b/packages/vue/src/runtime/animationBus.ts
@@ -1,3 +1,5 @@
+import { setCssAnimationsEnabled } from "../animation/registerAnimations";
+
 export interface FrameContext {
   delta: number;
   elapsed: number;
@@ -164,6 +166,11 @@ function halt() {
 }
 
 export function setReducedMotion(flag: boolean) {
+  // Reduced motion parks the JS frame scheduler AND the pure-CSS
+  // animations registered with the CSS animation registrar. Re-assert
+  // the switch on every call so a direct setCssAnimationsEnabled(false)
+  // from a performance-context caller is undone when motion resumes.
+  setCssAnimationsEnabled(!flag);
   if (paused === flag) return;
   paused = flag;
   if (flag) {

--- a/packages/vue/src/theme/theme.scss
+++ b/packages/vue/src/theme/theme.scss
@@ -15,3 +15,23 @@
 [data-mode="light"] body {
   color-scheme: light;
 }
+
+// ── Global CSS animation switch ────────────────────────────────────────
+// The animation registrar (`src/animation/registerAnimations.ts`) flips
+// `html[data-css-animations]` between "0" and "1" when the runtime
+// suspends animations (reduced motion via `setReducedMotion`, or
+// performance problems detected by the animation context). Pausing —
+// not display:none — keeps layouts stable and is cheap. The rules are
+// attribute-scoped so they compose with the per-component
+// `prefers-reduced-motion` blocks instead of fighting them.
+html[data-css-animations="0"] *,
+html[data-css-animations="0"] *::before,
+html[data-css-animations="0"] *::after {
+  animation-play-state: paused !important;
+}
+
+// Smooth scrolling is the keyframes' most expensive friend — it drives
+// sustained compositor work outside the animation-play-state switch.
+html[data-css-animations="0"] {
+  scroll-behavior: auto !important;
+}


### PR DESCRIPTION
## Summary

Every keyframes animation shipped by hikari is now **registered** in one central list, so a single global switch can suspend them all (e.g. when the animation context detects performance problems) without each component re-implementing reduced-motion handling. The registrar complements the existing JS frame scheduler (`animationBus.ts`) for pure-CSS animations.

## Changes

- **`src/animation/registerAnimations.ts`** (new) — tiny registrar: `registerCssAnimation(name, { infinite })`, `listCssAnimations()`, `setCssAnimationsEnabled(enabled)` (flips `html[data-css-animations]` between `"0"`/`"1"`), `isCssAnimationsEnabled()`. All 13 keyframes are registered in one centralized, greppable init list with the owning component noted per line.
- **`src/theme/theme.scss`** — `html[data-css-animations="0"] *, *::before, *::after { animation-play-state: paused !important; }` plus `scroll-behavior: auto` under the same attribute. Pausing (not `display: none`) keeps layouts stable, is cheap, and composes with the existing per-component `prefers-reduced-motion` blocks instead of fighting them. (`packages/vue/theme` is a symlink to `src/theme`, so both import paths see the rules.)
- **`src/runtime/animationBus.ts`** — `setReducedMotion(flag)` now re-asserts `setCssAnimationsEnabled(!flag)` before its early-return, so reduced motion and any direct performance-context suspension stay in sync.
- **`src/index.ts`** — exports `registerCssAnimation`, `listCssAnimations`, `setCssAnimationsEnabled`, `isCssAnimationsEnabled` + types.

## Keyframes inventory (13 registered)

| Name | Owner | Loops |
|---|---|---|
| `s-nav-item-badge-pulse` | styles/admin-tokens.scss | infinite |
| `s-auth-card-in` | styles/admin-tokens.scss | once |
| `hk-status-pill-pulse` | components/HkStatusPill.scss | infinite |
| `hk-rolling-number-up` | components/HkRollingNumber.scss | once |
| `hk-spinner-rotate` | components/HkSpinner.scss | infinite |
| `hk-modal-breadcrumb-in` | components/HkModalBreadcrumb.scss | once |
| `hk-toast-spin` | components/HkToast.scss | infinite |
| `hk-skeleton-shimmer` | components/HkSkeleton.scss | infinite |
| `hk-progress-indeterminate` | components/HkProgressBar.scss | infinite |
| `hk-pwd-flash` | components/HkPasswordInput.scss | once |
| `hk-pwd-breathe` | components/HkPasswordInput.scss | infinite |
| `plana-flip-out` | components/HkCountdownDigit.tsx | once |
| `plana-flip-in` | components/HkCountdownDigit.tsx | once |

(The 3 `breadcrumb-*` keyframes in HkBreadcrumb.scss are commented out in source and deliberately not counted.)

## Tests

New `src/animation/registerAnimations.test.ts` (5 tests): registry ↔ source parity (fs-parses every `@keyframes` from `src/**/*.scss|ts|tsx` with `//` comments stripped, so a future keyframe added without registration fails loudly), infinite-flag spot checks, dataset toggle in both directions, `setReducedMotion` bus integration, and idempotent re-registration.

## Verification

- `vue-tsc --noEmit` → 0 errors
- `vitest run` → **98/98 pass** (93 pre-existing + 5 new), 11 files
- `pnpm run build` → success; `sass` compiles `theme.scss` cleanly with all 4 `css-animations` selectors emitted
- Independent subagent cross-verification: 3 rounds, all PASS (keyframes parity 13/13, infinite flags, wiring/no circular imports, CSS composition, test soundness, regression scan)
