### PR TITLE
✨ Add theme extension token groups with hue-clamped pickers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ hikari currently carries two version lines, plus one stale tag:
   `v0.3.0`–`v0.3.2` and `v0.3.4` were published to crates.io without git
   tags, and `v0.3.15`–`v0.3.19` are unpublished master changes.
 - **Vue port (`@celestia-island/hikari`)** — the `0.4.x` line. The npm
-  package is at `0.4.7` on master but has **never been published** to npm;
+  package is at `0.4.18` on master but has **never been published** to npm;
   publication is pending (A3).
 - **Tag `v0.4.0` is a stale tag.** It was created on an early Vue-port
   commit (2026-07-21) before the npm package version line was established,
@@ -132,6 +132,35 @@ Current master, Rust workspace `0.3.19`.
 ### Removed
 
 - Remove dead HAuthCard and stale HkStatusBar references. (#88)
+
+## [v0.4.18] - 2026-08-17
+
+### Added
+
+- Add theme extension token groups for industrial/SCADA theming: downstream
+  apps register namespaced color slot groups (`registerTokenGroup`, e.g. a
+  `scada` group with `power-l1`/`pipe-h2` slots) and hikari emits them as
+  `--<group>-<slot>: "r g b"` CSS vars on every theme apply — preset and
+  custom-theme `groups` overrides win per mode and registry defaults are the
+  final fallback, so the vars exist even when no preset defines them. The
+  values round-trip through custom-theme storage (old saves without groups
+  still load), and `HkColorSchemeDialog` grows an expandable section per
+  registered group (an `HCollapse` titled via
+  `hikari::theme.groups.<id>.title` with the definition label as fallback,
+  plus a localized "Extended colors" header in every locale) editing every
+  slot per mode, with `pairWith` slots sharing one combined row for two-tone
+  wires. `HkColorPicker` gains optional `hueClamp`/`sRange`/`lRange` props
+  that clamp every emitted value into the allowed hue arc (circular
+  center±range math) and saturation/lightness bands — a green wire cannot
+  be picked red — showing the allowed hue band as a swatch strip inside the
+  popover; clamping is re-applied on dialog writes and on save as defense
+  in depth. Groups registered after the theme is live re-apply the current
+  theme immediately (microtask-coalesced through a re-apply hook that
+  useTheme injects into the registry, keeping tokenGroups.ts
+  import-cycle-free), and the registry carries a reactive version ref so
+  the dialog's group sections appear without a remount. Non-industrial
+  consumers are unaffected: nothing renders and no groups ship when
+  nothing is registered.
 
 ## [v0.3.14] - 2026-07-18
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -141,6 +141,40 @@
   width: 100%;
 }
 
+.hk-color-picker-band {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.hk-color-picker-hue-band {
+  position: relative;
+  height: 10px;
+  border-radius: var(--radius-full);
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 10%);
+}
+
+.hk-color-picker-hue-band-thumb {
+  position: absolute;
+  top: 50%;
+  width: 12px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+  border-radius: calc(var(--radius-xs) - 1px);
+  border: 2px solid rgb(255 255 255 / 90%);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 25%);
+  pointer-events: none;
+}
+
+.hk-color-picker-band-caption {
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  color: rgb(var(--color-muted));
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
 .hk-color-picker-hex-hash {
   font-size: var(--text-xs);
   font-weight: 600;

--- a/packages/vue/src/components/HkColorPicker.tsx
+++ b/packages/vue/src/components/HkColorPicker.tsx
@@ -1,5 +1,6 @@
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent, ref, type PropType } from "vue";
 
+import { clampRgbToBands, hueDelta, rgbToHsl, wrapHue, type HueClamp } from "../theme/tokenGroups";
 import HInput from "./HkInput";
 import HPopover from "./HkPopover";
 import "./HkColorPicker.scss";
@@ -108,6 +109,12 @@ export default defineComponent({
     g: { type: Number, required: true },
     b: { type: Number, required: true },
     label: { type: String, default: "" },
+    /** Optional physical-color clamp: hue locked to center±range (degrees, circular). */
+    hueClamp: { type: Object as PropType<HueClamp>, default: undefined },
+    /** Optional saturation safe band, 0–1. */
+    sRange: { type: Array as unknown as PropType<[number, number]>, default: undefined },
+    /** Optional lightness safe band, 0–1. */
+    lRange: { type: Array as unknown as PropType<[number, number]>, default: undefined },
   },
   emits: {
     change: (_rgb: { r: number; g: number; b: number }) => true,
@@ -119,21 +126,48 @@ export default defineComponent({
     const hex = computed(() => rgbToHex(props.r, props.g, props.b));
     const hexDisplay = computed(() => hex.value.replace(/^#/, ""));
 
+    // Defense in depth: every emitted value passes through the same band
+    // clamping the host applies on save.
+    function clampRGB(rgb: { r: number; g: number; b: number }) {
+      return clampRgbToBands(rgb, props.hueClamp, props.sRange, props.lRange);
+    }
+
     function updateChannel(ch: Channel, value: number) {
       const next = { r: props.r, g: props.g, b: props.b };
       next[ch] = clamp(value);
-      emit("change", next);
+      emit("change", clampRGB(next));
     }
 
     function onHexInput(v: string) {
       if (/^[0-9a-fA-F]{0,6}$/.test(v) && v.length === 6) {
-        emit("change", {
+        emit("change", clampRGB({
           r: parseInt(v.slice(0, 2), 16),
           g: parseInt(v.slice(2, 4), 16),
           b: parseInt(v.slice(4, 6), 16),
-        });
+        }));
       }
     }
+
+    // Visual affordance for the allowed hue band: a swatch strip of the
+    // permitted arc with the current color sitting at its position.
+    const hueBand = computed(() => {
+      const hc = props.hueClamp;
+      if (!hc || hc.range <= 0) return null;
+      const center = wrapHue(hc.center);
+      const from = center - hc.range;
+      const to = center + hc.range;
+      const gradient = `linear-gradient(to right, hsl(${from}, 70%, 50%), hsl(${center}, 70%, 50%), hsl(${to}, 70%, 50%))`;
+      const delta = Math.max(-hc.range, Math.min(hc.range, hueDelta(rgbToHsl({ r: props.r, g: props.g, b: props.b }).h, center)));
+      const pct = ((delta + hc.range) / (2 * hc.range)) * 100;
+      return { gradient, pct: Math.max(0, Math.min(100, pct)) };
+    });
+
+    const bandCaption = computed(() => {
+      const parts: string[] = [];
+      if (props.sRange) parts.push(`S ${Math.round(props.sRange[0] * 100)}–${Math.round(props.sRange[1] * 100)}%`);
+      if (props.lRange) parts.push(`L ${Math.round(props.lRange[0] * 100)}–${Math.round(props.lRange[1] * 100)}%`);
+      return parts.length > 0 ? parts.join(" · ") : null;
+    });
 
     return () => (
       <div class="hk-color-picker">
@@ -195,6 +229,30 @@ export default defineComponent({
                   }}
                 </HInput>
               </div>
+
+              {hueBand.value && (
+                <div class="hk-color-picker-band">
+                  <div
+                    class="hk-color-picker-hue-band"
+                    style={{ background: hueBand.value.gradient }}
+                  >
+                    <div
+                      class="hk-color-picker-hue-band-thumb"
+                      style={{ left: `${hueBand.value.pct}%`, background: hex.value }}
+                    />
+                  </div>
+                  {bandCaption.value && (
+                    <div class="hk-color-picker-band-caption">
+                      {bandCaption.value}
+                    </div>
+                  )}
+                </div>
+              )}
+              {!hueBand.value && bandCaption.value && (
+                <div class="hk-color-picker-band-caption">
+                  {bandCaption.value}
+                </div>
+              )}
             </div>
           </div>
         </HPopover>

--- a/packages/vue/src/components/HkColorSchemeDialog.scss
+++ b/packages/vue/src/components/HkColorSchemeDialog.scss
@@ -14,3 +14,29 @@
   justify-content: center;
   gap: var(--space-10, 0.625rem);
 }
+
+.s-scheme-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8, 0.5rem);
+}
+
+.s-scheme-groups-title {
+  font-size: var(--text-xs, 0.75rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgb(var(--color-muted));
+}
+
+.s-scheme-group-slots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-10, 0.625rem);
+  padding: var(--space-8, 0.5rem) var(--space-4, 0.25rem) 0;
+}
+
+.s-scheme-group-row {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-8, 0.5rem);
+}

--- a/packages/vue/src/components/HkColorSchemeDialog.test.ts
+++ b/packages/vue/src/components/HkColorSchemeDialog.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { registerTokenGroup, type TokenGroupDefinition } from "../theme/tokenGroups";
+import { HColorSchemeDialog } from "./HkColorSchemeDialog";
+
+// Fresh file = fresh registry module instance: no groups are registered
+// until a test registers one, mirroring an app that registers late.
+const DIALOG_GROUP: TokenGroupDefinition = {
+  id: "dialog-wires",
+  label: "Dialog wires",
+  slots: [
+    {
+      key: "a",
+      label: "A",
+      defaults: { dark: { r: 1, g: 2, b: 3 }, light: { r: 4, g: 5, b: 6 } },
+    },
+    {
+      key: "b",
+      label: "B",
+      defaults: { dark: { r: 7, g: 8, b: 9 }, light: { r: 10, g: 11, b: 12 } },
+      pairWith: "a",
+    },
+  ],
+};
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountDialog() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () => h(HColorSchemeDialog, { modelValue: true }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkColorSchemeDialog extension groups", () => {
+  it("renders the extension section reactively when a group is registered after mount", async () => {
+    mountDialog();
+    await nextTick();
+    // Zero-cost for consumers that register nothing.
+    expect(document.body.querySelector(".s-scheme-groups")).toBeNull();
+
+    // Late registration (after the dialog is already rendered): the
+    // registry's reactive version invalidates the computed and the
+    // section appears without a remount.
+    registerTokenGroup(DIALOG_GROUP);
+    await nextTick();
+
+    const section = document.body.querySelector(".s-scheme-groups");
+    expect(section).toBeTruthy();
+    // pairWith slots share one combined row carrying both pickers.
+    expect(section!.querySelectorAll(".hk-color-picker")).toHaveLength(2);
+    expect(section!.querySelector(".s-scheme-group-row")).toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/HkColorSchemeDialog.tsx
+++ b/packages/vue/src/components/HkColorSchemeDialog.tsx
@@ -1,14 +1,23 @@
-import { computed, defineComponent, nextTick, reactive, ref, watch } from "vue";
+import { computed, defineComponent, nextTick, reactive, ref, watch, type PropType, type VNode } from "vue";
 import {
   HColorPicker,
+  HCollapse,
   HInput,
   HModal,
   HMorphingTabs,
-  
+
   useI18n,
   useTheme,
+  clampToSlot,
+  getTokenGroups,
+  resolveGroupTokens,
+  tokenGroupsVersion,
   type ModalAction,
   type ThemeSchemeTokens,
+  type ThemeTokenGroupModes,
+  type ThemeTokenGroupValues,
+  type TokenGroupDefinition,
+  type TokenGroupSlot,
 } from "@celestia-island/hikari";
 
 import "./HkColorSchemeDialog.scss";
@@ -93,6 +102,8 @@ export interface HCustomTheme {
   name: string;
   dark: ThemeSchemeTokens;
   light: ThemeSchemeTokens;
+  /** Extension token group values (both modes), present when groups are registered. */
+  groups?: ThemeTokenGroupModes;
 }
 
 /**
@@ -100,10 +111,12 @@ export interface HCustomTheme {
  * presets/custom themes.
  *
  * Edits the seven accent tokens (primary/secondary/accent/success/error/
- * warning/info) per mode (dark/light); surface tokens are derived. Emits
- * `confirm` with a `HCustomTheme` (a hikari `CustomThemePreset`); the
- * caller persists it via `useTheme().addCustomTheme()` and applies it
- * with `setTheme()`.
+ * warning/info) per mode (dark/light); surface tokens are derived. When
+ * extension token groups are registered (`registerTokenGroup`), an
+ * expandable section per group edits their slots with hue-clamped pickers
+ * and rides the values along in the emitted theme. Emits `confirm` with a
+ * `HCustomTheme` (a hikari `CustomThemePreset`); the caller persists it
+ * via `useTheme().addCustomTheme()` and applies it with `setTheme()`.
  */
 export const HColorSchemeDialog = defineComponent({
   name: "HkColorSchemeDialog",
@@ -113,6 +126,8 @@ export const HColorSchemeDialog = defineComponent({
     initialDark: { type: Object, default: undefined },
     /** Prefill light tokens; defaults to the hikari synthwave light scheme. */
     initialLight: { type: Object, default: undefined },
+    /** Prefill extension token groups (per mode); defaults to registry defaults. */
+    initialGroups: { type: Object as PropType<ThemeTokenGroupModes>, default: undefined },
   },
   emits: {
     "update:modelValue": (_v: boolean) => true,
@@ -127,7 +142,33 @@ export const HColorSchemeDialog = defineComponent({
     const dark = reactive<ThemeSchemeTokens>({ ...defaultDark });
     const light = reactive<ThemeSchemeTokens>({ ...defaultLight });
 
+    // Extension token groups, edited per mode like the accent tokens.
+    // Seeded from the prefilled custom theme (if any) falling back to the
+    // registry defaults; empty (and rendered nowhere) while no downstream
+    // app has registered a group.
+    const groupDark = reactive<ThemeTokenGroupValues>({});
+    const groupLight = reactive<ThemeTokenGroupValues>({});
+    // Depends on the registry's reactive version so groups registered
+    // after this dialog first rendered appear without a remount.
+    const registeredGroups = computed<readonly TokenGroupDefinition[]>(() => {
+      void tokenGroupsVersion.value;
+      return getTokenGroups();
+    });
+
     const currentTokens = computed(() => (modeTab.value === "dark" ? dark : light));
+    const currentGroupValues = computed(() => (modeTab.value === "dark" ? groupDark : groupLight));
+
+    function seedGroups(
+      target: ThemeTokenGroupValues,
+      mode: "dark" | "light",
+      overrides?: ThemeTokenGroupValues,
+    ) {
+      const resolved = resolveGroupTokens(mode, overrides);
+      for (const key of Object.keys(target)) delete target[key];
+      for (const [groupId, slots] of Object.entries(resolved)) {
+        target[groupId] = slots;
+      }
+    }
 
     function rederiveSurface() {
       const target = modeTab.value === "dark" ? dark : light;
@@ -158,6 +199,9 @@ export const HColorSchemeDialog = defineComponent({
         const initialLight = props.initialLight as ThemeSchemeTokens | undefined;
         Object.assign(dark, initialDark ?? defaultDark);
         Object.assign(light, initialLight ?? defaultLight);
+        const initialGroups = props.initialGroups as ThemeTokenGroupModes | undefined;
+        seedGroups(groupDark, "dark", initialGroups?.dark);
+        seedGroups(groupLight, "light", initialGroups?.light);
         rederiveSurface();
       },
     );
@@ -167,6 +211,29 @@ export const HColorSchemeDialog = defineComponent({
       target[key] = { ...rgb };
     }
 
+    function updateGroupToken(groupId: string, slot: TokenGroupSlot, rgb: { r: number; g: number; b: number }) {
+      const values = currentGroupValues.value;
+      const group = values[groupId] ?? (values[groupId] = {});
+      // Defense in depth: the picker already clamps, clamp again on write.
+      group[slot.key] = clampToSlot(slot, rgb);
+    }
+
+    function clampGroups(
+      source: ThemeTokenGroupValues,
+      mode: "dark" | "light",
+    ): ThemeTokenGroupValues {
+      const out: ThemeTokenGroupValues = {};
+      for (const group of registeredGroups.value) {
+        const slots: Record<string, { r: number; g: number; b: number }> = {};
+        for (const slot of group.slots) {
+          const value = source[group.id]?.[slot.key] ?? slot.defaults[mode];
+          slots[slot.key] = clampToSlot(slot, value);
+        }
+        out[group.id] = slots;
+      }
+      return out;
+    }
+
     function handleConfirm() {
       const id = `custom-theme-${Date.now()}`;
       emit("confirm", {
@@ -174,6 +241,9 @@ export const HColorSchemeDialog = defineComponent({
         name: themeName.value || t("hikari::theme.customThemeName"),
         dark: { ...dark },
         light: { ...light },
+        ...(registeredGroups.value.length > 0
+          ? { groups: { dark: clampGroups(groupDark, "dark"), light: clampGroups(groupLight, "light") } }
+          : {}),
       });
       emit("update:modelValue", false);
     }
@@ -195,6 +265,55 @@ export const HColorSchemeDialog = defineComponent({
       { key: "dark", label: t("hikari::theme.modeDark") },
       { key: "light", label: t("hikari::theme.modeLight") },
     ]);
+
+    function renderGroupSlot(group: TokenGroupDefinition, slot: TokenGroupSlot) {
+      const mode = modeTab.value === "dark" ? "dark" : "light";
+      const rgb = currentGroupValues.value[group.id]?.[slot.key] ?? slot.defaults[mode];
+      return (
+        <HColorPicker
+          key={slot.key}
+          r={rgb.r}
+          g={rgb.g}
+          b={rgb.b}
+          label={t(`hikari::theme.groups.${group.id}.${slot.key}`, slot.label)}
+          hueClamp={slot.hueClamp}
+          sRange={slot.sRange}
+          lRange={slot.lRange}
+          onChange={(next: { r: number; g: number; b: number }) => updateGroupToken(group.id, slot, next)}
+        />
+      );
+    }
+
+    /** One picker per slot; `pairWith` slots share one combined row (e.g. PE a/b stripes). */
+    function renderGroupRows(group: TokenGroupDefinition) {
+      const rendered = new Set<string>();
+      const rows: VNode[] = [];
+      for (const slot of group.slots) {
+        if (rendered.has(slot.key)) continue;
+        rendered.add(slot.key);
+        // Pairing is symmetric: either side may declare `pairWith` —
+        // combine on the first of the two encountered, skip the second.
+        const pairKey = [
+          slot.pairWith,
+          ...group.slots.filter((s) => s.pairWith === slot.key).map((s) => s.key),
+        ].find((key) => key && key !== slot.key);
+        const pair = pairKey
+          ? group.slots.find((s) => s.key === pairKey && !rendered.has(s.key))
+          : undefined;
+        if (pair) {
+          rendered.add(pair.key);
+          rows.push(
+            <div key={`${slot.key}-${pair.key}`} class="s-scheme-group-row">
+              {renderGroupSlot(group, slot)}
+              {renderGroupSlot(group, pair)}
+            </div>,
+          );
+        } else {
+          rows.push(renderGroupSlot(group, slot));
+        }
+      }
+      return rows;
+    }
 
     return () => (
       <HModal
@@ -230,6 +349,23 @@ export const HColorSchemeDialog = defineComponent({
               />
             ))}
           </div>
+          {registeredGroups.value.length > 0 && (
+            <div class="s-scheme-groups">
+              <div class="s-scheme-groups-title">
+                {t("hikari::theme.extendedColors", "Extended colors")}
+              </div>
+              {registeredGroups.value.map((group) => (
+                <HCollapse
+                  key={group.id}
+                  title={t(`hikari::theme.groups.${group.id}.title`, group.label)}
+                >
+                  <div class="s-scheme-group-slots">
+                    {renderGroupRows(group)}
+                  </div>
+                </HCollapse>
+              ))}
+            </div>
+          )}
         </div>
       </HModal>
     );

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "خطأ",
     "hikari::theme.tokens.warning": "تحذير",
     "hikari::theme.tokens.info": "معلومات",
+    "hikari::theme.extendedColors": "ألوان موسعة",
     "hikari::secret.title": "سر",
     "hikari::secret.notice": "يُعرض هذا السر مرة واحدة فقط. انسخه واحفظه قبل الإغلاق.",
     "hikari::secret.copy": "نسخ",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Fehler",
     "hikari::theme.tokens.warning": "Warnung",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.extendedColors": "Erweiterte Farben",
     "hikari::secret.title": "Geheimnis",
     "hikari::secret.notice": "Dieses Geheimnis wird nur einmal angezeigt. Kopieren und speichern Sie es vor dem Schließen.",
     "hikari::secret.copy": "Kopieren",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Error",
     "hikari::theme.tokens.warning": "Warning",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.extendedColors": "Extended colors",
     "hikari::secret.title": "Secret",
     "hikari::secret.notice": "This secret is shown only once. Copy and store it before closing.",
     "hikari::secret.copy": "Copy",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Error",
     "hikari::theme.tokens.warning": "Advertencia",
     "hikari::theme.tokens.info": "Información",
+    "hikari::theme.extendedColors": "Colores extendidos",
     "hikari::secret.title": "Secreto",
     "hikari::secret.notice": "Este secreto se muestra solo una vez. Cópielo y guárdelo antes de cerrar.",
     "hikari::secret.copy": "Copiar",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Erreur",
     "hikari::theme.tokens.warning": "Avertissement",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.extendedColors": "Couleurs étendues",
     "hikari::secret.title": "Secret",
     "hikari::secret.notice": "Ce secret n'est affiché qu'une seule fois. Copiez-le et conservez-le avant de fermer.",
     "hikari::secret.copy": "Copier",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "エラー",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "情報",
+    "hikari::theme.extendedColors": "拡張カラー",
     "hikari::secret.title": "シークレット",
     "hikari::secret.notice": "このシークレットは一度だけ表示されます。閉じる前にコピーして保存してください。",
     "hikari::secret.copy": "コピー",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "오류",
     "hikari::theme.tokens.warning": "경고",
     "hikari::theme.tokens.info": "정보",
+    "hikari::theme.extendedColors": "확장 색상",
     "hikari::secret.title": "비밀",
     "hikari::secret.notice": "이 비밀은 한 번만 표시됩니다. 닫기 전에 복사하여 저장하세요.",
     "hikari::secret.copy": "복사",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Erro",
     "hikari::theme.tokens.warning": "Aviso",
     "hikari::theme.tokens.info": "Informação",
+    "hikari::theme.extendedColors": "Cores estendidas",
     "hikari::secret.title": "Segredo",
     "hikari::secret.notice": "Este segredo é mostrado apenas uma vez. Copie e guarde antes de fechar.",
     "hikari::secret.copy": "Copiar",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "Ошибка",
     "hikari::theme.tokens.warning": "Предупреждение",
     "hikari::theme.tokens.info": "Информация",
+    "hikari::theme.extendedColors": "Расширенные цвета",
     "hikari::secret.title": "Секрет",
     "hikari::secret.notice": "Этот секрет показывается только один раз. Скопируйте и сохраните его до закрытия.",
     "hikari::secret.copy": "Копировать",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "错误",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "信息",
+    "hikari::theme.extendedColors": "扩展配色",
     "hikari::secret.title": "密钥",
     "hikari::secret.notice": "此密钥仅显示一次，请先复制并妥善保存。",
     "hikari::secret.copy": "复制",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -33,6 +33,7 @@
     "hikari::theme.tokens.error": "錯誤",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "資訊",
+    "hikari::theme.extendedColors": "擴充配色",
     "hikari::secret.title": "金鑰",
     "hikari::secret.notice": "此金鑰僅顯示一次，請先複製並妥善保存。",
     "hikari::secret.copy": "複製",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -94,10 +94,16 @@ export { type TrendPen, type TrendPoint, type AlarmThresholds } from "./componen
 export {
   initTheme, useTheme, themePresets, tokensToCSSVars, getThemeTokens,
   loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme,
+  registerTokenGroup, getTokenGroups, resolveGroupTokens, clampToSlot,
+  clampRgbToBands, clampHue, hueDelta, wrapHue, groupTokensToCSSVars, rgbToHsl, hslToRgb,
+  tokenGroupsVersion,
   startLuminanceSampler, stopLuminanceSampler, sampleLuminanceNow, invalidateLuminanceCache,
   getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION,
   type ThemeTokenRGB, type ThemeSchemeTokens, type ThemePreset, type ThemeMode,
   type ThemeId, type ThemeTokens, type CustomThemePreset, type TimePeriod,
+  type ThemeTokenGroupValues, type ThemeTokenGroupModes,
+  type TokenGroupDefinition, type TokenGroupSlot, type HueClamp,
+  type ResolvedGroupTokens, type ColorHSL,
 } from "./theme";
 
 // Runtime systems

--- a/packages/vue/src/theme/index.ts
+++ b/packages/vue/src/theme/index.ts
@@ -1,7 +1,13 @@
 export { initTheme, useTheme } from "./useTheme";
 export { themePresets, tokensToCSSVars, getThemeTokens, loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme } from "./presets";
-export type { ThemeTokenRGB, ThemeSchemeTokens, ThemePreset, CustomThemePreset, ThemeId, ThemeMode } from "./presets";
+export type { ThemeTokenRGB, ThemeSchemeTokens, ThemePreset, CustomThemePreset, ThemeId, ThemeMode, ThemeTokenGroupValues, ThemeTokenGroupModes } from "./presets";
 export type { ThemeTokens } from "./presets";
+export {
+  registerTokenGroup, getTokenGroups, resolveGroupTokens, clampToSlot,
+  clampRgbToBands, clampHue, hueDelta, groupTokensToCSSVars, rgbToHsl, hslToRgb, wrapHue,
+  tokenGroupsVersion, setTokenGroupsReapply,
+} from "./tokenGroups";
+export type { TokenGroupDefinition, TokenGroupSlot, HueClamp, ResolvedGroupTokens, ColorHSL, TokenGroupsReapplyFn } from "./tokenGroups";
 export { getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION } from "./useSolarTime";
 export { startLuminanceSampler, stopLuminanceSampler, sampleLuminanceNow, invalidateLuminanceCache } from "./useBackgroundLuminance";
 export type { TimePeriod } from "./useSolarTime";

--- a/packages/vue/src/theme/presets.ts
+++ b/packages/vue/src/theme/presets.ts
@@ -23,11 +23,25 @@ export interface ThemeSchemeTokens {
   info: ThemeTokenRGB;
 }
 
+/**
+ * Extension token group values riding along with a preset/custom theme,
+ * keyed by group id then slot key (see ./tokenGroups.ts). Optional and
+ * additive: presets and saved custom themes without groups keep working —
+ * the registry defaults are the final fallback.
+ */
+export type ThemeTokenGroupValues = Record<string, Record<string, ThemeTokenRGB>>;
+
+export interface ThemeTokenGroupModes {
+  dark?: ThemeTokenGroupValues;
+  light?: ThemeTokenGroupValues;
+}
+
 export interface ThemePreset {
   id: string;
   name: string;
   dark: ThemeSchemeTokens;
   light: ThemeSchemeTokens;
+  groups?: ThemeTokenGroupModes;
 }
 
 export type ThemeId = string;
@@ -38,6 +52,7 @@ export interface CustomThemePreset {
   name: string;
   dark: ThemeSchemeTokens;
   light: ThemeSchemeTokens;
+  groups?: ThemeTokenGroupModes;
 }
 
 const CUSTOM_STORAGE_KEY = "hikari-custom-themes";
@@ -260,8 +275,15 @@ function mixToken(a: ThemeTokenRGB, b: ThemeTokenRGB, t: number): ThemeTokenRGB 
   };
 }
 
+/**
+ * Build the cssvar map for a scheme. `groupVars` (optional, from
+ * `groupTokensToCSSVars(resolveGroupTokens(...))`) is merged in so
+ * extension token groups ship alongside the fixed tokens; callers that
+ * omit it get the exact previous behavior.
+ */
 export function tokensToCSSVars(
   tokens: ThemeSchemeTokens,
+  groupVars?: Record<string, string>,
 ): Record<string, string> {
   const onPrimary = contrastColor(tokens.primary);
   const textSecondary = mixToken(tokens.text, tokens.muted, 0.25);
@@ -305,5 +327,6 @@ export function tokensToCSSVars(
     "--hi-color-bg-elevated": "rgb(var(--color-surface))",
     "--hi-color-bg-canvas": "rgb(var(--color-background))",
     "--hi-secondary-bg": "rgb(var(--color-surface) / 0.5)",
+    ...groupVars,
   };
 }

--- a/packages/vue/src/theme/tokenGroups.test.ts
+++ b/packages/vue/src/theme/tokenGroups.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addCustomTheme,
+  loadCustomThemes,
+  saveCustomThemes,
+  themePresets,
+  tokensToCSSVars,
+  type CustomThemePreset,
+} from "./presets";
+import {
+  clampToSlot,
+  getTokenGroups,
+  groupTokensToCSSVars,
+  registerTokenGroup,
+  resolveGroupTokens,
+  rgbToHsl,
+  hslToRgb,
+  setTokenGroupsReapply,
+  tokenGroupsVersion,
+  type TokenGroupDefinition,
+} from "./tokenGroups";
+import { initTheme, useTheme } from "./useTheme";
+
+// Test-only group — hikari itself registers nothing; the mechanism is the
+// product and the registration lives in the downstream app.
+const TEST_GROUP: TokenGroupDefinition = {
+  id: "test-wires",
+  label: "Test wires",
+  slots: [
+    {
+      key: "power-l1",
+      label: "Power L1",
+      defaults: { dark: { r: 220, g: 60, b: 60 }, light: { r: 180, g: 40, b: 40 } },
+      hueClamp: { center: 0, range: 20 },
+    },
+    {
+      key: "pipe-h2",
+      label: "Pipe H2",
+      defaults: { dark: { r: 60, g: 200, b: 120 }, light: { r: 40, g: 160, b: 90 } },
+      hueClamp: { center: 140, range: 30 },
+      sRange: [0.3, 0.9],
+      lRange: [0.25, 0.7],
+    },
+    {
+      key: "bus-n",
+      label: "Bus N",
+      defaults: { dark: { r: 200, g: 83, b: 60 }, light: { r: 160, g: 63, b: 40 } },
+      hueClamp: { center: 350, range: 20 },
+    },
+    {
+      key: "panel",
+      label: "Panel",
+      defaults: { dark: { r: 90, g: 90, b: 110 }, light: { r: 70, g: 70, b: 90 } },
+      sRange: [0.2, 0.8],
+      lRange: [0.2, 0.8],
+    },
+  ],
+};
+
+function slot(key: string) {
+  const found = TEST_GROUP.slots.find((s) => s.key === key);
+  if (!found) throw new Error(`unknown slot ${key}`);
+  return found;
+}
+
+beforeEach(() => {
+  registerTokenGroup(TEST_GROUP);
+  localStorage.clear();
+});
+
+describe("token group registry", () => {
+  it("resolves registry defaults per mode and lets overrides win", () => {
+    const dark = resolveGroupTokens("dark");
+    expect(dark["test-wires"]["power-l1"]).toEqual({ r: 220, g: 60, b: 60 });
+
+    const light = resolveGroupTokens("light");
+    expect(light["test-wires"]["power-l1"]).toEqual({ r: 180, g: 40, b: 40 });
+    expect(light["test-wires"]["power-l1"]).not.toEqual(dark["test-wires"]["power-l1"]);
+
+    const overridden = resolveGroupTokens("dark", {
+      "test-wires": { "power-l1": { r: 1, g: 2, b: 3 } },
+      "not-registered": { anything: { r: 9, g: 9, b: 9 } },
+    });
+    expect(overridden["test-wires"]["power-l1"]).toEqual({ r: 1, g: 2, b: 3 });
+    // Slots without an override keep their defaults.
+    expect(overridden["test-wires"]["pipe-h2"]).toEqual({ r: 60, g: 200, b: 120 });
+    // Unregistered groups never appear in the resolution.
+    expect(overridden["not-registered"]).toBeUndefined();
+  });
+
+  it("replaces the definition when re-registered with the same id", () => {
+    expect(getTokenGroups().filter((g) => g.id === "test-wires")).toHaveLength(1);
+    registerTokenGroup({
+      id: "test-wires",
+      label: "Test wires v2",
+      slots: [slot("power-l1")],
+    });
+    const groups = getTokenGroups().filter((g) => g.id === "test-wires");
+    expect(groups).toHaveLength(1);
+    expect(groups[0].label).toBe("Test wires v2");
+    expect(groups[0].slots).toHaveLength(1);
+  });
+
+  it("returns resolved values as fresh copies", () => {
+    const resolved = resolveGroupTokens("dark");
+    resolved["test-wires"]["power-l1"].r = 0;
+    expect(resolveGroupTokens("dark")["test-wires"]["power-l1"].r).toBe(220);
+  });
+
+  it("returns registry definitions as copies callers cannot mutate", () => {
+    const groups = getTokenGroups();
+    const wires = groups.find((g) => g.id === "test-wires")!;
+    wires.label = "Mutated";
+    wires.slots[0].hueClamp = { center: 99, range: 99 };
+    wires.slots[0].defaults.dark = { r: 0, g: 0, b: 0 };
+    const again = getTokenGroups().find((g) => g.id === "test-wires")!;
+    expect(again.label).toBe("Test wires");
+    expect(again.slots[0].hueClamp).toEqual({ center: 0, range: 20 });
+    expect(again.slots[0].defaults.dark).toEqual({ r: 220, g: 60, b: 60 });
+  });
+});
+
+describe("clampToSlot", () => {
+  it("keeps a hue inside the band unchanged", () => {
+    // rgb(200, 60, 60) → hsl(0, 0.56, 0.51); power-l1 allows 0 ± 20°.
+    expect(clampToSlot(slot("power-l1"), { r: 200, g: 60, b: 60 })).toEqual({
+      r: 200,
+      g: 60,
+      b: 60,
+    });
+    // rgb(60, 200, 90) → hue ≈ 132.9°; pipe-h2 allows 140 ± 30°.
+    expect(clampToSlot(slot("pipe-h2"), { r: 60, g: 200, b: 90 })).toEqual({
+      r: 60,
+      g: 200,
+      b: 90,
+    });
+  });
+
+  it("clamps an out-of-band hue to the nearest bound", () => {
+    // rgb(60, 60, 200) → hue 240°; power-l1 (0 ± 20°) clamps to 340°.
+    const clamped = clampToSlot(slot("power-l1"), { r: 60, g: 60, b: 200 });
+    expect(rgbToHsl(clamped).h).toBeCloseTo(340, 0);
+  });
+
+  it("allows hues across the 0° wrap and clamps the far side", () => {
+    // bus-n: center 350° ± 20° → [330°, 10°]. Hue 10° (rgb 200, 83, 60) is allowed.
+    expect(clampToSlot(slot("bus-n"), { r: 200, g: 83, b: 60 })).toEqual({
+      r: 200,
+      g: 83,
+      b: 60,
+    });
+    // Hue 30° is outside; nearest bound is 10° → same color as above.
+    expect(clampToSlot(slot("bus-n"), { r: 200, g: 130, b: 60 })).toEqual({
+      r: 200,
+      g: 83,
+      b: 60,
+    });
+  });
+
+  it("clamps saturation and lightness into their bands", () => {
+    // Pure gray has s = 0; panel demands s ≥ 0.2 (no hue clamp → stays neutral-hued).
+    // Integer rgb quantization wiggles the measured s slightly below the
+    // bound, so assert the band was reached and re-clamping is a fixed point.
+    const saturated = clampToSlot(slot("panel"), { r: 128, g: 128, b: 128 });
+    const sat = rgbToHsl(saturated);
+    expect(sat.s).toBeCloseTo(0.2, 1);
+    expect(clampToSlot(slot("panel"), saturated)).toEqual(saturated);
+
+    // Near-white has l ≈ 0.98; panel caps l at 0.8.
+    const dimmed = clampToSlot(slot("panel"), { r: 250, g: 250, b: 250 });
+    expect(rgbToHsl(dimmed).l).toBeCloseTo(0.8, 2);
+  });
+
+  it("clamps both hue and bands together", () => {
+    // Blue (hue 240°, s 0.56, l 0.51) under pipe-h2 (140 ± 30°, s ≤ 0.9, l ∈ [0.25, 0.7]):
+    // hue snaps to 170°, s/l already inside their bands.
+    const clamped = clampToSlot(slot("pipe-h2"), { r: 60, g: 60, b: 200 });
+    const hsl = rgbToHsl(clamped);
+    expect(hsl.h).toBeCloseTo(170, 0);
+    expect(hsl.s).toBeCloseTo(0.56, 2);
+    expect(hsl.l).toBeGreaterThan(0.25);
+    expect(hsl.l).toBeLessThan(0.7);
+  });
+
+  it("round-trips HSL conversions for exact rgb values", () => {
+    expect(hslToRgb(rgbToHsl({ r: 60, g: 200, b: 90 }))).toEqual({ r: 60, g: 200, b: 90 });
+    expect(hslToRgb(rgbToHsl({ r: 200, g: 83, b: 60 }))).toEqual({ r: 200, g: 83, b: 60 });
+  });
+});
+
+describe("group cssvars", () => {
+  it("emits --<group>-<slot> vars merged into the scheme map", () => {
+    const vars = tokensToCSSVars(
+      themePresets.nord.dark,
+      groupTokensToCSSVars(resolveGroupTokens("dark")),
+    );
+    expect(vars["--color-primary"]).toBe("136 192 208");
+    expect(vars["--test-wires-power-l1"]).toBe("220 60 60");
+    expect(vars["--test-wires-pipe-h2"]).toBe("60 200 120");
+    expect(vars["--test-wires-panel"]).toBe("90 90 110");
+  });
+
+  it("emits preset-group overrides when provided", () => {
+    const vars = tokensToCSSVars(
+      themePresets.nord.dark,
+      groupTokensToCSSVars(
+        resolveGroupTokens("dark", { "test-wires": { "power-l1": { r: 7, g: 8, b: 9 } } }),
+      ),
+    );
+    expect(vars["--test-wires-power-l1"]).toBe("7 8 9");
+    // Non-overridden slots still fall back to defaults.
+    expect(vars["--test-wires-pipe-h2"]).toBe("60 200 120");
+  });
+
+  it("keeps tokensToCSSVars backward compatible without groups", () => {
+    const vars = tokensToCSSVars(themePresets.nord.dark);
+    expect(vars["--test-wires-power-l1"]).toBeUndefined();
+    expect(Object.keys(vars).every((k) => k.startsWith("--color-") || k.startsWith("--hi-"))).toBe(true);
+  });
+});
+
+describe("custom theme storage with groups", () => {
+  const scheme = themePresets.nord.dark;
+  const themeWithGroups: CustomThemePreset = {
+    id: "custom-theme-1",
+    name: "Wired",
+    dark: scheme,
+    light: themePresets.nord.light,
+    groups: {
+      dark: { "test-wires": { "power-l1": { r: 210, g: 50, b: 50 } } },
+      light: { "test-wires": { "power-l1": { r: 170, g: 30, b: 30 } } },
+    },
+  };
+
+  it("round-trips groups through localStorage", () => {
+    saveCustomThemes([themeWithGroups]);
+    const loaded = loadCustomThemes();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].groups).toEqual(themeWithGroups.groups);
+  });
+
+  it("still loads old saves that carry no groups", () => {
+    localStorage.setItem(
+      "hikari-custom-themes",
+      JSON.stringify([{ id: "legacy", name: "Legacy", dark: scheme, light: scheme }]),
+    );
+    const loaded = loadCustomThemes();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe("legacy");
+    expect(loaded[0].groups).toBeUndefined();
+  });
+
+  it("replaces and persists groups via addCustomTheme", () => {
+    addCustomTheme(themeWithGroups);
+    addCustomTheme({ ...themeWithGroups, groups: { dark: { "test-wires": { "power-l1": { r: 1, g: 2, b: 3 } } } } });
+    const loaded = loadCustomThemes();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].groups?.dark?.["test-wires"]?.["power-l1"]).toEqual({ r: 1, g: 2, b: 3 });
+  });
+});
+
+describe("late registration", () => {
+  const LATE_GROUP: TokenGroupDefinition = {
+    id: "late-wires",
+    label: "Late wires",
+    slots: [
+      {
+        key: "a",
+        label: "A",
+        defaults: { dark: { r: 1, g: 2, b: 3 }, light: { r: 4, g: 5, b: 6 } },
+      },
+    ],
+  };
+
+  /** Flush all pending microtasks (the re-apply coalescing window). */
+  function flushMicrotasks(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it("bumps the reactive registry version on every registration", () => {
+    const before = tokenGroupsVersion.value;
+    registerTokenGroup(TEST_GROUP);
+    expect(tokenGroupsVersion.value).toBe(before + 1);
+    registerTokenGroup(TEST_GROUP);
+    expect(tokenGroupsVersion.value).toBe(before + 2);
+  });
+
+  it("re-emits group cssvars immediately when registered after applyTheme", async () => {
+    // Apply a theme FIRST (the chest ordering risk), then register.
+    const { setMode } = useTheme();
+    setMode("dark");
+    initTheme();
+    const el = document.documentElement;
+    expect(el.style.getPropertyValue("--late-wires-a")).toBe("");
+
+    registerTokenGroup(LATE_GROUP);
+    await flushMicrotasks();
+
+    // The injected hook re-applied the current dark theme, so the late
+    // group's registry defaults are already on the document element.
+    expect(el.style.getPropertyValue("--late-wires-a")).toBe("1 2 3");
+  });
+
+  it("coalesces same-tick registrations into a single re-apply", async () => {
+    const spy = vi.fn();
+    const previous = setTokenGroupsReapply(spy);
+    try {
+      registerTokenGroup(LATE_GROUP);
+      registerTokenGroup(TEST_GROUP);
+      registerTokenGroup({ ...LATE_GROUP, id: "late-wires-2" });
+      await flushMicrotasks();
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      setTokenGroupsReapply(previous);
+    }
+  });
+
+  it("re-applies again for a registration in a later tick", async () => {
+    const spy = vi.fn();
+    const previous = setTokenGroupsReapply(spy);
+    try {
+      registerTokenGroup(LATE_GROUP);
+      await flushMicrotasks();
+      registerTokenGroup({ ...LATE_GROUP, id: "late-wires-3" });
+      await flushMicrotasks();
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      setTokenGroupsReapply(previous);
+    }
+  });
+});

--- a/packages/vue/src/theme/tokenGroups.ts
+++ b/packages/vue/src/theme/tokenGroups.ts
@@ -1,0 +1,274 @@
+import { ref, type Ref } from "vue";
+
+import type { ThemeTokenGroupModes, ThemeTokenGroupValues, ThemeTokenRGB } from "./presets";
+
+/**
+ * Extension token groups — namespaced color slots beyond the 16 fixed UI
+ * tokens (industrial/SCADA theming: wire colors, pipe states, phase marks).
+ *
+ * A downstream app registers a group (`registerTokenGroup`); hikari then:
+ *   - emits `--<groupId>-<slotKey>: "r g b"` CSS vars on every theme apply
+ *     (registry defaults as the final fallback when no preset defines them),
+ *     and re-applies the current theme right away when a group is
+ *     registered after the theme is already live (see `setTokenGroupsReapply`),
+ *   - rides the values along with presets and custom themes (both modes),
+ *   - exposes them in the color scheme dialog with hue-clamped pickers
+ *     (a green wire must stay green: hue locked to center±range, s/l kept
+ *     inside safe bands).
+ */
+
+export interface HueClamp {
+  /** Band center in degrees (circular). */
+  center: number;
+  /** Allowed distance from the center in degrees, both directions. */
+  range: number;
+}
+
+export interface TokenGroupSlot {
+  /** cssvar suffix → `--<groupId>-<key>` */
+  key: string;
+  /** i18n key suffix — the dialog renders t(`hikari::theme.groups.${groupId}.${key}`) with fallback to this string. */
+  label: string;
+  defaults: { dark: ThemeTokenRGB; light: ThemeTokenRGB };
+  /** Picker hue clamp: hue locked to center±range (degrees, circular). */
+  hueClamp?: HueClamp;
+  /** Saturation / lightness safe bands, 0–1. */
+  sRange?: [number, number];
+  lRange?: [number, number];
+  /** Two-tone slot pair (e.g. PE wire a/b stripes): key of the sibling slot. */
+  pairWith?: string;
+}
+
+export interface TokenGroupDefinition {
+  /** cssvar prefix → `--<id>-<slotKey>` */
+  id: string;
+  /** i18n key fallback for the group title. */
+  label: string;
+  slots: TokenGroupSlot[];
+}
+
+/** Per-group slot values: `groups[groupId][slotKey] = rgb`. */
+export type { ThemeTokenGroupValues, ThemeTokenGroupModes };
+
+/** Fully resolved group values for one mode (every registered slot present). */
+export type ResolvedGroupTokens = ThemeTokenGroupValues;
+
+const registry = new Map<string, TokenGroupDefinition>();
+
+// Reactive registry version: bumps on every registration so UI derived
+// from the registry (e.g. the color scheme dialog's group sections) can
+// track groups registered after it first rendered.
+const registryVersion = ref(0);
+/** Read-only view of the registry version — consumers never bump it manually. */
+export const tokenGroupsVersion: Readonly<Ref<number>> = registryVersion;
+
+/**
+ * "Re-apply the current theme" callback injected by useTheme (which this
+ * module must not import — that would be a cycle). When present, every
+ * registration re-emits the theme cssvars through a microtask-coalesced
+ * call, so groups registered after `initTheme()` land their
+ * `--<group>-<slot>` vars immediately instead of waiting for the next
+ * theme/mode switch.
+ */
+export type TokenGroupsReapplyFn = () => void;
+
+let reapplyFn: TokenGroupsReapplyFn | null = null;
+let reapplyScheduled = false;
+
+/**
+ * Install (or clear, with null) the re-apply callback. Returns the
+ * previously installed callback so callers (and tests) can restore it.
+ * hikari wires this automatically in useTheme; applications normally
+ * never call it.
+ */
+export function setTokenGroupsReapply(fn: TokenGroupsReapplyFn | null): TokenGroupsReapplyFn | null {
+  const previous = reapplyFn;
+  reapplyFn = fn;
+  return previous;
+}
+
+/** Coalesce same-tick registrations into one re-apply (microtask flush). */
+function scheduleReapply(): void {
+  if (reapplyScheduled || !reapplyFn) return;
+  reapplyScheduled = true;
+  queueMicrotask(() => {
+    reapplyScheduled = false;
+    try {
+      reapplyFn?.();
+    } catch {
+      // A failing re-apply must never break the registration itself.
+    }
+  });
+}
+
+/** Deep-copy a slot (defaults + clamp bands) so registry and callers never share state. */
+function cloneSlot(slot: TokenGroupSlot): TokenGroupSlot {
+  return {
+    ...slot,
+    defaults: {
+      dark: { ...slot.defaults.dark },
+      light: { ...slot.defaults.light },
+    },
+    hueClamp: slot.hueClamp ? { ...slot.hueClamp } : undefined,
+    sRange: slot.sRange ? [...slot.sRange] : undefined,
+    lRange: slot.lRange ? [...slot.lRange] : undefined,
+  };
+}
+
+/**
+ * Register (or replace — idempotent by id) an extension token group.
+ * The definition is deep-copied so later mutation by the caller cannot
+ * desync the registry. Registering after the theme is live re-emits the
+ * theme cssvars (microtask-coalesced) so the new group's vars appear
+ * immediately.
+ */
+export function registerTokenGroup(def: TokenGroupDefinition): void {
+  registry.set(def.id, { ...def, slots: def.slots.map(cloneSlot) });
+  registryVersion.value++;
+  scheduleReapply();
+}
+
+/**
+ * All registered groups, in registration order. Returns fresh copies —
+ * treat the definitions as immutable and re-register to change them.
+ */
+export function getTokenGroups(): readonly TokenGroupDefinition[] {
+  return [...registry.values()].map((group) => ({ ...group, slots: group.slots.map(cloneSlot) }));
+}
+
+/**
+ * Resolve every registered group/slot for a mode:
+ * `overrides?.[group]?.[slot] ?? slot.defaults[mode]`. Unregistered
+ * override entries are ignored; returned values are fresh copies.
+ */
+export function resolveGroupTokens(
+  mode: "dark" | "light",
+  overrides?: ThemeTokenGroupValues,
+): ResolvedGroupTokens {
+  const resolved: ResolvedGroupTokens = {};
+  for (const group of registry.values()) {
+    const slots: Record<string, ThemeTokenRGB> = {};
+    for (const slot of group.slots) {
+      const override = overrides?.[group.id]?.[slot.key];
+      const value = override ?? slot.defaults[mode];
+      slots[slot.key] = { r: value.r, g: value.g, b: value.b };
+    }
+    resolved[group.id] = slots;
+  }
+  return resolved;
+}
+
+// ── RGB ↔ HSL helpers ─────────────────────────────────────────────
+
+export interface ColorHSL {
+  h: number;
+  s: number;
+  l: number;
+}
+
+export function wrapHue(h: number): number {
+  return ((h % 360) + 360) % 360;
+}
+
+export function rgbToHsl({ r, g, b }: ThemeTokenRGB): ColorHSL {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) return { h: 0, s: 0, l };
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === rn) {
+    h = ((gn - bn) / d + (gn < bn ? 6 : 0)) * 60;
+  } else if (max === gn) {
+    h = ((bn - rn) / d + 2) * 60;
+  } else {
+    h = ((rn - gn) / d + 4) * 60;
+  }
+  return { h: wrapHue(h), s, l };
+}
+
+export function hslToRgb({ h, s, l }: ColorHSL): ThemeTokenRGB {
+  const hp = wrapHue(h) / 60;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+/**
+ * Signed shortest circular distance from `center` to `h`, in
+ * [-180, 180) — the exactly-opposite angle maps to -180. Both inputs
+ * are normalized first.
+ */
+export function hueDelta(h: number, center: number): number {
+  return ((wrapHue(h) - wrapHue(center) + 540) % 360) - 180;
+}
+
+/** Clamp a hue to the circular band `center ± range`. */
+export function clampHue(h: number, center: number, range: number): number {
+  const delta = Math.max(-range, Math.min(range, hueDelta(h, center)));
+  return wrapHue(wrapHue(center) + delta);
+}
+
+function clampRange01(v: number, range?: [number, number]): number {
+  if (!range) return v;
+  return Math.max(range[0], Math.min(range[1], v));
+}
+
+/**
+ * Clamp an arbitrary color into the hue/saturation/lightness bands.
+ * Colors already inside every band round-trip through HSL unchanged
+ * (integer RGB is reproduced exactly up to float rounding).
+ */
+export function clampRgbToBands(
+  color: ThemeTokenRGB,
+  hueClamp?: HueClamp,
+  sRange?: [number, number],
+  lRange?: [number, number],
+): ThemeTokenRGB {
+  if (!hueClamp && !sRange && !lRange) return { r: color.r, g: color.g, b: color.b };
+  const hsl = rgbToHsl(color);
+  if (hueClamp) hsl.h = clampHue(hsl.h, hueClamp.center, hueClamp.range);
+  hsl.s = clampRange01(hsl.s, sRange);
+  hsl.l = clampRange01(hsl.l, lRange);
+  return hslToRgb(hsl);
+}
+
+/** Defense-in-depth clamping of a value destined for one slot. */
+export function clampToSlot(slot: TokenGroupSlot, color: ThemeTokenRGB): ThemeTokenRGB {
+  return clampRgbToBands(color, slot.hueClamp, slot.sRange, slot.lRange);
+}
+
+/**
+ * Render resolved group values as CSS custom properties:
+ * `{ "--<group>-<slot>": "r g b" }` — ready to merge into the theme
+ * cssvar map (values feed `rgb(var(--…))` consumers).
+ */
+export function groupTokensToCSSVars(
+  resolved: ResolvedGroupTokens,
+): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const [groupId, slots] of Object.entries(resolved)) {
+    for (const [slotKey, rgb] of Object.entries(slots)) {
+      vars[`--${groupId}-${slotKey}`] = `${rgb.r} ${rgb.g} ${rgb.b}`;
+    }
+  }
+  return vars;
+}

--- a/packages/vue/src/theme/useTheme.ts
+++ b/packages/vue/src/theme/useTheme.ts
@@ -2,6 +2,7 @@ import { computed, ref, watch } from "vue";
 
 import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
 import { addCustomTheme as addCustomThemeToStorage, loadCustomThemes, removeCustomTheme as removeCustomThemeFromStorage, themePresets, tokensToCSSVars, type CustomThemePreset, type ThemeId, type ThemeMode, type ThemePreset } from "./presets";
+import { groupTokensToCSSVars, resolveGroupTokens, setTokenGroupsReapply } from "./tokenGroups";
 import { invalidateLuminanceCache } from "./useBackgroundLuminance";
 import { getTimePeriod, DEFAULT_GEO_LOCATION, type TimePeriod } from "./useSolarTime";
 
@@ -92,7 +93,13 @@ function applyTheme() {
 
   const effectiveMode = resolveEffectiveMode(currentMode.value);
   const tokens = effectiveMode === "dark" ? preset.dark : preset.light;
-  const vars = tokensToCSSVars(tokens);
+  // Extension token groups always emit their cssvars: preset/custom-theme
+  // overrides win, registry defaults are the final fallback, so consumers
+  // can rely on `--<group>-<slot>` existing once the group is registered.
+  const groupVars = groupTokensToCSSVars(
+    resolveGroupTokens(effectiveMode, preset.groups?.[effectiveMode]),
+  );
+  const vars = tokensToCSSVars(tokens, groupVars);
 
   invalidateLuminanceCache();
 
@@ -109,6 +116,14 @@ function applyTheme() {
     transitionTimer = null;
   }, THEME_TRANSITION_DURATION);
 }
+
+// Late token-group registrations re-apply the current theme so their
+// cssvars land immediately (microtask-coalesced) instead of waiting for
+// the next theme/mode switch. The registry lives in tokenGroups.ts and
+// must not import this module (that would be a cycle), so it calls back
+// through this injected hook. Hikari wires it once on module load;
+// applications never call setTokenGroupsReapply themselves.
+setTokenGroupsReapply(() => applyTheme());
 
 function getAllThemePresets(): Record<string, ThemePreset> {
   const result: Record<string, ThemePreset> = { ...themePresets };


### PR DESCRIPTION
## Summary

Extends the theme system with **namespaced token groups** so downstream apps can register
domain color vocabularies (e.g. SCADA wire/pipe colors) that participate in dark/light modes,
custom themes, and the color-scheme dialog — with **hue-clamped pickers** so physically
meaningful colors (L1/L2/L3 phases, PE yellow-green) can be restyled but never re-hued.

- New `theme/tokenGroups.ts`: `registerTokenGroup` (idempotent, deep-copied), `getTokenGroups`,
  `resolveGroupTokens(mode, overrides)`, circular hue clamping (`clampHue`/`hueDelta`/`wrapHue`,
  `clampRgbToBands`, `clampToSlot`), `groupTokensToCSSVars` emitting `--<group>-<slot>: "r g b"`.
- `setTokenGroupsReapply(fn)` hook wired by `useTheme` at module load: groups registered **after**
  `initTheme()` re-emit their cssvars via a microtask-coalesced re-apply; `tokenGroupsVersion`
  ref makes the dialog react to late registration.
- `ThemePreset.groups?` / `CustomThemePreset.groups?` + `tokensToCSSVars(tokens, groupVars?)`
  (backward compatible); custom themes persist group overrides in localStorage.
- `HkColorSchemeDialog`: collapsible "Extended colors" section per registered group; per-slot
  clamped pickers; `pairWith` slots share one row; prefill via `initialGroups`; values clamped
  on change and on save; renders nothing when no groups are registered.
- `HkColorPicker`: optional `hueClamp` / `sRange` / `lRange` props; every emit path clamps;
  popover shows the allowed hue band with a position thumb; byte-identical behavior without props.
- i18n: `hikari::theme.extendedColors` in all 11 locales; group/slot labels fall back to
  registry strings when keys are missing. hikari itself registers no domain group (mechanism only).

## Test plan

- `pnpm exec vitest run`: **193 passed / 0 failed** (20 new tokenGroups tests + 1 new
  HkColorSchemeDialog component test).
- `pnpm run build` (`vue-tsc --noEmit`): 0 errors.
- Verification highlights (independent cross-check): hue wrap-around math verified
  numerically (center 350°±20° admits hue 10°, rejects 30°); RGB↔HSL round-trip exact over
  140k samples; late-registration re-apply verified at runtime; legacy custom themes without
  `groups` still load; admin-shell files untouched.

Downstream consumer: shittim-chest P34b (SCADA scene view) registers the `scada` token group.
