### PR TITLE
🛡️ Zero the element-level control baseline specificity with :where guards.

### DIFF
--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -380,13 +380,20 @@ li {
 // color reset #215 removed). Excluding any element carrying an `hk-` class
 // keeps the baseline for genuinely bare app markup while leaving every hikari
 // component interior untouched.
-input:not([class^="hk-"]):not([class*=" hk-"]),
-textarea:not([class^="hk-"]):not([class*=" hk-"]),
-select:not([class^="hk-"]):not([class*=" hk-"]) {
+//
+// 2026-08-19: the guards now sit inside :where(...) so they contribute ZERO
+// specificity. The plain :not() form measured (0,1,1) and outranked every
+// single-class button/label/select style in consuming apps (chest's
+// .s-workspace-btn grew a 16px/500 font overnight — hikari #233 fallout);
+// :where() keeps the hk- exclusion at (0,0,1), the exact cascade position
+// the element baseline had before the guards existed (#232/#233).
+input:where(:not([class^="hk-"]):not([class*=" hk-"])),
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"])),
+select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
     @include input-base;
 }
 
-textarea:not([class^="hk-"]):not([class*=" hk-"]) {
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
     min-height: 80px;
     resize: vertical;
 }
@@ -439,7 +446,7 @@ textarea:not([class^="hk-"]):not([class*=" hk-"]) {
 // components render bare <select>/<label>/<button> interiors that own their
 // chrome, and the element-level :focus-visible ring (0,1,1) would outrank
 // their plain-class styles exactly like the double-border input bug (#232).
-select:not([class^="hk-"]):not([class*=" hk-"]) {
+select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
     appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%239CA3AF" d="M2 4l4 4 4-4"/></svg>');
     background-repeat: no-repeat;
@@ -447,7 +454,7 @@ select:not([class^="hk-"]):not([class*=" hk-"]) {
     padding-right: 2.5rem;
 }
 
-label:not([class^="hk-"]):not([class*=" hk-"]) {
+label:where(:not([class^="hk-"]):not([class*=" hk-"])) {
     display: block;
     margin-bottom: $hikari-spacing-xs;
     font-weight: 500;
@@ -458,7 +465,7 @@ label:not([class^="hk-"]):not([class*=" hk-"]) {
 // 按钮样式
 // ------
 
-button:not([class^="hk-"]):not([class*=" hk-"]) {
+button:where(:not([class^="hk-"]):not([class*=" hk-"])) {
     @include button-base;
 }
 


### PR DESCRIPTION
## Problem

After #232/#233 shipped (and reached chest via today's sibling roll-forward), every single-class control style in consuming apps lost the cascade to the element-level baselines:

- chest's `.s-workspace-btn` (0,1,0) now renders at **16px / font-weight 500 / 8px 16px padding** instead of its `--text-2xs` chip styling — the guards `button:not([class^="hk-"]):not([class*=" hk-"])` measure **(0,1,1)**, higher than the bare `button` (0,0,1) they replaced, so they outrank every plain single-class button/label/select in apps.
- Same hazard class as the very double-border bug #232 fixed, but inverted: the "fix" exclusion now beats the app's own classes.

User-visible report: the top-left workspace chip in chest shows a single line "mock" in a suddenly huge font.

## Fix

Wrap the hk- exclusion guards in `:where(...)` — zero-specificity — so the baselines keep their original cascade position:

- `input/textarea/select` baseline, `select` chevron rule, `label` block rule, `button-base` rule — all become (0,0,1) again.
- Bare app markup still gets the baseline; hikari component interiors (any `hk-` class) stay excluded exactly as #232/#233 intended; app single classes win again (0,1,0 > 0,0,1).

## Verification

- `vue-tsc --noEmit` clean.
- vitest 21 files / 219 tests pass (one earlier run had 3 flaky NFS-contention failures that pass on rerun).
- Cascade math: `:where()` contributes (0,0,0) per CSS spec, restoring the pre-guard position while keeping the exclusion semantics.