### PR TITLE
🐛 Zero the global reset specificity so components can override it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Current master, Rust workspace `0.3.20`.
   in the cascade (e.g. `.hk-toast-item` padding zeroed in consumers who
   bundle the styles index). Top-level `:where()` keeps the reset as a
   default while letting every component rule win.
+- Hoist the base `html`/`body`/typography/form element rules out of the
+  same `:root` block — they compiled to `:root <element>` (class-level
+  specificity) and overrode component rules the same way; at top level
+  they carry element specificity, so consumer component rules win.
 
 - Align the admin tokens with shittim-chest's advanced status-bar
   rules: hover wash never applies to the active popup-menu item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Current master, Rust workspace `0.3.20`.
 
 ### Added
 
+- Move the legacy theme's global reset out of the `:root` token block
+  and pin its specificity at zero with `:where(*)`. Nested inside
+  `:root`, the reset compiled to `:root *` — class-level specificity
+  that silently overrode equal-specificity component rules loaded later
+  in the cascade (e.g. `.hk-toast-item` padding zeroed in consumers who
+  bundle the styles index). Top-level `:where()` keeps the reset as a
+  default while letting every component rule win.
+
 - Align the admin tokens with shittim-chest's advanced status-bar
   rules: hover wash never applies to the active popup-menu item
   (`:not([data-active])`), the center strip is shrink-flex (wide tab

--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -16,6 +16,7 @@
 // ------
 
 :root {
+
     // 默认浅色主题（作为 fallback）
     --hi-color-background: #D6ECF0;  // 月白
     --hi-color-surface: #F0F4F8;  // 更亮的白色
@@ -258,17 +259,7 @@
     --hi-shadow-lg: 0 10px 15px -3px var(--hi-color-black-10);
     --hi-shadow-xl: 0 20px 25px -5px var(--hi-color-black-10);
 
-
-
-// ------
-// 全局重置
-// ------
-// `:where()` keeps the specificity at ZERO: consumers bundle this file
-// through the styles index, and minifiers may rewrite the bare `*`
-// selectors into `:root *` (specificity of a class), which then silently
-// overrides equal-specificity component rules that load later in the
-// cascade (e.g. `.hk-toast-item` padding). Zero specificity means the
-// reset still applies as a default, but ANY component rule wins.
+}
 
 html {
     font-size: 16px;
@@ -341,7 +332,6 @@ a {
     }
 }
 
-
 code {
     font-family: $hikari-font-family-mono;
     font-size: 0.9em;
@@ -388,17 +378,7 @@ textarea {
     min-height: 80px;
     resize: vertical;
 }
-}
-// ------
-// 全局重置
-// ------
-// TOP-LEVEL, OUTSIDE `:root`: the legacy theme wraps its tokens in
-// `:root`, and a reset nested there compiles to `:root *` — class-level
-// specificity that silently overrides equal-specificity component rules
-// loaded later in the cascade (e.g. `.hk-toast-item` padding after the
-// consumer minifier rewrites `*` into `:root *`). `:where()` pins the
-// specificity at ZERO: the reset stays a default, and every component
-// rule wins over it.
+
 :where(*),
 
 :where(*::before),
@@ -442,7 +422,6 @@ textarea {
         --hi-card-bg-light: rgba(0, 0, 0, 0.95);
     }
 }
-
 
 select {
     appearance: none;

--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -263,14 +263,12 @@
 // ------
 // 全局重置
 // ------
-
-*,
-*::before,
-*::after {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
-}
+// `:where()` keeps the specificity at ZERO: consumers bundle this file
+// through the styles index, and minifiers may rewrite the bare `*`
+// selectors into `:root *` (specificity of a class), which then silently
+// overrides equal-specificity component rules that load later in the
+// cascade (e.g. `.hk-toast-item` padding). Zero specificity means the
+// reset still applies as a default, but ANY component rule wins.
 
 html {
     font-size: 16px;
@@ -390,6 +388,24 @@ textarea {
     min-height: 80px;
     resize: vertical;
 }
+}
+// ------
+// 全局重置
+// ------
+// TOP-LEVEL, OUTSIDE `:root`: the legacy theme wraps its tokens in
+// `:root`, and a reset nested there compiles to `:root *` — class-level
+// specificity that silently overrides equal-specificity component rules
+// loaded later in the cascade (e.g. `.hk-toast-item` padding after the
+// consumer minifier rewrites `*` into `:root *`). `:where()` pins the
+// specificity at ZERO: the reset stays a default, and every component
+// rule wins over it.
+:where(*),
+
+:where(*::before),
+:where(*::after) {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
 }
 
 // ------


### PR DESCRIPTION
Fixes the toast style gap reported on demo.dev.celestia.world after chest's styles-bundle unification (chest #339).

Root cause: hikari's legacy theme wraps its tokens in a `:root` block, and the global reset (`*, *::before, *::after { margin:0; padding:0 }`) plus all base element rules (html/body/typography/form) sat inside it — every one compiled to `:root <selector>` at class-level specificity. In consumers that bundle the styles index, that reset lands in the main CSS chunk which loads AFTER component chunks; at equal specificity the later rule wins, zeroing e.g. `.hk-toast-item`'s padding.

Fix:
- Move the reset out of `:root` to top level and pin it at ZERO specificity with `:where(*)` — it stays a default, every component rule wins.
- Hoist the base element rules (html/body/h1-h6/p/a/code/pre/ul/ol/input/textarea/select/label) out of `:root` too, so they compile at element specificity (0,0,0,1) instead of `:root <element>` (class-level) — same bug class eliminated.

Verification: 2 verification rounds + final sweep (zero `:root <element>` rules in compiled output, sass index compile exit 0, vitest 212/212, vue-tsc clean). Version 0.4.20.