### PR TITLE
🐛 Restore the touch longpress reveal mode that chest's footer consumes.

### DIFF
--- a/packages/vue/src/components/HkHoverRevealAction.test.ts
+++ b/packages/vue/src/components/HkHoverRevealAction.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, defineComponent } from "vue";
+
+import HHoverRevealAction from "./HkHoverRevealAction";
+
+/** Mount the component into a detached container and return the host element. */
+async function mountHost(props: Record<string, unknown> = {}) {
+  const host = document.createElement("div");
+  document.body.appendChild(host);
+  const app = createApp({
+    render: () =>
+      h(HHoverRevealAction, props, {
+        default: () => h("span", "main"),
+        extension: () => h("span", "ext"),
+      }),
+  });
+  app.mount(host);
+  const el = host.querySelector(".hk-hover-reveal") as HTMLElement;
+  return { host, app, el };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("HHoverRevealAction touch reveal modes", () => {
+  it("tap mode (default) reveals on touchstart immediately", async () => {
+    const { el } = await mountHost();
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    await Promise.resolve();
+    expect(el.className).toContain("is-revealed");
+  });
+
+  it("longpress mode does NOT reveal on a quick tap", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    vi.advanceTimersByTime(100);
+    el.dispatchEvent(new Event("touchend", { bubbles: true }));
+    vi.advanceTimersByTime(1000);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+
+  it("longpress mode reveals only after the finger rests long enough", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    await Promise.resolve();
+    expect(el.className).toContain("is-revealed");
+    // Lifting starts the linger countdown; after it elapses it hides again.
+    el.dispatchEvent(new Event("touchend", { bubbles: true }));
+    vi.advanceTimersByTime(3100);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+
+  it("longpress mode cancels the pending reveal when the finger slides", async () => {
+    vi.useFakeTimers();
+    const { el } = await mountHost({ touchRevealMode: "longpress", longPressDelay: 500 });
+    el.dispatchEvent(new Event("touchstart", { bubbles: true }));
+    el.dispatchEvent(new Event("touchmove", { bubbles: true }));
+    vi.advanceTimersByTime(600);
+    await Promise.resolve();
+    expect(el.className).not.toContain("is-revealed");
+  });
+});

--- a/packages/vue/src/components/HkHoverRevealAction.tsx
+++ b/packages/vue/src/components/HkHoverRevealAction.tsx
@@ -13,6 +13,14 @@ export default defineComponent({
      *  lifts. Touch devices have no hover, so a swipe/tap on the host
      *  reveals the extension and it lingers for this delay before hiding. */
     touchHideDelay: { type: Number, default: 3000 },
+    /** When the extension may appear on touch devices:
+     *  - "tap" (default): any touch reveals it (legacy behaviour).
+     *  - "longpress": the finger must REST on the host for longPressDelay
+     *    before the extension reveals — casual taps and swipes never flash
+     *    it. Reveals still linger for touchHideDelay after the lift. */
+    touchRevealMode: { type: String as PropType<"tap" | "longpress">, default: "tap" },
+    /** Rest duration before a longpress reveal fires. */
+    longPressDelay: { type: Number, default: 500 },
     as: { type: String, default: "span" },
     placement: { type: String as PropType<HoverRevealPlacement>, default: "right" },
     forceRevealed: { type: Boolean, default: false },
@@ -23,11 +31,20 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const revealed = ref(false);
     let hideTimer: CronHandle | null = null;
+    // Long-press reveal timer (touchRevealMode="longpress").
+    let longPressTimer: CronHandle | null = null;
     // Touch interactions fire emulated mouseenter/mouseleave a moment
     // later on touch devices; without this guard the 140ms mouse delay
     // would instantly undo a touch reveal. Suppress the mouse path for
     // the duration of the touch linger so the touch timer owns the hide.
     let suppressMouseUntil = 0;
+
+    function clearLongPressTimer() {
+      if (longPressTimer) {
+        longPressTimer.disconnect();
+        longPressTimer = null;
+      }
+    }
 
     function clearHideTimer() {
       if (hideTimer) {
@@ -56,14 +73,28 @@ export default defineComponent({
     }
 
     function onTouchStart() {
-      // Any touch (tap or swipe over a scrollable main slot) reveals the
-      // extension; the finger can keep sweeping without it flickering.
+      // Any touch suppresses the mouse path (emulated mouseenter would
+      // otherwise instantly undo the touch reveal).
       suppressMouseUntil = Date.now() + props.touchHideDelay;
+      if (props.touchRevealMode === "longpress") {
+        // Long-press mode: arm a timer; a quick lift or a slide cancels it
+        // without ever revealing, so casual tab taps never flash the "+".
+        clearLongPressTimer();
+        longPressTimer = scheduleCronAfter(() => {
+          longPressTimer = null;
+          reveal();
+        }, props.longPressDelay);
+        return;
+      }
+      // Tap mode (legacy): any touch (tap or swipe over a scrollable main
+      // slot) reveals the extension; the finger can keep sweeping without
+      // it flickering.
       reveal();
     }
 
     function onTouchEnd() {
       suppressMouseUntil = Date.now() + props.touchHideDelay;
+      clearLongPressTimer();
       scheduleHide(props.touchHideDelay);
     }
 
@@ -89,7 +120,10 @@ export default defineComponent({
       },
     );
 
-    onUnmounted(clearHideTimer);
+    onUnmounted(() => {
+      clearHideTimer();
+      clearLongPressTimer();
+    });
 
     return () => {
       return h(
@@ -102,6 +136,12 @@ export default defineComponent({
           onTouchstart: onTouchStart,
           onTouchend: onTouchEnd,
           onTouchcancel: onTouchEnd,
+          // A sliding finger is a swipe, not a press — cancel any pending
+          // long-press reveal so scrolling over the tabs never flashes
+          // the extension.
+          onTouchmove: () => {
+            if (props.touchRevealMode === "longpress") clearLongPressTimer();
+          },
         },
         [
           h("span", { class: "hk-hover-reveal-main" }, slots.default?.()),


### PR DESCRIPTION
## Problem

#226 dropped `touchRevealMode`/`longPressDelay` from `HkHoverRevealAction` as part of the dead connection-status chain cleanup — but the mode is **not dead**: shittim-chest #355 gates its mobile footer add-view reveals behind a long press, and chest master fails to compile against hikari master (TS2322 `touchRevealMode does not exist` on ChatLayout.tsx:430 and StatusBar.tsx:129). The zero-consumer claim only held for the connection-status chain, not the longpress mode that landed in #222 for chest's #355.

## Fix

Restores the props, the long-press timer wiring, and the four component tests verbatim from 10cb583 (pre-#226).

## Verification

- `vue-tsc --noEmit` ✅
- `vitest run` **219/219** ✅ (215 current + 4 restored longpress tests)