### PR TITLE
✨ Generalize the admin shell and header with the chest-proven specializations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,27 @@ Current master, Rust workspace `0.3.19`.
 
 ### Added
 
+- Generalize the admin shell/header with the specializations proven in
+  shittim-chest's plana-legacy fork: `HkAdminShell` gains an
+  `onOpenDrawer` header-slot prop (a header trigger such as the avatar
+  can open the mobile nav drawer), a `userPanel` slot riding the drawer
+  footer beside the nav, an `inDrawer` flag on the drawer's sidebar slot
+  so the nav can fill the drawer width, `drawerPanelClass` for
+  consumer-side nesting adjustments, and a `contentPadding` prop applied
+  through an inner wrapper inside the scroll viewport so card
+  box-shadows are never clipped at the viewport edges.
+- `HkAdminHeader`: `title` is now optional and an empty title hides the
+  node entirely (the in-page HPageHeader convention); `avatarAction`
+  selects between "menu" (desktop dropdown) and "drawer" (emits
+  `avatarClick` for the shell to open its nav drawer, username hidden);
+  an empty identity renders a signing-in placeholder with a
+  force-sign-out escape hatch; the user menu leads with the full
+  identity block (name/email/permission badges via the new shared
+  `s-user-header` styles); the locale trigger passes its ref OBJECT
+  through the `locale-picker` slot so pickers anchor to the button
+  instead of freezing a null snapshot; closing the outer menu now also
+  closes the locale submenu; the popover widens to `w-56` to fit the
+  identity block.
 - Add a `variant="sidebar"` mode to `HkMenu`: an inline vertical nav list
   (no popover, no history) where rows carry icon/flag/badge/active states
   with a consistent 4px rhythm, and root items with `children` render as

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAdminHeader.test.tsx
+++ b/packages/vue/src/components/HkAdminHeader.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h } from "vue";
+
+// HPopover teleports to body — stubbing Teleport stringifies its vnode
+// children. Replace just HPopover with an inline passthrough that renders
+// its default slot while open; the rest of hikari stays real.
+vi.mock("@celestia-island/hikari", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@celestia-island/hikari")>();
+  const { defineComponent, h } = await import("vue");
+  const HPopoverStub = defineComponent({
+    name: "HPopover",
+    props: {
+      modelValue: { type: Boolean, default: false },
+      placement: { type: String, default: "bottom" },
+    },
+    setup(props, { slots }) {
+      return () =>
+        props.modelValue
+          ? h("div", { class: "popover-stub" }, slots.default?.())
+          : null;
+    },
+  });
+  return { ...actual, HPopover: HPopoverStub };
+});
+
+import { HkAdminHeader } from "./HkAdminHeader";
+
+/**
+ * HkAdminHeader contract tests for the generalized avatar/identity
+ * behaviors ported from the chest plana-legacy fork:
+ * - avatarAction "menu" (default) toggles the user dropdown; "drawer"
+ *   emits avatarClick so the shell can open its nav drawer.
+ * - the identity block (name/email/groups) leads the menu; an empty
+ *   identity renders the signing-in placeholder + force-sign-out escape.
+ * - an empty title hides the context-title node entirely (pages carry
+ *   their own in-page title in the HPageHeader convention).
+ *
+ * (Repo test convention: raw createApp + container queries, no
+ * @vue/test-utils dependency.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+type HeaderProps = Record<string, unknown>;
+
+function headerNode(props: HeaderProps = {}, slots?: Record<string, unknown>) {
+  return h(HkAdminHeader, { username: "alice", ...props } as never, slots as never);
+}
+
+const avatarButton = (c: HTMLElement) =>
+  c.querySelector('button[aria-haspopup]') as HTMLButtonElement | null;
+
+async function click(el: Element | null) {
+  el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("HkAdminHeader", () => {
+  it("toggles the user dropdown on avatar click in menu mode", async () => {
+    const c = mount(headerNode({ logoutLabel: "Log out" }));
+    const btn = avatarButton(c);
+    expect(btn?.getAttribute("aria-haspopup")).toBe("menu");
+
+    await click(btn);
+    const menu = c.querySelector(".popover-stub");
+    // The dropdown leads with the identity block and ends with logout.
+    expect(menu?.textContent).toContain("alice");
+    expect(c.querySelector(".s-user-header")).toBeTruthy();
+    expect(menu?.textContent).toContain("Log out");
+
+    await click(btn);
+    expect(c.querySelector(".s-user-header")).toBeNull();
+  });
+
+  it("emits avatarClick instead of the dropdown in drawer mode", async () => {
+    const clicks: number[] = [];
+    const c = mount(headerNode({
+      avatarAction: "drawer",
+      logoutLabel: "Log out",
+      onAvatarClick: () => clicks.push(1),
+    }));
+    const btn = avatarButton(c);
+    expect(btn?.getAttribute("aria-haspopup")).toBe("dialog");
+
+    await click(btn);
+    expect(clicks).toHaveLength(1);
+    // The dropdown must NOT open in drawer mode, and the username stays
+    // hidden — the identity block lives in the drawer footer.
+    expect(c.querySelector(".s-user-header")).toBeNull();
+    expect(c.textContent).not.toContain("alice");
+  });
+
+  it("renders the signing-in placeholder with the force-sign-out escape when the identity is empty", async () => {
+    const onForceSignOut = vi.fn();
+    const c = mount(headerNode({
+      username: "",
+      userEmail: "",
+      signingInLabel: "Signing in…",
+      forceSignOutLabel: "Sign out now",
+      onForceSignOut,
+    }));
+    await click(avatarButton(c));
+
+    expect(c.querySelector(".s-user-header--pending")).toBeTruthy();
+    expect(c.textContent).toContain("Signing in…");
+    // No action items above an absent identity.
+    expect(c.textContent).not.toContain("Avatar");
+
+    await click(c.querySelector(".s-popup-menu-item"));
+    expect(onForceSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the context title entirely when it is empty", () => {
+    const withTitle = mount(headerNode({ title: "Dashboard" }));
+    expect(withTitle.querySelector("h2")?.textContent).toBe("Dashboard");
+
+    const withoutTitle = mount(headerNode());
+    expect(withoutTitle.querySelector("h2")).toBeNull();
+  });
+
+  it("passes the locale trigger ref OBJECT through the slot so the picker anchors to the button", async () => {
+    let captured: unknown = null;
+    const c = mount(headerNode(
+      { username: "alice" },
+      {
+        "locale-picker": (scope: { triggerRef: unknown }) => {
+          captured = scope.triggerRef;
+          return null;
+        },
+      },
+    ));
+    await click(avatarButton(c));
+    // The slot must receive the ref object itself (reactive), not its
+    // frozen .value snapshot from the first render (null before the
+    // ref attached).
+    expect(captured).toBeTruthy();
+    expect((captured as { value?: unknown }).value).toBeInstanceOf(HTMLElement);
+  });
+});

--- a/packages/vue/src/components/HkAdminHeader.tsx
+++ b/packages/vue/src/components/HkAdminHeader.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, ref, type PropType, type VNode } from "vue";
 import { Camera, Languages, LogOut, Menu } from "lucide-vue-next";
-import { HBadge, HButton, HDivider, HPopover } from "@celestia-island/hikari";
+import { HBadge, HButton, HDivider, HPopover, HSpinner } from "@celestia-island/hikari";
 
 export interface LocaleOption {
   code: string;
@@ -10,7 +10,10 @@ export interface LocaleOption {
 export const HkAdminHeader = defineComponent({
   name: "HkAdminHeader",
   props: {
-    title: { type: String, required: true },
+    /** Optional context title — empty (the default) hides the node
+     *  entirely, for layouts whose pages carry their own in-page title
+     *  (the HPageHeader convention). */
+    title: { type: String, default: "" },
     showHamburger: { type: Boolean, default: false },
     compact: { type: Boolean, default: false },
     actions: { type: Array as PropType<VNode[]>, default: () => [] },
@@ -18,6 +21,24 @@ export const HkAdminHeader = defineComponent({
     avatarUrl: { type: String, default: "" },
     userEmail: { type: String, default: "" },
     userGroups: { type: Array as PropType<{ id: string; name: string }[]>, default: () => [] },
+    /** What the avatar trigger does:
+     *  - "menu"   (default, desktop): toggle the user dropdown popover
+     *    (identity, avatar edit, language, logout).
+     *  - "drawer" (mobile): emit `avatarClick` so the shell opens its nav
+     *    drawer, whose `userPanel` footer carries the same user content.
+     *    The username stays hidden in this mode — the identity block
+     *    lives in the drawer, so a header username would read as a
+     *    duplicated stray control. */
+    avatarAction: { type: String as PropType<"menu" | "drawer">, default: "menu" },
+    /** Placeholder row shown while the identity is still loading (a
+     *  fetchUser race on hard refresh) — the action items stay hidden
+     *  until there is an identity to act on. */
+    signingInLabel: { type: String, default: "Signing in…" },
+    /** Pending-state escape hatch: typically wired to logout (clears
+     *  cookies and returns to the login page) when the network wedges
+     *  the session restore and the user wants to break out manually. */
+    onForceSignOut: { type: Function, default: undefined },
+    forceSignOutLabel: { type: String, default: "Sign out" },
     showEmergencyStop: { type: Boolean, default: false },
     emergencyStopActive: { type: Boolean, default: false },
     emergencyStopActiveLabel: { type: String, default: "" },
@@ -26,6 +47,8 @@ export const HkAdminHeader = defineComponent({
     emergencyStopTitle: { type: String, default: "" },
     emergencyStopLoading: { type: Boolean, default: false },
     avatarMenuLabel: { type: String, default: "Avatar" },
+    /** Accessible label for the avatar trigger button. */
+    avatarTriggerLabel: { type: String, default: "Account menu" },
     localeMenuLabel: { type: String, default: "Language" },
     logoutLabel: { type: String, default: "Logout" },
     adminGroupLabel: { type: String, default: "Administrators" },
@@ -33,8 +56,8 @@ export const HkAdminHeader = defineComponent({
   emits: {
     logout: () => true,
     hamburger: () => true,
-    emergencyStop: () => true,
     avatarClick: () => true,
+    emergencyStop: () => true,
   },
   setup(props, { emit, slots }) {
     const userMenuOpen = ref(false);
@@ -43,6 +66,15 @@ export const HkAdminHeader = defineComponent({
     const avatarFailed = ref(false);
     const localeMenuOpen = ref(false);
     const localeTriggerRef = ref<HTMLElement | null>(null);
+
+    function onAvatarClick(e: MouseEvent) {
+      e.stopPropagation();
+      if (props.avatarAction === "drawer") {
+        emit("avatarClick");
+        return;
+      }
+      userMenuOpen.value = !userMenuOpen.value;
+    }
 
     return () => (
       <header
@@ -61,7 +93,7 @@ export const HkAdminHeader = defineComponent({
           </HButton>
         )}
 
-        <div ref={userTriggerRef} class="flex items-center gap-2">
+        <div ref={userTriggerRef} class="flex items-center gap-2 min-w-0">
           <button
             class={[
               "w-7 h-7 rounded-full overflow-hidden shrink-0 cursor-pointer transition-opacity relative group p-0 border-0",
@@ -69,11 +101,10 @@ export const HkAdminHeader = defineComponent({
                 ? ""
                 : "bg-primary/10 border-2 border-primary/15 hover:border-primary/30",
             ]}
-            onClick={(e) => {
-              e.stopPropagation();
-              avatarModalOpen.value = true;
-              emit("avatarClick");
-            }}
+            aria-label={props.avatarTriggerLabel}
+            aria-haspopup={props.avatarAction === "drawer" ? "dialog" : "menu"}
+            aria-expanded={props.avatarAction === "menu" ? userMenuOpen.value : undefined}
+            onClick={onAvatarClick}
           >
             {props.avatarUrl && !avatarFailed.value ? (
               <img
@@ -87,51 +118,91 @@ export const HkAdminHeader = defineComponent({
                 {props.username?.charAt(0).toUpperCase() || "?"}
               </span>
             )}
-            <div class="absolute inset-0 rounded-full bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-              <Camera size={10} class="text-white" />
-            </div>
+            {props.avatarAction === "menu" && (
+              <div class="absolute inset-0 rounded-full bg-black/30 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+                <Camera size={10} class="text-white" />
+              </div>
+            )}
           </button>
-          <span class="text-sm font-semibold text-text truncate max-w-[8rem]">
-            {props.username}
-          </span>
+          {props.avatarAction === "menu" && (
+            <span class="text-sm font-semibold text-text truncate max-w-[8rem]">
+              {props.username}
+            </span>
+          )}
         </div>
 
         <HPopover
           modelValue={userMenuOpen.value}
-          onUpdate:modelValue={(v: boolean) => { userMenuOpen.value = v; }}
+          onUpdate:modelValue={(v: boolean) => {
+            userMenuOpen.value = v;
+            // Closing the outer menu must also close the locale submenu,
+            // or it stays orphaned for the next open.
+            if (!v) localeMenuOpen.value = false;
+          }}
           placement="bottom-start"
           anchorRef={userTriggerRef.value ?? null}
-          class="w-40"
+          class="w-56"
         >
-          <div class="py-1">
-            {props.userGroups && props.userGroups.length > 0 && (
-              <>
-                <div class="px-3 py-1.5 flex flex-wrap gap-1">
-                  {props.userGroups.map((g: { id: string; name: string }) => (
-                    <HBadge
-                      key={g.id}
-                      variant={g.name === "Administrators" ? "error" : "primary"}
-                      size="sm"
-                    >
-                      {g.name === "Administrators" ? props.adminGroupLabel : g.name}
-                    </HBadge>
-                  ))}
-                </div>
-                <HDivider spacing="sm" />
-              </>
-            )}
-            <button
-              class="s-popup-menu-item"
-              onClick={() => {
-                userMenuOpen.value = false;
-                avatarModalOpen.value = true;
-              }}
-            >
-              <Camera size={14} />
-              {props.avatarMenuLabel}
-            </button>
-            <div ref={localeTriggerRef}>
+          {/* Empty identity (fetchUser race on a hard refresh): render a
+              single subtle placeholder row instead of the action items —
+              "Change Avatar"/"Logout" floating above no identity read as a
+              broken menu. The force-sign-out escape hatch lets the user
+              break out of a wedged session restore. */}
+          {!props.username && !props.userEmail ? (
+            <div>
+              <div class="s-user-header s-user-header--pending">
+                <HSpinner size="sm" />
+                <div class="s-user-header-email">{props.signingInLabel}</div>
+              </div>
+              <HDivider spacing="sm" />
               <button
+                class="s-popup-menu-item"
+                onClick={() => props.onForceSignOut?.()}
+              >
+                <LogOut size={14} />
+                {props.forceSignOutLabel}
+              </button>
+            </div>
+          ) : (
+            <div>
+              {/* Identity header FIRST — nickname, login email, permission
+                  badges — so every account surface reads identically. */}
+              <div class="s-user-header">
+                {props.username && <div class="s-user-header-name">{props.username}</div>}
+                {props.userEmail && <div class="s-user-header-email">{props.userEmail}</div>}
+                {props.userGroups && props.userGroups.length > 0 && (
+                  <div class="s-user-header-groups">
+                    {props.userGroups.map((g: { id: string; name: string }) => (
+                      <HBadge
+                        key={g.id}
+                        variant={g.name === "Administrators" ? "error" : "primary"}
+                        size="sm"
+                      >
+                        {g.name === "Administrators" ? props.adminGroupLabel : g.name}
+                      </HBadge>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <HDivider spacing="sm" />
+              <button
+                class="s-popup-menu-item"
+                onClick={() => {
+                  userMenuOpen.value = false;
+                  avatarModalOpen.value = true;
+                }}
+              >
+                <Camera size={14} />
+                {props.avatarMenuLabel}
+              </button>
+              {/* The language trigger owns the locale anchor: the ref sits
+                  on the BUTTON itself (not a wrapper div) so the picker
+                  popup anchors to it instead of falling back to inline
+                  rendering. The ref OBJECT is passed through the slot —
+                  reading .value here would freeze null from the first
+                  render before the ref attached. */}
+              <button
+                ref={localeTriggerRef}
                 class="s-popup-menu-item"
                 onClick={() => (localeMenuOpen.value = !localeMenuOpen.value)}
               >
@@ -144,28 +215,35 @@ export const HkAdminHeader = defineComponent({
                   localeMenuOpen.value = v;
                   if (!v) userMenuOpen.value = false;
                 },
-                triggerRef: localeTriggerRef.value,
+                triggerRef: localeTriggerRef,
               })}
+              {slots["user-menu-extra"]?.()}
+              <HDivider spacing="sm" />
+              <button
+                class="s-popup-menu-item"
+                onClick={() => {
+                  userMenuOpen.value = false;
+                  emit("logout");
+                }}
+              >
+                <LogOut size={14} />
+                {props.logoutLabel}
+              </button>
             </div>
-            {slots["user-menu-extra"]?.()}
-            <HDivider spacing="sm" />
-            <button
-              class="s-popup-menu-item"
-              onClick={() => {
-                userMenuOpen.value = false;
-                emit("logout");
-              }}
-            >
-              <LogOut size={14} />
-              {props.logoutLabel}
-            </button>
-          </div>
+          )}
         </HPopover>
 
-        <h2 class="text-sm font-semibold text-text">
-          {props.title}
-        </h2>
-        <div class="ml-auto flex items-center gap-1.5">
+        {/* The page title lives INSIDE each page in the HPageHeader
+            convention (big title left, tool buttons right). The bar
+            renders an optional context title only when one is given —
+            empty hides the node, keeping the bar to identity + theme
+            controls. */}
+        {props.title && (
+          <h2 class="text-sm font-semibold text-text truncate min-w-0">
+            {props.title}
+          </h2>
+        )}
+        <div class="ml-auto flex items-center gap-1.5 shrink-0">
           {props.showEmergencyStop && (
             <button
               class={[

--- a/packages/vue/src/components/HkAdminShell.test.tsx
+++ b/packages/vue/src/components/HkAdminShell.test.tsx
@@ -179,7 +179,8 @@ describe("HkAdminShell", () => {
     // padding on the container itself).
     const viewport = c.querySelector(".hk-scroll-container-viewport")
       ?? c.querySelector(".hk-scroll-container");
-    const inner = viewport?.querySelector("div[style*='2rem']");
+    const inner = viewport?.firstElementChild as HTMLElement | null | undefined;
     expect(inner).toBeTruthy();
+    expect(inner?.style.padding).toBe("2rem");
   });
 });

--- a/packages/vue/src/components/HkAdminShell.test.tsx
+++ b/packages/vue/src/components/HkAdminShell.test.tsx
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+// HDrawer teleports and animates; replace it with an inline passthrough
+// exposing the body/footer split so the drawer contract is testable.
+vi.mock("@celestia-island/hikari", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@celestia-island/hikari")>();
+  const { defineComponent, h } = await import("vue");
+  const HDrawerStub = defineComponent({
+    name: "HDrawer",
+    props: {
+      modelValue: { type: Boolean, default: false },
+      side: { type: String, default: "left" },
+      size: { type: String, default: "280px" },
+      title: { type: String, default: undefined },
+      panelClass: { type: String, default: undefined },
+    },
+    setup(props, { slots }) {
+      return () =>
+        props.modelValue
+          ? h("div", { class: ["drawer-stub", props.panelClass] }, [
+              h("div", { class: "drawer-stub-body" }, slots.default?.()),
+              slots.footer
+                ? h("div", { class: "drawer-stub-footer" }, slots.footer())
+                : null,
+            ])
+          : null;
+    },
+  });
+  return { ...actual, HDrawer: HDrawerStub };
+});
+
+import { HkAdminShell } from "./HkAdminShell";
+
+/**
+ * HkAdminShell contract tests for the generalized slot surface ported
+ * from the chest plana-legacy fork:
+ * 1. Scoped slots are functions: rendering `slots.overlays` without
+ *    calling it stringifies the compiled slot source into a text node.
+ * 2. The mobile drawer footer carries the `userPanel` slot so the
+ *    account block (identity + actions) rides the drawer bottom.
+ * 3. The header slot receives `onOpenDrawer` so a header trigger (the
+ *    avatar in drawer action mode) can open the nav drawer.
+ * 4. Content padding rides an inner wrapper inside the scroll viewport
+ *    (card box-shadows are never clipped at the viewport edges).
+ *
+ * (Repo test convention: raw createApp + container queries, no
+ * @vue/test-utils dependency.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  setWidth(1024);
+});
+
+const setWidth = (w: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: w,
+  });
+  window.dispatchEvent(new Event("resize"));
+};
+
+function shellNode(
+  props: Record<string, unknown>,
+  slots: Record<string, unknown>,
+) {
+  return h(HkAdminShell, props as never, slots as never);
+}
+
+const NAV = () => h("nav", { class: "nav-mock" }, "NAV");
+const CONTENT = () => h("main", null, "CONTENT");
+
+describe("HkAdminShell", () => {
+  it("renders the overlays slot content, never its source text", () => {
+    setWidth(1024);
+    const c = mount(shellNode(
+      { navTitle: "Navigation" },
+      {
+        header: () => null,
+        sidebar: NAV,
+        content: CONTENT,
+        overlays: () => h("div", { class: "overlay-mock" }, "OVERLAY-MARK"),
+      },
+    ));
+    const html = c.innerHTML;
+    expect(html).toContain("OVERLAY-MARK");
+    // The regression: a slot function rendered un-invoked stringifies to
+    // its minified source (arrow params, r._d, etc.).
+    expect(html).not.toContain("=>");
+    expect(c.querySelector(".overlay-mock")).toBeTruthy();
+  });
+
+  it("renders the desktop sidebar inline and skips the drawer", () => {
+    setWidth(1024);
+    const c = mount(shellNode(
+      { navTitle: "Navigation" },
+      { header: () => null, sidebar: NAV, content: CONTENT },
+    ));
+    expect(c.querySelector("aside .nav-mock")).toBeTruthy();
+    // No drawer (mocked HDrawer) in the tree at desktop width.
+    expect(c.querySelector(".drawer-stub")).toBeNull();
+  });
+
+  it("opens the mobile drawer with nav body and userPanel footer", async () => {
+    setWidth(500);
+    let openDrawer: (() => void) | null = null;
+    const c = mount(shellNode(
+      { navTitle: "Navigation", drawerPanelClass: "my-drawer" },
+      {
+        header: (ctx: { onOpenDrawer: () => void }) => {
+          openDrawer = ctx.onOpenDrawer;
+          return null;
+        },
+        sidebar: NAV,
+        userPanel: () => h("div", { class: "s-drawer-user-panel" }, "USER-PANEL"),
+        content: CONTENT,
+      },
+    ));
+    expect(openDrawer).toBeTruthy();
+    openDrawer!();
+    await nextTick();
+    await nextTick();
+    // Drawer carries the nav in its body…
+    expect(c.querySelector(".drawer-stub-body .nav-mock")).toBeTruthy();
+    // …and the user panel in its footer, unwrapped (the slot's own root
+    // carries the styling hooks).
+    const panel = c.querySelector(".drawer-stub-footer .s-drawer-user-panel");
+    expect(panel).toBeTruthy();
+    expect(panel?.textContent).toContain("USER-PANEL");
+    // The drawer panel class passes through for consumer-side nesting
+    // adjustments.
+    expect(c.querySelector(".drawer-stub.my-drawer")).toBeTruthy();
+  });
+
+  it("omits the drawer footer wrapper when no userPanel slot is given", async () => {
+    setWidth(500);
+    let openDrawer: (() => void) | null = null;
+    const c = mount(shellNode(
+      { navTitle: "Navigation" },
+      {
+        header: (ctx: { onOpenDrawer: () => void }) => {
+          openDrawer = ctx.onOpenDrawer;
+          return null;
+        },
+        sidebar: NAV,
+        content: CONTENT,
+      },
+    ));
+    openDrawer!();
+    await nextTick();
+    await nextTick();
+    expect(c.querySelector(".drawer-stub-footer")).toBeNull();
+    expect(c.querySelector(".s-drawer-user-panel")).toBeNull();
+  });
+
+  it("applies the content padding inside the scroll viewport so shadows are not clipped", () => {
+    setWidth(1024);
+    const c = mount(shellNode(
+      { navTitle: "Navigation", contentPadding: "2rem" },
+      { header: () => null, sidebar: NAV, content: CONTENT },
+    ));
+    // The padded inner wrapper exists INSIDE the scroll viewport (not as
+    // padding on the container itself).
+    const viewport = c.querySelector(".hk-scroll-container-viewport")
+      ?? c.querySelector(".hk-scroll-container");
+    const inner = viewport?.querySelector("div[style*='2rem']");
+    expect(inner).toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/HkAdminShell.tsx
+++ b/packages/vue/src/components/HkAdminShell.tsx
@@ -7,6 +7,10 @@ export const HkAdminShell = defineComponent({
   props: {
     sidebarCollapsed: { type: Boolean, default: false },
     sidebarWidth: { type: String, default: "224px" },
+    // NOTE: not yet wired — the desktop/mobile split currently follows
+    // useBreakpoint()'s shared 1024px threshold regardless of this value.
+    // Kept for API compatibility; wiring it needs a threshold param on
+    // useBreakpoint (follow-up).
     mobileBreakpoint: { type: Number, default: 768 },
     footerHeight: { type: String, default: "var(--s-footer-height)" },
     navTitle: { type: String, default: "Navigation" },
@@ -94,7 +98,7 @@ export const HkAdminShell = defineComponent({
                 default: () =>
                   slots.sidebar?.({ collapsed: false, onNavigate: closeSidebar, inDrawer: true }),
                 footer: slots.userPanel
-                  ? () => <div>{slots.userPanel!()}</div>
+                  ? () => slots.userPanel!()
                   : undefined,
               }}
             </HDrawer>

--- a/packages/vue/src/components/HkAdminShell.tsx
+++ b/packages/vue/src/components/HkAdminShell.tsx
@@ -10,6 +10,14 @@ export const HkAdminShell = defineComponent({
     mobileBreakpoint: { type: Number, default: 768 },
     footerHeight: { type: String, default: "var(--s-footer-height)" },
     navTitle: { type: String, default: "Navigation" },
+    /** Extra class for the mobile nav drawer's panel — lets consumers zero
+     *  nested paddings so drawer nav rows and a `userPanel` footer share
+     *  one left edge. */
+    drawerPanelClass: { type: String, default: undefined },
+    /** Content-area padding (inside the scroll viewport). Padding is
+     *  applied to an inner wrapper rather than the scroll container so
+     *  card box-shadows are never clipped at the viewport edges. */
+    contentPadding: { type: String, default: "1.5rem" },
   },
   setup(props, { slots }) {
     const { isDesktop } = useBreakpoint();
@@ -19,6 +27,10 @@ export const HkAdminShell = defineComponent({
 
     const toggleHamburger = () => {
       sidebarOpen.value = !sidebarOpen.value;
+    };
+
+    const openSidebar = () => {
+      sidebarOpen.value = true;
     };
 
     const closeSidebar = () => {
@@ -35,6 +47,9 @@ export const HkAdminShell = defineComponent({
               compact: !isDesktop.value,
               actions: actionBar.actions.value ? actionBar.actions.value() : [],
               onHamburger: toggleHamburger,
+              // Lets a header trigger (e.g. the avatar in "drawer" action
+              // mode) open the mobile nav drawer directly.
+              onOpenDrawer: openSidebar,
             })}
           </div>
         )}
@@ -54,8 +69,11 @@ export const HkAdminShell = defineComponent({
             </aside>
           )}
           <main class="flex-1 flex flex-col min-w-0 min-h-0">
-            <HScrollContainer class="flex-1 p-6 min-h-0">
-              {slots.content?.()}
+            <HScrollContainer class="flex-1 min-h-0">
+              {/* Padding lives INSIDE the scroll viewport (an inner
+                  wrapper) so card box-shadows are not clipped at the
+                  viewport edges. */}
+              <div style={{ padding: props.contentPadding }}>{slots.content?.()}</div>
             </HScrollContainer>
           </main>
 
@@ -66,8 +84,19 @@ export const HkAdminShell = defineComponent({
               side="left"
               size="280px"
               title={props.navTitle}
+              panelClass={props.drawerPanelClass}
             >
-              {slots.sidebar?.({ collapsed: false, onNavigate: closeSidebar })}
+              {/* The drawer body carries the nav; a `userPanel` slot rides
+                  the drawer footer (identity + account actions) so mobile
+                  gets the same content the desktop user menu exposes.
+                  `inDrawer` lets the sidebar slot fill the drawer width. */}
+              {{
+                default: () =>
+                  slots.sidebar?.({ collapsed: false, onNavigate: closeSidebar, inDrawer: true }),
+                footer: slots.userPanel
+                  ? () => <div>{slots.userPanel!()}</div>
+                  : undefined,
+              }}
             </HDrawer>
           )}
         </div>
@@ -78,7 +107,10 @@ export const HkAdminShell = defineComponent({
           </footer>
         )}
 
-        {slots.overlays}
+        {/* Scoped slots are functions — rendering the slot itself instead of
+            calling it would stringify the compiled withCtx source into a text
+            node (normalizeVNode String()s non-vnode children). */}
+        {slots.overlays?.()}
       </div>
     );
   },

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -321,6 +321,57 @@
   font-weight: 600;
 }
 
+/* ── User identity header (shared) ─ */
+/* One identity block for every account surface — the admin user
+   dropdown's header, a mobile drawer's user panel footer — so all
+   account surfaces read identically: nickname, login email, then
+   permission badges. Consumers that nest it inside their own padded
+   container (a drawer footer) drop the padding via context
+   overrides. */
+.s-user-header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  /* In menus this aligns with .s-popup-menu-item's own space-14 (menu
+     padding applies equally to both); bare surfaces (the popover
+     wrapper) rely on it entirely. Vertical breathing keeps the block
+     off the menu's top edge and the divider below. */
+  padding: var(--space-10) var(--space-14) var(--space-12);
+}
+
+/* Pending variant (identity not yet hydrated): spinner beside the
+   label reads as "actively working", not a frozen panel. */
+.s-user-header--pending {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-8, 8px);
+}
+
+.s-user-header-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: rgb(var(--color-text));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.s-user-header-email {
+  font-size: var(--text-2xs);
+  color: rgb(var(--color-muted));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.s-user-header-groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4, 4px);
+  margin-top: var(--space-4, 4px);
+}
+
 /* ── Nav sidebar ─ */
 .s-nav-item-content {
   display: flex;


### PR DESCRIPTION
Generalizes the admin chrome so shittim-chest can consume hikari directly and delete its plana-legacy fork (P33 evaluation outcome; the genuinely chest-specific parts — userPanel drawer content, s-admin-drawer nesting styles, actionBar abstention, dashboard-owned emergency stop — stay consumer-side by design).

**HkAdminShell**: `onOpenDrawer` header-slot prop (a header trigger such as the avatar can open the mobile nav drawer); `userPanel` slot riding the drawer footer beside the nav (rendered directly, no wrapper); `inDrawer` flag on the drawer's sidebar slot so the nav can fill the drawer width; `drawerPanelClass` for consumer-side nesting adjustments; `contentPadding` applied through an inner wrapper inside the scroll viewport so card box-shadows are never clipped; `slots.overlays?.()` fixes the scoped-slot stringification leak.

**HkAdminHeader**: `title` optional (empty hides the node — the in-page HPageHeader convention); `avatarAction` menu/drawer (drawer mode emits avatarClick, hides username/camera overlay, aria dialog semantics); empty-identity signing-in placeholder with a force-sign-out escape hatch; full identity block leading the user menu (name/email/badges via the new shared `s-user-header` styles in admin-tokens); locale trigger ref moved onto the button and passed as the ref OBJECT through the `locale-picker` slot (anchor-freeze fix); locale submenu closes with the outer menu; popover widens to w-56.

Verification: 3-round subagent cycle green (parity vs the chest fork confirmed as a strict superset; real-HkDrawer footer-slot contract verified against source; stray wrapper div removed; SCSS vars all present in hikari tokens). vitest 162/162, vue-tsc clean. Version 0.4.18.