### PR TITLE
🐛 Unify the narrow-viewport modal into one bottom-sheet rule.

### DIFF
--- a/packages/vue/src/components/HkConfirmDialog.tsx
+++ b/packages/vue/src/components/HkConfirmDialog.tsx
@@ -49,14 +49,8 @@ export default defineComponent({
             <div class="hk-confirm-dialog">
               <p class="hk-confirm-dialog-message">{props.message}</p>
               <div class="hk-confirm-dialog-actions">
-                <HButton
-                  variant="secondary"
-                  size="sm"
-                  disabled={props.loading}
-                  onClick={onCancel}
-                >
-                  {props.cancelLabel || t("hk.confirmDialog.cancel", "Cancel")}
-                </HButton>
+                {/* Shell UX policy: dialogs dismiss via the header X;
+                 * only the affirmative action stays in the footer. */}
                 <HButton
                   variant={props.confirmVariant}
                   size="sm"

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -68,29 +68,6 @@
   flex-direction: column;
 }
 
-// Mobile / narrow viewports: modals dock to the bottom edge as a sheet.
-// The top of the screen is crowded (breadcrumb overlays from nested
-// flows hover there), and a centered/top sheet wastes the natural thumb
-// zone. The transition transform still animates; the sheet rises from
-// the bottom via the existing height/opacity reveal.
-@media (max-width: 640px) {
-  .hk-modal-content {
-    top: auto;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    transform: none;
-    width: 100%;
-    max-width: 100%;
-    max-height: calc(100vh - 2rem);
-    border-left: none;
-    border-right: none;
-    border-bottom: none;
-    border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
-      var(--hk-modal-radius, var(--hi-radius-lg, 12px)) 0 0;
-  }
-}
-
 // ------
 // Content enter/leave transitions
 //
@@ -309,18 +286,24 @@
 }
 
 // ------
-// Responsive — full-screen on narrow viewports
+// Responsive — bottom sheet on narrow viewports
 // ------
 
 @media (max-width: 640px) {
   .hk-modal-content {
     max-width: 100% !important;
-    border-radius: 0;
-    max-height: 100vh;
-    top: 0;
+    max-height: calc(100dvh - 2rem);
+    top: auto;
+    bottom: 0;
     left: 0;
+    right: 0;
     transform: none;
     width: 100%;
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+      var(--hk-modal-radius, var(--hi-radius-lg, 12px)) 0 0;
   }
 
   .hk-modal-header {

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -68,6 +68,29 @@
   flex-direction: column;
 }
 
+// Mobile / narrow viewports: modals dock to the bottom edge as a sheet.
+// The top of the screen is crowded (breadcrumb overlays from nested
+// flows hover there), and a centered/top sheet wastes the natural thumb
+// zone. The transition transform still animates; the sheet rises from
+// the bottom via the existing height/opacity reveal.
+@media (max-width: 640px) {
+  .hk-modal-content {
+    top: auto;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    transform: none;
+    width: 100%;
+    max-width: 100%;
+    max-height: calc(100vh - 2rem);
+    border-left: none;
+    border-right: none;
+    border-bottom: none;
+    border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+      var(--hk-modal-radius, var(--hi-radius-lg, 12px)) 0 0;
+  }
+}
+
 // ------
 // Content enter/leave transitions
 //

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -305,9 +305,18 @@ export default defineComponent({
         return <div class="hk-modal-footer">{slots.footer()}</div>;
       }
       if (props.footerActions && props.footerActions.length > 0) {
+        // Per shell UX policy every modal closes via the header X, so
+        // drop caller-provided dismiss actions (Cancel/Close across the
+        // supported locales) instead of rendering a second way out.
+        const CANCEL_LABEL_RE =
+          /^(cancel|close|取消|关闭|キャンセル|閉じる|취소|닫기|abbrechen|schließen|annuler|fermer|cancelar|cerrar|отмена|закрыть|fechar|cancelar)$/i;
+        const actions = props.footerActions.filter(
+          (a) => !CANCEL_LABEL_RE.test(String(a.label ?? "").trim()),
+        );
+        if (actions.length === 0) return null;
         return (
           <div class="hk-modal-footer">
-            {props.footerActions.map((action, i) => (
+            {actions.map((action, i) => (
               <HButton
                 key={i}
                 variant={action.variant ?? "secondary"}


### PR DESCRIPTION
The pre-existing mobile media query (top: 0; max-height: 100vh) fought the new bottom-sheet rule: it came later with a full-screen top dock, so mobile modals stayed full-height at the top instead of rising from the bottom with a 2rem top gap. Merge both into one media query: bottom docking, max-height calc(100dvh - 2rem), top-only radius, and the narrow header/footer padding.