### PR TITLE
🎨 Give the gauge ring a palette-context variant API and stop the icon button from filling stroke icons.

### DIFF
--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -32,6 +32,11 @@
         <HIconButton icon="search" variant="ghost" :size="16" />
         <HIconButton icon="settings" variant="secondary" :size="24" />
         <HIconButton icon="heart" variant="primary" :size="40" />
+        <!-- The icon slot accepts any component (lucide etc.); attrs like
+             aria-label now fall through to the button element. -->
+        <HIconButton variant="ghost" :size="24" aria-label="Refresh">
+          <template #icon><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" /><path d="M21 3v5h-5" /><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" /><path d="M8 16H3v5" /></svg></template>
+        </HIconButton>
       </div>
     </section>
 
@@ -82,6 +87,17 @@
       <h2>HProgressBar / HProgressRing / HGaugeRing</h2>
       <div class="row"><HProgressBar :value="65" style="width:200px" /></div>
       <div class="row"><HProgressRing :value="75" :size="80" /><HGaugeRing :rings="gaugeRings" :size="80" center-label="CPU" /></div>
+      <!-- Variant API: colors come from the theme palette context; `auto`
+           thresholds (>=90 danger, >=75 warning, else success) fit host
+           resource gauges; `value` is the single-ring convenience. -->
+      <div class="row">
+        <HGaugeRing :value="62" :size="72" :stroke-width="6" variant="auto" center-value="62%" center-label="AUTO" />
+        <HGaugeRing :value="80" :size="72" :stroke-width="6" variant="auto" center-value="80%" center-label="AUTO" />
+        <HGaugeRing :value="95" :size="72" :stroke-width="6" variant="auto" center-value="95%" center-label="AUTO" />
+        <HGaugeRing :value="40" :size="72" :stroke-width="6" variant="primary" center-value="40%" center-label="PRIMARY" />
+        <HGaugeRing :value="40" :size="72" :stroke-width="6" variant="info" center-value="40%" center-label="INFO" />
+        <HGaugeRing :value="40" :size="72" :stroke-width="6" variant="muted" center-value="40%" center-label="MUTED" />
+      </div>
     </section>
 
     <section>

--- a/packages/vue/src/components/HkGaugeRing.scss
+++ b/packages/vue/src/components/HkGaugeRing.scss
@@ -1,4 +1,74 @@
+// HkGaugeRing — self-contained styles.
+//
+// The center overlay and its typography live HERE, not in host-app utility
+// classes: the component used to lean on Tailwind-style utilities
+// (`absolute inset-0 flex ... text-lg`) that only exist in apps with an
+// atomic-CSS layer, so in any other host the center content drifted beside
+// the ring with default font sizes. Everything the ring renders is styled
+// by this file.
+//
+// Arc/track colors resolve from the theme-palette context by variant
+// (`data-variant`). We deliberately read the bridged `--hi-color-*`
+// family only: apps that load the hikari style bundle (chest, erp) get
+// `--hi-color-*` bridged onto their own `--color-*` palette by
+// styles/admin-tokens.scss, and hikari-standalone hosts have the
+// foundation defaults — one family covers both. Callers may still pass an
+// explicit CSS color, which lands as an inline style and outranks these
+// rules.
+
 .hk-gauge-ring {
   position: relative;
   display: inline-flex;
+
+  // ── Track (background circle) ─────────────────────────────────────
+  &__track {
+    stroke: var(--hk-gauge-ring-track, var(--hi-color-border, rgba(128, 128, 128, 0.25)));
+
+    &[data-variant="surface"] {
+      stroke: var(--hi-color-surface, rgba(128, 128, 128, 0.2));
+    }
+  }
+
+  // ── Arc (value circle) ────────────────────────────────────────────
+  &__arc {
+    stroke: var(--hi-color-primary, #58a6ff);
+
+    &[data-variant="primary"] { stroke: var(--hi-color-primary, #58a6ff); }
+    &[data-variant="success"] { stroke: var(--hi-color-success, #3fb950); }
+    &[data-variant="warning"] { stroke: var(--hi-color-warning, #d29922); }
+    &[data-variant="danger"]  { stroke: var(--hi-color-danger, #f85149); }
+    &[data-variant="info"]    { stroke: var(--hi-color-info, #58a6ff); }
+    &[data-variant="muted"]   { stroke: var(--hi-color-muted, #8b949e); }
+  }
+
+  // ── Center overlay ────────────────────────────────────────────────
+  // Absolute + inset-0 keeps the value/label optically centered inside the
+  // ring at any size; pointer events pass through to the host element.
+  &__center {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1px;
+    pointer-events: none;
+  }
+
+  &__value {
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -0.01em;
+    // Font size is set inline (scales with `size`); color from palette.
+    color: var(--hi-color-text-primary, inherit);
+    // Tabular figures keep live percentages from jittering as they tick.
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__label {
+    line-height: 1;
+    letter-spacing: 0.02em;
+    color: var(--hi-color-text-secondary, inherit);
+    white-space: nowrap;
+  }
 }

--- a/packages/vue/src/components/HkGaugeRing.test.tsx
+++ b/packages/vue/src/components/HkGaugeRing.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkGaugeRing from "./HkGaugeRing";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+function mountRing(props: Record<string, unknown> = {}): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(HkGaugeRing, { animate: false, ...props });
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return container;
+}
+
+/** The rendered arc circle (value arc, not the track). */
+function arc(container: HTMLElement): SVGCircleElement | null {
+  return container.querySelector(".hk-gauge-ring__arc");
+}
+
+afterEach(() => {
+  mounts.splice(0).forEach((app) => app.unmount());
+  containers.splice(0).forEach((c) => c.remove());
+});
+
+describe("HkGaugeRing", () => {
+  it("colors a single-value ring from the component variant", () => {
+    const c = mountRing({ value: 42, variant: "info" });
+    expect(arc(c)?.getAttribute("data-variant")).toBe("info");
+    // Single-arc rings expose progressbar semantics.
+    expect(c.firstElementChild?.getAttribute("role")).toBe("progressbar");
+    expect(c.firstElementChild?.getAttribute("aria-valuenow")).toBe("42");
+  });
+
+  it("resolves the auto variant by utilisation thresholds", () => {
+    const ok = mountRing({ value: 50, variant: "auto" });
+    expect(arc(ok)?.getAttribute("data-variant")).toBe("success");
+
+    const warn = mountRing({ value: 80, variant: "auto" });
+    expect(arc(warn)?.getAttribute("data-variant")).toBe("warning");
+
+    const hot = mountRing({ value: 93, variant: "auto" });
+    expect(arc(hot)?.getAttribute("data-variant")).toBe("danger");
+  });
+
+  it("keeps an explicit color as an inline stroke override", () => {
+    const c = mountRing({ value: 10, color: undefined, rings: [{ pct: 10, color: "#123456" }] });
+    const el = arc(c) as unknown as HTMLElement;
+    expect(el.style.stroke).toBe("#123456");
+  });
+
+  it("clamps values above 100 in aria and geometry", () => {
+    const c = mountRing({ value: 250 });
+    const root = c.firstElementChild as HTMLElement;
+    expect(root.getAttribute("aria-valuenow")).toBe("100");
+    // dashoffset for 100% with animate=false is exactly 0 (full circle).
+    const el = arc(c) as unknown as HTMLElement;
+    expect(el.getAttribute("stroke-dashoffset")).toBe("0");
+  });
+
+  it("renders the center value/label with its own classes, not utilities", () => {
+    const c = mountRing({ value: 33, centerValue: "33%", centerLabel: "CPU", size: 72 });
+    const center = c.querySelector(".hk-gauge-ring__center") as HTMLElement;
+    expect(center).not.toBeNull();
+    // Self-contained classes only — no host-app utility classes on the
+    // overlay (the old markup leaned on `absolute inset-0 flex ...`).
+    expect(center.className).toBe("hk-gauge-ring__center");
+    const value = c.querySelector(".hk-gauge-ring__value") as HTMLElement;
+    const label = c.querySelector(".hk-gauge-ring__label") as HTMLElement;
+    expect(value.textContent).toBe("33%");
+    expect(label.textContent).toBe("CPU");
+    // Typography scales with size (72px ring → 12px value font).
+    expect(value.style.fontSize).toBe("12px");
+    expect(label.style.fontSize).toBe("9px");
+  });
+
+  it("marks multi-ring gauges as img (progressbar only for single value)", () => {
+    const c = mountRing({ rings: [{ pct: 30 }, { pct: 70 }] });
+    const root = c.firstElementChild as HTMLElement;
+    expect(root.getAttribute("role")).toBe("img");
+    expect(root.getAttribute("aria-valuenow")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkGaugeRing.tsx
+++ b/packages/vue/src/components/HkGaugeRing.tsx
@@ -1,13 +1,35 @@
-import { computed, defineComponent, onMounted, ref, watch } from "vue";
+import { computed, defineComponent, onMounted, ref, watch, type PropType } from "vue";
 
 import { useReportedTransition } from "../composables/useReportedTransition";
 import { onceFrame } from "../runtime/animationBus";
 import "./HkGaugeRing.scss";
 
-interface RingData {
+/** Visual variant of one arc. `auto` picks from the theme palette by
+ *  utilisation thresholds (>= 90 danger, >= 75 warning, else success). */
+export type GaugeVariant =
+  | "primary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "muted"
+  | "auto";
+
+/** Resolve the `auto` variant against a concrete pct. */
+function resolveAuto(pct: number): Exclude<GaugeVariant, "auto"> {
+  if (pct >= 90) return "danger";
+  if (pct >= 75) return "warning";
+  return "success";
+}
+
+export interface RingData {
   pct: number;
-  color: string;
-  trackColor: string;
+  /** Explicit color override (any CSS color). Wins over `variant`. */
+  color?: string;
+  /** Theme-palette variant. Wins over the component-level `variant`. */
+  variant?: GaugeVariant;
+  /** Explicit track color override (any CSS color). */
+  trackColor?: string;
 }
 
 const RING_ANIM_MS = 800;
@@ -15,9 +37,25 @@ const RING_ANIM_MS = 800;
 export default defineComponent({
   name: "HkGaugeRing",
   props: {
+    /** Multi-ring layout (concentric arcs). When both `rings` and `value`
+     *  are given, `rings` wins (backwards compatibility). */
     rings: {
       type: Array as () => RingData[],
-      required: true,
+      default: undefined,
+    },
+    /** Single-ring convenience: builds one arc from a 0-100 value colored
+     *  by the component-level `variant`. */
+    value: { type: Number, default: undefined },
+    /** Default arc variant — colors resolve from the theme palette context
+     *  (`--color-*` with `--hi-color-*` fallbacks), never hard-coded. */
+    variant: {
+      type: String as PropType<GaugeVariant>,
+      default: "primary",
+    },
+    /** Default track treatment for arcs without an explicit trackColor. */
+    trackVariant: {
+      type: String as PropType<"muted" | "surface">,
+      default: "muted",
     },
     size: { type: Number, default: 140 },
     strokeWidth: { type: Number, default: 8 },
@@ -47,6 +85,23 @@ export default defineComponent({
       if (!props.animate) return;
       kickRamp();
     });
+    watch(() => props.value, () => {
+      if (!props.animate) return;
+      kickRamp();
+    });
+
+    /** Normalised arc list: the explicit `rings` array, or a single arc
+     *  built from `value` (defaulting to 0 so the track still renders). */
+    const arcs = computed<RingData[]>(() => {
+      if (props.rings) return props.rings;
+      return [{ pct: props.value ?? 0, variant: props.variant }];
+    });
+
+    /** Concrete stroke variant for an arc (explicit color short-circuits). */
+    function arcVariant(ring: RingData): Exclude<GaugeVariant, "auto"> {
+      const v = ring.variant ?? props.variant;
+      return v === "auto" ? resolveAuto(ring.pct) : v;
+    }
 
     const rings = computed(() => {
       const { strokeWidth, gap, size } = props;
@@ -54,12 +109,13 @@ export default defineComponent({
         radius: number;
         circumference: number;
         dashOffset: number;
-        color: string;
-        trackColor: string;
+        variant: Exclude<GaugeVariant, "auto">;
+        color: string | undefined;
+        trackColor: string | undefined;
         strokeWidth: number;
       }[] = [];
       let r = (size - strokeWidth) / 2;
-      for (const ring of props.rings) {
+      for (const ring of arcs.value) {
         const radius = Math.max(r, 1);
         const circumference = 2 * Math.PI * radius;
         const dashOffset = circumference * (1 - (Math.min(ring.pct, 100) / 100) * progress.value);
@@ -67,6 +123,7 @@ export default defineComponent({
           radius,
           circumference,
           dashOffset,
+          variant: arcVariant(ring),
           color: ring.color,
           trackColor: ring.trackColor,
           strokeWidth,
@@ -79,8 +136,29 @@ export default defineComponent({
 
     const center = computed(() => props.size / 2);
 
+    /** Center typography scales with the ring so callers never need their
+     *  own font hacks: value = clamp(11, size/6, 22)px. */
+    const valueFontSize = computed(() =>
+      Math.round(Math.min(22, Math.max(11, props.size / 6))));
+    const labelFontSize = computed(() =>
+      Math.round(Math.min(12, Math.max(8, valueFontSize.value * 0.75))));
+
+    const aria = computed(() => {
+      const single = arcs.value.length === 1 ? arcs.value[0] : null;
+      if (!single) return { role: "img" as const, now: undefined };
+      return { role: "progressbar" as const, now: Math.round(Math.min(single.pct, 100)) };
+    });
+
     return () => (
-      <div class="hk-gauge-ring" style={{ width: `${props.size}px`, height: `${props.size}px` }}>
+      <div
+        class="hk-gauge-ring"
+        style={{ width: `${props.size}px`, height: `${props.size}px` }}
+        role={aria.value.role}
+        aria-valuenow={aria.value.now}
+        aria-valuemin={aria.value.now != null ? 0 : undefined}
+        aria-valuemax={aria.value.now != null ? 100 : undefined}
+        aria-label={aria.value.role === "progressbar" && props.centerLabel ? props.centerLabel : undefined}
+      >
         <svg
           width={props.size}
           height={props.size}
@@ -90,24 +168,30 @@ export default defineComponent({
           {rings.value.map((ring, i) => (
             <g key={i}>
               <circle
+                class="hk-gauge-ring__track"
                 cx={center.value}
                 cy={center.value}
                 r={ring.radius}
                 fill="none"
-                stroke={ring.trackColor}
+                data-variant={props.trackVariant}
                 stroke-width={ring.strokeWidth}
+                /* Inline style so an explicit trackColor outranks the
+                 * data-variant palette rules (inline > class > attribute). */
+                style={ring.trackColor ? { stroke: ring.trackColor } : undefined}
               />
               <circle
+                class="hk-gauge-ring__arc"
                 cx={center.value}
                 cy={center.value}
                 r={ring.radius}
                 fill="none"
-                stroke={ring.color}
+                data-variant={ring.variant}
                 stroke-width={ring.strokeWidth}
                 stroke-linecap="round"
                 stroke-dasharray={ring.circumference}
                 stroke-dashoffset={ring.dashOffset}
                 style={{
+                  ...(ring.color ? { stroke: ring.color } : {}),
                   transition: props.animate ? "stroke-dashoffset 0.8s cubic-bezier(0.4, 0, 0.2, 1)" : "none",
                 }}
               />
@@ -115,12 +199,16 @@ export default defineComponent({
           ))}
         </svg>
         {(props.centerValue || props.centerLabel) && (
-          <div class="absolute inset-0 flex flex-col items-center justify-center pointer-events-none">
+          <div class="hk-gauge-ring__center">
             {props.centerValue && (
-              <div class="text-lg font-bold text-text leading-none">{props.centerValue}</div>
+              <div class="hk-gauge-ring__value" style={{ fontSize: `${valueFontSize.value}px` }}>
+                {props.centerValue}
+              </div>
             )}
             {props.centerLabel && (
-              <div class="text-2xs text-muted mt-0.5">{props.centerLabel}</div>
+              <div class="hk-gauge-ring__label" style={{ fontSize: `${labelFontSize.value}px` }}>
+                {props.centerLabel}
+              </div>
             )}
           </div>
         )}

--- a/packages/vue/src/components/HkIconButton.scss
+++ b/packages/vue/src/components/HkIconButton.scss
@@ -150,7 +150,11 @@
       width: var(--hi-icon-button-icon-size);
       height: var(--hi-icon-button-icon-size);
       display: block;
-      fill: currentColor;
+      // NOTE: no `fill` override. CSS beats SVG presentation attributes, so a
+      // fill here would solid-fill stroke-based icon sets (lucide renders
+      // `fill="none"` on the root and inherits it to the paths — forcing
+      // currentColor turned every lucide glyph into a filled blob). Icons
+      // carry their own fill/stroke intent; the box only fixes geometry.
     }
   }
 

--- a/packages/vue/src/components/HkIconButton.test.tsx
+++ b/packages/vue/src/components/HkIconButton.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkIconButton from "./HkIconButton";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+function mountButton(
+  props: Record<string, unknown> = {},
+  slots: Record<string, () => unknown> = {},
+): HTMLButtonElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () => h(HkIconButton, props, slots);
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return container.querySelector("button") as HTMLButtonElement;
+}
+
+afterEach(() => {
+  mounts.splice(0).forEach((app) => app.unmount());
+  containers.splice(0).forEach((c) => c.remove());
+});
+
+describe("HkIconButton", () => {
+  it("forwards fallthrough attrs (aria-label) onto the button", () => {
+    const btn = mountButton({ "aria-label": "Refresh", size: 24 });
+    expect(btn.getAttribute("aria-label")).toBe("Refresh");
+  });
+
+  it("merges a caller class into the component class list", () => {
+    const btn = mountButton({ class: "s-view-panel-refresh", size: 24 });
+    expect(btn.classList.contains("hk-icon-button")).toBe(true);
+    expect(btn.classList.contains("s-view-panel-refresh")).toBe(true);
+  });
+
+  it("emits click when the button is activated", async () => {
+    let clicked = 0;
+    const btn = mountButton({ size: 24, onClick: () => { clicked += 1; } });
+    btn.click();
+    expect(clicked).toBe(1);
+  });
+
+  it("renders the slotted icon instead of the fallback glyph", () => {
+    const btn = mountButton(
+      { size: 24 },
+      { icon: () => h("span", { class: "slotted" }, "x") },
+    );
+    expect(btn.querySelector(".slotted")).not.toBeNull();
+    // The fallback circle svg must not coexist with the slot content.
+    expect(btn.querySelectorAll("svg").length).toBe(0);
+  });
+});

--- a/packages/vue/src/components/HkIconButton.tsx
+++ b/packages/vue/src/components/HkIconButton.tsx
@@ -14,15 +14,21 @@ export default defineComponent({
   emits: {
     click: (_e: MouseEvent) => true,
   },
-  setup(props, { emit, slots }) {
+  setup(props, { emit, slots, attrs }) {
     const cls = computed(() => [
       "hk-icon-button",
       `hk-icon-button-${props.size}`,
       `hk-icon-button-${props.variant}`,
+      // inheritAttrs is false, so a caller's class would be silently dropped.
+      // Merge it manually (string or array forms).
+      ...(typeof attrs.class === "string" ? [attrs.class]
+        : Array.isArray(attrs.class) ? attrs.class as string[]
+          : []),
     ]);
 
     return () => (
       <button
+        {...attrs}
         class={cls.value}
         disabled={props.disabled}
         onClick={(e: MouseEvent) => emit("click", e)}

--- a/packages/vue/src/components/HkIconButtonVars.scss
+++ b/packages/vue/src/components/HkIconButtonVars.scss
@@ -81,7 +81,9 @@
 
 .hk-icon-button-24 {
   --hi-icon-button-size: 24px;
-  --hi-icon-button-icon-size: var(--hi-icon-size-xs);
+  // sm (14px), not xs: a 12px glyph inside a 24px hit target reads as a
+  // broken/dotted speck — 14px restores the intended ghost-button balance.
+  --hi-icon-button-icon-size: var(--hi-icon-size-sm);
 }
 
 .hk-icon-button-32 {


### PR DESCRIPTION
## What

- **HkGaugeRing** becomes a real theme-system citizen:
  - New `variant` prop (`primary | success | warning | danger | info | muted | auto`) — colors resolve from the theme palette context via the bridged `--hi-color-*` token family (`styles/admin-tokens.scss` bridges app `--color-*` triplets onto it; hikari-standalone gets foundation defaults). `auto` colors by utilisation thresholds (>= 90 danger, >= 75 warning, else success).
  - New single-ring `value` prop alongside the multi-ring `rings` API; explicit `color`/`trackColor` overrides still win (inline style).
  - Self-contained center overlay: `.hk-gauge-ring__center/__value/__label` replace the Tailwind-style utility classes (`absolute inset-0 flex … text-lg`) that only existed in hosts with an atomic-CSS layer — in any other host the center content drifted beside the ring at default font sizes. Typography now scales with `size` (value = clamp(11, size/6, 22)px), tabular figures for live ticks.
  - Aria: single-value rings expose `progressbar` semantics with `aria-valuenow`; multi-ring gauges are `img`.
- **HkIconButton** fixes:
  - Stop forcing `fill: currentColor` on slotted SVGs — CSS beats the SVG presentation attribute, so every lucide (stroke-based) icon rendered as a filled blob (the workspace-manager refresh glyph was the visible casualty).
  - `inheritAttrs: false` silently dropped caller attrs: `aria-label` never reached the DOM (icon-only buttons had no accessible name) and caller `class` was discarded. Attrs are now spread and the class merged.
  - 24px size class icon token xs(12px) → sm(14px): a 12px glyph in a 24px hit target read as a speck.

## Verification

- vitest 229/229 (incl. 10 new: variant mapping, auto thresholds, clamp, aria roles, center classes, icon-button attr fallthrough/class merge/click/slot)
- vue-tsc --noEmit clean

Chest follow-up consumes the variant API in the bridge-node manager and the admin system info page.