### PR TITLE
✨ Add a top slot and username overrides to the shared HSignInCard.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,17 @@ Current master, Rust workspace `0.3.20`.
 
 - Remove dead HAuthCard and stale HkStatusBar references. (#88)
 
+## [v0.4.21] - 2026-08-18
+
+### ✨ New
+
+- **HSignInCard** extension points for flows beyond plain username+password:
+  `top` slot (content between the card header and the credential form,
+  rendered outside the `<form>` so channel-tab clicks never submit), plus
+  `usernamePlaceholder` / `usernameType` props for email-identifier logins
+  (placeholder falls back to the `hikari::signIn.usernamePlaceholder`
+  locale). Backward compatible; erp usage unchanged.
+
 ## [v0.4.20] - 2026-08-18
 
 ### ✨ New

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSignInCard.test.ts
+++ b/packages/vue/src/components/HkSignInCard.test.ts
@@ -117,4 +117,38 @@ describe("HkSignInCard", () => {
     const img = c.querySelector(".s-auth-header img") as HTMLImageElement;
     expect(img.getAttribute("src")).toBe("/logo.webp");
   });
+
+  it("renders top slot content above the form but outside it", () => {
+    const c = mount(
+      h(HkSignInCard, { title: "T" }, { top: () => h("div", { id: "top-slot" }, "tabs") }),
+    );
+    const top = c.querySelector("#top-slot") as HTMLElement;
+    expect(top).toBeTruthy();
+    // The top slot must not be inside the <form> — tab clicks must never
+    // trigger a submit.
+    expect(top.closest("form")).toBeNull();
+    // And it sits above the credential fields.
+    const form = c.querySelector("form") as HTMLElement;
+    expect(
+      top.compareDocumentPosition(form) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("overrides the username type and placeholder", () => {
+    const c = mount(
+      h(HkSignInCard, {
+        title: "T",
+        usernameType: "email",
+        usernamePlaceholder: "name@example.com",
+      }),
+    );
+    const field = usernameField(c);
+    expect(field.getAttribute("type")).toBe("email");
+    expect(field.getAttribute("placeholder")).toBe("name@example.com");
+  });
+
+  it("keeps the locale username placeholder by default", () => {
+    const c = mount(h(HkSignInCard, { title: "T" }));
+    expect(usernameField(c).getAttribute("placeholder")).toBeTruthy();
+  });
 });

--- a/packages/vue/src/components/HkSignInCard.tsx
+++ b/packages/vue/src/components/HkSignInCard.tsx
@@ -21,6 +21,16 @@ import HkAuthSubmitButton from "./HkAuthSubmitButton";
  * own login API (erp `meLogin`, chest's auth, …) while the visual language
  * stays identical everywhere.
  *
+ * Extension points for flows that outgrow plain username+password:
+ * - `top` slot — content between the card header and the credential form
+ *   (channel tabs, SSO buttons, …). Rendered outside the `<form>` so tab
+ *   clicks never trigger a submit.
+ * - `usernamePlaceholder` / `usernameType` — override the username field
+ *   (e.g. email-identifier logins); the placeholder falls back to the
+ *   `hikari::signIn.usernamePlaceholder` locale when unset.
+ * - `footer` slot — content below the submit button (remember-me,
+ *   protocol links, …).
+ *
  * ```tsx
  * <HSignInCard
  *   title="Sign in"
@@ -47,6 +57,10 @@ export const HkSignInCard = defineComponent({
     passwordAutocomplete: { type: String, default: "current-password" },
     /** Submit label; defaults to the hikari::signIn.submit locale. */
     submitLabel: { type: String, default: undefined },
+    /** Username-field type; switch to "email" for identifier logins. */
+    usernameType: { type: String, default: "text" },
+    /** Username placeholder; defaults to the hikari::signIn locale. */
+    usernamePlaceholder: { type: String, default: undefined },
   },
   emits: {
     /** Fired on explicit click or Enter; never with empty fields or while busy. */
@@ -74,17 +88,22 @@ export const HkSignInCard = defineComponent({
               <img class="hk-logo-img" src={props.logoSrc} alt="" style={{ width: "3.5rem", height: "3.5rem" }} />
             ) : null,
           default: () => (
-            <form onSubmit={(e: Event) => { e.preventDefault(); attemptSubmit(); }}>
-              <HkInput
-                modelValue={username.value}
-                onUpdate:modelValue={(v: string) => (username.value = v)}
-                type="text"
-                name="signin-username"
-                autocomplete={props.usernameAutocomplete}
-                placeholder={t("hikari::signIn.usernamePlaceholder", "Username")}
-                disabled={props.loading || props.disabled}
-                submitOnEnter={attemptSubmit}
-              >
+            <>
+              {slots.top?.()}
+              <form onSubmit={(e: Event) => { e.preventDefault(); attemptSubmit(); }}>
+                <HkInput
+                  modelValue={username.value}
+                  onUpdate:modelValue={(v: string) => (username.value = v)}
+                  type={props.usernameType}
+                  name="signin-username"
+                  autocomplete={props.usernameAutocomplete}
+                  placeholder={
+                    props.usernamePlaceholder ??
+                    t("hikari::signIn.usernamePlaceholder", "Username")
+                  }
+                  disabled={props.loading || props.disabled}
+                  submitOnEnter={attemptSubmit}
+                >
                 {{
                   prefixIcon: () =>
                     slots.usernameIcon ? (
@@ -125,7 +144,8 @@ export const HkSignInCard = defineComponent({
                 disabled={props.disabled || !username.value.trim() || !password.value}
                 doSubmit={() => Promise.resolve(attemptSubmit())}
               />
-            </form>
+              </form>
+            </>
           ),
           footer: () => slots.footer?.(),
         }}


### PR DESCRIPTION
Extends the shared HSignInCard for flows that outgrow plain username+password (needed by the shittim-chest login migration):

- `top` slot: content between the card header and the credential form, rendered OUTSIDE the `<form>` so channel-tab clicks never trigger a submit
- `usernamePlaceholder` / `usernameType` props: email-identifier logins (e.g. chest org channel); placeholder falls back to the hikari::signIn.usernamePlaceholder locale
- 3 new vitest cases; full suite 215/215 green; vue-tsc clean; version 0.4.20 → 0.4.21