### PR TITLE
🎨 Align the password and color picker labels with the caption family.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ Current master, Rust workspace `0.3.19`.
 
 ### Fixed
 
+- Align the remaining field labels with the caption family:
+  `HkPasswordInput`'s label drops its legacy full-size style (0.875rem/500)
+  and `HkColorPicker`'s label gains the 600 weight and the shared
+  `--hk-field-label-alpha` (72%) — every labeled hikari form control now
+  reads identically.
 - Raise select/input caption labels from 60% to 72% text alpha (dark-theme
   tinted surfaces kept the 60% captions below comfortable contrast);
   `--hk-field-label-alpha` overrides per app.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -33,9 +33,12 @@
 }
 
 .hk-color-picker-label {
+  display: block;
   font-size: var(--text-xs);
-  font-weight: 500;
-  color: rgb(var(--color-muted));
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
   white-space: nowrap;
   line-height: 1;
   transition: color var(--duration-short);

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -6,10 +6,12 @@
 
 .hk-pwd-label {
   display: block;
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-bottom: 0.375rem;
-  color: var(--hi-color-text-primary, #333);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  /* Matches the HkSelect/HkInput/HkPopupSelect caption family. */
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
 }
 
 .hk-pwd-required {


### PR DESCRIPTION
Completes the label consistency task deferred from #200: `HkPasswordInput`'s label drops its legacy full-size style (0.875rem/500/#333) and `HkColorPicker`'s label gains the 600 weight — both now use the caption family (text-xs/600/letter-spacing, `rgb(var(--color-text) / var(--hk-field-label-alpha, 72%))`) shared by HkSelect/HkPopupSelect/HkInput. HkNumberInput/HkTextarea render no labels of their own (callers wrap), so the labeled form controls are now uniform. vitest 152/152, vue-tsc clean; SCSS-only change (Rust checks unaffected). Per user directive, merging on local gates without waiting on CI.