### PR TITLE
🔥 Kill the mobile tap highlight at the document root.

### DIFF
--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -265,6 +265,13 @@ html {
     font-size: 16px;
     scroll-behavior: smooth;
 
+    // Kill the mobile browsers' default tap highlight (the grey/blue flash
+    // on touch). Interactive elements draw their OWN pressed/hover states;
+    // the native highlight flashing whole containers (e.g. an entire
+    // minimap widget) reads as a bug, not feedback. Applied at the root so
+    // every consuming app inherits it once.
+    -webkit-tap-highlight-color: transparent;
+
     // Hide native scrollbar (using custom scrollbar component)
     &::-webkit-scrollbar {
         display: none;


### PR DESCRIPTION
## Problem (user field report, phone)

Tapping anywhere on the minimap (and other container-level interactive surfaces) flashes the ENTIRE widget blue — the mobile browsers' default tap highlight. Components draw their own pressed/hover states; the native highlight over whole containers reads as a bug.

## Fix

`-webkit-tap-highlight-color: transparent` once at the `html` root in the theme base — every consuming app inherits it. The minimap's whole-surface drag-seek stays by design (P34c: hold and drag to pan); only the spurious flash is gone.

## Verification

- vue-tsc clean; vitest 21 files / 219 tests pass.