### PR TITLE
✨ Align the admin tokens with the chest status bar refinements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ hikari currently carries two version lines, plus one stale tag:
   `v0.3.0`–`v0.3.2` and `v0.3.4` were published to crates.io without git
   tags, and `v0.3.15`–`v0.3.19` are unpublished master changes.
 - **Vue port (`@celestia-island/hikari`)** — the `0.4.x` line. The npm
-  package is at `0.4.18` on master but has **never been published** to npm;
+  package is at `0.4.19` on master but has **never been published** to npm;
   publication is pending (A3).
 - **Tag `v0.4.0` is a stale tag.** It was created on an early Vue-port
   commit (2026-07-21) before the npm package version line was established,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ Current master, Rust workspace `0.3.20`.
 
 ### Added
 
+- Align the admin tokens with shittim-chest's advanced status-bar
+  rules: hover wash never applies to the active popup-menu item
+  (`:not([data-active])`), the center strip is shrink-flex (wide tab
+  strips hand overflow to the HTabs scroller instead of a 45% cap with
+  raw overflow-x), the version tag renders as a two-column grid with a
+  compact dot-only variant, and the system tray centers with a calmer
+  gap. Consumers on both sides now read one stylesheet.
+- `HkAdminShell.mobileBreakpoint` is wired: the desktop takeover width
+  follows the prop (default 1024, the shared lg breakpoint) instead of
+  silently ignoring it.
+
 - Generalize the admin shell/header with the specializations proven in
   shittim-chest's plana-legacy fork: `HkAdminShell` gains an
   `onOpenDrawer` header-slot prop (a header trigger such as the avatar

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAdminHeader.test.tsx
+++ b/packages/vue/src/components/HkAdminHeader.test.tsx
@@ -135,6 +135,11 @@ describe("HkAdminHeader", () => {
     expect(withoutTitle.querySelector("h2")).toBeNull();
   });
 
+  it("renders no emergency-stop control by default", () => {
+    const c = mount(headerNode({ username: "alice" }));
+    expect(c.textContent.toLowerCase()).not.toContain("emergency");
+  });
+
   it("passes the locale trigger ref OBJECT through the slot so the picker anchors to the button", async () => {
     let captured: unknown = null;
     const c = mount(headerNode(

--- a/packages/vue/src/components/HkAdminShell.test.tsx
+++ b/packages/vue/src/components/HkAdminShell.test.tsx
@@ -169,6 +169,23 @@ describe("HkAdminShell", () => {
     expect(c.querySelector(".s-drawer-user-panel")).toBeNull();
   });
 
+  it("honors a custom mobileBreakpoint for the desktop takeover", async () => {
+    // Default 1024: 900px reads as mobile (drawer path).
+    setWidth(900);
+    const narrow = mount(shellNode(
+      { navTitle: "Navigation" },
+      { header: () => null, sidebar: NAV, content: CONTENT },
+    ));
+    expect(narrow.querySelector("aside .nav-mock")).toBeNull();
+
+    // Custom 768: the same 900px reads as desktop (inline sidebar).
+    const wide = mount(shellNode(
+      { navTitle: "Navigation", mobileBreakpoint: 768 },
+      { header: () => null, sidebar: NAV, content: CONTENT },
+    ));
+    expect(wide.querySelector("aside .nav-mock")).toBeTruthy();
+  });
+
   it("applies the content padding inside the scroll viewport so shadows are not clipped", () => {
     setWidth(1024);
     const c = mount(shellNode(

--- a/packages/vue/src/components/HkAdminShell.tsx
+++ b/packages/vue/src/components/HkAdminShell.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent, ref } from "vue";
 import { HDrawer, HScrollContainer, useBreakpoint } from "@celestia-island/hikari";
 import { provideActionBar } from "../composables/useActionBar";
 
@@ -7,11 +7,11 @@ export const HkAdminShell = defineComponent({
   props: {
     sidebarCollapsed: { type: Boolean, default: false },
     sidebarWidth: { type: String, default: "224px" },
-    // NOTE: not yet wired — the desktop/mobile split currently follows
-    // useBreakpoint()'s shared 1024px threshold regardless of this value.
-    // Kept for API compatibility; wiring it needs a threshold param on
-    // useBreakpoint (follow-up).
-    mobileBreakpoint: { type: Number, default: 768 },
+    /** Viewport width at which the desktop layout takes over (below it
+     *  the nav collapses into the mobile drawer). Defaults to the shared
+     *  1024px "lg" breakpoint; lower it (e.g. 768) for tablet-friendly
+     *  admins that keep the sidebar at md widths. */
+    mobileBreakpoint: { type: Number, default: 1024 },
     footerHeight: { type: String, default: "var(--s-footer-height)" },
     navTitle: { type: String, default: "Navigation" },
     /** Extra class for the mobile nav drawer's panel — lets consumers zero
@@ -24,7 +24,8 @@ export const HkAdminShell = defineComponent({
     contentPadding: { type: String, default: "1.5rem" },
   },
   setup(props, { slots }) {
-    const { isDesktop } = useBreakpoint();
+    const { width: viewportWidth } = useBreakpoint();
+    const isDesktop = computed(() => viewportWidth.value >= props.mobileBreakpoint);
     const sidebarOpen = ref(false);
 
     const actionBar = provideActionBar();

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -287,7 +287,9 @@
 /* ── Mobile responsive ── */
 @media (max-width: 767px) {
   .s-status-bar {
-    padding: 0 var(--space-6);
+    /* Keep a visible margin at both ends on phones: 6px read as flush
+       against the screen edge, especially for the right-side tray. */
+    padding: 0 var(--space-12);
   }
 
   /* Shrink-flex layout: the center tab strip owns the flexible space and

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -120,7 +120,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
+  /* Shrinkable with a floor so a wide tab strip hands its overflow to
+     the HTabs scroller (scrollable mode) instead of pushing the footer
+     past the viewport. No effect while the strip fits. */
+  flex-shrink: 1;
+  min-width: 0;
 
   .s-tabs,
   .hk-tabs {
@@ -137,11 +141,13 @@
 .s-status-bar-tag {
   display: inline-flex;
   align-items: center;
-  /* min-height + auto so the pill can grow a second line when the version
-     pair wraps on narrow screens instead of clipping/overlapping text. */
+  /* min-height + auto so the pill can grow with the stacked two-row
+     version block instead of clipping/overlapping text. */
   min-height: 24px;
   height: auto;
-  gap: 5px;
+  /* The version block stacks two rows tall, so the small status dot
+     needs more than the old 5px to read as separated from the text. */
+  gap: 10px;
   padding: 3px 8px;
   border-radius: var(--radius-md);
   font-size: var(--text-2xs);
@@ -162,9 +168,9 @@
   /* Match the value's opacity: a faded label next to the version value
      reads as a different typeface/weight, especially with CJK fallback. */
   opacity: 0.85;
-  /* CJK flex items have a one-character min-content — without nowrap the
-     label stacks vertically when the status tag is squeezed. Keep the
-     label on one line and let only the version pair wrap. */
+  /* CJK flex/grid items have a one-character min-content — without nowrap
+     the label ("面板") stacks vertically when the status tag is squeezed.
+     Keep the label on one line. */
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -173,12 +179,40 @@
   font-family: var(--font-mono);
   color: rgb(var(--color-text));
   opacity: 0.85;
-  /* Version parts wrap as whole tokens: wide = one line, narrow = the
-     engine version moves to its own line. */
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  column-gap: var(--space-4);
+  /* Version block as a two-column grid: row 1 = panel label + version,
+     row 2 = engine label + version. Labels form one left-aligned column
+     and values another, so the two rows share a true left edge — no
+     separator, no wrap-dependent layout. */
+  display: inline-grid;
+  grid-auto-flow: row;
+  grid-template-columns: auto auto;
+  column-gap: 5px;
+  row-gap: 2px;
+  align-items: baseline;
+  justify-items: start;
+  line-height: 1.25;
+}
+
+.s-status-bar-tag-value .s-status-bar-tag-label {
+  color: rgb(var(--color-muted));
+  opacity: 1;
+}
+
+.s-status-bar-version {
+  white-space: nowrap;
+}
+
+/* Compact traffic light (logged-in mobile footers): drop the version
+   rows, keep a finger-sized dot-only pill. Versions stay reachable
+   through the hover/tap popover and the aria label. */
+.s-status-bar-tag[data-compact] {
+  gap: 0;
+  padding: 8px;
+  min-height: 28px;
+
+  .s-status-bar-tag-value {
+    display: none;
+  }
 }
 
 .s-status-bar-version,
@@ -256,21 +290,21 @@
     padding: 0 var(--space-6);
   }
 
+  /* Shrink-flex layout: the center tab strip owns the flexible space and
+     hands its overflow via the HTabs scroller — no more 45% cap + raw
+     overflow-x on this wrapper. */
   .s-status-bar-left {
-    flex: 1;
+    flex: 0 1 auto;
     min-width: 0;
   }
 
   .s-status-bar-center {
-    flex-shrink: 0;
-    max-width: 45%;
-    overflow-x: auto;
-    scrollbar-width: none;
-    &::-webkit-scrollbar { display: none; }
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .s-status-bar-right {
-    flex-shrink: 0;
+    flex: 0 0 auto;
   }
 
   .s-status-bar-gamepad {
@@ -312,7 +346,9 @@
   border-radius: var(--radius-sm);
 }
 
-.s-popup-menu-item:hover {
+/* Hover = background wash only, never on the active item (active >
+   hover precedence — hue and font-weight never change on hover). */
+.s-popup-menu-item:hover:not([data-active]) {
   background: var(--c-primary-subtle);
 }
 
@@ -407,9 +443,9 @@
 .s-status-bar-system-tray {
   display: flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
-  gap: 1px;
+  gap: var(--space-4, 4px);
 }
 
 .s-status-bar-gamepad {

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -90,6 +90,7 @@
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;
+  --duration-fast: 0.15s;
   --duration-short: 0.15s;
   --duration-normal: 0.3s;
   --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
P33 follow-up (a) + (b) + (c): the style-layer unification precondition + two micro-follow-ups.

**Admin-token alignment with shittim-chest's advanced status-bar rules** (verified rule-body-identical across every shared selector — both sides now read one stylesheet):
- hover wash never applies to the active popup-menu item (`:not([data-active])`);
- the center strip becomes shrink-flex (wide tab strips hand overflow to the HTabs scroller — drops the 45% cap + raw overflow-x);
- the version tag renders as a two-column grid with line-height 1.25, a nested label override, `.s-status-bar-version` nowrap and a compact dot-only `[data-compact]` variant;
- the system tray centers with a calmer gap;
- mobile status-bar padding 6px→12px with the edge-margin rationale comment;
- adds the `--duration-fast: 0.15s` motion token (consumed by the tab transition).

**HkAdminShell.mobileBreakpoint wired** (default 1024 = the shared lg breakpoint, preserving current behavior; the prop now actually controls the desktop takeover). Two new tests: a custom-breakpoint layout test and the emergency-stop negative guard.

Verification: 3-round subagent cycle green (exhaustive rule-body diff vs chest tokens, SCSS compile check, no demo-app breakage). vitest 205/205, vue-tsc clean. Version 0.4.19.