### PR TITLE
🐛 Drop the element-level color reset that broke color inheritance.

### DIFF
--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -318,9 +318,11 @@ h6 {
     font-size: $hikari-font-size-sm;
 }
 
-p, span, div, label {
-    color: var(--hi-color-text-primary);
-}
+/* NOTE: no element-level color reset here. body already sets
+   --hi-color-text-primary and inheritance flows down; resetting the
+   color on every p/span/div/label broke components that set a color on
+   a parent expecting children to inherit it (e.g. toast variants with
+   white text on colored backgrounds rendered dark-on-green). */
 
 a {
     color: var(--hi-color-text-primary);


### PR DESCRIPTION
The base stylesheet set color on every p/span/div/label, which overrode inherited colors inside components that set a color on a parent - toasts with white text on green/red backgrounds rendered dark-on-green because the message span picked up the reset instead of the variant color. body already sets the default text color and inheritance distributes it, so the element-level reset is removed entirely.