### PR TITLE
🎨 Lift the field caption labels to 72 percent text alpha.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ Current master, Rust workspace `0.3.19`.
 
 ### Fixed
 
+- Raise select/input caption labels from 60% to 72% text alpha (dark-theme
+  tinted surfaces kept the 60% captions below comfortable contrast);
+  `--hk-field-label-alpha` overrides per app.
 - Theme every scrollable menu/select surface: `HkSelect` popouts, the
   `HkPopupSelect` viewport (whose hidden scrollbar now shows as a themed
   thin bar) and `HkMenu` panels/sheets use a 6px themed scrollbar instead

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -12,7 +12,9 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   margin-bottom: var(--space-4);
-  color: rgb(var(--color-text) / 60%);
+  /* 72% keeps the caption hierarchy while surviving dark-theme tinted
+   * surfaces; override per-app with --hk-field-label-alpha. */
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
 }
 
 .hk-input-required {

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -13,7 +13,9 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   margin-bottom: var(--space-4);
-  color: rgb(var(--color-text) / 60%);
+  /* 72% keeps the caption hierarchy while surviving dark-theme tinted
+   * surfaces; override per-app with --hk-field-label-alpha. */
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
 }
 
 .hk-popup-select-required {

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -13,7 +13,9 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   margin-bottom: var(--space-4);
-  color: rgb(var(--color-text) / 60%);
+  /* 72% keeps the caption hierarchy while surviving dark-theme tinted
+   * surfaces; override per-app with --hk-field-label-alpha. */
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
 }
 
 .hk-select-required {


### PR DESCRIPTION
Follow-up to #198: the 60% caption alpha dropped below comfortable contrast on dark-theme tinted surfaces (erp payment modals on wallpaper). Raised to 72% with a `--hk-field-label-alpha` per-app override. vitest 152/152, vue-tsc clean. Note: HkPasswordInput's legacy .hk-pwd-label still uses the old full-size label style — aligning it to the caption pattern is deferred as a separate consistency task.