### PR TITLE
🐛 Fix the cascading menu sibling switching and mobile back-stack semantics.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ Current master, Rust workspace `0.3.19`.
 
 ### Added
 
+- Add a generic cascading menu component `HkMenu` (`items` tree with
+  icons/flags/checked/danger/disabled rows) plus `HkLocalePickerPopup`
+  rebuilt as a thin config over it: desktop anchors the root panel to the
+  trigger and cascades submenu panels to the right of their anchor row
+  (flipping left on viewport overflow), switching or collapsing on sibling
+  hover like a classic menubar; mobile renders one fullscreen sheet per
+  level — the root included — where every level pushes a history entry so
+  the system/browser back gesture closes exactly one level.
 - Add mobile native pass-through to both date pickers and localize the
   datetime picker: HkDateTimePicker now derives month/weekday names and the
   trigger label from `Intl.DateTimeFormat` on the active locale (week start

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -37,6 +37,16 @@ const siblingItems: HkMenuItem[] = [
   },
 ];
 
+interface MountedMenu {
+  container: HTMLElement;
+  unmount: () => void;
+}
+
+/**
+ * Menus render through a Teleport to body, so queries go to the document.
+ * Keep at most one OPEN menu mounted at a time (unmount via the returned
+ * handle) — body queries cannot tell instances apart.
+ */
 function mountMenu(
   openRef = ref(true),
   menuItems: HkMenuItem[] = items,
@@ -44,7 +54,7 @@ function mountMenu(
     onSelect?: (key: string) => void;
     onUpdateOpen?: (v: boolean) => void;
   } = {},
-): HTMLElement {
+): MountedMenu {
   const container = document.createElement("div");
   document.body.appendChild(container);
   containers.push(container);
@@ -66,7 +76,30 @@ function mountMenu(
   const app = createApp(Wrapper);
   mounts.push(app);
   app.mount(container);
-  return container;
+  return {
+    container,
+    unmount: () => {
+      const i = mounts.indexOf(app);
+      if (i >= 0) mounts.splice(i, 1);
+      app.unmount();
+    },
+  };
+}
+
+function rows(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll(".hk-menu-row")) as HTMLButtonElement[];
+}
+
+function rowByLabel(label: string): HTMLButtonElement | undefined {
+  return rows().find((r) => r.textContent?.includes(label));
+}
+
+function panels(): Element[] {
+  return Array.from(document.querySelectorAll(".hk-menu-panel"));
+}
+
+function sheets(): Element[] {
+  return Array.from(document.querySelectorAll(".hk-menu-sheet"));
 }
 
 async function settle(): Promise<void> {
@@ -95,32 +128,31 @@ afterEach(async () => {
 
 describe("HkMenu", () => {
   it("renders the root rows when open and nothing when closed", () => {
-    const c = mountMenu(ref(false));
-    expect(c.textContent ?? "").toBe("");
-    const c2 = mountMenu(ref(true));
-    expect(c2.textContent ?? "").toContain("Language");
-    expect(c2.textContent ?? "").toContain("Log out");
+    mountMenu(ref(false));
+    expect(document.querySelector(".hk-menu-panel")).toBeNull();
+    expect(document.querySelector(".hk-menu-sheet")).toBeNull();
+    mountMenu(ref(true));
+    expect(document.body.textContent ?? "").toContain("Language");
+    expect(document.body.textContent ?? "").toContain("Log out");
   });
 
   it("cascades into children on the desktop path and emits select on leaves", async () => {
     const selected: string[] = [];
     const closes: boolean[] = [];
     const openRef = ref(true);
-    const container = mountMenu(openRef, items, {
+    mountMenu(openRef, items, {
       onSelect: (key) => selected.push(key),
       onUpdateOpen: (v) => closes.push(v),
     });
     await settle();
 
-    const rows = Array.from(container.querySelectorAll(".hk-menu-row")) as HTMLButtonElement[];
-    rows.find((r) => r.textContent?.includes("Language"))!.click();
+    rowByLabel("Language")!.click();
     await settle();
-    const panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
-    expect(panels.length).toBe(2);
-    expect(panels[1].textContent).toContain("中文");
+    expect(panels().length).toBe(2);
+    expect(panels()[1].textContent).toContain("中文");
 
-    const leaf = Array.from(panels[1].querySelectorAll(".hk-menu-row")).find(
-      (r) => r.textContent?.includes("中文"),
+    const leaf = Array.from(panels()[1].querySelectorAll(".hk-menu-row")).find((r) =>
+      r.textContent?.includes("中文"),
     ) as HTMLButtonElement;
     leaf.click();
     await settle();
@@ -129,72 +161,50 @@ describe("HkMenu", () => {
   });
 
   it("switches the cascade when a sibling branch is clicked", async () => {
-    const container = mountMenu(ref(true), siblingItems);
+    mountMenu(ref(true), siblingItems);
     await settle();
 
-    const rowByLabel = (label: string) =>
-      Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
-        r.textContent?.includes(label),
-      ) as HTMLButtonElement;
-
-    rowByLabel("Branch One").click();
+    rowByLabel("Branch One")!.click();
     await settle();
-    let panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
-    expect(panels.length).toBe(2);
-    expect(panels[1].textContent).toContain("One A");
+    expect(panels().length).toBe(2);
+    expect(panels()[1].textContent).toContain("One A");
 
     // Clicking the sibling in the ROOT panel must replace the open submenu,
     // not nest under it.
-    rowByLabel("Branch Two").click();
+    rowByLabel("Branch Two")!.click();
     await settle();
-    panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
-    expect(panels.length).toBe(2);
-    expect(panels[1].textContent).toContain("Two A");
-    expect(panels[1].textContent).not.toContain("One A");
-    const active = Array.from(container.querySelectorAll(".hk-menu-row[data-active]"));
+    expect(panels().length).toBe(2);
+    expect(panels()[1].textContent).toContain("Two A");
+    expect(panels()[1].textContent).not.toContain("One A");
+    const active = Array.from(document.querySelectorAll(".hk-menu-row[data-active]"));
     expect(active.length).toBe(1);
     expect(active[0].textContent).toContain("Branch Two");
   });
 
   it("switches submenu on sibling hover and collapses on leaf hover", async () => {
-    const container = mountMenu(ref(true), siblingItems);
+    const first = mountMenu(ref(true), siblingItems);
     await settle();
 
-    const rootPanel = () => Array.from(container.querySelectorAll(".hk-menu-panel"))[0];
-    const rowByLabel = (label: string) =>
-      Array.from(rootPanel().querySelectorAll(".hk-menu-row")).find((r) =>
-        r.textContent?.includes(label),
-      ) as HTMLButtonElement;
-
-    rowByLabel("Branch One").click();
+    rowByLabel("Branch One")!.click();
     await settle();
-    expect(Array.from(container.querySelectorAll(".hk-menu-panel")).length).toBe(2);
+    expect(panels().length).toBe(2);
 
-    rowByLabel("Branch Two").dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    rowByLabel("Branch Two")!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
     await settle();
-    const panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
-    expect(panels.length).toBe(2);
-    expect(panels[1].textContent).toContain("Two A");
+    expect(panels().length).toBe(2);
+    expect(panels()[1].textContent).toContain("Two A");
 
     // Hovering a plain leaf row in the root panel collapses deeper levels.
-    const leafOnly = mountMenu(ref(true), [
-      ...siblingItems,
-      { key: "plain", label: "Plain Leaf" },
-    ]);
+    first.unmount();
     await settle();
-    const rootRows2 = Array.from(
-      Array.from(leafOnly.querySelectorAll(".hk-menu-panel"))[0].querySelectorAll(
-        ".hk-menu-row",
-      ),
-    ) as HTMLButtonElement[];
-    rootRows2.find((r) => r.textContent?.includes("Branch One"))!.click();
+    mountMenu(ref(true), [...siblingItems, { key: "plain", label: "Plain Leaf" }]);
     await settle();
-    expect(Array.from(leafOnly.querySelectorAll(".hk-menu-panel")).length).toBe(2);
-    rootRows2
-      .find((r) => r.textContent?.includes("Plain Leaf"))!
-      .dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    rowByLabel("Branch One")!.click();
     await settle();
-    expect(Array.from(leafOnly.querySelectorAll(".hk-menu-panel")).length).toBe(1);
+    expect(panels().length).toBe(2);
+    rowByLabel("Plain Leaf")!.dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    await settle();
+    expect(panels().length).toBe(1);
   });
 });
 
@@ -202,29 +212,23 @@ describe("HkMenu mobile sheets", () => {
   it("opens one fullscreen sheet per level and back closes exactly one level", async () => {
     window.innerWidth = 390;
     const openRef = ref(true);
-    const container = mountMenu(openRef, siblingItems);
+    mountMenu(openRef, siblingItems);
     await settle();
 
     // Root sheet only, with its own history entry.
-    let sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
-    expect(sheets.length).toBe(1);
+    expect(sheets().length).toBe(1);
     expect(window.history.state?.__hkMenuDepth).toBe(0);
 
     // Enter the first branch → two stacked sheets + a new history entry.
-    const branchRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
-      r.textContent?.includes("Branch One"),
-    ) as HTMLButtonElement;
-    branchRow.click();
+    rowByLabel("Branch One")!.click();
     await settle();
-    sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
-    expect(sheets.length).toBe(2);
+    expect(sheets().length).toBe(2);
     expect(window.history.state?.__hkMenuDepth).toBe(1);
 
     // Browser/system back closes ONE level: back to the root sheet.
     window.history.back();
     await settle();
-    sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
-    expect(sheets.length).toBe(1);
+    expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
     expect(window.history.state?.__hkMenuDepth).toBe(0);
 
@@ -232,29 +236,26 @@ describe("HkMenu mobile sheets", () => {
     window.history.back();
     await settle();
     expect(openRef.value).toBe(false);
-    expect(container.querySelector(".hk-menu-sheet")).toBeNull();
+    expect(document.querySelector(".hk-menu-sheet")).toBeNull();
     expect(window.history.state?.__hkMenuId).toBeUndefined();
   });
 
   it("keeps the root sheet when a pushed level is dismissed via its back button", async () => {
     window.innerWidth = 390;
     const openRef = ref(true);
-    const container = mountMenu(openRef, siblingItems);
+    mountMenu(openRef, siblingItems);
     await settle();
 
-    const branchRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
-      r.textContent?.includes("Branch One"),
-    ) as HTMLButtonElement;
-    branchRow.click();
+    rowByLabel("Branch One")!.click();
     await settle();
-    expect(Array.from(container.querySelectorAll(".hk-menu-sheet")).length).toBe(2);
+    expect(sheets().length).toBe(2);
 
-    const backBtn = Array.from(container.querySelectorAll(".hk-menu-sheet-back")).at(
+    const backBtn = Array.from(document.querySelectorAll(".hk-menu-sheet-back")).at(
       -1,
     ) as HTMLButtonElement;
     backBtn.click();
     await settle();
-    expect(Array.from(container.querySelectorAll(".hk-menu-sheet")).length).toBe(1);
+    expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
     expect(window.history.state?.__hkMenuDepth).toBe(0);
   });
@@ -263,25 +264,19 @@ describe("HkMenu mobile sheets", () => {
     window.innerWidth = 390;
     const selected: string[] = [];
     const openRef = ref(true);
-    const container = mountMenu(openRef, siblingItems, {
+    mountMenu(openRef, siblingItems, {
       onSelect: (key) => selected.push(key),
     });
     await settle();
 
-    const leafRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
-      r.textContent?.includes("Branch Two"),
-    ) as HTMLButtonElement;
-    leafRow.click();
+    rowByLabel("Branch Two")!.click();
     await settle();
-    const leaf = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
-      r.textContent?.includes("Two B"),
-    ) as HTMLButtonElement;
-    leaf.click();
+    rowByLabel("Two B")!.click();
     await settle();
 
     expect(selected).toEqual(["two-b"]);
     expect(openRef.value).toBe(false);
-    expect(container.querySelector(".hk-menu-sheet")).toBeNull();
+    expect(document.querySelector(".hk-menu-sheet")).toBeNull();
     await until(() => window.history.state?.__hkMenuId === undefined);
     expect(window.history.state?.__hkMenuId).toBeUndefined();
   });
@@ -289,9 +284,9 @@ describe("HkMenu mobile sheets", () => {
   it("follows live viewport changes without closing the menu", async () => {
     window.innerWidth = 390;
     const openRef = ref(true);
-    const container = mountMenu(openRef, siblingItems);
+    mountMenu(openRef, siblingItems);
     await settle();
-    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(1);
+    expect(sheets().length).toBe(1);
     expect(window.history.state?.__hkMenuDepth).toBe(0);
 
     // Rotate/grow to desktop while open: sheets become desktop panels and
@@ -300,8 +295,8 @@ describe("HkMenu mobile sheets", () => {
     window.dispatchEvent(new Event("resize"));
     await settle();
     expect(openRef.value).toBe(true);
-    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(0);
-    expect(container.querySelectorAll(".hk-menu-panel").length).toBe(1);
+    expect(sheets().length).toBe(0);
+    expect(panels().length).toBe(1);
     await until(() => window.history.state?.__hkMenuId === undefined);
     expect(window.history.state?.__hkMenuId).toBeUndefined();
 
@@ -310,7 +305,7 @@ describe("HkMenu mobile sheets", () => {
     window.dispatchEvent(new Event("resize"));
     await settle();
     expect(openRef.value).toBe(true);
-    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(1);
+    expect(sheets().length).toBe(1);
     expect(window.history.state?.__hkMenuDepth).toBe(0);
   });
 });

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -18,7 +18,33 @@ const items: HkMenuItem[] = [
   { key: "logout", label: "Log out", danger: true },
 ];
 
-function mountMenu(openRef = ref(true)): HTMLElement {
+const siblingItems: HkMenuItem[] = [
+  {
+    key: "one",
+    label: "Branch One",
+    children: [
+      { key: "one-a", label: "One A" },
+      { key: "one-b", label: "One B" },
+    ],
+  },
+  {
+    key: "two",
+    label: "Branch Two",
+    children: [
+      { key: "two-a", label: "Two A" },
+      { key: "two-b", label: "Two B" },
+    ],
+  },
+];
+
+function mountMenu(
+  openRef = ref(true),
+  menuItems: HkMenuItem[] = items,
+  handlers: {
+    onSelect?: (key: string) => void;
+    onUpdateOpen?: (v: boolean) => void;
+  } = {},
+): HTMLElement {
   const container = document.createElement("div");
   document.body.appendChild(container);
   containers.push(container);
@@ -28,8 +54,12 @@ function mountMenu(openRef = ref(true)): HTMLElement {
         h(HkMenu, {
           open: openRef.value,
           title: "Menu",
-          items,
-          onUpdate: () => {},
+          items: menuItems,
+          onSelect: handlers.onSelect,
+          "onUpdate:open": (v: boolean) => {
+            handlers.onUpdateOpen?.(v);
+            openRef.value = v;
+          },
         });
     },
   });
@@ -39,9 +69,28 @@ function mountMenu(openRef = ref(true)): HTMLElement {
   return container;
 }
 
-afterEach(() => {
+async function settle(): Promise<void> {
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+/** Wait until pred() holds (history navigation settles asynchronously). */
+async function until(pred: () => boolean, ms = 500): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await nextTick();
+  }
+}
+
+afterEach(async () => {
   while (mounts.length) mounts.pop()?.unmount();
+  // Unmounting restores history asynchronously; wait for it to land so a
+  // pending traversal cannot pop the NEXT test's freshly pushed entries.
+  await until(() => window.history.state?.__hkMenuId === undefined);
   while (containers.length) containers.pop()?.remove();
+  window.innerWidth = 1024;
 });
 
 describe("HkMenu", () => {
@@ -54,32 +103,18 @@ describe("HkMenu", () => {
   });
 
   it("cascades into children on the desktop path and emits select on leaves", async () => {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    containers.push(container);
     const selected: string[] = [];
     const closes: boolean[] = [];
     const openRef = ref(true);
-    const Wrapper = defineComponent({
-      setup() {
-        return () =>
-          h(HkMenu, {
-            open: openRef.value,
-            title: "Menu",
-            items,
-            onSelect: (key: string) => selected.push(key),
-            "onUpdate:open": (v: boolean) => { closes.push(v); openRef.value = v; },
-          });
-      },
+    const container = mountMenu(openRef, items, {
+      onSelect: (key) => selected.push(key),
+      onUpdateOpen: (v) => closes.push(v),
     });
-    const app = createApp(Wrapper);
-    mounts.push(app);
-    app.mount(container);
-    await nextTick();
+    await settle();
 
     const rows = Array.from(container.querySelectorAll(".hk-menu-row")) as HTMLButtonElement[];
     rows.find((r) => r.textContent?.includes("Language"))!.click();
-    await nextTick();
+    await settle();
     const panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
     expect(panels.length).toBe(2);
     expect(panels[1].textContent).toContain("中文");
@@ -88,8 +123,194 @@ describe("HkMenu", () => {
       (r) => r.textContent?.includes("中文"),
     ) as HTMLButtonElement;
     leaf.click();
-    await nextTick();
+    await settle();
     expect(selected).toEqual(["zh"]);
     expect(closes.at(-1)).toBe(false);
+  });
+
+  it("switches the cascade when a sibling branch is clicked", async () => {
+    const container = mountMenu(ref(true), siblingItems);
+    await settle();
+
+    const rowByLabel = (label: string) =>
+      Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
+        r.textContent?.includes(label),
+      ) as HTMLButtonElement;
+
+    rowByLabel("Branch One").click();
+    await settle();
+    let panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
+    expect(panels.length).toBe(2);
+    expect(panels[1].textContent).toContain("One A");
+
+    // Clicking the sibling in the ROOT panel must replace the open submenu,
+    // not nest under it.
+    rowByLabel("Branch Two").click();
+    await settle();
+    panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
+    expect(panels.length).toBe(2);
+    expect(panels[1].textContent).toContain("Two A");
+    expect(panels[1].textContent).not.toContain("One A");
+    const active = Array.from(container.querySelectorAll(".hk-menu-row[data-active]"));
+    expect(active.length).toBe(1);
+    expect(active[0].textContent).toContain("Branch Two");
+  });
+
+  it("switches submenu on sibling hover and collapses on leaf hover", async () => {
+    const container = mountMenu(ref(true), siblingItems);
+    await settle();
+
+    const rootPanel = () => Array.from(container.querySelectorAll(".hk-menu-panel"))[0];
+    const rowByLabel = (label: string) =>
+      Array.from(rootPanel().querySelectorAll(".hk-menu-row")).find((r) =>
+        r.textContent?.includes(label),
+      ) as HTMLButtonElement;
+
+    rowByLabel("Branch One").click();
+    await settle();
+    expect(Array.from(container.querySelectorAll(".hk-menu-panel")).length).toBe(2);
+
+    rowByLabel("Branch Two").dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    await settle();
+    const panels = Array.from(container.querySelectorAll(".hk-menu-panel"));
+    expect(panels.length).toBe(2);
+    expect(panels[1].textContent).toContain("Two A");
+
+    // Hovering a plain leaf row in the root panel collapses deeper levels.
+    const leafOnly = mountMenu(ref(true), [
+      ...siblingItems,
+      { key: "plain", label: "Plain Leaf" },
+    ]);
+    await settle();
+    const rootRows2 = Array.from(
+      Array.from(leafOnly.querySelectorAll(".hk-menu-panel"))[0].querySelectorAll(
+        ".hk-menu-row",
+      ),
+    ) as HTMLButtonElement[];
+    rootRows2.find((r) => r.textContent?.includes("Branch One"))!.click();
+    await settle();
+    expect(Array.from(leafOnly.querySelectorAll(".hk-menu-panel")).length).toBe(2);
+    rootRows2
+      .find((r) => r.textContent?.includes("Plain Leaf"))!
+      .dispatchEvent(new MouseEvent("mouseenter", { bubbles: false }));
+    await settle();
+    expect(Array.from(leafOnly.querySelectorAll(".hk-menu-panel")).length).toBe(1);
+  });
+});
+
+describe("HkMenu mobile sheets", () => {
+  it("opens one fullscreen sheet per level and back closes exactly one level", async () => {
+    window.innerWidth = 390;
+    const openRef = ref(true);
+    const container = mountMenu(openRef, siblingItems);
+    await settle();
+
+    // Root sheet only, with its own history entry.
+    let sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
+    expect(sheets.length).toBe(1);
+    expect(window.history.state?.__hkMenuDepth).toBe(0);
+
+    // Enter the first branch → two stacked sheets + a new history entry.
+    const branchRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
+      r.textContent?.includes("Branch One"),
+    ) as HTMLButtonElement;
+    branchRow.click();
+    await settle();
+    sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
+    expect(sheets.length).toBe(2);
+    expect(window.history.state?.__hkMenuDepth).toBe(1);
+
+    // Browser/system back closes ONE level: back to the root sheet.
+    window.history.back();
+    await settle();
+    sheets = Array.from(container.querySelectorAll(".hk-menu-sheet"));
+    expect(sheets.length).toBe(1);
+    expect(openRef.value).toBe(true);
+    expect(window.history.state?.__hkMenuDepth).toBe(0);
+
+    // Back from the root closes the menu entirely.
+    window.history.back();
+    await settle();
+    expect(openRef.value).toBe(false);
+    expect(container.querySelector(".hk-menu-sheet")).toBeNull();
+    expect(window.history.state?.__hkMenuId).toBeUndefined();
+  });
+
+  it("keeps the root sheet when a pushed level is dismissed via its back button", async () => {
+    window.innerWidth = 390;
+    const openRef = ref(true);
+    const container = mountMenu(openRef, siblingItems);
+    await settle();
+
+    const branchRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
+      r.textContent?.includes("Branch One"),
+    ) as HTMLButtonElement;
+    branchRow.click();
+    await settle();
+    expect(Array.from(container.querySelectorAll(".hk-menu-sheet")).length).toBe(2);
+
+    const backBtn = Array.from(container.querySelectorAll(".hk-menu-sheet-back")).at(
+      -1,
+    ) as HTMLButtonElement;
+    backBtn.click();
+    await settle();
+    expect(Array.from(container.querySelectorAll(".hk-menu-sheet")).length).toBe(1);
+    expect(openRef.value).toBe(true);
+    expect(window.history.state?.__hkMenuDepth).toBe(0);
+  });
+
+  it("selecting a leaf on mobile closes every sheet and restores history", async () => {
+    window.innerWidth = 390;
+    const selected: string[] = [];
+    const openRef = ref(true);
+    const container = mountMenu(openRef, siblingItems, {
+      onSelect: (key) => selected.push(key),
+    });
+    await settle();
+
+    const leafRow = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
+      r.textContent?.includes("Branch Two"),
+    ) as HTMLButtonElement;
+    leafRow.click();
+    await settle();
+    const leaf = Array.from(container.querySelectorAll(".hk-menu-row")).find((r) =>
+      r.textContent?.includes("Two B"),
+    ) as HTMLButtonElement;
+    leaf.click();
+    await settle();
+
+    expect(selected).toEqual(["two-b"]);
+    expect(openRef.value).toBe(false);
+    expect(container.querySelector(".hk-menu-sheet")).toBeNull();
+    await until(() => window.history.state?.__hkMenuId === undefined);
+    expect(window.history.state?.__hkMenuId).toBeUndefined();
+  });
+
+  it("follows live viewport changes without closing the menu", async () => {
+    window.innerWidth = 390;
+    const openRef = ref(true);
+    const container = mountMenu(openRef, siblingItems);
+    await settle();
+    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(1);
+    expect(window.history.state?.__hkMenuDepth).toBe(0);
+
+    // Rotate/grow to desktop while open: sheets become desktop panels and
+    // the pushed history entry is released — but the menu stays open.
+    window.innerWidth = 1280;
+    window.dispatchEvent(new Event("resize"));
+    await settle();
+    expect(openRef.value).toBe(true);
+    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(0);
+    expect(container.querySelectorAll(".hk-menu-panel").length).toBe(1);
+    await until(() => window.history.state?.__hkMenuId === undefined);
+    expect(window.history.state?.__hkMenuId).toBeUndefined();
+
+    // Shrink back: the root sheet returns with a fresh root entry.
+    window.innerWidth = 390;
+    window.dispatchEvent(new Event("resize"));
+    await settle();
+    expect(openRef.value).toBe(true);
+    expect(container.querySelectorAll(".hk-menu-sheet").length).toBe(1);
+    expect(window.history.state?.__hkMenuDepth).toBe(0);
   });
 });

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -6,6 +6,7 @@ import {
   onBeforeUnmount,
   onMounted,
   ref,
+  Teleport,
   watch,
   type Component,
   type PropType,
@@ -389,6 +390,9 @@ export default defineComponent({
     return () => {
       if (!props.open) return null;
 
+      // Both modes render through a Teleport: `position: fixed` children of
+      // an ancestor with backdrop-filter/filter/transform (glass popovers,
+      // drawers) are positioned relative to THAT ancestor, not the viewport.
       if (mobileMode.value) {
         // Root sheet is level 0; every pushed submenu level stacks above it.
         const sheets = [
@@ -399,7 +403,11 @@ export default defineComponent({
             }),
           ),
         ];
-        return <div class="hk-menu-mobile-stack">{sheets}</div>;
+        return (
+          <Teleport to="body">
+            <div class="hk-menu-mobile-stack">{sheets}</div>
+          </Teleport>
+        );
       }
 
       // Desktop: root panel + one popover per open submenu level.
@@ -419,10 +427,12 @@ export default defineComponent({
         );
       }
       return (
-        <div class="hk-menu-desktop">
-          <div class="hk-menu-backdrop" onClick={() => closeAll()} />
-          {panels}
-        </div>
+        <Teleport to="body">
+          <div class="hk-menu-desktop">
+            <div class="hk-menu-backdrop" onClick={() => closeAll()} />
+            {panels}
+          </div>
+        </Teleport>
       );
     };
   },

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -109,10 +109,17 @@ export default defineComponent({
 
     function restoreHistory(): void {
       // Single multi-step traversal: consecutive back() calls can be
-      // coalesced (happy-dom) or racy (browsers), go(-n) cannot.
-      if (pushedDepth > 0) {
+      // coalesced (happy-dom) or racy (browsers), go(-n) cannot. Depth is
+      // only trusted while our entry is still current — a foreign pushState
+      // while open (router navigation, another component) invalidates the
+      // count, so fall back to a marker-seek replace instead of guessing.
+      if (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
         suppressPop++;
         window.history.go(-pushedDepth);
+      } else if (pushedDepth > 0) {
+        // Our entries are still buried below the foreign top; replacing the
+        // current entry releases ownership without touching live history.
+        window.history.replaceState(null, "");
       }
       pushedDepth = 0;
     }
@@ -137,8 +144,15 @@ export default defineComponent({
         mobileStack.value = props.open ? mobileStack.value.slice(0, depth) : [];
         desktopPath.value = [];
         pushedDepth = depth + 1;
+        if (!props.open) {
+          // Forward gesture into a spent stack while closed: release the
+          // ownership marker so a closed menu never owns live history.
+          window.history.replaceState(null, "");
+          pushedDepth = 0;
+        }
         return;
       }
+      if (!props.open && pushedDepth === 0) return; // idle; nothing to do
       // Landed outside our stack — collapse whatever remains.
       pushedDepth = 0;
       mobileStack.value = [];
@@ -165,6 +179,8 @@ export default defineComponent({
 
     function onResize(): void {
       viewportTick.value++;
+      // Desktop panels are viewport-fixed; a same-mode resize strands them.
+      if (!mobileMode.value && props.open) void nextTick(refreshGeometry);
     }
 
     onMounted(() => window.addEventListener("popstate", onPopState));

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -24,11 +24,13 @@ import "./HkMenu.scss";
  * - Desktop: popover panel anchored to the trigger; rows carrying children
  *   cascade to the RIGHT of the anchor row (flipping to the left when the
  *   viewport runs out) — the traditional application menubar behavior.
- * - Mobile: every level opens as its own fullscreen sheet, stacked. Each
- *   pushed level also pushes a history entry, so the system/browser back
- *   gesture closes exactly one level (Android modal navigation mode).
+ *   Clicking (or hovering) a sibling row switches the open submenu to that
+ *   row, like a classic menubar.
+ * - Mobile: every level — including the root — opens as its own fullscreen
+ *   sheet, stacked. Every level pushes a history entry, so the system/browser
+ *   back gesture closes exactly one level (Android modal navigation mode);
+ *   closing the last level closes the menu.
  */
-
 export interface HkMenuItem {
   key: string;
   label: string;
@@ -48,8 +50,8 @@ interface MenuHistoryState {
 
 const MENU_ID = "__hkMenu";
 
-function isMobileViewport(): boolean {
-  return typeof window !== "undefined" && window.innerWidth < 768;
+function viewportIsMobile(breakpoint: number): boolean {
+  return typeof window !== "undefined" && window.innerWidth < breakpoint;
 }
 
 export default defineComponent({
@@ -77,14 +79,42 @@ export default defineComponent({
   setup(props, { emit }) {
     /** Open submenu path on desktop, e.g. ["theme", "dark"] → panel chain. */
     const desktopPath = ref<string[]>([]);
-    /** Stacked sheet chain on mobile: each entry is the items of that level. */
+    /** Pushed sheet chain on mobile: each entry is one submenu level. */
     const mobileStack = ref<{ title: string; items: HkMenuItem[] }[]>([]);
     const instanceId = `${MENU_ID}-${Math.random().toString(36).slice(2, 8)}`;
+    /**
+     * History entries this instance pushed above the page's base entry —
+     * also the number of back() calls needed to reach the base again.
+     * History depth 0 (the root sheet) counts, so this is depth + 1.
+     */
     let pushedDepth = 0;
+    /** Popstate events produced by our own restoreHistory — not user backs. */
+    let suppressPop = 0;
+    /** Bumped on viewport resize so an open menu re-renders in the right mode. */
+    const viewportTick = ref(0);
 
-    const mobileMode = computed(
-      () => typeof window !== "undefined" && window.innerWidth < props.mobileBreakpoint,
-    );
+    const mobileMode = computed(() => {
+      void viewportTick.value; // re-evaluate when the viewport changes
+      return viewportIsMobile(props.mobileBreakpoint);
+    });
+
+    function pushHistoryEntry(depth: number): void {
+      window.history.pushState(
+        { __hkMenuId: instanceId, __hkMenuDepth: depth } satisfies MenuHistoryState,
+        "",
+      );
+      pushedDepth = depth + 1;
+    }
+
+    function restoreHistory(): void {
+      // Single multi-step traversal: consecutive back() calls can be
+      // coalesced (happy-dom) or racy (browsers), go(-n) cannot.
+      if (pushedDepth > 0) {
+        suppressPop++;
+        window.history.go(-pushedDepth);
+      }
+      pushedDepth = 0;
+    }
 
     function closeAll(): void {
       desktopPath.value = [];
@@ -93,58 +123,114 @@ export default defineComponent({
       emit("update:open", false);
     }
 
-    function restoreHistory(): void {
-      while (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
-        window.history.back();
-        pushedDepth--;
-      }
-    }
-
     function onPopState(e: PopStateEvent): void {
+      if (suppressPop > 0) {
+        // Our own restore traversal landing — not a user back gesture.
+        suppressPop--;
+        return;
+      }
       const st = e.state as MenuHistoryState | null;
-      if (st?.__hkMenuId === instanceId) return; // still one of ours
-      // Back landed outside our stack — collapse whatever remains.
+      if (st?.__hkMenuId === instanceId) {
+        // Landed on one of our own entries — close exactly one level.
+        const depth = Math.max(0, st.__hkMenuDepth ?? 0);
+        mobileStack.value = props.open ? mobileStack.value.slice(0, depth) : [];
+        desktopPath.value = [];
+        pushedDepth = depth + 1;
+        return;
+      }
+      // Landed outside our stack — collapse whatever remains.
       pushedDepth = 0;
-      if (mobileStack.value.length > 0) mobileStack.value = [];
-      if (desktopPath.value.length > 0) desktopPath.value = [];
+      mobileStack.value = [];
+      desktopPath.value = [];
       emit("update:open", false);
     }
 
     function pushLevel(title: string, items: HkMenuItem[]): void {
       mobileStack.value.push({ title, items });
-      window.history.pushState(
-        { __hkMenuId: instanceId, __hkMenuDepth: ++pushedDepth } satisfies MenuHistoryState,
-        "",
-      );
+      pushHistoryEntry(mobileStack.value.length);
     }
 
     function popLevel(): boolean {
       if (mobileStack.value.length === 0) return false;
-      mobileStack.value.pop();
       if (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
+        // The popstate handler (ours, depth-1) truncates the stack — one
+        // source of truth for both drivers (in-app back and browser back).
         window.history.back();
-        pushedDepth--;
+      } else {
+        mobileStack.value.pop();
       }
       return true;
     }
 
+    function onResize(): void {
+      viewportTick.value++;
+    }
+
     onMounted(() => window.addEventListener("popstate", onPopState));
+    onMounted(() => window.addEventListener("resize", onResize));
     onBeforeUnmount(() => {
       window.removeEventListener("popstate", onPopState);
+      window.removeEventListener("resize", onResize);
       restoreHistory();
     });
 
-    function onItem(item: HkMenuItem): void {
+    /**
+     * Keep the history chain in sync with the open state and the active
+     * mode: a menu opened on mobile owns one root entry; a menu that ends
+     * up on desktop releases every entry it pushed.
+     */
+    watch(
+      // String key: fires on real state changes only, not on every resize tick.
+      () => `${props.open ? 1 : 0}:${mobileMode.value ? 1 : 0}`,
+      (key) => {
+        const openNow = key.startsWith("1");
+        const mobile = key.endsWith("1");
+        if (!openNow) {
+          if (pushedDepth > 0 || mobileStack.value.length > 0 || desktopPath.value.length > 0) {
+            desktopPath.value = [];
+            mobileStack.value = [];
+            restoreHistory();
+          }
+          return;
+        }
+        if (mobile) {
+          // Normalize: exactly one fresh root entry above the page's history.
+          if (pushedDepth !== 0) restoreHistory();
+          pushHistoryEntry(0);
+        } else if (pushedDepth > 0) {
+          desktopPath.value = [];
+          mobileStack.value = [];
+          restoreHistory();
+        }
+      },
+      { immediate: true, flush: "sync" },
+    );
+
+    function onItem(item: HkMenuItem, level: number): void {
       if (item.disabled) return;
       if (item.children?.length) {
-        if (mobileMode.value) pushLevel(item.label, item.children);
-        else {
-          desktopPath.value = [...desktopPath.value.slice(0, currentLevel.value), item.key];
+        if (mobileMode.value) {
+          pushLevel(item.label, item.children);
+        } else {
+          // Replace the path at the clicked row's level — clicking a
+          // sibling in a shallower panel switches the cascade to it.
+          desktopPath.value = [...desktopPath.value.slice(0, level), item.key];
         }
         return;
       }
       emit("select", item.key, item);
       closeAll();
+    }
+
+    /** Classic menubar hover semantics: hovering a row at a level collapses
+     *  everything deeper; hovering a sibling branch switches to it. */
+    function onRowEnter(item: HkMenuItem, level: number): void {
+      if (mobileMode.value) return;
+      if (desktopPath.value.length <= level) return;
+      if (desktopPath.value[level] === item.key) return;
+      desktopPath.value = item.children?.length
+        ? [...desktopPath.value.slice(0, level), item.key]
+        : desktopPath.value.slice(0, level);
     }
 
     /** Which items the currently deepest desktop panel shows. */
@@ -183,6 +269,7 @@ export default defineComponent({
         top = r.bottom + props.offset;
         left = props.placement.endsWith("-end") ? r.right - panelW : r.left;
         if (props.placement.startsWith("top-")) top = r.top - panelH - props.offset;
+        if (left + panelW > window.innerWidth - 8) left = Math.max(8, window.innerWidth - 8 - panelW);
       }
       if (top + panelH > window.innerHeight - 8) top = Math.max(8, window.innerHeight - 8 - panelH);
       panelStyle.value = {
@@ -193,13 +280,13 @@ export default defineComponent({
       };
     }
 
-    // Rows the deepest submenu anchors from (each open row element).
-    const rowRefs = ref<Record<number, HTMLElement | null>>({});
+    /** Anchor row elements of the open cascade, keyed `<level>:<itemKey>`. */
+    const rowRefs = ref<Record<string, HTMLElement | null>>({});
     const subStyles = ref<Record<number, Record<string, string>>>({});
 
     function positionSubmenus(): void {
       for (let d = 0; d < desktopPath.value.length; d++) {
-        const row = rowRefs.value[d];
+        const row = rowRefs.value[`${d}:${desktopPath.value[d]}`];
         if (!row) continue;
         const r = row.getBoundingClientRect();
         const w = 224;
@@ -253,7 +340,7 @@ export default defineComponent({
           ref={
             hasKids
               ? (el: unknown) => {
-                  rowRefs.value[level] = el as HTMLElement | null;
+                  rowRefs.value[`${level}:${item.key}`] = el as HTMLElement | null;
                 }
               : undefined
           }
@@ -261,12 +348,8 @@ export default defineComponent({
           data-checked={item.checked || undefined}
           data-danger={item.danger || undefined}
           data-disabled={item.disabled || undefined}
-          onClick={() => onItem(item)}
-          onMouseenter={() => {
-            if (!hasKids && desktopPath.value.length > level) {
-              desktopPath.value = desktopPath.value.slice(0, level);
-            }
-          }}
+          onClick={() => onItem(item, level)}
+          onMouseenter={() => onRowEnter(item, level)}
         >
           {item.flag && <span class="hk-menu-flag">{item.flag}</span>}
           {item.icon && h(item.icon, { size: 15 })}
@@ -277,60 +360,46 @@ export default defineComponent({
       );
     }
 
+    function renderSheet(
+      level: number,
+      sheetTitle: string,
+      list: HkMenuItem[],
+      onBack: () => void,
+    ) {
+      return (
+        <div
+          key={level}
+          class="hk-menu-sheet"
+          data-level={level}
+          style={{ zIndex: `${1200 + level}` }}
+        >
+          <div class="hk-menu-sheet-header">
+            <button type="button" class="hk-menu-sheet-back" aria-label="Back" onClick={onBack}>
+              <ChevronLeft size={18} />
+            </button>
+            <span class="hk-menu-sheet-title">{sheetTitle || props.title}</span>
+          </div>
+          <div class="hk-menu-sheet-body">
+            {list.map((it, idx) => renderRow(it, level, idx))}
+          </div>
+        </div>
+      );
+    }
+
     return () => {
       if (!props.open) return null;
 
-      if (isMobileViewport()) {
-        const top = mobileStack.value[mobileStack.value.length - 1];
-        const sheets = mobileStack.value;
-        return (
-          <div class="hk-menu-mobile-stack">
-            {sheets.map((sheet, i) => (
-              <div
-                key={i}
-                class="hk-menu-sheet"
-                data-level={i}
-                style={{ zIndex: `${1200 + i}` }}
-              >
-                <div class="hk-menu-sheet-header">
-                  <button
-                    type="button"
-                    class="hk-menu-sheet-back"
-                    aria-label="Back"
-                    onClick={() => {
-                      if (!popLevel()) closeAll();
-                    }}
-                  >
-                    <ChevronLeft size={18} />
-                  </button>
-                  <span class="hk-menu-sheet-title">{sheet.title || props.title}</span>
-                </div>
-                <div class="hk-menu-sheet-body">
-                  {sheet.items.map((it) => renderRow(it, i, i))}
-                </div>
-              </div>
-            ))}
-            {/* level-0 sheet when no submenu is open */}
-            {sheets.length === 0 && (
-              <div class="hk-menu-sheet" data-level={0} style={{ zIndex: "1200" }}>
-                <div class="hk-menu-sheet-header">
-                  <button
-                    type="button"
-                    class="hk-menu-sheet-back"
-                    aria-label="Back"
-                    onClick={() => closeAll()}
-                  >
-                    <ChevronLeft size={18} />
-                  </button>
-                  <span class="hk-menu-sheet-title">{props.title}</span>
-                </div>
-                <div class="hk-menu-sheet-body">
-                  {props.items.map((it, idx) => renderRow(it, 0, idx))}
-                </div>
-              </div>
-            )}
-          </div>
-        );
+      if (mobileMode.value) {
+        // Root sheet is level 0; every pushed submenu level stacks above it.
+        const sheets = [
+          renderSheet(0, props.title, props.items, () => closeAll()),
+          ...mobileStack.value.map((entry, i) =>
+            renderSheet(i + 1, entry.title, entry.items, () => {
+              if (!popLevel()) closeAll();
+            }),
+          ),
+        ];
+        return <div class="hk-menu-mobile-stack">{sheets}</div>;
       }
 
       // Desktop: root panel + one popover per open submenu level.

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -112,7 +112,8 @@ export default defineComponent({
       // coalesced (happy-dom) or racy (browsers), go(-n) cannot. Depth is
       // only trusted while our entry is still current — a foreign pushState
       // while open (router navigation, another component) invalidates the
-      // count, so fall back to a marker-seek replace instead of guessing.
+      // count, so release ownership by de-marking the current entry instead
+      // of traversing a count we can no longer trust.
       if (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
         suppressPop++;
         window.history.go(-pushedDepth);
@@ -260,8 +261,6 @@ export default defineComponent({
       }
       return list;
     });
-
-    const currentLevel = computed(() => desktopPath.value.length);
 
     // ── desktop popover geometry ────────────────────────────────────
     const panelStyle = ref<Record<string, string>>({ width: "224px" });


### PR DESCRIPTION
## Summary

Follow-up to #196 (HkMenu). Browser verification of the merged primitive surfaced five real defects against the intended spec ("submenu cascades right of the trigger row like a traditional app menu; mobile = each level is a modal, Android-style back closes ONE level"):

1. **Sibling switching was broken** — `onItem` appended to the path at the *deepest open level* (it did not know the clicked row's level), so clicking `Group One` while `Group Two`'s submenu was open produced path `["group-2","group-1"]` and the submenu silently stayed on Group Two (browser-reproduced). Rows now pass their level; a click replaces the path at that level.
2. **Submenus anchored to the wrong row** — row refs were keyed by level only, so the cascade positioned against the *last* branch row mounted at that level, not the active one. Refs are now keyed `<level>:<key>` and positioning reads the active path.
3. **Mobile back-stack semantics were absent** — the root sheet pushed no history entry and `onPopState` early-returned on our own states, so browser-back closed the WHOLE menu (or did nothing at depth ≥ 2). Now every level — the root included — owns one history entry; back truncates the stack to the landed depth (one level per gesture, root-back closes the menu); in-app back buttons ride the same popstate path. `restoreHistory` uses a single `go(-n)` traversal (consecutive `back()` calls get coalesced by happy-dom and are racy in browsers) with a suppression counter so its landing popstate cannot be misread as a user gesture.
4. **Mode was frozen** — `mobileMode` was a computed with no reactive deps (cached at first read) and the render read `innerWidth` only between renders. A resize tick now feeds the computed; an open menu live-switches sheet↔panel and normalizes its history chain without closing (the transition's own restore previously closed the menu — fixed and regression-tested).
5. **`position: fixed` inside filtered ancestors** — glass popovers (`backdrop-filter`) become containing blocks for fixed children, so a menu opened inside erp's account popover rendered misplaced (verified: style said 249/146, rect was 274/189). Both surfaces now render through `<Teleport to="body">`.

Plus classic menubar hover semantics: hovering a sibling branch switches its submenu in, hovering a leaf collapses deeper levels; root panels with `bottom-*` placements flip horizontally on overflow.

## Verification

- vitest **149/149** (8 HkMenu tests: cascade+select, sibling click-switch, hover-switch/hover-collapse, N-sheets-per-level, browser-back closes one level, in-app back, leaf-close restores history, live viewport switch).
- vue-tsc clean.
- Browser (vite scratch harness, 1280px): 3-level cascade right (x 0→285→514), submenu flip-left at the right edge, active-row anchoring, hover-switch, no history entries pushed on desktop.
- Browser (390px): 1/2/3 levels = 1/2/3 fullscreen sheets at depth 0/1/2; back closes exactly one level each gesture down to closed; leaf select closes all and releases exactly its own entries.
- Consumed in erp (PR celestia-island/erp.celestia.world#28): locale panel anchors exactly at the Language row's right edge (249 = 243+6, top-aligned) inside the glass popover; mobile drawer language sheet is fullscreen, back gesture closes the sheet but not the drawer; locale switch applies + persists.