### PR TITLE
🎨 Style the locale picker popup as a proper surface submenu.

### DIFF
--- a/packages/vue/src/components/HkLocalePickerPopup.scss
+++ b/packages/vue/src/components/HkLocalePickerPopup.scss
@@ -1,0 +1,75 @@
+/* ── Locale picker popup (submenu-style listbox) ────────────────────
+ * Anchored flyout listing the supported locales. Renders as a proper
+ * hikari surface menu: elevated panel, hover wash, selected row with a
+ * check affordance — NOT an unstyled/native-looking list. */
+
+.hk-locale-picker-popup {
+  position: fixed;
+  z-index: var(--z-popover, 1100);
+  min-width: 11rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  padding: 4px;
+  border-radius: var(--radius-md, 8px);
+  background: color-mix(in srgb, rgb(var(--color-surface)) 96%, transparent);
+  backdrop-filter: blur(var(--blur-md, 12px)) saturate(1.15);
+  border: 1px solid rgb(var(--color-border) / 14%);
+  box-shadow: var(--shadow-dropdown, 0 8px 24px rgb(0 0 0 / 18%));
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.hk-locale-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: rgb(var(--color-text));
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+  appearance: none;
+}
+
+.hk-locale-picker-item:hover {
+  background: rgb(var(--color-primary) / 10%);
+}
+
+.hk-locale-picker-item[data-selected] {
+  background: rgb(var(--color-primary) / 14%);
+  font-weight: 600;
+}
+
+.hk-locale-picker-flag {
+  flex-shrink: 0;
+  font-size: var(--text-base);
+  line-height: 1;
+}
+
+.hk-locale-picker-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-locale-picker-item[data-selected] .hk-locale-picker-label::after {
+  content: "✓";
+  margin-left: 6px;
+  color: rgb(var(--color-primary));
+  font-weight: 700;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-locale-picker-item {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkLocalePickerPopup.tsx
+++ b/packages/vue/src/components/HkLocalePickerPopup.tsx
@@ -1,4 +1,5 @@
 import { defineComponent, type PropType } from "vue";
+import "./HkLocalePickerPopup.scss";
 import type { Ref } from "vue";
 
 const HkLocalePickerPopup = defineComponent({


### PR DESCRIPTION
## Summary

`HkLocalePickerPopup` shipped with **zero styles** — the `hk-locale-picker-*` classes had no scss anywhere, so the popup rendered as bare unstyled buttons (read as "native select" in consuming apps; reported from erp.celestia.world, and shittim-chest has the same unstyled render behind its own wrapper).

This adds `HkLocalePickerPopup.scss`: elevated glass surface (blur + border + dropdown shadow), row hover wash, selected row with primary tint + ✓ affordance, flag column, ellipsised labels, reduced-motion support. Wire-in is a one-line scss import in the component.

## Verification

vue-tsc green; vitest 141/141 green (13 files).