### PR TITLE
🎨 Give the warning toast dark text for readable contrast.

### DIFF
--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -82,9 +82,22 @@
   color: #fff;
 }
 
+/* Warning toasts use a light, saturated amber background where white text
+ * lands at ~2.6:1 contrast (unreadable). Dark text keeps >= 4.5:1 on the
+ * amber in BOTH color schemes; the copy/close buttons inherit it. */
 .hk-toast-warning {
   background: var(--hi-color-warning, #d29922);
-  color: #fff;
+  color: #1c1c1e;
+}
+
+.hk-toast-warning .hk-toast-copy-btn,
+.hk-toast-warning .hk-toast-close {
+  color: #1c1c1e;
+}
+
+.hk-toast-warning .hk-toast-copy-btn:hover,
+.hk-toast-warning .hk-toast-close:hover {
+  background: rgb(0 0 0 / 12%);
 }
 
 .hk-toast-info {


### PR DESCRIPTION
## Summary

`.hk-toast-warning` kept `color: #fff` on the amber `--hi-color-warning` (#d29922) background — a ~2.6:1 contrast ratio that made warning text effectively unreadable in both color schemes (reported on dark mode where the amber renders brightest). Per the design rule for light/saturated backgrounds, the warning variant now uses dark text (`#1c1c1e`, ≥4.5:1 on the amber in both schemes); the copy/close buttons inherit it with a darkened hover wash.

Other variants (error/success/info) keep white text — their backgrounds are dark enough for contrast.

## Verification

- vue-tsc green; vitest 117/117 green.