### PR TITLE
🐛 Keep the password placeholder layers from doubling on Tab focus.

### DIFF
--- a/packages/vue/src/components/HkPasswordInput.test.ts
+++ b/packages/vue/src/components/HkPasswordInput.test.ts
@@ -240,3 +240,42 @@ describe("HkPasswordInput variants and icons", () => {
     expect(placeholderText(container)).toBe("Confirm password (custom)");
   });
 });
+
+describe("HkPasswordInput placeholder layers on Tab focus", () => {
+  it("shows exactly one placeholder text on focus of an empty field", async () => {
+    const { container, input } = mountPasswordInput("", {});
+    expect(placeholderText(container)).toBeTruthy();
+    const before = placeholderText(container);
+    input.focus();
+    await nextTick();
+    await nextTick();
+    // Exactly one .hk-pwd-placeholder node, holding ONE of the valid texts.
+    const nodes = container.querySelectorAll(".hk-pwd-placeholder");
+    expect(nodes.length).toBe(1);
+    const txt = nodes[0].textContent ?? "";
+    expect([before, "已聚焦，请输入密码", "Focused, enter your password"]).toContain(txt);
+    // No hint/blur overlays doubled on top.
+    expect(container.querySelectorAll(".hk-pwd-blur-hint").length).toBe(0);
+    expect(container.querySelectorAll(".hk-pwd-select-hint").length).toBe(0);
+  });
+
+  it("keeps the marquee overlay text in lockstep with the static layer on focus", async () => {
+    const { container, input } = mountPasswordInput("", {
+      placeholder: "输入密码",
+      placeholderVariant: "marquee",
+    });
+    input.focus();
+    await nextTick();
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    await nextTick();
+    const staticText = container.querySelector(".hk-pwd-placeholder-text")
+      ?.textContent;
+    const marqueeText = container
+      .querySelector(".hk-placeholder-marquee__copy")
+      ?.textContent;
+    // Both layers must carry the SAME resolved text (the focused prompt)
+    // so their visibility handshake never shows two different strings.
+    expect(staticText).toBeTruthy();
+    expect(marqueeText).toBe(staticText);
+  });
+});

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -686,6 +686,7 @@ export default defineComponent({
           {(!props.modelValue || (pendingClear.value && focused.value)) &&
           !revealing.value ? (
             <span
+              key={`ph-${pendingClear.value && props.modelValue ? "has-value" : focused.value ? "focused" : "idle"}`}
               class="hk-pwd-placeholder"
               onPointerdown={(e: PointerEvent) => {
                 // Tapping the placeholder refocuses the field — after an
@@ -714,7 +715,9 @@ export default defineComponent({
                   text={
                     pendingClear.value && props.modelValue
                       ? t("hikari::passwordInput.focusedHasValuePlaceholder")
-                      : props.placeholder || t(variantPlaceholderKey.value)
+                      : focused.value
+                        ? t("hikari::passwordInput.focusedPlaceholder")
+                        : props.placeholder || t(variantPlaceholderKey.value)
                   }
                   variant={props.placeholderVariant}
                   onOverflowChange={(v: boolean) => {


### PR DESCRIPTION
## Bug (user report)
Tab from the previous field into a password input: the ORIGINAL placeholder may not clear, leaving TWO placeholders visible at once.

## Root causes (two, stacked)
1. **Marquee overlay text desync** — `HkPlaceholderMarquee`'s text ternary inside `HkPasswordInput` lacked the `focused` branch: on focus the static layer swapped to the focused prompt while the marquee kept rendering the original placeholder. In marquee mode the `marqueeOverflow` flag is measured from the marquee's (original) text, so the static stayed `visibility:hidden` and the original never cleared on Tab; when the visibility handshake ran a frame behind the re-measure, both texts showed simultaneously.
2. **Swap-patch across states** — the placeholder span persisted across the idle→focused text swap; any mid-flight render could show the stale and fresh text together.

## Fix
- Marquee text now resolves the SAME ternary as the static layer (focused branch included) — the two layers can never disagree.
- The placeholder span is keyed on the resolved state (`idle | focused | has-value`) so a flip re-creates the node instead of patching across it.
- +2 tests: single-text invariant on empty-field Tab focus; static/marquee text lockstep.

## Verification
- vue-tsc 0 errors · vitest **143/143** (13 files) · build ✓.
- Downstream note (chest): its login field also carried `autocomplete="new-password"` on a LOGIN page — that triggers Chrome's own suggest-strong-password inline overlay (a second placeholder-looking text) exactly on Tab focus; chest master now uses `current-password` there (register/setup keep `new-password`).