### PR TITLE
💡 Localize the datetime picker and pass through to native controls on mobile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ Current master, Rust workspace `0.3.19`.
 
 ### Added
 
+- Add mobile native pass-through to both date pickers and localize the
+  datetime picker: HkDateTimePicker now derives month/weekday names and the
+  trigger label from `Intl.DateTimeFormat` on the active locale (week start
+  from `Intl.Locale` weekInfo, Sunday fallback) instead of hardcoded English
+  tables, its previously dead popup mode renders a real trigger anchored to
+  HPopover (`placement`/`offset` finally wired), and both HkDateTimePicker
+  and HkDatePicker gain `nativeOnMobile` (default true) which swaps the
+  custom popup for the OS `<input type="datetime-local">`/`type="date"`
+  control below the 768px breakpoint with Date-to-wire-format conversion,
+  min/max clamping and model re-sync on rejected edits.
 - Add safe centering and overflow sensing to HkScrollContainer (`align="center"`
   wraps the slot in an auto-margin aligner; `data-h-overflow` /
   `data-v-overflow` mirror sensed overflow; optional `fade` masks the edges

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -267,3 +267,40 @@
   padding-top: var(--hi-space-6, 6px);
   border-top: 1px solid color-mix(in srgb, var(--hi-color-border) 10%, transparent);
 }
+
+/* ── Native mobile input ─────────────────────────────────────── */
+
+.hk-dp-native {
+  display: block;
+  width: 100%;
+  min-height: 2.5rem;
+  box-sizing: border-box;
+  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
+  border-radius: var(--hi-radius-sm, 4px);
+  color: rgb(var(--color-text));
+  font-family: inherit;
+  font-size: var(--hi-text-sm, 0.875rem);
+  line-height: 1.5;
+  font-variant-numeric: tabular-nums;
+  transition:
+    background-color var(--hi-duration-fast, 0.15s) ease,
+    border-color var(--hi-duration-fast, 0.15s) ease,
+    box-shadow var(--hi-duration-fast, 0.15s) ease;
+}
+
+.hk-dp:not(.is-disabled) .hk-dp-native:hover,
+.hk-dp-native:focus-visible {
+  border-color: rgb(var(--color-focused-border));
+}
+
+.hk-dp-native:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  background: rgb(var(--color-surface));
+}
+
+.hk-dp.is-disabled .hk-dp-native {
+  cursor: not-allowed;
+}

--- a/packages/vue/src/components/HkDatePicker.test.ts
+++ b/packages/vue/src/components/HkDatePicker.test.ts
@@ -6,6 +6,7 @@ import { setLocale } from "../i18n/context";
 
 const mounts: ReturnType<typeof createApp>[] = [];
 const containers: HTMLElement[] = [];
+const originalWidth = window.innerWidth;
 
 interface PickerHarness {
   container: HTMLElement;
@@ -61,10 +62,20 @@ function clickDay(day: number) {
   target?.click();
 }
 
+/** Pretend the viewport is touch-sized so `useBreakpoint` reports mobile. */
+function useMobileViewport() {
+  (window as unknown as { innerWidth: number }).innerWidth = 375;
+}
+
+function nativeInput(root: ParentNode): HTMLInputElement | null {
+  return root.querySelector<HTMLInputElement>("input.hk-dp-native");
+}
+
 afterEach(async () => {
   for (const app of mounts.splice(0)) app.unmount();
   for (const el of containers.splice(0)) el.remove();
   document.querySelectorAll(".hk-dp-panel, .hk-popover-backdrop").forEach((el) => el.remove());
+  (window as unknown as { innerWidth: number }).innerWidth = originalWidth;
   await setLocale("en");
 });
 
@@ -287,5 +298,64 @@ describe("HkDatePicker", () => {
     const now = new Date();
     const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
     expect(p.emitted).toEqual([expected]);
+  });
+
+  // ── Mobile pass-through to the native OS control ────────────────
+
+  it("renders a native date input instead of the calendar on mobile", () => {
+    useMobileViewport();
+    const p = mountPicker({ modelValue: "2026-08-16" });
+    const input = nativeInput(p.container);
+    expect(input).not.toBeNull();
+    expect(input?.type).toBe("date");
+    expect(input?.value).toBe("2026-08-16");
+    expect(p.container.querySelector(".hk-dp-trigger")).toBeNull();
+    expect(p.container.querySelector(".hk-dp-panel")).toBeNull();
+  });
+
+  it("keeps the custom calendar on mobile when nativeOnMobile is false", async () => {
+    useMobileViewport();
+    const p = mountPicker({ modelValue: "2026-08-16", nativeOnMobile: false });
+    expect(p.container.querySelector(".hk-dp-trigger")).not.toBeNull();
+    expect(nativeInput(p.container)).toBeNull();
+    openViaEnter(p);
+    await nextTick();
+    // The custom panel is portaled to the body, not the container.
+    expect(panel()).not.toBeNull();
+  });
+
+  it("passes min/max through to the native input", () => {
+    useMobileViewport();
+    const p = mountPicker({ modelValue: "2026-08-16", min: "2026-08-10", max: "2026-08-20" });
+    const input = nativeInput(p.container);
+    expect(input?.min).toBe("2026-08-10");
+    expect(input?.max).toBe("2026-08-20");
+  });
+
+  it("native input edits emit the ISO date and clearing emits null", async () => {
+    useMobileViewport();
+    const p = mountPicker({ modelValue: "2026-08-16" });
+    const input = nativeInput(p.container);
+    input!.value = "2026-08-20";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted).toEqual(["2026-08-20"]);
+    expect(input?.value).toBe("2026-08-20");
+
+    input!.value = "";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted).toEqual(["2026-08-20", null]);
+  });
+
+  it("native input edits outside the bounds are rejected and re-synced", async () => {
+    useMobileViewport();
+    const p = mountPicker({ modelValue: "2026-08-16", max: "2026-08-20" });
+    const input = nativeInput(p.container);
+    input!.value = "2026-09-01";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted).toEqual([]);
+    expect(input?.value).toBe("2026-08-16");
   });
 });

--- a/packages/vue/src/components/HkDatePicker.tsx
+++ b/packages/vue/src/components/HkDatePicker.tsx
@@ -2,6 +2,7 @@ import { Calendar, ChevronLeft, ChevronRight, X } from "lucide-vue-next";
 import { computed, defineComponent, ref, watch, type PropType } from "vue";
 
 import { useI18n } from "../i18n/context";
+import { useBreakpoint } from "../runtime/useBreakpoint";
 import HkButton from "./HkButton";
 import HPopover from "./HkPopover";
 import "./HkDatePicker.scss";
@@ -70,12 +71,20 @@ export default defineComponent({
     min: { type: String as PropType<string | undefined>, default: undefined },
     /** Inclusive upper bound as an ISO date; later days render disabled. */
     max: { type: String as PropType<string | undefined>, default: undefined },
+    /** Render the OS native `<input type="date">` on touch-sized viewports. */
+    nativeOnMobile: { type: Boolean, default: true },
   },
   emits: {
     "update:modelValue": (_value: string | null) => true,
   },
   setup(props, { emit }) {
     const { t } = useI18n();
+    const { isMobile } = useBreakpoint();
+
+    // On touch devices the OS picker beats a custom popup: swap the whole
+    // chrome for a native date input (the model already speaks its ISO wire
+    // format) and keep the custom calendar on desktop widths only.
+    const useNative = computed(() => props.nativeOnMobile && isMobile.value);
 
     const selected = computed(() => parseISODate(props.modelValue));
     const hasValue = computed(() => selected.value !== null);
@@ -218,7 +227,48 @@ export default defineComponent({
       emit("update:modelValue", null);
     }
 
-    return () => (
+    // ── Native mobile input ─────────────────────────────────────────
+    function onNativeInput(e: Event) {
+      const el = e.target as HTMLInputElement;
+      if (!el.value) {
+        if (props.modelValue !== null) emit("update:modelValue", null);
+        return;
+      }
+      const d = parseISODate(el.value);
+      if (!d || isDisabledDay(d)) {
+        // Out-of-range or malformed: re-sync the field to the model so the
+        // visible value can never drift from what the parent owns.
+        el.value = props.modelValue ?? "";
+        return;
+      }
+      emit("update:modelValue", toISODate(d));
+    }
+
+    function renderNative() {
+      return (
+        <input
+          class="hk-dp-native"
+          type="date"
+          value={props.modelValue ?? ""}
+          min={props.min}
+          max={props.max}
+          disabled={props.disabled || undefined}
+          aria-label={t("hk.datePicker.pickDate", "Pick a date")}
+          onInput={onNativeInput}
+        />
+      );
+    }
+
+    return () => {
+      if (useNative.value) {
+        return (
+          <div class={["hk-dp", props.disabled ? "is-disabled" : ""].filter(Boolean).join(" ")}>
+            {renderNative()}
+          </div>
+        );
+      }
+
+      return (
       <div class={["hk-dp", props.disabled ? "is-disabled" : ""].filter(Boolean).join(" ")}>
         <div
           ref={triggerRef}
@@ -322,6 +372,7 @@ export default defineComponent({
           </div>
         </HPopover>
       </div>
-    );
+      );
+    };
   },
 });

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -359,3 +359,36 @@
   &:hover { filter: brightness(1.08); }
   &:focus-visible { outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent); outline-offset: 2px; }
 }
+
+/* ── Native mobile input ─────────────────────────────────────── */
+
+.hk-dtp-native {
+  appearance: none;
+  display: block;
+  width: 100%;
+  min-height: 2.5rem;
+  box-sizing: border-box;
+  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  background: var(--hi-color-surface);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
+  border-radius: var(--hi-radius-sm, 4px);
+  color: var(--hi-color-text-primary);
+  font-family: inherit;
+  font-size: var(--hi-text-sm, 0.875rem);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.5;
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--hi-color-primary) 50%, transparent);
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--hi-color-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--hi-color-primary) 35%, transparent);
+  }
+}
+
+.hk-dtp-popup-root {
+  display: inline-flex;
+}

--- a/packages/vue/src/components/HkDateTimePicker.test.ts
+++ b/packages/vue/src/components/HkDateTimePicker.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkDateTimePicker from "./HkDateTimePicker";
+import { setLocale } from "../i18n/context";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+const originalWidth = window.innerWidth;
+
+interface PickerHarness {
+  container: HTMLElement;
+  emitted: Date[];
+}
+
+function mountPicker(props: Record<string, unknown> = {}): PickerHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const value = ref(props.modelValue as Date ?? new Date(2026, 7, 16, 9, 30));
+  const emitted: Date[] = [];
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkDateTimePicker, {
+          ...props,
+          modelValue: value.value,
+          "onUpdate:modelValue": (v: Date) => { emitted.push(v); value.value = v; },
+        });
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { container, emitted };
+}
+
+/** Let Vue's leave transitions (frame/timeout based) finish in happy-dom. */
+async function settle() {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 20));
+  await nextTick();
+}
+
+function picker(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".hk-dtp");
+}
+
+function dayCells(): HTMLButtonElement[] {
+  return Array.from(picker()?.querySelectorAll<HTMLButtonElement>(".hk-dtp-cell") ?? []);
+}
+
+function clickDay(day: number) {
+  const target = dayCells().find((c) => c.textContent === String(day) && !c.classList.contains("is-out"));
+  target?.click();
+}
+
+function weekdayLabels(): string[] {
+  return Array.from(picker()?.querySelectorAll<HTMLElement>(".hk-dtp-wd") ?? [])
+    .map((el) => el.textContent ?? "");
+}
+
+/** Mirror of the component's week-start derivation (ISO 1..6, Sunday → 0). */
+function firstWeekdayOfLocale(locale: string): number {
+  try {
+    const n = Number((new Intl.Locale(locale) as Intl.Locale & { weekInfo?: { firstDay?: number } }).weekInfo?.firstDay);
+    if (Number.isInteger(n) && n >= 1 && n <= 6) return n;
+  } catch {
+    // Fall through to the Sunday default.
+  }
+  return 0;
+}
+
+function expectedWeekdayLabels(locale: string): string[] {
+  const fmt = new Intl.DateTimeFormat(locale, { weekday: "short" });
+  const first = firstWeekdayOfLocale(locale);
+  return Array.from({ length: 7 }, (_, i) => fmt.format(new Date(2024, 0, 7 + ((first + i) % 7))));
+}
+
+/** Pretend the viewport is touch-sized so `useBreakpoint` reports mobile. */
+function useMobileViewport() {
+  (window as unknown as { innerWidth: number }).innerWidth = 375;
+}
+
+function nativeInput(root: ParentNode = document): HTMLInputElement | null {
+  return root.querySelector<HTMLInputElement>("input.hk-dtp-native");
+}
+
+afterEach(async () => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  document.querySelectorAll(".hk-dtp-popup, .hk-popover-backdrop").forEach((el) => el.remove());
+  (window as unknown as { innerWidth: number }).innerWidth = originalWidth;
+  await setLocale("en");
+});
+
+describe("HkDateTimePicker", () => {
+  it("renders the inline calendar with a 42-cell month grid", () => {
+    const p = mountPicker();
+    expect(p.container.querySelector(".hk-dtp")).not.toBeNull();
+    expect(dayCells().length).toBe(42);
+    expect(p.container.querySelector(".hk-dtp-native")).toBeNull();
+  });
+
+  it("derives weekday header labels from Intl for the locale", () => {
+    mountPicker();
+    expect(weekdayLabels()).toEqual(expectedWeekdayLabels("en"));
+  });
+
+  it("keeps the week column order on a Monday-first locale", async () => {
+    mountPicker();
+    await setLocale("de");
+    await nextTick();
+    // de-DE weeks start Monday when the runtime exposes weekInfo; the grid
+    // start shifts with it, so the first label is Monday's short name.
+    const first = new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2024, 0, 1));
+    if (firstWeekdayOfLocale("de") === 1) {
+      expect(weekdayLabels()[0]).toBe(first);
+    }
+    expect(weekdayLabels()).toEqual(expectedWeekdayLabels("de"));
+  });
+
+  it("re-derives month and weekday labels after a locale switch", async () => {
+    mountPicker();
+    const zhMonth = new Intl.DateTimeFormat("zh-Hans", { month: "long" }).format(new Date(2026, 7, 1));
+    await setLocale("zh-Hans");
+    await nextTick();
+    const title = picker()?.querySelector<HTMLElement>(".hk-dtp-title-btn")?.textContent ?? "";
+    expect(title).toContain(zhMonth);
+    expect(weekdayLabels()).toEqual(expectedWeekdayLabels("zh-Hans"));
+  });
+
+  it("localizes month names in the drill-down grid", async () => {
+    mountPicker();
+    const monthBtn = picker()?.querySelectorAll<HTMLButtonElement>(".hk-dtp-title-btn")[0];
+    monthBtn?.click();
+    await settle();
+    const cells = Array.from(picker()?.querySelectorAll<HTMLElement>(".hk-dtp-cell") ?? [])
+      .map((c) => c.textContent ?? "");
+    const expected = Array.from({ length: 12 }, (_, i) =>
+      new Intl.DateTimeFormat("en", { month: "short" }).format(new Date(2024, i, 15)));
+    expect(cells).toEqual(expected);
+  });
+
+  it("selecting a day emits a new Date preserving the time of day", async () => {
+    const p = mountPicker();
+    clickDay(20);
+    await nextTick();
+    expect(p.emitted.length).toBe(1);
+    const d = p.emitted[0];
+    expect(d instanceof Date).toBe(true);
+    expect([d.getFullYear(), d.getMonth(), d.getDate()]).toEqual([2026, 7, 20]);
+    expect([d.getHours(), d.getMinutes()]).toEqual([9, 30]);
+  });
+
+  it("disables days outside the inclusive min/max bounds", () => {
+    mountPicker({
+      min: new Date(2026, 7, 10, 0, 0),
+      max: new Date(2026, 7, 20, 23, 59),
+    });
+    const byDay = new Map(
+      dayCells().filter((c) => !c.classList.contains("is-out")).map((c) => [c.textContent ?? "", c]),
+    );
+    expect(byDay.get("9")?.disabled).toBe(true);
+    expect(byDay.get("10")?.disabled).toBe(false);
+    expect(byDay.get("20")?.disabled).toBe(false);
+    expect(byDay.get("21")?.disabled).toBe(true);
+  });
+
+  it("blocked days never emit an update when clicked", async () => {
+    const p = mountPicker({ max: new Date(2026, 7, 20, 23, 59) });
+    clickDay(25);
+    await nextTick();
+    expect(p.emitted).toEqual([]);
+  });
+
+  it("marks days present in markedDays with a dot", () => {
+    mountPicker({ markedDays: new Set(["2026-08-18"]) });
+    const marked = Array.from(picker()?.querySelectorAll<HTMLButtonElement>(".hk-dtp-cell") ?? [])
+      .filter((c) => c.querySelector(".hk-dtp-cell-dot"));
+    expect(marked.length).toBe(1);
+    expect(marked[0].textContent).toBe("18");
+  });
+
+  it("opens in popup mode from the trigger button", async () => {
+    const p = mountPicker({ mode: "popup", confirmLabel: "Confirm" });
+    const trigger = p.container.querySelector<HTMLButtonElement>(".hk-dtp-trigger");
+    expect(trigger).not.toBeNull();
+    expect(document.querySelector(".hk-dtp-popup")).toBeNull();
+    trigger?.click();
+    await nextTick();
+    expect(document.querySelector(".hk-dtp-popup")).not.toBeNull();
+    expect(document.querySelectorAll(".hk-dtp-popup .hk-dtp-cell").length).toBe(42);
+  });
+
+  // ── Mobile pass-through to the native OS control ────────────────
+
+  it("renders a native datetime-local input instead of the calendar on mobile", () => {
+    useMobileViewport();
+    const p = mountPicker();
+    const input = nativeInput(p.container);
+    expect(input).not.toBeNull();
+    expect(input?.type).toBe("datetime-local");
+    expect(input?.value).toBe("2026-08-16T09:30");
+    expect(p.container.querySelector(".hk-dtp")).toBeNull();
+    expect(p.container.querySelector(".hk-dtp-grid")).toBeNull();
+  });
+
+  it("uses a native date input when showTime is false", () => {
+    useMobileViewport();
+    const p = mountPicker({ showTime: false });
+    const input = nativeInput(p.container);
+    expect(input?.type).toBe("date");
+    expect(input?.value).toBe("2026-08-16");
+  });
+
+  it("passes min/max through to the native input in its wire format", () => {
+    useMobileViewport();
+    const p = mountPicker({
+      min: new Date(2026, 7, 10, 8, 0),
+      max: new Date(2026, 7, 20, 18, 30),
+    });
+    const input = nativeInput(p.container);
+    expect(input?.min).toBe("2026-08-10T08:00");
+    expect(input?.max).toBe("2026-08-20T18:30");
+  });
+
+  it("keeps the custom calendar on mobile when nativeOnMobile is false", () => {
+    useMobileViewport();
+    const p = mountPicker({ nativeOnMobile: false });
+    expect(p.container.querySelector(".hk-dtp")).not.toBeNull();
+    expect(dayCells().length).toBe(42);
+    expect(nativeInput(p.container)).toBeNull();
+  });
+
+  it("native input edits update the model as a local-time Date", async () => {
+    useMobileViewport();
+    const p = mountPicker();
+    const input = nativeInput(p.container);
+    input!.value = "2026-08-20T14:05";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted.length).toBe(1);
+    expect(p.emitted[0].getTime()).toBe(new Date(2026, 7, 20, 14, 5).getTime());
+    expect(input?.value).toBe("2026-08-20T14:05");
+  });
+
+  it("native date edits preserve the clock time when showTime is false", async () => {
+    useMobileViewport();
+    const p = mountPicker({ showTime: false });
+    const input = nativeInput(p.container);
+    input!.value = "2026-08-20";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted[0].getTime()).toBe(new Date(2026, 7, 20, 9, 30).getTime());
+  });
+
+  it("native input edits outside the bounds are rejected and re-synced", async () => {
+    useMobileViewport();
+    const p = mountPicker({ max: new Date(2026, 7, 20, 23, 59) });
+    const input = nativeInput(p.container);
+    input!.value = "2026-09-01T10:00";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted).toEqual([]);
+    expect(input?.value).toBe("2026-08-16T09:30");
+  });
+
+  it("clearing the native input falls back to the model value", async () => {
+    useMobileViewport();
+    const p = mountPicker();
+    const input = nativeInput(p.container);
+    input!.value = "";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(p.emitted).toEqual([]);
+    expect(input?.value).toBe("2026-08-16T09:30");
+  });
+
+  it("native input replaces even the popup chrome on mobile", () => {
+    useMobileViewport();
+    const p = mountPicker({ mode: "popup", confirmLabel: "Confirm" });
+    expect(nativeInput(p.container)).not.toBeNull();
+    expect(p.container.querySelector(".hk-dtp-trigger")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkDateTimePicker.tsx
+++ b/packages/vue/src/components/HkDateTimePicker.tsx
@@ -1,15 +1,10 @@
 import { ArrowLeft, Calendar, ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from "lucide-vue-next";
-import { computed, defineComponent, onBeforeUnmount, ref, Transition, watch, type PropType } from "vue";
-
-
-
-
-
-
+import { computed, defineComponent, ref, Transition, watch, type PropType } from "vue";
 
 import { useI18n } from "../i18n/context";
+import { useBreakpoint } from "../runtime/useBreakpoint";
 import "./HkDateTimePicker.scss";
-import HPopover from "./HkPopover";
+import HPopover, { type PopupPlacement } from "./HkPopover";
 
 function startOfDay(d: Date): Date {
   return new Date(d.getFullYear(), d.getMonth(), d.getDate());
@@ -25,19 +20,67 @@ function dayKeyOf(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
+const pad2 = (n: number) => (n < 10 ? `0${n}` : String(n));
+
+// Wire format of the mobile native input: `YYYY-MM-DD` with an optional
+// `THH:mm` (some engines also append `:ss`, which we tolerate and drop).
+const NATIVE_INPUT_RE = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::\d{2})?)?$/;
+
+/** Serialize a Date to the local-time wire format of the native input. */
+function toNativeInputValue(d: Date, withTime: boolean): string {
+  const date = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  return withTime ? `${date}T${pad2(d.getHours())}:${pad2(d.getMinutes())}` : date;
+}
+
+/**
+ * Parse a native-input value (`YYYY-MM-DD` + optional `THH:mm`) into its
+ * parts, rejecting rollovers such as 2026-02-31 (Date normalizes them).
+ */
+function parseNativeInputValue(value: string): { y: number; m: number; d: number; hh: number | null; mm: number | null } | null {
+  const match = NATIVE_INPUT_RE.exec(value);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const m = Number(match[2]);
+  const d = Number(match[3]);
+  const probe = new Date(y, m - 1, d);
+  if (probe.getFullYear() !== y || probe.getMonth() !== m - 1 || probe.getDate() !== d) {
+    return null;
+  }
+  return {
+    y,
+    m,
+    d,
+    hh: match[4] !== undefined ? Number(match[4]) : null,
+    mm: match[5] !== undefined ? Number(match[5]) : null,
+  };
+}
+
+/**
+ * First day of the week (0 = Sunday … 6 = Saturday) for a locale, taken from
+ * `Intl.Locale#weekInfo` (or the older `getInfo`) when the runtime provides
+ * it and defaulting to Sunday.
+ */
+function firstWeekdayOf(locale: string): number {
+  try {
+    const loc = new Intl.Locale(locale) as Intl.Locale & {
+      weekInfo?: { firstDay?: number | string };
+      getInfo?: () => { firstDayOfWeek?: string };
+    };
+    if (loc.weekInfo) {
+      const n = Number(loc.weekInfo.firstDay);
+      if (Number.isInteger(n) && n >= 0 && n <= 6) return n;
+    }
+    if (typeof loc.getInfo === "function") {
+      const n = Number(loc.getInfo().firstDayOfWeek);
+      if (Number.isInteger(n) && n >= 0 && n <= 6) return n;
+    }
+  } catch {
+    // Fall through to the Sunday default.
+  }
+  return 0;
+}
+
 type ViewKind = "days" | "months" | "years";
-
-const MONTH_NAMES = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
-
-const MONTH_NAMES_LONG = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
-];
-
-const WEEKDAY_NAMES = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 export default defineComponent({
   name: "HkDateTimePicker",
@@ -47,10 +90,12 @@ export default defineComponent({
     max: { type: [Date, null] as unknown as PropType<Date | null>, default: null },
     markedDays: { type: Set as unknown as PropType<Set<string>>, default: () => new Set<string>() },
     mode: { type: String as PropType<"inline" | "popup">, default: "inline" },
-    placement: { type: String, default: "bottom-start" },
+    placement: { type: String as PropType<PopupPlacement>, default: "bottom-start" },
     offset: { type: Number, default: 6 },
     confirmLabel: { type: String, default: undefined },
     showTime: { type: Boolean, default: true },
+    /** Render the OS native `<input type="datetime-local">` on touch-sized viewports. */
+    nativeOnMobile: { type: Boolean, default: true },
   },
   emits: {
     "update:modelValue": (_d: Date) => true,
@@ -59,6 +104,13 @@ export default defineComponent({
   },
   setup(props, { emit, slots }) {
     const { t } = useI18n();
+    const { isMobile } = useBreakpoint();
+
+    // On touch devices the OS picker beats a custom popup: swap the whole
+    // chrome for a native datetime-local input and keep the custom UI on
+    // desktop widths only.
+    const useNative = computed(() => props.nativeOnMobile && isMobile.value);
+
     const viewYear = ref(props.modelValue.getFullYear());
     const viewMonth = ref(props.modelValue.getMonth());
     const view = ref<ViewKind>("days");
@@ -86,8 +138,37 @@ export default defineComponent({
       },
     );
 
+    // ── Localization (all derived from the active locale, no tables) ──
+    const locale = computed(() => useI18n().locale);
+    const firstDay = computed(() => firstWeekdayOf(locale.value));
+
+    const formatters = computed(() => {
+      const loc = locale.value;
+      return {
+        monthShort: new Intl.DateTimeFormat(loc, { month: "short" }),
+        monthLong: new Intl.DateTimeFormat(loc, { month: "long" }),
+        weekday: new Intl.DateTimeFormat(loc, { weekday: "short" }),
+        // h23 keeps the trigger in the same 24-hour form as the time steppers.
+        triggerDateTime: new Intl.DateTimeFormat(loc, {
+          month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hourCycle: "h23",
+        }),
+        triggerDate: new Intl.DateTimeFormat(loc, { year: "numeric", month: "short", day: "numeric" }),
+      };
+    });
+
+    const monthNames = computed(() =>
+      Array.from({ length: 12 }, (_, i) => formatters.value.monthShort.format(new Date(2024, i, 15))),
+    );
+
     const monthName = computed(() =>
-      MONTH_NAMES_LONG[viewMonth.value],
+      formatters.value.monthLong.format(new Date(viewYear.value, viewMonth.value, 1)),
+    );
+
+    // 2024-01-07 is a Sunday; offset by the locale's first weekday so the
+    // label column follows the locale instead of a hardcoded week start.
+    const weekdayLabels = computed(() =>
+      Array.from({ length: 7 }, (_, i) =>
+        formatters.value.weekday.format(new Date(2024, 0, 7 + ((firstDay.value + i) % 7)))),
     );
 
     const yearBlockStart = computed(() =>
@@ -97,7 +178,7 @@ export default defineComponent({
     const cells = computed(() => {
       const first = new Date(viewYear.value, viewMonth.value, 1);
       const start = new Date(first);
-      start.setDate(first.getDate() - first.getDay());
+      start.setDate(first.getDate() - ((first.getDay() - firstDay.value + 7) % 7));
       const out: Date[] = [];
       for (let i = 0; i < 42; i++) {
         const d = new Date(start);
@@ -163,15 +244,13 @@ export default defineComponent({
       selectDay(tgt);
     }
 
-    const pad = (n: number) => (n < 10 ? `0${n}` : String(n));
-
     function stepper(label: string, value: number, onUp: () => void, onDown: () => void) {
       return (
         <div class="hk-dtp-step">
           <button class="hk-dtp-step-btn" type="button" aria-label={`${label} +`} onClick={onUp}>
             <ChevronUp size={13} />
           </button>
-          <span class="hk-dtp-step-val">{pad(value)}</span>
+          <span class="hk-dtp-step-val">{pad2(value)}</span>
           <button class="hk-dtp-step-btn" type="button" aria-label={`${label} -`} onClick={onDown}>
             <ChevronDown size={13} />
           </button>
@@ -181,20 +260,56 @@ export default defineComponent({
 
     // ── Popup-mode state ────────────────────────────────────────────
     const open = ref(false);
+    // HPopover renders no trigger slot of its own — the wrap below is the
+    // real DOM anchor and must live outside the teleported popover.
+    const triggerWrapRef = ref<HTMLElement | null>(null);
     function toggleOpen() { open.value = !open.value; if (open.value) emit("open"); }
     function onConfirm() { emit("confirm"); open.value = false; }
 
-    const triggerLabel = computed(() => {
-      const d = props.modelValue;
-      const month = MONTH_NAMES[d.getMonth()];
-      const day = d.getDate();
-      if (props.showTime) {
-        const h = pad(d.getHours());
-        const m = pad(d.getMinutes());
-        return `${month} ${day}, ${h}:${m}`;
+    const triggerLabel = computed(() =>
+      props.showTime
+        ? formatters.value.triggerDateTime.format(props.modelValue)
+        : formatters.value.triggerDate.format(props.modelValue),
+    );
+
+    // ── Native mobile input ─────────────────────────────────────────
+    function onNativeInput(e: Event) {
+      const el = e.target as HTMLInputElement;
+      if (!el.value) {
+        // The model is a required Date with no null semantics — a cleared
+        // field must fall back to it instead of silently drifting.
+        el.value = toNativeInputValue(props.modelValue, props.showTime);
+        return;
       }
-      return `${month} ${day}, ${d.getFullYear()}`;
-    });
+      const parsed = parseNativeInputValue(el.value);
+      if (!parsed) return;
+      // Without a time part (showTime=false) keep the model's clock time,
+      // mirroring how the custom grid preserves it across day selection.
+      const cur = props.modelValue;
+      const next = new Date(
+        parsed.y, parsed.m - 1, parsed.d,
+        parsed.hh ?? cur.getHours(), parsed.mm ?? cur.getMinutes(),
+      );
+      if (isDisabled(next)) {
+        el.value = toNativeInputValue(cur, props.showTime);
+        return;
+      }
+      emit("update:modelValue", next);
+    }
+
+    function renderNative() {
+      return (
+        <input
+          class="hk-dtp-native"
+          type={props.showTime ? "datetime-local" : "date"}
+          value={toNativeInputValue(props.modelValue, props.showTime)}
+          min={props.min ? toNativeInputValue(props.min, props.showTime) : undefined}
+          max={props.max ? toNativeInputValue(props.max, props.showTime) : undefined}
+          aria-label={t("hk.dateTimePicker.pickDate", "Pick a date and time")}
+          onInput={onNativeInput}
+        />
+      );
+    }
 
     // ── Header ──────────────────────────────────────────────────────
 
@@ -262,7 +377,7 @@ export default defineComponent({
       if (view.value === "months") {
         return (
           <div class="hk-dtp-grid" data-variant="pick">
-            {MONTH_NAMES.map((name, i) => {
+            {monthNames.value.map((name, i) => {
               const selected = viewYear.value === props.modelValue.getFullYear() && i === props.modelValue.getMonth();
               const isNow = viewYear.value === now.getFullYear() && i === now.getMonth();
               return (
@@ -315,7 +430,7 @@ export default defineComponent({
       return (
         <>
           <div class="hk-dtp-weekdays">
-            {WEEKDAY_NAMES.map((w, i) => (
+            {weekdayLabels.value.map((w, i) => (
               <span key={i} class="hk-dtp-wd">{w}</span>
             ))}
           </div>
@@ -378,6 +493,10 @@ export default defineComponent({
     }
 
     return () => {
+      if (useNative.value) {
+        return renderNative();
+      }
+
       const body = (
         <div class="hk-dtp" role="group" aria-label={t("hk.dateTimePicker.pickDate", "Pick a date and time")}>
           {renderBody()}
@@ -396,34 +515,33 @@ export default defineComponent({
       }
 
       return (
-        <HPopover
-          modelValue={open.value}
-          onUpdate:modelValue={(v: boolean) => { open.value = v; }}
-        >
-          {{
-            trigger: () => (
-              <div class="hk-dtp-trigger-wrap" onClick={toggleOpen}>
-                {slots.trigger
-                  ? slots.trigger({ open: open.value })
-                  : (
-                    <button class="hk-dtp-trigger" type="button" aria-expanded={open.value}>
-                      <Calendar size={14} class="hk-dtp-trigger-icon" />
-                      <span class="hk-dtp-trigger-val">{triggerLabel.value}</span>
-                      <ChevronDown
-                        size={14}
-                        class={["hk-dtp-trigger-chev", open.value ? "is-open" : ""].filter(Boolean).join(" ")}
-                      />
-                    </button>
-                  )}
-              </div>
-            ),
-            default: () => (
-              <div class="hk-dtp-popup">
-                {body}
-              </div>
-            ),
-          }}
-        </HPopover>
+        <div class="hk-dtp-popup-root">
+          <div ref={triggerWrapRef} class="hk-dtp-trigger-wrap" onClick={toggleOpen}>
+            {slots.trigger
+              ? slots.trigger({ open: open.value })
+              : (
+                <button class="hk-dtp-trigger" type="button" aria-expanded={open.value}>
+                  <Calendar size={14} class="hk-dtp-trigger-icon" />
+                  <span class="hk-dtp-trigger-val">{triggerLabel.value}</span>
+                  <ChevronDown
+                    size={14}
+                    class={["hk-dtp-trigger-chev", open.value ? "is-open" : ""].filter(Boolean).join(" ")}
+                  />
+                </button>
+              )}
+          </div>
+          <HPopover
+            modelValue={open.value}
+            onUpdate:modelValue={(v: boolean) => { open.value = v; }}
+            anchorRef={triggerWrapRef.value ?? null}
+            placement={props.placement}
+            offset={props.offset}
+          >
+            <div class="hk-dtp-popup">
+              {body}
+            </div>
+          </HPopover>
+        </div>
       );
     };
   },


### PR DESCRIPTION
## Spec

Admin pages carry half-done native picker components. This upgrades both date pickers in the Vue package so desktop keeps hikari's own chrome (with hikari's own i18n layer), while touch-sized viewports pass through to the phone's native OS controls — the better interaction on mobile.

## Changes

### HkDateTimePicker — the half-done one

1. **Locale-derived names instead of hardcoded English.** `MONTH_NAMES` / `MONTH_NAMES_LONG` / `WEEKDAY_NAMES` literal arrays are gone. Month short/long names, weekday labels and the trigger label are now derived via `Intl.DateTimeFormat` from the shared i18n locale state (same approach as `HkDatePicker.tsx`): `locale = computed(() => useI18n().locale)`, `new Intl.DateTimeFormat(locale, { month: "short" })` etc., and the week-start column from `Intl.Locale` `weekInfo` (with the older `getInfo` and the Sunday fallback HkDatePicker already established). Trigger time stays 24-hour (`hourCycle: "h23"`) to match the steppers. A11y labels still route through `t("hk.dateTimePicker.*")`.
2. **Mobile pass-through.** New prop `nativeOnMobile?: boolean` (default **true**). When true and `useBreakpoint().isMobile` (< 768px), renders a native `<input type="datetime-local">` (or `type="date"` when `showTime=false`) instead of the custom popup. Conversion between the `Date` model and the input's local-time wire format is careful: strict `YYYY-MM-DD[THH:mm]` parsing that rejects rollovers (`2026-02-31`), tolerates engine-appended seconds, preserves clock time when `showTime=false` (mirroring day selection in the custom grid), passes `min`/`max` through in wire format, clamps rejected edits by re-syncing the field to the model, and restores the model value when the field is cleared (the model is a required `Date` with no null semantics). Desktop keeps the custom picker untouched.
3. **Fixed the dead popup mode.** `mode="popup"` previously passed its trigger via `slots.trigger` to `HPopover` — but HPopover renders **only** its default slot, so the trigger never appeared and the popover had no anchor (and `placement`/`offset` were never forwarded). The trigger wrap now renders beside HPopover and feeds it `anchorRef`/`placement`/`offset`.

### HkDatePicker — same mobile pass-through

New `nativeOnMobile` prop (default **true**) rendering `<input type="date">` below 768px. The model already speaks the ISO wire format; the handler emits `null` on clear, rejects out-of-bounds/invalid edits and re-syncs the field to the model.

### Tests

- New `HkDateTimePicker.test.ts` (19 tests) following the `HkDatePicker.test.ts` harness conventions (happy-dom, createApp mounts, `setLocale`): renders with a 42-cell grid, weekday/month labels derive from `Intl` and re-derive after `setLocale("zh-Hans")`/`"de"`, Monday-first week column, day selection preserves time-of-day, min/max disable + reject clicks, `markedDays` dots, popup opens from the trigger, and the full native mobile branch (datetime-local/date types, wire-format value + min/max, model updates, clock preservation, rejection re-sync, cleared-field fallback, popup chrome replacement, opt-out via `nativeOnMobile=false`). The mobile seam is `window.innerWidth`, which `useBreakpoint` reads at setup — no composable mock needed.
- `HkDatePicker.test.ts` extended with 5 mobile-branch tests (native input replaces calendar, opt-out, min/max pass-through, edit + clear emissions, rejected-edit re-sync).

Also: CHANGELOG `Unreleased → Added` entry and npm package version bump 0.4.12 → 0.4.13 (version bumps ride the main PR).

## Verification

From `packages/vue` with `COREPACK_HOME=/mnt/work/corepack corepack pnpm@11.18.0 --config.verifyDepsBeforeRun=false` (worktree reuses the main checkout's `node_modules` via symlink per AGENTS.md §9.6 — no install):

- `exec vue-tsc --noEmit` → **0 errors**
- `exec vitest run` → **13 files / 141 tests passed** (baseline 117 + 24 new: 19 in HkDateTimePicker.test.ts, +5 in HkDatePicker.test.ts)
- `run build` → **success**

Cross-verified by an independent verification subagent (code review, git hygiene, all three commands re-run, public API additivity check, native-input edge cases) — all pass. Not merging; leaving for review.