### PR TITLE
🛡️ Exclude hikari component interiors from the remaining element-level control rules.

### DIFF
--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -435,7 +435,11 @@ textarea:not([class^="hk-"]):not([class*=" hk-"]) {
     }
 }
 
-select {
+// Same hk- exclusion as the input/textarea/select baseline above: hikari
+// components render bare <select>/<label>/<button> interiors that own their
+// chrome, and the element-level :focus-visible ring (0,1,1) would outrank
+// their plain-class styles exactly like the double-border input bug (#232).
+select:not([class^="hk-"]):not([class*=" hk-"]) {
     appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%239CA3AF" d="M2 4l4 4 4-4"/></svg>');
     background-repeat: no-repeat;
@@ -443,7 +447,7 @@ select {
     padding-right: 2.5rem;
 }
 
-label {
+label:not([class^="hk-"]):not([class*=" hk-"]) {
     display: block;
     margin-bottom: $hikari-spacing-xs;
     font-weight: 500;
@@ -454,7 +458,7 @@ label {
 // 按钮样式
 // ------
 
-button {
+button:not([class^="hk-"]):not([class*=" hk-"]) {
     @include button-base;
 }
 


### PR DESCRIPTION
## Problem

The select chevron baseline, the label block rule, and the button-base element rule were the last bare-element form/control selectors in `theme/styles/base.scss` without the hk- exclusion that #232 added to the input/textarea baseline — flagged as the advisory in #232's verification round.

Same specificity hazard as the double-border input bug: the element-level `button:focus-visible` ring (0,1,1) outranks the component's plain-class styles on every hk- button interior (`hk-btn` / `hk-icon-button` / `hk-tabs-trigger`), and the label block's `margin-bottom` can leak into `.hk-input-label` where the class doesn't reset it. No hikari component renders a bare `<select>` today, so the chevron guard is purely symmetric defense.

## Fix

The same `:not([class^="hk-"]):not([class*=" hk-"])` exclusion applied to all three remaining rules (`select`, `label`, `button`). Bare app markup keeps the baseline; every hikari component interior is untouched.

## Verification

- `vue-tsc --noEmit` ✅ · `vitest run` 219/219 ✅
- Selector-chain logic identical to #232's (verified pattern)