### PR TITLE
✨ Add the shared HSignInCard credential form for all front ends.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,17 @@ Current master, Rust workspace `0.3.20`.
 
 - Remove dead HAuthCard and stale HkStatusBar references. (#88)
 
+## [v0.4.20] - 2026-08-18
+
+### ✨ New
+
+- **HSignInCard** — the shared controlled credential form composing the auth
+  kit (HkAuthCard shell + HkInput with user-icon prefix + HkPasswordInput
+  with the full hint surface from hikari's own i18n + block HkAuthSubmitButton).
+  Fields live inside the card; consumers inject 
+  and feed back .  locale keys ship for all 11
+  languages.
+
 ## [v0.4.18] - 2026-08-17
 
 ### Added

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSignInCard.test.ts
+++ b/packages/vue/src/components/HkSignInCard.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h } from "vue";
+
+import { HkSignInCard } from "./HkSignInCard";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+function typeInto(input: HTMLInputElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** The username field is the first text input inside the card. */
+function usernameField(c: HTMLElement) {
+  return c.querySelector('input[name="signin-username"]') as HTMLInputElement;
+}
+
+function passwordField(c: HTMLElement) {
+  return c.querySelector('input[name="signin-password"]') as HTMLInputElement;
+}
+
+describe("HkSignInCard", () => {
+  it("renders the auth-card shell with title, subtitle and both fields", () => {
+    const c = mount(h(HkSignInCard, { title: "Sign in", subtitle: "Continue" }));
+    expect(c.querySelector(".s-auth-card")).toBeTruthy();
+    expect(c.querySelector(".s-auth-title")?.textContent).toBe("Sign in");
+    expect(c.querySelector(".s-auth-subtitle")?.textContent).toBe("Continue");
+    expect(usernameField(c)).toBeTruthy();
+    expect(passwordField(c)).toBeTruthy();
+  });
+
+  it("emits submit with the credentials and trims the username", async () => {
+    const onSubmit = vi.fn();
+    const c = mount(h(HkSignInCard, { title: "T", onSubmit }));
+    typeInto(usernameField(c), "  langyo  ");
+    typeInto(passwordField(c), "secret");
+    await Promise.resolve();
+    // The block button submits: find it and click.
+    const btn = c.querySelector(".hk-btn-primary") as HTMLElement;
+    btn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith("langyo", "secret");
+  });
+
+  it("never emits submit while either field is empty", async () => {
+    const onSubmit = vi.fn();
+    const c = mount(h(HkSignInCard, { title: "T", onSubmit }));
+    const btn = c.querySelector(".hk-btn-primary") as HTMLElement;
+    expect(btn.getAttribute("disabled")).not.toBeNull(); // empty guard disables the button
+    typeInto(usernameField(c), "langyo");
+    await Promise.resolve();
+    expect(btn.getAttribute("disabled")).not.toBeNull(); // password still empty
+    btn.click();
+    await Promise.resolve();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("gates on the external loading prop", async () => {
+    const onSubmit = vi.fn();
+    const c = mount(h(HkSignInCard, { title: "T", loading: true, onSubmit }));
+    typeInto(usernameField(c), "langyo");
+    typeInto(passwordField(c), "secret");
+    await Promise.resolve();
+    const btn = c.querySelector(".hk-btn-primary") as HTMLElement;
+    expect(btn.getAttribute("disabled")).not.toBeNull();
+    btn.click();
+    await Promise.resolve();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("honors the hard disabled prop even with valid credentials", async () => {
+    const onSubmit = vi.fn();
+    const c = mount(h(HkSignInCard, { title: "T", disabled: true, onSubmit }));
+    typeInto(usernameField(c), "langyo");
+    typeInto(passwordField(c), "secret");
+    await Promise.resolve();
+    const btn = c.querySelector(".hk-btn-primary") as HTMLElement;
+    expect(btn.getAttribute("disabled")).not.toBeNull();
+    btn.click();
+    await Promise.resolve();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter from the username field", async () => {
+    const onSubmit = vi.fn();
+    const c = mount(h(HkSignInCard, { title: "T", onSubmit }));
+    typeInto(usernameField(c), "langyo");
+    typeInto(passwordField(c), "secret");
+    await Promise.resolve();
+    usernameField(c).dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onSubmit).toHaveBeenCalledWith("langyo", "secret");
+  });
+
+  it("renders a logo image from logoSrc", () => {
+    const c = mount(h(HkSignInCard, { title: "T", logoSrc: "/logo.webp" }));
+    const img = c.querySelector(".s-auth-header img") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe("/logo.webp");
+  });
+});

--- a/packages/vue/src/components/HkSignInCard.tsx
+++ b/packages/vue/src/components/HkSignInCard.tsx
@@ -1,0 +1,135 @@
+import { defineComponent, ref } from "vue";
+import { useI18n } from "../i18n/context";
+
+import { HkAuthCard } from "./HkAuthCard";
+import HkInput from "./HkInput";
+import HkPasswordInput from "./HkPasswordInput";
+import HkAuthSubmitButton from "./HkAuthSubmitButton";
+
+/**
+ * HkSignInCard — the shared credential form for every Celestia front end.
+ *
+ * One controlled composition of the auth kit: `HkAuthCard` shell + `HkInput`
+ * (username, prefix-icon slot) + `HkPasswordInput` (centered placeholder
+ * layer, caps-lock / full-width / all-selected hints — all from hikari's own
+ * i18n, no per-consumer prop plumbing) + `HkAuthSubmitButton` (block submit
+ * with external loading).
+ *
+ * Control contract: the fields live INSIDE the card; the consumer injects
+ * `onSubmit(username, password)` and feeds the in-flight state back through
+ * `loading`. The card never talks to a backend itself, so each app binds its
+ * own login API (erp `meLogin`, chest's auth, …) while the visual language
+ * stays identical everywhere.
+ *
+ * ```tsx
+ * <HSignInCard
+ *   title="Sign in"
+ *   subtitle="Continue to your account"
+ *   :logo-src="logo"
+ *   :loading="pending"
+ *   @submit="(u, p) => signIn(u, p)"
+ * />
+ * ```
+ */
+export const HkSignInCard = defineComponent({
+  name: "HkSignInCard",
+  props: {
+    title: { type: String, required: true },
+    subtitle: { type: String, default: "" },
+    /** Optional logo image URL for the card header. */
+    logoSrc: { type: String, default: undefined },
+    /** External in-flight state; disables fields + submit while true. */
+    loading: { type: Boolean, default: false },
+    /** Extra guard on top of the built-in empty-field check. */
+    disabled: { type: Boolean, default: false },
+    /** autocomplete hints, override only when the flow demands it. */
+    usernameAutocomplete: { type: String, default: "username" },
+    passwordAutocomplete: { type: String, default: "current-password" },
+    /** Submit label; defaults to the hikari::signIn.submit locale. */
+    submitLabel: { type: String, default: undefined },
+  },
+  emits: {
+    /** Fired on explicit click or Enter; never with empty fields or while busy. */
+    submit: (_username: string, _password: string) => true,
+  },
+  setup(props, { emit, slots }) {
+    const { t } = useI18n();
+    const username = ref("");
+    const password = ref("");
+
+    function attemptSubmit() {
+      if (props.loading || props.disabled) return;
+      const u = username.value.trim();
+      if (!u || !password.value) return;
+      emit("submit", u, password.value);
+    }
+
+    return () => (
+      <HkAuthCard title={props.title} subtitle={props.subtitle}>
+        {{
+          logo: () =>
+            slots.logo ? (
+              slots.logo()
+            ) : props.logoSrc ? (
+              <img class="hk-logo-img" src={props.logoSrc} alt="" style={{ width: "3.5rem", height: "3.5rem" }} />
+            ) : null,
+          default: () => (
+            <form onSubmit={(e: Event) => { e.preventDefault(); attemptSubmit(); }}>
+              <HkInput
+                modelValue={username.value}
+                onUpdate:modelValue={(v: string) => (username.value = v)}
+                type="text"
+                name="signin-username"
+                autocomplete={props.usernameAutocomplete}
+                placeholder={t("hikari::signIn.usernamePlaceholder", "Username")}
+                disabled={props.loading || props.disabled}
+                submitOnEnter={attemptSubmit}
+              >
+                {{
+                  prefixIcon: () =>
+                    slots.usernameIcon ? (
+                      slots.usernameIcon()
+                    ) : (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        class="w-4 h-4"
+                        aria-hidden="true"
+                      >
+                        <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path>
+                        <circle cx="12" cy="7" r="4"></circle>
+                      </svg>
+                    ),
+                }}
+              </HkInput>
+              <HkPasswordInput
+                modelValue={password.value}
+                onUpdate:modelValue={(v: string) => (password.value = v)}
+                name="signin-password"
+                autocomplete={props.passwordAutocomplete}
+                placeholder={t("hikari::signIn.passwordPlaceholder", "Password")}
+                disabled={props.loading || props.disabled}
+                submitOnEnter={attemptSubmit}
+              />
+              <HkAuthSubmitButton
+                label={props.submitLabel ?? t("hikari::signIn.submit", "Sign in")}
+                block
+                loading={props.loading}
+                disabled={props.disabled || !username.value.trim() || !password.value}
+                doSubmit={() => Promise.resolve(attemptSubmit())}
+              />
+            </form>
+          ),
+          footer: () => slots.footer?.(),
+        }}
+      </HkAuthCard>
+    );
+  },
+});

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "أدخل كلمة المرور",
     "hikari::passwordInput.placeholderConfirm": "تأكيد كلمة المرور",
     "hikari::passwordInput.focusedPlaceholder": "تم التركيز، أدخل كلمة المرور",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "تم التركيز، ستؤدي الكتابة إلى مسح كلمة المرور الحالية"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "تم التركيز، ستؤدي الكتابة إلى مسح كلمة المرور الحالية",
+    "hikari::signIn.usernamePlaceholder": "اسم المستخدم",
+    "hikari::signIn.passwordPlaceholder": "كلمة المرور",
+    "hikari::signIn.submit": "تسجيل الدخول"
   }
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Passwort eingeben",
     "hikari::passwordInput.placeholderConfirm": "Passwort bestätigen",
     "hikari::passwordInput.focusedPlaceholder": "Fokussiert, Passwort eingeben",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "Fokussiert, weitere Eingaben löschen das bisherige Passwort"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Fokussiert, weitere Eingaben löschen das bisherige Passwort",
+    "hikari::signIn.usernamePlaceholder": "Benutzername",
+    "hikari::signIn.passwordPlaceholder": "Passwort",
+    "hikari::signIn.submit": "Anmelden"
   }
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Enter your password",
     "hikari::passwordInput.placeholderConfirm": "Confirm your password",
     "hikari::passwordInput.focusedPlaceholder": "Focused, enter your password",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "Focused, typing will clear the current password"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Focused, typing will clear the current password",
+    "hikari::signIn.usernamePlaceholder": "Username",
+    "hikari::signIn.passwordPlaceholder": "Password",
+    "hikari::signIn.submit": "Sign in"
   }
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Introduzca la contraseña",
     "hikari::passwordInput.placeholderConfirm": "Confirme la contraseña",
     "hikari::passwordInput.focusedPlaceholder": "Enfocado, introduzca su contraseña",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "Enfocado, escribir borrará la contraseña actual"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Enfocado, escribir borrará la contraseña actual",
+    "hikari::signIn.usernamePlaceholder": "Usuario",
+    "hikari::signIn.passwordPlaceholder": "Contraseña",
+    "hikari::signIn.submit": "Iniciar sesión"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Saisissez le mot de passe",
     "hikari::passwordInput.placeholderConfirm": "Confirmez le mot de passe",
     "hikari::passwordInput.focusedPlaceholder": "Champ actif, saisissez votre mot de passe",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "Champ actif, la saisie effacera le mot de passe actuel"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Champ actif, la saisie effacera le mot de passe actuel",
+    "hikari::signIn.usernamePlaceholder": "Nom d'utilisateur",
+    "hikari::signIn.passwordPlaceholder": "Mot de passe",
+    "hikari::signIn.submit": "Se connecter"
   }
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "パスワードを入力",
     "hikari::passwordInput.placeholderConfirm": "パスワードを確認",
     "hikari::passwordInput.focusedPlaceholder": "フォーカス中、パスワードを入力してください",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "フォーカス中、入力を続けると現在のパスワードは消去されます"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "フォーカス中、入力を続けると現在のパスワードは消去されます",
+    "hikari::signIn.usernamePlaceholder": "ユーザー名",
+    "hikari::signIn.passwordPlaceholder": "パスワード",
+    "hikari::signIn.submit": "ログイン"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "비밀번호 입력",
     "hikari::passwordInput.placeholderConfirm": "비밀번호 확인",
     "hikari::passwordInput.focusedPlaceholder": "포커스됨, 비밀번호를 입력하세요",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "포커스됨, 입력을 계속하면 현재 비밀번호가 지워집니다"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "포커스됨, 입력을 계속하면 현재 비밀번호가 지워집니다",
+    "hikari::signIn.usernamePlaceholder": "사용자 이름",
+    "hikari::signIn.passwordPlaceholder": "비밀번호",
+    "hikari::signIn.submit": "로그인"
   }
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Digite a senha",
     "hikari::passwordInput.placeholderConfirm": "Confirme a senha",
     "hikari::passwordInput.focusedPlaceholder": "Focado, digite sua senha",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "Focado, digitar apagará a senha atual"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "Focado, digitar apagará a senha atual",
+    "hikari::signIn.usernamePlaceholder": "Usuário",
+    "hikari::signIn.passwordPlaceholder": "Senha",
+    "hikari::signIn.submit": "Entrar"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "Введите пароль",
     "hikari::passwordInput.placeholderConfirm": "Подтвердите пароль",
     "hikari::passwordInput.focusedPlaceholder": "В фокусе, введите пароль",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "В фокусе, ввод очистит текущий пароль"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "В фокусе, ввод очистит текущий пароль",
+    "hikari::signIn.usernamePlaceholder": "Имя пользователя",
+    "hikari::signIn.passwordPlaceholder": "Пароль",
+    "hikari::signIn.submit": "Войти"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "输入密码",
     "hikari::passwordInput.placeholderConfirm": "确认密码",
     "hikari::passwordInput.focusedPlaceholder": "已聚焦，请输入密码",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，继续输入将清空原密码"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，继续输入将清空原密码",
+    "hikari::signIn.usernamePlaceholder": "用户名",
+    "hikari::signIn.passwordPlaceholder": "密码",
+    "hikari::signIn.submit": "登录"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -47,6 +47,9 @@
     "hikari::passwordInput.placeholderPassword": "輸入密碼",
     "hikari::passwordInput.placeholderConfirm": "確認密碼",
     "hikari::passwordInput.focusedPlaceholder": "已聚焦，請輸入密碼",
-    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，繼續輸入將清除原密碼"
+    "hikari::passwordInput.focusedHasValuePlaceholder": "已聚焦，繼續輸入將清除原密碼",
+    "hikari::signIn.usernamePlaceholder": "使用者名稱",
+    "hikari::signIn.passwordPlaceholder": "密碼",
+    "hikari::signIn.submit": "登入"
   }
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -197,6 +197,7 @@ export { HkConnectionStatus as HConnectionStatus } from "./components/HkConnecti
 export type { HBackendStatus } from "./components/HkConnectionStatus";
 export { HkThemeToggle as HThemeToggle } from "./components/HkThemeToggle";
 export { HkAuthCard as HAuthCard } from "./components/HkAuthCard";
+export { HkSignInCard as HSignInCard } from "./components/HkSignInCard";
 export { default as HAuthSubmitButton } from "./components/HkAuthSubmitButton";
 export { usePageTitle, useRouteTitle } from "./composables/usePageTitle";
 export { provideActionBar, useActionBar } from "./composables/useActionBar";


### PR DESCRIPTION
## What

Per the P37 plan (PLAN.md): the sign-in card that every front end hand-rolls moves upstream as a **controlled** composition of the existing auth kit:

- `HkSignInCard` = `HkAuthCard` shell + `HkInput` (username, default user-icon prefix with a slot override) + `HkPasswordInput` (centered placeholder layer, caps-lock / full-width / all-selected hints — all from hikari's own i18n, so consumers pass **zero hint props**) + block `HkAuthSubmitButton`.
- Control contract: fields live inside the card; the consumer injects `@submit(username, password)` and feeds the in-flight state back via `loading`. The card never talks to a backend — erp binds `meLogin`, chest can bind its own auth.
- `hikari::signIn.*` keys (username/password placeholders + submit label) added for all 11 locales (en, zh-Hans, zh-Hant, ja, ko, ru, ar, de, es, fr, pt).
- Logo via `logoSrc` prop or `logo` slot; optional footer slot.
- Version 0.4.19 → 0.4.20 with CHANGELOG.

## Verification

- vitest 212/212 (7 new tests: shell render, submit with username trim, empty-field guard, external loading gate, hard disabled gate, Enter-to-submit from the username field, logoSrc render)
- vue-tsc clean
- erp consumption follows in the erp PR (P37-b)