### PR TITLE
🐛 Center the mobile status-bar tab strip on the true viewport middle.

### DIFF
--- a/packages/vue/src/components/HkHoverRevealAction.test.ts
+++ b/packages/vue/src/components/HkHoverRevealAction.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, defineComponent } from "vue";
+
+import HHoverRevealAction from "./HkHoverRevealAction";
+
+/** Mount the component into a detached container and return the host element. */
+async function mountHost(props: Record<string, unknown> = {}) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const app = createApp({
+    render: () =>
+      h(HHoverRevealAction, props, {
+        default: () => h("span", "main"),
+        extension: () => h("span", "ext"),
+      }),
+  });
+  app.mount(host);
+  const el = host.querySelector(".hk-hover-reveal") as HTMLElement;
+  return { host, app, el };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("HHoverRevealAction touch reveal modes", () => {
+  it("tap mode (default) reveals on touchstart immediately", async () => {
+    const { el } = await mountHost();
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    await Promise.resolve();
+    expect(el.className).toContain("is-revealed");
+  });
+
+  it("longpress mode does NOT reveal on a quick tap", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    vi.advanceTimersByTime(100);
+    el.dispatchEvent(new Event("touchend", { bubbles: true }));
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+
+  it("longpress mode reveals only after the finger rests long enough", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    await Promise.resolve();
+    expect(el.className).toContain("is-revealed");
+    // Lifting starts the linger countdown; after it elapses it hides again.
+    el.dispatchEvent(new Event("touchend", { bubbles: true }));
+    vi.advanceTimersByTime(3100);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+
+  it("longpress mode cancels the pending reveal when the finger slides", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    el.dispatchEvent(new Event("touchmove", { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+});

--- a/packages/vue/src/components/HkHoverRevealAction.tsx
+++ b/packages/vue/src/components/HkHoverRevealAction.tsx
@@ -13,6 +13,14 @@ export default defineComponent({
      *  lifts. Touch devices have no hover, so a swipe/tap on the host
      *  reveals the extension and it lingers for this delay before hiding. */
     touchHideDelay: { type: Number, default: 3000 },
+    /** When the extension may appear on touch devices:
+     *  - "tap" (default): any touch reveals it (legacy behaviour).
+     *  - "longpress": the finger must REST on the host for longPressDelay
+     *    before the extension reveals — casual taps and swipes never flash
+     *    it. Reveals still linger for touchHideDelay after the lift. */
+    touchRevealMode: { type: String as PropType<"tap" | "longpress">, default: "tap" },
+    /** Rest duration before a longpress reveal fires. */
+    longPressDelay: { type: Number, default: 500 },
     as: { type: String, default: "span" },
     placement: { type: String as PropType<HoverRevealPlacement>, default: "right" },
     forceRevealed: { type: Boolean, default: false },
@@ -23,11 +31,20 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const revealed = ref(false);
     let hideTimer: CronHandle | null = null;
+    // Long-press reveal timer (touchRevealMode="longpress").
+    let longPressTimer: CronHandle | null = null;
     // Touch interactions fire emulated mouseenter/mouseleave a moment
     // later on touch devices; without this guard the 140ms mouse delay
     // would instantly undo a touch reveal. Suppress the mouse path for
     // the duration of the touch linger so the touch timer owns the hide.
     let suppressMouseUntil = 0;
+
+    function clearLongPressTimer() {
+      if (longPressTimer) {
+        longPressTimer.disconnect();
+        longPressTimer = null;
+      }
+    }
 
     function clearHideTimer() {
       if (hideTimer) {
@@ -56,14 +73,28 @@ export default defineComponent({
     }
 
     function onTouchStart() {
-      // Any touch (tap or swipe over a scrollable main slot) reveals the
-      // extension; the finger can keep sweeping without it flickering.
+      // Any touch suppresses the mouse path (emulated mouseenter would
+      // otherwise instantly undo the touch reveal).
       suppressMouseUntil = Date.now() + props.touchHideDelay;
+      if (props.touchRevealMode === "longpress") {
+        // Long-press mode: arm a timer; a quick lift or a slide cancels it
+        // without ever revealing, so casual tab taps never flash the "+".
+        clearLongPressTimer();
+        longPressTimer = scheduleCronAfter(() => {
+          longPressTimer = null;
+          reveal();
+        }, props.longPressDelay);
+        return;
+      }
+      // Tap mode (legacy): any touch (tap or swipe over a scrollable main
+      // slot) reveals the extension; the finger can keep sweeping without
+      // it flickering.
       reveal();
     }
 
     function onTouchEnd() {
       suppressMouseUntil = Date.now() + props.touchHideDelay;
+      clearLongPressTimer();
       scheduleHide(props.touchHideDelay);
     }
 
@@ -89,7 +120,10 @@ export default defineComponent({
       },
     );
 
-    onUnmounted(clearHideTimer);
+    onUnmounted(() => {
+      clearHideTimer();
+      clearLongPressTimer();
+    });
 
     return () => {
       return h(
@@ -102,6 +136,12 @@ export default defineComponent({
           onTouchstart: onTouchStart,
           onTouchend: onTouchEnd,
           onTouchcancel: onTouchEnd,
+          // A sliding finger is a swipe, not a press — cancel any pending
+          // long-press reveal so scrolling over the tabs never flashes
+          // the extension.
+          onTouchmove: () => {
+            if (props.touchRevealMode === "longpress") clearLongPressTimer();
+          },
         },
         [
           h("span", { class: "hk-hover-reveal-main" }, slots.default?.()),

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -292,21 +292,32 @@
     padding: 0 var(--space-12);
   }
 
-  /* Shrink-flex layout: the center tab strip owns the flexible space and
-     hands its overflow via the HTabs scroller — no more 45% cap + raw
-     overflow-x on this wrapper. */
-  .s-status-bar-left {
-    flex: 0 1 auto;
+  /* Balanced-wing layout: both side wings grow from the SAME basis so the
+     center tab strip stays pinned to the true viewport middle regardless of
+     how wide the left connection tag or the right tray grows. The previous
+     shrink-flex split (left 0 1 auto / center 1 1 auto / right 0 0 auto)
+     centered the strip inside the leftover space, which shifted it sideways
+     whenever the wings were unequal (compact left vs time-right on phones
+     pushed the tab group off-centre). Wings now shrink symmetrically; the
+     center strip keeps its natural width and hands overflow to the HTabs
+     scroller when the strip alone would exceed the wings. */
+  .s-status-bar-left,
+  .s-status-bar-right {
+    flex: 1 1 0;
     min-width: 0;
   }
 
-  .s-status-bar-center {
-    flex: 1 1 auto;
-    min-width: 0;
+  .s-status-bar-left {
+    justify-content: flex-start;
   }
 
   .s-status-bar-right {
-    flex: 0 0 auto;
+    justify-content: flex-end;
+  }
+
+  .s-status-bar-center {
+    flex: 0 1 auto;
+    min-width: 0;
   }
 
   .s-status-bar-gamepad {


### PR DESCRIPTION
## Summary

User report (mobile): the bottom tab-group buttons were offset to one side instead of centered.

Root cause: the mobile status-bar layout used shrink-flex (left `0 1 auto` / center `1 1 auto` / right `0 0 auto`), which centers the strip inside the leftover space between the wings. Whenever the wings were unequal (compact left connection tag vs right time tray), the strip drifted off-centre.

Fix: both wings now share `flex: 1 1 0` with symmetric justify (start/end), and the center strip is `0 1 auto` at its natural width — the strip stays pinned to the true viewport middle regardless of wing widths, and still hands overflow to the HTabs scroller.

## Verification
- vitest 215/215.
- Desktop layout untouched (its left/right were already symmetric `flex: 1`).