### PR TITLE
🛡️ Register the select and menu overlays with the popup z context.

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hikari-e2e"
-version = "0.3.19"
+version = "0.3.20"
 description = "E2E testing framework for Hikari UI components"
 authors = ["Hikari Contributors"]
 license-file = "../../LICENSE"

--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -65,16 +65,33 @@
   --opacity-half: 0.92;
   --opacity-more: 0.96;
 
-  // ── Z-index hierarchy ─
+  // ── Z-index hierarchy (group bands) ─
+  // One registered context: every layer family owns a band. Members inside
+  // a band stack by DOM order (browser default) — only the band boundaries
+  // are managed. Overlay-class components (modal/drawer/popover/select
+  // popout/menu sheet/locale picker) MUST register with usePopupManager,
+  // which allocates from the popup band (1000 + 2n, reset when the stack
+  // empties); fixed layers above the stack (toast/tooltip/fatal/titlebar)
+  // never register.
+  //   0–9      local — intra-component stacking (self-contained contexts)
+  //   10–99    content float — sticky columns, in-page lifts, minimaps
+  //   100–199  app chrome — header, footer, header popups
+  //   200–899  app overlay — reserved for app-level decorations
+  //   900–999  app sheet — drawer sidebars, bottom sheets
+  //   1000–1999 popup stack — manager-allocated (modal/drawer/popover/…)
+  //   9999     toast   10000 tooltip   10001 fatal
+  //   100001   native titlebar (Tauri caption)   100002 modal breadcrumb
   --z-base: 0;
   --z-above: 1;
   --z-overlay: 2;
   --z-top: 3;
   --z-content: 10;
-  --z-header: 30;
-  --z-sidebar: 40;
   --z-floating: 50;
+  --z-header: 100;
+  --z-footer: 110;
   --z-header-popup: 150;
+  --z-sheet: 900;
+  --z-sidebar: 900;
   --z-modal: 1000;
   --z-modal-base: 1000;
   --z-modal-step: 2;

--- a/packages/vue/src/components/HkLocalePicker.tsx
+++ b/packages/vue/src/components/HkLocalePicker.tsx
@@ -63,7 +63,10 @@ export const HkLocalePicker = defineComponent({
               border: "1px solid var(--border-faint, rgb(var(--color-border) / 10%))",
               borderRadius: "var(--radius-md, 6px)",
               boxShadow: "0 4px 16px rgb(0 0 0 / 12%)",
-              zIndex: 1000,
+              // Local stacking inside the header's own context — the
+              // app-chrome header-popup band documents the intent (this
+              // value is scoped, it never races the popup stack).
+              zIndex: "var(--z-header-popup, 150)",
               overflow: "hidden",
               padding: "4px",
             }}

--- a/packages/vue/src/components/HkMenu.scss
+++ b/packages/vue/src/components/HkMenu.scss
@@ -190,7 +190,7 @@
 .hk-menu-desktop {
   position: fixed;
   inset: 0;
-  z-index: var(--z-popover, 1100);
+  /* z-index comes from the popup manager (inline) — registered overlay. */
   pointer-events: none;
 }
 
@@ -221,7 +221,7 @@
 .hk-menu-mobile-stack {
   position: fixed;
   inset: 0;
-  z-index: var(--z-modal, 1200);
+  /* z-index comes from the popup manager (inline) — registered overlay. */
 }
 
 .hk-menu-sheet {

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -14,6 +14,7 @@ import {
 
 import { ChevronLeft, ChevronRight } from "lucide-vue-next";
 
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import "./HkMenu.scss";
 
 /**
@@ -104,6 +105,13 @@ export default defineComponent({
     let suppressPop = 0;
     /** Bumped on viewport resize so an open menu re-renders in the right mode. */
     const viewportTick = ref(0);
+
+    // Registered overlay: the whole menu (desktop panels + mobile sheets)
+    // stacks inside the shared popup context instead of hardcoded
+    // 1100/1200+n values that later-opened modals could overtake.
+    const manager = usePopupManager();
+    const handle = ref<PopupHandle | null>(null);
+    const menuZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
 
     const mobileMode = computed(() => {
       void viewportTick.value; // re-evaluate when the viewport changes
@@ -201,6 +209,10 @@ export default defineComponent({
       window.addEventListener("resize", onResize);
     });
     onBeforeUnmount(() => {
+      if (handle.value) {
+        manager.unregister(handle.value.id);
+        handle.value = null;
+      }
       if (props.variant === "sidebar") return;
       window.removeEventListener("popstate", onPopState);
       window.removeEventListener("resize", onResize);
@@ -221,12 +233,19 @@ export default defineComponent({
         const openNow = key.startsWith("1");
         const mobile = key.endsWith("1");
         if (!openNow) {
+          if (handle.value) {
+            manager.unregister(handle.value.id);
+            handle.value = null;
+          }
           if (pushedDepth > 0 || mobileStack.value.length > 0 || desktopPath.value.length > 0) {
             desktopPath.value = [];
             mobileStack.value = [];
             restoreHistory();
           }
           return;
+        }
+        if (!handle.value) {
+          handle.value = manager.register("dropdown", false);
         }
         if (mobile) {
           // Normalize: exactly one fresh root entry above the page's history.
@@ -404,7 +423,6 @@ export default defineComponent({
           key={level}
           class="hk-menu-sheet"
           data-level={level}
-          style={{ zIndex: `${1200 + level}` }}
         >
           <div class="hk-menu-sheet-header">
             <button type="button" class="hk-menu-sheet-back" aria-label="Back" onClick={onBack}>
@@ -566,7 +584,7 @@ export default defineComponent({
         ];
         return (
           <Teleport to="body">
-            <div class="hk-menu-mobile-stack">{sheets}</div>
+            <div class="hk-menu-mobile-stack" style={{ zIndex: menuZ.value }}>{sheets}</div>
           </Teleport>
         );
       }
@@ -589,7 +607,7 @@ export default defineComponent({
       }
       return (
         <Teleport to="body">
-          <div class="hk-menu-desktop">
+          <div class="hk-menu-desktop" style={{ zIndex: menuZ.value }}>
             <div class="hk-menu-backdrop" onClick={() => closeAll()} />
             {panels}
           </div>

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -92,7 +92,7 @@
 
 .hk-select-popout {
   position: fixed;
-  z-index: 1100;
+  /* z-index comes from the popup manager (inline) — registered overlay. */
   min-width: 180px;
   max-height: 240px;
   display: flex;

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -11,6 +11,7 @@ import {
 
 
 import { ChevronDown, Search } from "lucide-vue-next";
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import "./HkSelect.scss";
 
 export interface HkSelectOption {
@@ -42,6 +43,13 @@ export default defineComponent({
     const panelRef = ref<HTMLElement>();
     const highlightedIndex = ref(-1);
 
+    // The popout registers with the popup manager so it stacks inside the
+    // shared overlay context (1000+2n) instead of a hardcoded z that later
+    // modals could overtake (select-in-modal used to get covered).
+    const manager = usePopupManager();
+    const handle = ref<PopupHandle | null>(null);
+    const popoutZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
+
     function onDocumentClick(e: MouseEvent) {
       if (!isOpen.value) return;
       const target = e.target as Node;
@@ -52,14 +60,23 @@ export default defineComponent({
 
     watch(isOpen, (open) => {
       if (open) {
+        handle.value = manager.register("dropdown", false);
         document.addEventListener("click", onDocumentClick, true);
       } else {
         document.removeEventListener("click", onDocumentClick, true);
+        if (handle.value) {
+          manager.unregister(handle.value.id);
+          handle.value = null;
+        }
       }
     });
 
     onBeforeUnmount(() => {
       document.removeEventListener("click", onDocumentClick, true);
+      if (handle.value) {
+        manager.unregister(handle.value.id);
+        handle.value = null;
+      }
     });
 
     const normalizedOptions = computed<HkSelectOption[]>(
@@ -199,7 +216,7 @@ export default defineComponent({
             <div
               ref={panelRef}
               class="hk-select-popout"
-              style={triggerCoords.value}
+              style={{ ...triggerCoords.value, zIndex: popoutZ.value }}
               onKeydown={onPopoutKeydown}
             >
               {slots.default

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -7,7 +7,7 @@
   /* ── Layout tokens ─ */
   --s-footer-height: 3rem;
   --s-header-height: 3rem;
-  --z-header: 30;
+  --z-header: 100;
   --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   /* A pure mono stack: every entry is monospace, the generic `monospace`
      keyword is the final catch-all — the UI sans must NEVER sit inside it.
@@ -28,8 +28,8 @@
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;
-  --z-sidebar: 40;
-  --z-base: 0;
+  --z-sidebar: 900; /* app-sheet band — drawer sidebars (see theme/_layout.scss) */
+  --z-base: 0; /* z tokens mirror theme/styles/_layout.scss — keep both in sync */
   --space-2: 0.125rem;
   --space-4: 0.25rem;
   --space-6: 0.375rem;
@@ -115,7 +115,7 @@
   background: rgb(var(--color-surface));
   backdrop-filter: blur(var(--blur-md));
   border-top: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
-  z-index: var(--z-sidebar, 30);
+  z-index: var(--z-footer, 110);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Problem

The z hierarchy existed in THREE duplicated token sets that disagreed (`--z-header` 30 vs 100, `--z-sidebar` 40 vs the HkSidebar component default 900), and two overlay components escaped the registered context: **HkSelect's popout hardcoded z 1100** and **HkMenu's panels/sheets 1200+level** — values inside the popup-manager band (1000+2n) but unregistered, so a later-opened modal overtakes them (select-in-modal gets covered).

## Fix

- **Canonical band table** in `theme/styles/_layout.scss` with explicit group bands — local 0-9 / content-float 10-99 / app-chrome 100-199 / app-overlay 200-899 / app-sheet 900-999 / popup-stack 1000-1999 (manager) / toast 9999 / tooltip 10000 / fatal 10001 / titlebar 100001 / breadcrumb 100002. `admin-tokens.scss` mirrors the same values; `.s-status-bar` stops misusing `--z-sidebar` (gets `--z-footer`).
- **HkSelect / HkMenu register** with `usePopupManager` (kind=dropdown, 1000+2n) — their teleported roots take the allocated z inline; the hardcoded SCSS values are gone. HkMenu's mobile sheet levels now stack by DOM order inside the registered context (the per-sheet `` was redundant once the root owns a context).
- **HkLocalePicker**: scoped dropdown (absolute inside the header's own stacking context, not teleported) — inline 1000 → `var(--z-header-popup, 150)`, documenting the band it conceptually belongs to without racing the popup stack.

## Verification

- `vue-tsc --noEmit` ✅ · `vitest run` 219/219 ✅
- Companion PRs align chest/erp's vendored token blocks to the same band table