### PR TITLE
🐛 Resolve component theme styles through grass load paths in both layouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,20 @@ hikari currently carries two version lines, plus one stale tag:
 
 ## [Unreleased]
 
-Current master, Rust workspace `0.3.19`.
+Current master, Rust workspace `0.3.20`.
+
+### Fixed (0.3.20)
+
+- Fix component SCSS imports for crates.io consumption: all 39 component
+  stylesheets referenced theme partials with relative URLs
+  (`@use '../../../../theme/styles/variables'`), which only resolve inside
+  the monorepo layout. Published crates resolve them to a nonexistent
+  `theme/styles` sibling and grass compiles every `styles()` call to a
+  `/* CSS generation failed */` comment — downstream SSR (lagrange docs
+  sites) shipped with all `hi-*` component styles missing. Imports are now
+  bare (`@use 'variables'`), resolved through grass load paths in both
+  layouts; `hikari-builder`'s bundle build script gained the same theme
+  load-path discovery.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.19"
+version = "0.3.20"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Hikari Contributors"]

--- a/packages/builder/build.rs
+++ b/packages/builder/build.rs
@@ -198,9 +198,35 @@ fn compile_scss_bundle(workspace_root: &Path) -> anyhow::Result<()> {
     // through tairitsu-packager, which dragged in the whole WASM toolchain
     // (wasmtime) for icon-only consumers like hikari-icons; grass is a pure-Rust
     // Sass compiler and is all this build step needs.
+    // Component SCSS references theme partials with bare load-path imports
+    // (`@use 'variables'`), which resolve in both layouts: monorepo
+    // (`packages/theme/styles`) and crates.io (sibling `hikari-theme-*`
+    // under the same registry index).
+    let mut load_paths: Vec<std::path::PathBuf> = Vec::new();
+    let theme_styles = workspace_root.join("packages/theme/styles");
+    if theme_styles.is_dir() {
+        load_paths.push(theme_styles);
+    }
+    if let Some(parent) = workspace_root.parent() {
+        // crates.io: workspace_root here is the extracted crate root; theme
+        // styles live in a sibling `hikari-theme-<ver>` directory.
+        if let Ok(entries) = fs::read_dir(parent) {
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name.starts_with("hikari-theme-") {
+                    let styles = entry.path().join("styles");
+                    if styles.is_dir() {
+                        load_paths.push(styles);
+                        break;
+                    }
+                }
+            }
+        }
+    }
     let opts = grass::Options::default()
         .style(grass::OutputStyle::Compressed)
-        .input_syntax(grass::InputSyntax::Scss);
+        .input_syntax(grass::InputSyntax::Scss)
+        .load_paths(&load_paths);
     let css_content = grass::from_path(&index_scss, &opts)
         .map_err(|e| anyhow::anyhow!("Failed to compile SCSS {:?}: {}", index_scss, e))?;
 

--- a/packages/components/src/styles/checkbox.scss
+++ b/packages/components/src/styles/checkbox.scss
@@ -1,7 +1,7 @@
 // Hikari Checkbox Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Checkbox Component

--- a/packages/components/src/styles/components/alert.scss
+++ b/packages/components/src/styles/components/alert.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Alert Component

--- a/packages/components/src/styles/components/arrow.scss
+++ b/packages/components/src/styles/components/arrow.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Hikari Arrow Component - FUI Styling

--- a/packages/components/src/styles/components/aside.scss
+++ b/packages/components/src/styles/components/aside.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Icon color inheritance for theme support

--- a/packages/components/src/styles/components/avatar.scss
+++ b/packages/components/src/styles/components/avatar.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Hikari Avatar Component

--- a/packages/components/src/styles/components/background.scss
+++ b/packages/components/src/styles/components/background.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Background Component - Gradient Animation

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Badge Component

--- a/packages/components/src/styles/components/breadcrumb.scss
+++ b/packages/components/src/styles/components/breadcrumb.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Breadcrumb Component

--- a/packages/components/src/styles/components/button.scss
+++ b/packages/components/src/styles/components/button.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 @use './button-vars.scss' as button-vars;
 
 // ------

--- a/packages/components/src/styles/components/card.scss
+++ b/packages/components/src/styles/components/card.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 @use './card-vars.scss' as card-vars;
 
 // ------

--- a/packages/components/src/styles/components/cascader.scss
+++ b/packages/components/src/styles/components/cascader.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari // Hikari // Hikari // Hikari // Hikari Cascader Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/checkbox.scss
+++ b/packages/components/src/styles/components/checkbox.scss
@@ -1,7 +1,7 @@
 // Hikari Checkbox Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Checkbox Component

--- a/packages/components/src/styles/components/container.scss
+++ b/packages/components/src/styles/components/container.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Hikari Container Component

--- a/packages/components/src/styles/components/flex.scss
+++ b/packages/components/src/styles/components/flex.scss
@@ -1,7 +1,7 @@
 // hi-components/src/layout/flex.scss
 // FlexBox component styles
 
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // FlexBox Component

--- a/packages/components/src/styles/components/glow.scss
+++ b/packages/components/src/styles/components/glow.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Glow Component - Single Glow Color System

--- a/packages/components/src/styles/components/grid.scss
+++ b/packages/components/src/styles/components/grid.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Hikari Grid System

--- a/packages/components/src/styles/components/header.scss
+++ b/packages/components/src/styles/components/header.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Header Component

--- a/packages/components/src/styles/components/icon_button.scss
+++ b/packages/components/src/styles/components/icon_button.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 @use './icon-button-vars.scss' as icon-button-vars;
 
 // ------

--- a/packages/components/src/styles/components/image.scss
+++ b/packages/components/src/styles/components/image.scss
@@ -1,5 +1,5 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Hikari Image Component

--- a/packages/components/src/styles/components/input.scss
+++ b/packages/components/src/styles/components/input.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 @use './input-vars.scss' as input-vars;
 
 // ------

--- a/packages/components/src/styles/components/input_wrapper.scss
+++ b/packages/components/src/styles/components/input_wrapper.scss
@@ -8,7 +8,7 @@
 // - Input field takes remaining space
 // - Icon sizes: Small(24px), Medium(32px), Large(40px)
 
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Wrapper Container

--- a/packages/components/src/styles/components/layout.scss
+++ b/packages/components/src/styles/components/layout.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Layout Component

--- a/packages/components/src/styles/components/link.scss
+++ b/packages/components/src/styles/components/link.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Link Component

--- a/packages/components/src/styles/components/menu.scss
+++ b/packages/components/src/styles/components/menu.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Menu Component

--- a/packages/components/src/styles/components/modal.scss
+++ b/packages/components/src/styles/components/modal.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 @use './modal-vars.scss' as modal-vars;
 
 // ------

--- a/packages/components/src/styles/components/number_input.scss
+++ b/packages/components/src/styles/components/number_input.scss
@@ -1,7 +1,7 @@
 // NumberInput Component Styles
 // Uses InputWrapper for layout, only number-input-specific styles here
 
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // NumberInput Wrapper

--- a/packages/components/src/styles/components/pagination.scss
+++ b/packages/components/src/styles/components/pagination.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari // Hikari // Hikari // Hikari // Hikari Pagination Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/radio.scss
+++ b/packages/components/src/styles/components/radio.scss
@@ -1,7 +1,7 @@
 // Hikari Radio Component Styles
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Radio Component

--- a/packages/components/src/styles/components/search.scss
+++ b/packages/components/src/styles/components/search.scss
@@ -1,7 +1,7 @@
 // Search Component Styles
 // Uses InputWrapper for layout, only search-specific styles here
 
-@use '../../../../theme/styles/variables' as vars;
+@use 'variables' as vars;
 
 // ------
 // Search Wrapper

--- a/packages/components/src/styles/components/section.scss
+++ b/packages/components/src/styles/components/section.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Section Component

--- a/packages/components/src/styles/components/select.scss
+++ b/packages/components/src/styles/components/select.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Select Component — Custom FUI Dropdown

--- a/packages/components/src/styles/components/sidebar.scss
+++ b/packages/components/src/styles/components/sidebar.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Sidebar Component - Multi-level Navigation

--- a/packages/components/src/styles/components/table.scss
+++ b/packages/components/src/styles/components/table.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Table Component - FUI Styling

--- a/packages/components/src/styles/components/tabs.scss
+++ b/packages/components/src/styles/components/tabs.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari // Hikari // Hikari // Hikari // Hikari Tabs Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/toast.scss
+++ b/packages/components/src/styles/components/toast.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Toast Component - Emphasis Style

--- a/packages/components/src/styles/components/tooltip.scss
+++ b/packages/components/src/styles/components/tooltip.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Tooltip Component - FUI Styling

--- a/packages/components/src/styles/components/transfer.scss
+++ b/packages/components/src/styles/components/transfer.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari // Hikari // Hikari // Hikari // Hikari Transfer Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/tree.scss
+++ b/packages/components/src/styles/components/tree.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari // Hikari // Hikari // Hikari // Hikari Tree View Component - FUI Styling Component Component Component Component

--- a/packages/components/src/styles/components/typography.scss
+++ b/packages/components/src/styles/components/typography.scss
@@ -1,6 +1,6 @@
 // Use theme variables with namespace to avoid conflicts
-@use '../../../../theme/styles/variables' as vars;
-@use '../../../../theme/styles/mixins' as mix;
+@use 'variables' as vars;
+@use 'mixins' as mix;
 
 // ------
 // Hikari Typography Component


### PR DESCRIPTION
## Summary

Every lagrange-built docs site (arona.docs, hikari.docs, kirino.docs, hub) currently ships with **all hikari component CSS missing** — the live pages contain 26 × `/* CSS generation failed: Can't find stylesheet to import */` comments where button/table/alert/code-highlight styles should be, so `hi-code-highlight` and every other `hi-*` block renders unstyled.

Root cause: all 39 component stylesheets import theme partials with **relative** URLs (`@use '../../../../theme/styles/variables' as vars;`). Relative URLs resolve against the importing file's own directory, which only works in the monorepo layout (`packages/theme/styles`). From crates.io, the sibling is named `hikari-theme-0.3.19/styles` — and per Sass semantics load paths never take over `../`-prefixed URLs — so grass fails every compilation when a downstream crate (lagrange) compiles hikari-components from the registry.

## Fix

- Convert all 39 imports to **bare** load-path form (`@use 'variables' as vars;`), which resolves through grass load paths in both layouts: the `scss!` macro's discovery already adds monorepo `../theme/styles` and registry sibling `hikari-theme-*/styles`.
- `hikari-builder`'s bundle build script (the second compilation pipeline, entry `index.scss`) gains the same load-path discovery.
- Workspace version 0.3.19 → 0.3.20, CHANGELOG entry.

## Verification

- `cargo build -p hikari-components` green in the monorepo.
- A probe crate calling `styles()` on button/alert/table/code-highlight: `failed=false` for all, output lengths 12396/5786/4596/7956.
- **Registry-layout simulation**: `cargo package` → extracted normalized crate into a fake registry dir with sibling `hikari-theme-0.3.19/` → probe re-run: **all clean** (this reproduces exactly how lagrange consumes the crate from crates.io).

## Release

Tag `v0.3.20` after merge triggers the crates.io publish workflow (publish.yml). Downstream lagrange bumps its floor in a companion PR.