### PR TITLE
🐛 Drop the UI sans from the mono stack so no-concrete-mono environments stay monospace.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -19,10 +19,12 @@
 
   // ── Font families (body text, mono for version/numbers) ─
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  // Mono faces first for latin/digits; sans sits before the generic keyword
-  // only so CJK glyphs (uncovered by latin mono faces) fall back to the UI
-  // CJK font instead of the system's kai-style monospace CJK.
-  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, var(--font-sans), monospace;
+  // Pure mono stack (see admin-tokens.scss for the full rationale): no
+  // sans inside — environments without a concrete mono face (stock Linux,
+  // most Androids) must fall to the generic `monospace`, never to the
+  // proportional sans; CJK glyphs fall through to the platform's
+  // last-resort CJK font (= the UI sans CJK on modern platforms).
+  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", monospace;
 
   // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
   --space-1: 0.0625rem;

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -9,16 +9,22 @@
   --s-header-height: 3rem;
   --z-header: 30;
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  /* Monospace FIRST for latin/digits (Fira Code when installed, else the
-     system mono: ui-monospace/SF Mono on Apple, Roboto Mono-ish on Android,
-     Menlo/Consolas on desktops). The sans stack sits before the generic
-     `monospace` keyword ONLY so CJK glyphs (which no latin mono face covers)
-     fall back to the normal UI CJK font instead of the system's kai-style
-     monospace CJK — putting sans right after Fira Code (the old order) made
-     every Fira-Code-less device (all phones) render digits proportionally,
-     silently breaking every mono alignment in the app. */
+  /* A pure mono stack: every entry is monospace, the generic `monospace`
+     keyword is the final catch-all — the UI sans must NEVER sit inside it.
+     Two prior shapes both broke real devices: (1) sans right after Fira
+     Code made every Fira-Code-less device (all phones) render digits
+     proportionally; (2) sans before the generic keyword still let
+     environments with no concrete mono face installed (stock Linux
+     desktops, most Androids — ui-monospace is Apple-only) hit the
+     proportional sans first. Latin/digits now always land on a real mono
+     face (Fira Code → ui-monospace/SF Mono on Apple, Consolas on Windows,
+     DejaVu/Liberation on Linux, the generic monospace = Roboto Mono-ish on
+     Android). CJK glyphs are not covered by any latin mono face, so they
+     fall through to the platform's last-resort CJK font — on every modern
+     platform that resolves to the UI sans CJK, not kai. */
   --font-mono: "Fira Code", ui-monospace, "JetBrains Mono",
-    "SF Mono", Menlo, Consolas, var(--font-sans), monospace;
+    "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono",
+    monospace;
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;


### PR DESCRIPTION
## Problem

The v1 reorder in #228 (`var(--font-sans)` before the generic `monospace` keyword) still fails on environments with **no concrete mono face installed** — stock Linux desktops and most Androids (`ui-monospace` is Apple-only): the proportional sans wins before the generic fallback, so digits still render proportionally (pixel-verified on a Linux host: two 14-char hashes measured 87.5px vs 94.34px).

## Fix

Pure mono stack — sans removed entirely, Linux monos added, generic `monospace` as the final catch-all:

- Apple → ui-monospace / SF Mono; Windows → Consolas; Linux → DejaVu/Liberation Sans Mono; Android → generic monospace (Roboto Mono-ish)
- CJK glyphs fall through to the platform last-resort CJK font (= the UI sans CJK on every modern platform — the kai concern the original comment guarded against)

Both definitions aligned (`admin-tokens.scss`, `theme/_layout.scss`).

## Verification

- `vue-tsc --noEmit` ✅, `vitest run` 219/219 ✅
- Pixel check on a Linux host (no Fira Code/JetBrains Mono installed) after this change lands in the consuming app follows in the P44 deploy verification