### PR TITLE
🐛 Close the orphaned rule block left in the date picker styles.

### DIFF
--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -50,16 +50,17 @@
     background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   }
 }
-  &:focus-visible {
-    outline: none;
-    box-shadow: var(--shadow-focus);
-    background: rgb(var(--color-surface));
-  }
 
-  &.is-open {
-    border-color: rgb(var(--color-focused-border));
-    box-shadow: var(--shadow-focus);
-  }
+/* Focus ring + open state live on the trigger itself. */
+.hk-dp-trigger:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  background: rgb(var(--color-surface));
+}
+
+.hk-dp-trigger.is-open {
+  border-color: rgb(var(--color-focused-border));
+  box-shadow: var(--shadow-focus);
 }
 
 .hk-dp-trigger-sm {


### PR DESCRIPTION
## What
The squash of #190 left the tail of a deduplicated trigger block stranded at top level in `HkDatePicker.scss` — an unmatched closing brace that breaks the sass compile for any downstream consumer building from source (shittim-chest's worktree build failed on exactly this). The focus-ring and open-state rules are restored as proper selectors on the trigger, and the file balances again.

## Verification
- packages/vue: vue-tsc 0 errors, vitest 117/117, sass compile of the file exits 0, brace-balance asserted.
- Downstream: shittim-chest worktree `vite build` was failing on this file and passes after the fix.