### PR TITLE
✨ Add a sidebar variant to the menu and theme the select surfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Current master, Rust workspace `0.3.19`.
 
 ### Added
 
+- Add a `variant="sidebar"` mode to `HkMenu`: an inline vertical nav list
+  (no popover, no history) where rows carry icon/flag/badge/active states
+  with a consistent 4px rhythm, and root items with `children` render as
+  collapsible groups (defaulting open when they contain the `activeKey`
+  row; deeper levels indent). `HkMenuItem` gains `badge` for sidebar count
+  pills. Built for admin sidebars and mobile nav drawers.
 - Add a generic cascading menu component `HkMenu` (`items` tree with
   icons/flags/checked/danger/disabled rows) plus `HkLocalePickerPopup`
   rebuilt as a thin config over it: desktop anchors the root panel to the
@@ -80,6 +86,14 @@ Current master, Rust workspace `0.3.19`.
 
 ### Fixed
 
+- Theme every scrollable menu/select surface: `HkSelect` popouts, the
+  `HkPopupSelect` viewport (whose hidden scrollbar now shows as a themed
+  thin bar) and `HkMenu` panels/sheets use a 6px themed scrollbar instead
+  of the browser-native chrome.
+- Restyle `HkSelect` / `HkPopupSelect` / `HkInput` labels as small muted
+  captions (xs, 600, 60% text) instead of full-size text, and give
+  dropdown option rows a consistent 2px rhythm so rounded hover pills
+  never touch.
 - Add admin KPI widgets: HkStatCard (label/value/hint with a tone DOT —
   text hue never changes, per the interaction-state precedence), HkStatusPill
   (compact ok/warn/error/unknown pill with optional latency + version, gentle

--- a/packages/vue/__scratch.html
+++ b/packages/vue/__scratch.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Menu polish scratch</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/__scratch.tsx"></script>
+  </body>
+</html>

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/__scratch.tsx
+++ b/packages/vue/src/__scratch.tsx
@@ -1,0 +1,78 @@
+// Temporary browser-verification scaffold — NOT committed.
+import { defineComponent, ref } from "vue";
+import { createApp } from "vue";
+import { HMenu, HSelect, type HkMenuItem } from "./index";
+import { LayoutDashboard, ShoppingCart, Settings, LogOut } from "lucide-vue-next";
+import "./demo.scss";
+import { initTheme } from "./theme/useTheme";
+
+localStorage.setItem("hikari-theme", "tokyonight");
+initTheme();
+
+const nav: HkMenuItem[] = [
+  { key: "dashboard", label: "Dashboard", icon: LayoutDashboard },
+  {
+    key: "shop",
+    label: "Shop",
+    icon: ShoppingCart,
+    children: [
+      { key: "products", label: "Products" },
+      { key: "listings", label: "Listings", badge: "3" },
+      { key: "orders", label: "Orders", badge: "12" },
+    ],
+  },
+  {
+    key: "system",
+    label: "System",
+    icon: Settings,
+    children: [
+      { key: "general", label: "General" },
+      { key: "network", label: "Network" },
+    ],
+  },
+  { key: "logout", label: "Log out", icon: LogOut, danger: true },
+];
+
+const manyOptions = Array.from({ length: 20 }, (_, i) => ({
+  value: `r${i}`,
+  label: `Region option ${i + 1}`,
+}));
+
+const Scratch = defineComponent({
+  name: "Scratch",
+  setup() {
+    const active = ref("listings");
+    const region = ref("r0");
+    const selLabel = ref("");
+    return () => (
+      <div style={{ display: "flex", gap: "32px", padding: "24px", alignItems: "flex-start" }}>
+        <div style={{ width: "224px", flexShrink: 0 }}>
+          <HMenu
+            variant="sidebar"
+            open={true}
+            title="Navigation"
+            items={nav}
+            activeKey={active.value}
+            onSelect={(k: string) => { active.value = k; }}
+          />
+        </div>
+        <div style={{ width: "320px", display: "flex", flexDirection: "column", gap: "20px" }}>
+          <HSelect
+            label="Region (scroll me)"
+            modelValue={region.value}
+            onUpdate:modelValue={(v: string) => { region.value = v; }}
+            options={manyOptions}
+          />
+          <HSelect
+            label="With selection"
+            modelValue={selLabel.value}
+            onUpdate:modelValue={(v: string) => { selLabel.value = v; }}
+            options={[{ value: "a", label: "Alpha" }, { value: "b", label: "Beta" }]}
+          />
+        </div>
+      </div>
+    );
+  },
+});
+
+createApp(Scratch).mount("#app");

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -8,10 +8,11 @@
 
 .hk-input-label {
   display: block;
-  font-size: var(--text-base);
-  font-weight: 500;
-  margin-bottom: var(--space-6);
-  color: rgb(var(--color-text));
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  color: rgb(var(--color-text) / 60%);
 }
 
 .hk-input-required {

--- a/packages/vue/src/components/HkMenu.scss
+++ b/packages/vue/src/components/HkMenu.scss
@@ -148,10 +148,6 @@
   color: rgb(var(--color-danger, 240 70 80));
 }
 
-.hk-menu-sidebar-row[data-depth] {
-  padding-left: calc(var(--space-12, 12px) + var(--space-16, 16px));
-}
-
 .hk-menu-sidebar-group {
   display: flex;
   flex-direction: column;

--- a/packages/vue/src/components/HkMenu.scss
+++ b/packages/vue/src/components/HkMenu.scss
@@ -68,6 +68,127 @@
   opacity: 0.55;
 }
 
+/* Themed scrollbars for every scrollable menu surface (panels, sheets). */
+.hk-menu-panel,
+.hk-menu-sheet-body {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--color-border) / 45%) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgb(var(--color-border) / 45%);
+    border-radius: 3px;
+  }
+}
+
+/* ── sidebar variant ────────────────────────────────────────────── */
+/* Inline vertical nav list — always rendered, no popover machinery.
+ * Rows share the popup row's interaction grammar (hover wash, active
+ * tint + weight, disabled/danger) but with nav-appropriate rhythm:
+ * a consistent 4px gap between rows so rounded hover pills never touch,
+ * deeper levels indenting under their group. */
+
+.hk-menu-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 4px);
+  width: 100%;
+}
+
+.hk-menu-sidebar-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8, 8px);
+  width: 100%;
+  padding: var(--space-8, 8px) var(--space-12, 12px);
+  border: 0;
+  border-radius: var(--radius-sm, 4px);
+  background: transparent;
+  color: rgb(var(--color-text) / 82%);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  .hk-menu-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.hk-menu-sidebar-row:hover:not([data-disabled]):not([data-active]) {
+  background: rgb(var(--color-primary) / 10%);
+  color: rgb(var(--color-text));
+}
+
+.hk-menu-sidebar-row[data-active] {
+  background: rgb(var(--color-primary) / 14%);
+  color: rgb(var(--color-primary));
+  font-weight: 600;
+}
+
+.hk-menu-sidebar-row[data-disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.hk-menu-sidebar-row[data-danger] {
+  color: rgb(var(--color-danger, 240 70 80));
+}
+
+.hk-menu-sidebar-row[data-depth] {
+  padding-left: calc(var(--space-12, 12px) + var(--space-16, 16px));
+}
+
+.hk-menu-sidebar-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 4px);
+}
+
+.hk-menu-sidebar-group-toggle .hk-menu-more {
+  transition: transform var(--duration-fast, 0.15s) ease;
+}
+
+.hk-menu-sidebar-group[data-open] .hk-menu-sidebar-group-toggle .hk-menu-more {
+  transform: rotate(90deg);
+}
+
+.hk-menu-sidebar-children {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4, 4px);
+  margin-top: var(--space-2, 2px);
+}
+
+.hk-menu-sidebar-badge {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 var(--space-4, 4px);
+  border-radius: 999px;
+  background: rgb(var(--color-error, 240 70 80));
+  color: #fff;
+  font-size: var(--text-2xs, 10px);
+  font-weight: 700;
+  line-height: 1;
+}
+
 /* ── desktop panels ─────────────────────────────────────────────── */
 
 .hk-menu-desktop {
@@ -96,7 +217,7 @@
   box-shadow: var(--shadow-dropdown, 0 8px 24px rgb(0 0 0 / 18%));
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--space-2, 2px);
 }
 
 /* ── mobile fullscreen sheets ───────────────────────────────────── */
@@ -165,7 +286,7 @@
   padding: 6px 8px;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: var(--space-2, 2px);
 }
 
 .hk-menu-sheet-body .hk-menu-row {

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -309,3 +309,97 @@ describe("HkMenu mobile sheets", () => {
     expect(window.history.state?.__hkMenuDepth).toBe(0);
   });
 });
+
+describe("HkMenu sidebar variant", () => {
+  const navItems: HkMenuItem[] = [
+    { key: "dashboard", label: "Dashboard" },
+    {
+      key: "shop",
+      label: "Shop",
+      children: [
+        { key: "products", label: "Products" },
+        { key: "listings", label: "Listings", badge: "3" },
+      ],
+    },
+    { key: "logout", label: "Log out", danger: true },
+  ];
+
+  it("renders an inline nav list with active row, badge and groups", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const app = createApp({
+      render: () =>
+        h(HkMenu, {
+          variant: "sidebar",
+          open: true,
+          title: "Navigation",
+          items: navItems,
+          activeKey: "listings",
+        }),
+    });
+    mounts.push(app);
+    app.mount(container);
+
+    // Inline render: no teleport, no panels, no history ownership.
+    expect(document.querySelector(".hk-menu-panel")).toBeNull();
+    expect(document.querySelector(".hk-menu-sheet")).toBeNull();
+    expect(window.history.state?.__hkMenuId).toBeUndefined();
+
+    const nav = container.querySelector(".hk-menu-sidebar");
+    expect(nav).not.toBeNull();
+    expect(nav!.getAttribute("aria-label")).toBe("Navigation");
+
+    // Group containing the active row starts expanded.
+    expect(container.textContent).toContain("Products");
+    expect(container.textContent).toContain("Listings");
+
+    const active = container.querySelector(".hk-menu-sidebar-row[data-active]");
+    expect(active?.textContent).toContain("Listings");
+
+    const badge = container.querySelector(".hk-menu-sidebar-badge");
+    expect(badge?.textContent).toBe("3");
+  });
+
+  it("emits select on leaf rows and toggles groups without selecting", async () => {
+    const selected: string[] = [];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const app = createApp({
+      render: () =>
+        h(HkMenu, {
+          variant: "sidebar",
+          open: true,
+          items: navItems,
+          onSelect: (key: string) => selected.push(key),
+        }),
+    });
+    mounts.push(app);
+    app.mount(container);
+    await settle();
+
+    // Groups default collapsed when nothing active inside them.
+    expect(container.textContent).not.toContain("Products");
+
+    const toggle = container.querySelector(
+      ".hk-menu-sidebar-group-toggle",
+    ) as HTMLButtonElement;
+    toggle.click();
+    await settle();
+    expect(container.textContent).toContain("Products");
+    expect(selected).toEqual([]); // toggling is navigation, not selection
+
+    const leaf = [...container.querySelectorAll(".hk-menu-sidebar-row")].find(
+      (r) => r.textContent?.includes("Products"),
+    ) as HTMLButtonElement;
+    leaf.click();
+    await settle();
+    expect(selected).toEqual(["products"]);
+
+    // Collapse again — children disappear.
+    toggle.click();
+    await settle();
+    expect(container.textContent).not.toContain("Products");
+  });
+});

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -402,4 +402,57 @@ describe("HkMenu sidebar variant", () => {
     await settle();
     expect(container.textContent).not.toContain("Products");
   });
+
+  it("lets the user collapse the active group and keeps siblings independent", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const app = createApp({
+      render: () =>
+        h(HkMenu, {
+          variant: "sidebar",
+          open: true,
+          items: [
+            ...navItems,
+            {
+              key: "system",
+              label: "System",
+              children: [{ key: "general", label: "General" }],
+            },
+          ],
+          activeKey: "listings",
+        }),
+    });
+    mounts.push(app);
+    app.mount(container);
+    await settle();
+
+    const toggleOf = (label: string) =>
+      Array.from(container.querySelectorAll(".hk-menu-sidebar-group-toggle")).find(
+        (r) => r.textContent?.includes(label),
+      ) as HTMLButtonElement;
+
+    // Active group auto-expanded at mount.
+    expect(container.textContent).toContain("Products");
+
+    // First toggle COLLAPSES it (regression: it used to be a no-op).
+    toggleOf("Shop").click();
+    await settle();
+    expect(container.textContent).not.toContain("Products");
+
+    // Re-expand; expanding a sibling must not collapse the active group.
+    toggleOf("Shop").click();
+    await settle();
+    expect(container.textContent).toContain("Products");
+    toggleOf("System").click();
+    await settle();
+    expect(container.textContent).toContain("Products");
+    expect(container.textContent).toContain("General");
+
+    // Collapsing the sibling keeps the active group open.
+    toggleOf("System").click();
+    await settle();
+    expect(container.textContent).toContain("Products");
+    expect(container.textContent).not.toContain("General");
+  });
 });

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -420,8 +420,10 @@ export default defineComponent({
     }
 
     // ── sidebar variant ─────────────────────────────────────────────
-    /** Expanded group keys (items whose children are shown). */
-    const expandedGroups = ref<string[]>([]);
+    /** Group keys the USER has expanded or collapsed (their word wins). */
+    const userGroups = ref<Set<string>>(new Set());
+    /** Groups auto-expanded at mount because they contain the active row. */
+    const autoGroups = ref<Set<string>>(new Set());
 
     function isGroup(item: HkMenuItem): boolean {
       return !!item.children?.length;
@@ -432,10 +434,48 @@ export default defineComponent({
       return (item.children ?? []).some(containsActive);
     }
 
+    /** Keys the user explicitly collapsed (overrides the auto set). */
+    const userCollapsed = ref<Set<string>>(new Set());
+
+    function isGroupExpanded(key: string): boolean {
+      if (userGroups.value.has(key)) return true;
+      if (autoGroups.value.has(key)) return !userCollapsed.value.has(key);
+      return false;
+    }
+
+    /** Seed the auto set whenever the active key or items change: groups
+     *  the user has not touched yet default open when they contain the
+     *  active row (a fresh sidebar shows where you are); touched groups
+     *  keep the user's word — auto-expand is a default, never a
+     *  resurrection. */
+    watch(
+      () => [props.activeKey, props.items] as const,
+      () => {
+        const actives = new Set(
+          props.items
+            .filter((it) => isGroup(it) && containsActive(it))
+            .map((it) => it.key),
+        );
+        autoGroups.value = new Set(
+          [...actives].filter(
+            (k) => !userGroups.value.has(k) && !userCollapsed.value.has(k),
+          ),
+        );
+      },
+      { immediate: true },
+    );
+
     function toggleGroup(key: string): void {
-      expandedGroups.value = expandedGroups.value.includes(key)
-        ? expandedGroups.value.filter((k) => k !== key)
-        : [...expandedGroups.value, key];
+      const wasExpanded = isGroupExpanded(key);
+      // Move the key fully into the user set — auto defaults stop applying.
+      autoGroups.value.delete(key);
+      if (wasExpanded) {
+        userGroups.value.delete(key);
+        userCollapsed.value.add(key);
+      } else {
+        userCollapsed.value.delete(key);
+        userGroups.value.add(key);
+      }
     }
 
     function renderSidebarRow(item: HkMenuItem, depth: number) {
@@ -464,18 +504,21 @@ export default defineComponent({
 
     function renderSidebarItem(item: HkMenuItem, depth: number) {
       if (!isGroup(item)) return renderSidebarRow(item, depth);
-      // Root groups default to expanded when they contain the active row
-      // (a freshly mounted sidebar shows where you are); user toggles win.
-      const expanded =
-        expandedGroups.value.includes(item.key) ||
-        (expandedGroups.value.length === 0 && containsActive(item));
+      // Auto-expanded when containing the active row (fresh mount shows
+      // where you are); the user's first toggle on a group takes over.
+      const expanded = isGroupExpanded(item.key);
       return (
         <div key={item.key} class="hk-menu-sidebar-group" data-open={expanded || undefined}>
           <button
             type="button"
             class="hk-menu-sidebar-row hk-menu-sidebar-group-toggle"
-            aria-expanded={expanded || undefined}
-            onClick={() => toggleGroup(item.key)}
+            data-disabled={item.disabled || undefined}
+            aria-expanded={expanded}
+            aria-haspopup="true"
+            onClick={() => {
+              if (item.disabled) return;
+              toggleGroup(item.key);
+            }}
           >
             {item.icon && h(item.icon, { size: 16 })}
             <span class="hk-menu-label">{item.label}</span>

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -40,6 +40,8 @@ export interface HkMenuItem {
   checked?: boolean;
   disabled?: boolean;
   danger?: boolean;
+  /** Right-aligned count pill (sidebar variant nav rows). */
+  badge?: string;
   children?: HkMenuItem[];
 }
 
@@ -58,6 +60,15 @@ function viewportIsMobile(breakpoint: number): boolean {
 export default defineComponent({
   name: "HkMenu",
   props: {
+    /**
+     * Presentation: "popup" = the anchored cascading menu (desktop panels /
+     * mobile sheets, driven by `open`); "sidebar" = an inline vertical nav
+     * list — always rendered, no popover, no history — where root items
+     * carrying `children` render as collapsible groups.
+     */
+    variant: { type: String as PropType<"popup" | "sidebar">, default: "popup" },
+    /** Key of the currently active row (sidebar variant). */
+    activeKey: { type: String, default: undefined },
     /** Panel title (mobile sheet header / desktop a11y label root). */
     title: { type: String, default: "" },
     items: { type: Array as PropType<HkMenuItem[]>, required: true },
@@ -184,9 +195,13 @@ export default defineComponent({
       if (!mobileMode.value && props.open) void nextTick(refreshGeometry);
     }
 
-    onMounted(() => window.addEventListener("popstate", onPopState));
-    onMounted(() => window.addEventListener("resize", onResize));
+    onMounted(() => {
+      if (props.variant === "sidebar") return; // no popover machinery
+      window.addEventListener("popstate", onPopState);
+      window.addEventListener("resize", onResize);
+    });
     onBeforeUnmount(() => {
+      if (props.variant === "sidebar") return;
       window.removeEventListener("popstate", onPopState);
       window.removeEventListener("resize", onResize);
       restoreHistory();
@@ -199,8 +214,10 @@ export default defineComponent({
      */
     watch(
       // String key: fires on real state changes only, not on every resize tick.
-      () => `${props.open ? 1 : 0}:${mobileMode.value ? 1 : 0}`,
+      // The sidebar variant owns no history at all.
+      () => (props.variant === "sidebar" ? "sidebar" : `${props.open ? 1 : 0}:${mobileMode.value ? 1 : 0}`),
       (key) => {
+        if (key === "sidebar") return;
         const openNow = key.startsWith("1");
         const mobile = key.endsWith("1");
         if (!openNow) {
@@ -402,7 +419,88 @@ export default defineComponent({
       );
     }
 
+    // ── sidebar variant ─────────────────────────────────────────────
+    /** Expanded group keys (items whose children are shown). */
+    const expandedGroups = ref<string[]>([]);
+
+    function isGroup(item: HkMenuItem): boolean {
+      return !!item.children?.length;
+    }
+
+    function containsActive(item: HkMenuItem): boolean {
+      if (item.key === props.activeKey) return true;
+      return (item.children ?? []).some(containsActive);
+    }
+
+    function toggleGroup(key: string): void {
+      expandedGroups.value = expandedGroups.value.includes(key)
+        ? expandedGroups.value.filter((k) => k !== key)
+        : [...expandedGroups.value, key];
+    }
+
+    function renderSidebarRow(item: HkMenuItem, depth: number) {
+      const active = item.key === props.activeKey;
+      return (
+        <button
+          key={item.key}
+          type="button"
+          class="hk-menu-sidebar-row"
+          data-depth={depth || undefined}
+          data-active={active || undefined}
+          data-danger={item.danger || undefined}
+          data-disabled={item.disabled || undefined}
+          onClick={() => {
+            if (item.disabled) return;
+            emit("select", item.key, item);
+          }}
+        >
+          {item.icon && h(item.icon, { size: 16 })}
+          {item.flag && <span class="hk-menu-flag">{item.flag}</span>}
+          <span class="hk-menu-label">{item.label}</span>
+          {item.badge && <span class="hk-menu-sidebar-badge">{item.badge}</span>}
+        </button>
+      );
+    }
+
+    function renderSidebarItem(item: HkMenuItem, depth: number) {
+      if (!isGroup(item)) return renderSidebarRow(item, depth);
+      // Root groups default to expanded when they contain the active row
+      // (a freshly mounted sidebar shows where you are); user toggles win.
+      const expanded =
+        expandedGroups.value.includes(item.key) ||
+        (expandedGroups.value.length === 0 && containsActive(item));
+      return (
+        <div key={item.key} class="hk-menu-sidebar-group" data-open={expanded || undefined}>
+          <button
+            type="button"
+            class="hk-menu-sidebar-row hk-menu-sidebar-group-toggle"
+            aria-expanded={expanded || undefined}
+            onClick={() => toggleGroup(item.key)}
+          >
+            {item.icon && h(item.icon, { size: 16 })}
+            <span class="hk-menu-label">{item.label}</span>
+            {item.badge && <span class="hk-menu-sidebar-badge">{item.badge}</span>}
+            <ChevronRight size={14} class="hk-menu-more" />
+          </button>
+          {expanded && (
+            <div class="hk-menu-sidebar-children">
+              {item.children!.map((child) => renderSidebarItem(child, depth + 1))}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function renderSidebar() {
+      return (
+        <nav class="hk-menu-sidebar" aria-label={props.title || "menu"}>
+          {props.items.map((it) => renderSidebarItem(it, 0))}
+        </nav>
+      );
+    }
+
     return () => {
+      if (props.variant === "sidebar") return renderSidebar();
       if (!props.open) return null;
 
       // Both modes render through a Teleport: `position: fixed` children of

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -489,6 +489,11 @@ export default defineComponent({
           data-active={active || undefined}
           data-danger={item.danger || undefined}
           data-disabled={item.disabled || undefined}
+          style={
+            depth > 0
+              ? { paddingLeft: `calc(var(--space-12, 12px) + ${16 * depth}px)` }
+              : undefined
+          }
           onClick={() => {
             if (item.disabled) return;
             emit("select", item.key, item);

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -108,7 +108,7 @@
   scrollbar-color: rgb(var(--color-border) / 45%) transparent;
 
   &::-webkit-scrollbar {
-    display: block;
+    display: block !important;
     width: 6px;
   }
 

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -9,10 +9,11 @@
 
 .hk-popup-select-label {
   display: block;
-  font-size: var(--text-base);
-  font-weight: 500;
-  margin-bottom: var(--space-6);
-  color: rgb(var(--color-text));
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  color: rgb(var(--color-text) / 60%);
 }
 
 .hk-popup-select-required {
@@ -96,9 +97,29 @@
   overflow: hidden;
 }
 
-.hk-popup-select-viewport {
-  flex: 1;
-  min-height: 0;
+/* The viewport is an HkScrollContainer; items live in its inner scroller,
+ * whose default hides the bar — a themed thin bar beats the native chrome. */
+.hk-popup-select-viewport .hk-scroll-container-viewport {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  scrollbar-width: thin !important;
+  scrollbar-color: rgb(var(--color-border) / 45%) transparent;
+
+  &::-webkit-scrollbar {
+    display: block;
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgb(var(--color-border) / 45%);
+    border-radius: 3px;
+  }
 }
 
 .hk-popup-select-item {

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -9,10 +9,11 @@
 
 .hk-select-label {
   display: block;
-  font-size: var(--text-base);
-  font-weight: 500;
-  margin-bottom: var(--space-6);
-  color: rgb(var(--color-text));
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  color: rgb(var(--color-text) / 60%);
 }
 
 .hk-select-required {
@@ -94,6 +95,7 @@
   max-height: 240px;
   display: flex;
   flex-direction: column;
+  gap: var(--space-2);
   padding: var(--space-4);
   border-radius: var(--radius-md);
   overflow-y: auto;
@@ -101,6 +103,23 @@
   backdrop-filter: blur(var(--blur-md));
   border: 1px solid var(--border-subtle);
   box-shadow: var(--shadow-dropdown);
+
+  /* Themed scrollbar — never the browser-native chrome. */
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--color-border) / 45%) transparent;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgb(var(--color-border) / 45%);
+    border-radius: 3px;
+  }
 }
 
 .hk-select-option {


### PR DESCRIPTION
## Summary

The selector/menu polish wave (user-reported gaps, consumed by erp and chest):

- **`HkMenu variant="sidebar"`** — an inline vertical nav list (no popover, no history): rows with icon/flag/label/badge/active/disabled/danger and a 4px rhythm; root items with `children` render as collapsible groups; groups containing the `activeKey` row default open (seeded, not virtual — the user's first toggle takes over and can collapse them; sibling toggles are independent); deeper levels indent. `HkMenuItem` gains `badge`. Built for admin sidebars and mobile nav drawers.
- **Themed scrollbars** — `HkSelect` popouts (was native chrome), the `HkPopupSelect` viewport (hidden bar → themed thin bar, beating HkScrollContainer's `!important` hide), and `HkMenu` panels/sheets.
- **Small caption labels** — `HkSelect` / `HkPopupSelect` / `HkInput` labels restyled as muted captions (xs / 600 / 60% text), the "tiny title above each field" convention.
- **Option row rhythm** — 2px gaps in select popouts and menu panels so rounded hover pills never touch.

## Verification

- vitest **152/152** (4 HkMenu sidebar tests incl. the active-group collapse regression), vue-tsc clean.
- Browser scratch (1280px): sidebar renders groups/badges/active rows; the region select opens a 20-option popout with a themed thin scrollbar, 2px row rhythm and the caption label.
- 3-round verify: R1 found a MAJOR (auto-expand virtual-state: active group uncollapsible + sibling flicker) — fixed in R2 with a materialized three-set state machine + regression test; R3 pending.

Downstream: erp.celestia.world (labels + PNavSidebar → HkMenu sidebar variant) and shittim-chest /backend sidebar in follow-up PRs.