### PR TITLE
🐛 Stop the element-level input baseline from double-bordering hikari fields.

### DIFF
--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -370,13 +370,23 @@ li {
 // 表单元素
 // ------
 
-input,
-textarea,
-select {
+// Element-level baseline for BARE app inputs only. Hikari components render
+// their own <input>/<textarea>/<select> inside a styled shell (.hk-input-box
+// etc.) and must not inherit this border/focus ring: the bare-element
+// `input:focus-visible` (0,1,1) outranks the component's `.hk-input-element`
+// (0,1,0) `border: none`, so a focused field showed BOTH the shell's
+// focus-within border AND an inner 2px ring — the "double border" on the
+// add-view wizard's title/purpose fields (same disease class as the element
+// color reset #215 removed). Excluding any element carrying an `hk-` class
+// keeps the baseline for genuinely bare app markup while leaving every hikari
+// component interior untouched.
+input:not([class^="hk-"]):not([class*=" hk-"]),
+textarea:not([class^="hk-"]):not([class*=" hk-"]),
+select:not([class^="hk-"]):not([class*=" hk-"]) {
     @include input-base;
 }
 
-textarea {
+textarea:not([class^="hk-"]):not([class*=" hk-"]) {
     min-height: 80px;
     resize: vertical;
 }

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -85,6 +85,18 @@
   color: rgb(var(--color-text));
   text-align: center;
   padding: var(--space-8) var(--space-12);
+
+  // The interactive states stay clean too: the shell (.hk-input-box) owns
+  // the focus affordance via :focus-within. Without these overrides any
+  // element-level `input { … :focus-visible { box-shadow } }` baseline
+  // outranks the plain-class `border: none` here and paints a second,
+  // inner ring on top of the shell's border (the double-border bug).
+  &:focus,
+  &:focus-visible {
+    border: none;
+    outline: none;
+    box-shadow: none;
+  }
 }
 
 .hk-input-element.hk-input-textarea {


### PR DESCRIPTION
## Problem

The theme base stylesheet applies `input-base` (border + `:focus-visible` 2px ring) to every **bare** `input`/`textarea`/`select`. Hikari components render their own bare elements inside styled shells (e.g. `.hk-input-box`), and while the component's `.hk-input-element { border: none }` (0,1,0) wins the resting state over `input` (0,0,1), the element-level **`input:focus-visible` (0,1,1) outranks it** — so a focused field showed BOTH the shell's `focus-within` border AND an inner 2px primary ring. User-visible as the "double border" on the add-view wizard's title/purpose fields (chest); same disease class as the element color reset #215 removed, and it touches every component with a bare interior input (Checkbox/Radio/Switch/DatePicker/NumberInput/…).

## Fix (two layers)

1. `theme/styles/base.scss`: the element-level baseline now excludes any element carrying an `hk-` class — `input:not([class^="hk-"]):not([class*=" hk-"])` etc. Bare app markup keeps the baseline; every hikari component interior is untouched.
2. `HkInput.scss`: `.hk-input-element` additionally clears `&:focus`/`&:focus-visible` (border/outline/box-shadow none) as defense-in-depth against any other element-level baseline.

## Verification

- `vue-tsc --noEmit` ✅ · `vitest run` 219/219 ✅
- Consuming-app deploy + mobile browser verification follows in PLAN P45