### PR TITLE
🐛 Remove the dead neon indicator rules that squashed the Vue pill tabs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,22 @@ Current master, Rust workspace `0.3.20`.
 
 - Remove dead HAuthCard and stale HkStatusBar references. (#88)
 
+## [v0.4.22] - 2026-08-18
+
+### 🐛 Fixed
+
+- **Tabs pill slider restored on bundle consumers** — the legacy
+  components stylesheet (re-exported through the Vue styles index and
+  bundled by shittim-chest via plana-legacy tokens.scss) still carried a
+  dead `.hk-tabs-indicator` block: a 3px neon underline plus
+  `.hk-tabs-top/bottom/left/right .hk-tabs-indicator` variant overrides.
+  No Rust component ever renders that class (the Rust Tabs emits
+  `.hk-tabs-ink-bar`), but the variant rules' specificity beat the Vue
+  HkTabs pill chunk and squashed the login/status-bar tab slider into a
+  3px strip on dev.celestia.world and demo. All indicator rules are now
+  removed from the legacy stylesheet; the Vue HkTabs.scss is the single
+  authority for `.hk-tabs-indicator`.
+
 ## [v0.4.21] - 2026-08-18
 
 ### ✨ New

--- a/packages/components/src/styles/components/tabs.scss
+++ b/packages/components/src/styles/components/tabs.scss
@@ -212,34 +212,17 @@
 // Glowing Indicator (for active tab)
 // ------
 
-.hk-tabs-indicator {
-  // Layout
-  position: absolute;
-  bottom: 0;
-  left: 0;
-
-  // Appearance
-  height: 3px;
-  background: linear-gradient(
-    90deg,
-    var(--hi-color-primary) 0%,
-    var(--hi-primary) 50%,
-    var(--hi-color-primary) 100%
-  );
-
-  // Glow effect
-  box-shadow:
-    0 0 8px var(--hi-color-primary),
-    0 0 16px var(--hi-primary);
-
-  // Transitions - smooth sliding animation
-  // DISABLED - migrated to JS animation
-
-  // transition: all vars.$hikari-duration-normal vars.$hikari-ease-smooth;
-
-  // Border radius
-  border-radius: 2px 2px 0 0;
-}
+// REMOVED (.hk-tabs-indicator rules): the Rust Tabs renders the sliding
+// element as `.hk-tabs-ink-bar`, so no Rust markup ever emitted
+// `.hk-tabs-indicator` — the block was dead weight here. Worse, the Vue
+// port's HkTabs (the pill design, own HkTabs.scss chunk) DOES use this
+// class, and consumers that bundle this stylesheet through the vue styles
+// index (shittim-chest via plana-legacy tokens.scss) got both: the pill
+// from the component chunk plus this 3px neon strip and its
+// `.hk-tabs-top/bottom/left/right .hk-tabs-indicator` variant overrides
+// (higher specificity) — which beat the pill and broke the slider. The
+// authoritative `.hk-tabs-indicator` styling lives in the Vue
+// HkTabs.scss only.
 
 // ------
 // Tabs Content
@@ -298,11 +281,6 @@
   .hk-tabs-header {
     border-bottom: 1px solid var(--hi-color-border);
   }
-
-  .hk-tabs-indicator {
-    bottom: 0;
-    border-radius: 2px 2px 0 0;
-  }
 }
 
 // Bottom
@@ -312,12 +290,6 @@
   .hk-tabs-header {
     border-top: 1px solid var(--hi-color-border);
     border-bottom: none;
-  }
-
-  .hk-tabs-indicator {
-    top: 0;
-    bottom: auto;
-    border-radius: 0 0 2px 2px;
   }
 }
 
@@ -341,15 +313,6 @@
     width: 100%;
     justify-content: flex-start;
   }
-
-  .hk-tabs-indicator {
-    top: 0;
-    left: 0;
-    right: auto;
-    width: 3px;
-    height: auto;
-    border-radius: 0 2px 2px 0;
-  }
 }
 
 // Right
@@ -371,15 +334,6 @@
   .hk-tab {
     width: 100%;
     justify-content: flex-start;
-  }
-
-  .hk-tabs-indicator {
-    top: 0;
-    right: 0;
-    left: auto;
-    width: 3px;
-    height: auto;
-    border-radius: 2px 0 0 2px;
   }
 }
 
@@ -467,10 +421,6 @@
         0 0 12px var(--hi-primary),
         inset 0 0 8px var(--hi-white-10, rgba(255, 255, 255, 0.1));
     }
-  }
-
-  .hk-tabs-indicator {
-    display: none;
   }
 }
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Root cause of the dev.celestia.world + demo tab-slider bug (user-reported "旧缓存" symptom that was actually a live CSS conflict):

- chest bundles hikari's vue styles index via plana-legacy tokens.scss → that index re-exports the LEGACY components stylesheet
- the legacy tabs.scss styled `.hk-tabs-indicator` as a 3px neon underline (+ `.hk-tabs-top/bottom/left/right` variant overrides, specificity 0,2,0)
- no Rust component renders `.hk-tabs-indicator` (the Rust Tabs emits `.hk-tabs-ink-bar`) — the block was dead weight in the Rust line
- the Vue HkTabs pill (own chunk CSS, specificity 0,1,0) loads later but LOSES to the legacy variant rules → the login/status-bar tab slider collapsed to a 3px strip

Fix: remove all `.hk-tabs-indicator` rules from the legacy stylesheet (base block, 4 position variants, segment hide); the Vue HkTabs.scss is now the single authority. Verified: sass compile clean, bundle grep shows zero indicator rules, vitest 215/215.

Also audited: 18 component families have legacy/vue class overlap; this PR fixes the one with a live conflict. The systematic realignment is tracked in PLAN.md P39-e.