### PR TITLE
🐛 Keep the touch hide timer alive through the emulated mouseenter.

### DIFF
--- a/packages/vue/src/components/HkHoverRevealAction.tsx
+++ b/packages/vue/src/components/HkHoverRevealAction.tsx
@@ -68,6 +68,11 @@ export default defineComponent({
     }
 
     function onMouseEnter() {
+      // Touch devices fire an emulated mouseenter a moment after a tap;
+      // during the touch linger window the touch reveal owns the state and
+      // its hide timer must survive, so do not re-reveal (which would clear
+      // the timer and leave the extension visible forever).
+      if (Date.now() < suppressMouseUntil) return;
       reveal();
     }
 


### PR DESCRIPTION
  🐛 Keep the touch hide timer alive through the emulated mouseenter.
  
  Touch devices fire an emulated mouseenter shortly after a tap; the
  previous onMouseEnter re-revealed unconditionally, which cleared the
  touch hide timer and left the extension visible forever after a touch
  (3s linger never fired). During the touch-suppress window the mouse
  path now yields to the touch reveal so its hide timer survives.