### PR TITLE
🛡️ Add touch-action none to the minimap so its drag is never stolen by the surrounding pan surface.

### DIFF
--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -11,6 +11,10 @@
   cursor: pointer;
   overflow: hidden;
   pointer-events: auto;
+  /* The minimap owns its own drag gestures — the surrounding pannable
+     surface must never claim them (mobile browsers would otherwise fire
+     pointercancel and kill the drag). */
+  touch-action: none;
 
   &:hover {
     border-color: rgb(var(--color-primary) / 0.3);


### PR DESCRIPTION
Companion to the chest minimap-unification PR: HMinimap is embedded in pannable surfaces (topology overview, media canvas, SCADA scene) whose containers own pan/pinch via `touch-action: none`. The minimap drags itself — declare `touch-action: none` on `.hk-minimap` so mobile browsers never claim its gestures and fire pointercancel mid-drag.