### PR TITLE
📝 Merge every class binding form into the icon button and align the icon size ladder doc with the foundation tokens.

### DIFF
--- a/docs/zh-Hans/design/layer1.md
+++ b/docs/zh-Hans/design/layer1.md
@@ -182,12 +182,12 @@ packages/theme/styles/foundation.scss
 
 ```scss
 :root {
-  // 图标尺寸
+  // 图标尺寸（与 theme/styles/foundation.scss 一致）
   --hi-icon-size-xs: 12px;
-  --hi-icon-size-sm: 16px;
-  --hi-icon-size-md: 20px;
-  --hi-icon-size-lg: 24px;
-  --hi-icon-size-xl: 32px;
+  --hi-icon-size-sm: 14px;
+  --hi-icon-size-md: 16px;
+  --hi-icon-size-lg: 20px;
+  --hi-icon-size-xl: 24px;
 
   // 图标颜色
   --hi-icon-color: var(--hi-color-text-primary);

--- a/packages/vue/src/components/HkIconButton.test.tsx
+++ b/packages/vue/src/components/HkIconButton.test.tsx
@@ -43,6 +43,22 @@ describe("HkIconButton", () => {
     expect(btn.classList.contains("s-view-panel-refresh")).toBe(true);
   });
 
+  it("merges array-form and object-form class bindings", () => {
+    // Array form: ["a", { b: true, c: false }]
+    const arr = mountButton({ class: ["alpha", { beta: true, gamma: false }], size: 24 });
+    expect(arr.classList.contains("alpha")).toBe(true);
+    expect(arr.classList.contains("beta")).toBe(true);
+    expect(arr.classList.contains("gamma")).toBe(false);
+
+    // Object form: { delta: true, epsilon: false }
+    const obj = mountButton({ class: { delta: true, epsilon: false }, size: 24 });
+    expect(obj.classList.contains("delta")).toBe(true);
+    expect(obj.classList.contains("epsilon")).toBe(false);
+    // Component classes survive alongside the merged caller classes.
+    expect(obj.classList.contains("hk-icon-button")).toBe(true);
+    expect(obj.classList.contains("hk-icon-button-ghost")).toBe(true);
+  });
+
   it("emits click when the button is activated", async () => {
     let clicked = 0;
     const btn = mountButton({ size: 24, onClick: () => { clicked += 1; } });

--- a/packages/vue/src/components/HkIconButton.tsx
+++ b/packages/vue/src/components/HkIconButton.tsx
@@ -2,6 +2,25 @@ import { computed, defineComponent, type PropType } from "vue";
 import "./HkIconButton.scss";
 import "./HkIconButtonVars.scss";
 
+/** Flatten every Vue class-binding form (string | array | object) into
+ *  class-name strings. Object keys whose value is truthy are kept — the
+ *  same normalization Vue itself applies to `class` bindings. */
+function classesOf(raw: unknown): string[] {
+  if (!raw) return [];
+  if (typeof raw === "string") {
+    return raw.split(/\s+/).filter(Boolean);
+  }
+  if (Array.isArray(raw)) {
+    return raw.flatMap((entry) => classesOf(entry));
+  }
+  if (typeof raw === "object") {
+    return Object.entries(raw as Record<string, unknown>)
+      .filter(([, on]) => !!on)
+      .map(([name]) => name);
+  }
+  return [];
+}
+
 export default defineComponent({
   name: "HkIconButton",
   inheritAttrs: false,
@@ -19,11 +38,10 @@ export default defineComponent({
       "hk-icon-button",
       `hk-icon-button-${props.size}`,
       `hk-icon-button-${props.variant}`,
-      // inheritAttrs is false, so a caller's class would be silently dropped.
-      // Merge it manually (string or array forms).
-      ...(typeof attrs.class === "string" ? [attrs.class]
-        : Array.isArray(attrs.class) ? attrs.class as string[]
-          : []),
+      // inheritAttrs is false, so the caller's class would be silently
+      // dropped by the spread below (explicit class wins). Merge every
+      // binding form back in manually.
+      ...classesOf(attrs.class),
     ]);
 
     return () => (


### PR DESCRIPTION
## What

Sweeps the two leftovers flagged by the P48 cross-verification report:

- **HkIconButton class merge now handles every Vue class-binding form.** The #238 fix merged only string/array forms; an object-form binding (`:class="{ active: cond }"`) was silently dropped. A tiny `classesOf` normalizer (string | array | object, recursive — the same semantics Vue applies to class bindings) feeds the computed class list. No caller is affected today (all chest call sites use string form), this closes the robustness gap.
- **docs/zh-Hans/design/layer1.md icon-size ladder realigned with foundation.scss.** The doc listed xs=12/sm=16/md=20/lg=24/xl=32; the tokens are xs=12/sm=14/md=16/lg=20/xl=24 — only xs matched. The whole ladder is corrected and annotated as mirroring `theme/styles/foundation.scss`. Other locales record no literal values (zh-Hans is the only affected file); layer2/button docs reference `var(--hi-icon-size-*)` symbolically and stay correct.

## Verification

- vitest 230/230 (new case: array-form `["alpha", {beta: true, gamma: false}]` and object-form `{delta: true, epsilon: false}` bindings merge correctly; falsy keys excluded; component classes survive)
- vue-tsc --noEmit clean