### PR TITLE
🛡️ Move the admin shell footer onto the footer band.

### DIFF
--- a/packages/vue/src/components/HkAdminShell.tsx
+++ b/packages/vue/src/components/HkAdminShell.tsx
@@ -107,7 +107,8 @@ export const HkAdminShell = defineComponent({
         </div>
 
         {slots.footer && (
-          <footer class="s-status-bar" style={{ position: "fixed", bottom: 0, left: 0, right: 0, zIndex: 40 }}>
+          <footer class="s-status-bar" style={{ position: "fixed", bottom: 0, left: 0, right: 0, // Footer band (was a bare 40 — the pre-band chrome value).
+            zIndex: "var(--z-footer, 110)" }}>
             {slots.footer()}
           </footer>
         )}


### PR DESCRIPTION
## Problem

HkAdminShell's footer slot wrapper still carried the pre-band inline `zIndex: 40`, so auth/admin layouts rendered a nested double footer (outer shell at 40, inner PFooter content at 110) after the band wave (#234 + chest #373).

## Fix

The shell footer now uses `var(--z-footer, 110)` — the same band token the vendored footers use.

## Verification

- `vue-tsc --noEmit` ✅ · `vitest run` 219/219 ✅