### PR TITLE
🐛 Reorder the mono font stack so Fira-Code-less devices keep monospace digits.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -19,7 +19,10 @@
 
   // ── Font families (body text, mono for version/numbers) ─
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
+  // Mono faces first for latin/digits; sans sits before the generic keyword
+  // only so CJK glyphs (uncovered by latin mono faces) fall back to the UI
+  // CJK font instead of the system's kai-style monospace CJK.
+  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, var(--font-sans), monospace;
 
   // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
   --space-1: 0.0625rem;

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -9,11 +9,16 @@
   --s-header-height: 3rem;
   --z-header: 30;
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  /* Fira Code first for latin/digits; the regular sans stack right after so
-     CJK glyphs fall back to the normal UI CJK font (not the system's
-     monospace CJK fallback, which is kai-style on some platforms). */
-  --font-mono: "Fira Code", var(--font-sans), ui-monospace, "JetBrains Mono",
-    "SF Mono", Menlo, Consolas, monospace;
+  /* Monospace FIRST for latin/digits (Fira Code when installed, else the
+     system mono: ui-monospace/SF Mono on Apple, Roboto Mono-ish on Android,
+     Menlo/Consolas on desktops). The sans stack sits before the generic
+     `monospace` keyword ONLY so CJK glyphs (which no latin mono face covers)
+     fall back to the normal UI CJK font instead of the system's kai-style
+     monospace CJK — putting sans right after Fira Code (the old order) made
+     every Fira-Code-less device (all phones) render digits proportionally,
+     silently breaking every mono alignment in the app. */
+  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono",
+    "SF Mono", Menlo, Consolas, var(--font-sans), monospace;
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;


### PR DESCRIPTION
## Problem

`--font-mono` put `var(--font-sans)` directly after "Fira Code" (the intent: CJK glyphs fall back to the UI CJK font, avoiding kai-style system mono CJK). But **Fira Code is a system font — phones never have it installed**, so on every mobile device the latin/digits silently rendered in the proportional sans, breaking every mono alignment in consuming apps (status-bar version hashes, latency readouts, code samples).

## Fix

Sans now sits right **before the generic `monospace` keyword**:

- latin/digits: Fira Code → ui-monospace (SF Mono/Roboto Mono on phones) → JetBrains Mono → …
- CJK glyphs (uncovered by latin mono faces): still fall to `--font-sans` — the original kai-avoidance intent preserved
- generic `monospace` remains the last resort only

Both definitions aligned: `packages/vue/src/styles/admin-tokens.scss` and `packages/theme/styles/_layout.scss`.

## Verification

- `vue-tsc --noEmit` ✅, `vitest run` 215/215 ✅
- Downstream: erp's vendored copy of the same stack fixed in its own PR; chest consumes this via the sibling link