### PR TITLE
🐛 Contain markdown renderer overflow on mobile and rescue unseparated tables.

### DIFF
--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -119,7 +119,7 @@
 
 .hk-md-table-wrap table {
   margin: 0;
-  min-width: 24rem;
+  min-width: fit-content;
 }
 
 .hk-markdown th,

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -3,10 +3,20 @@
   line-height: 1.7;
   color: var(--hi-color-text-primary, #c9d1d9);
   position: relative;
+  /* Mobile containment: the renderer often lives inside flex/grid cards.
+     Without min-width:0 a flex child refuses to shrink below its content's
+     intrinsic width, so one long token (URL, JSON string, unbroken CJK-less
+     identifier) blows the card past the viewport. */
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .hk-markdown-body {
   min-height: 120px;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .hk-markdown h1,
@@ -95,6 +105,21 @@
   width: 100%;
   border-collapse: collapse;
   margin: 0.75em 0;
+}
+
+/* Wide tables scroll horizontally inside the renderer instead of stretching
+   the card beyond the viewport. The wrapper div is emitted by the marked
+   table renderer (see HkMarkdownRenderer.tsx). */
+.hk-md-table-wrap {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0.75em 0;
+}
+
+.hk-md-table-wrap table {
+  margin: 0;
+  min-width: 24rem;
 }
 
 .hk-markdown th,

--- a/packages/vue/src/components/HkMarkdownRenderer.tsx
+++ b/packages/vue/src/components/HkMarkdownRenderer.tsx
@@ -53,6 +53,45 @@ function renderPlain(content: string): string {
   return `<pre class="hk-md-plain">${escaped}</pre>`;
 }
 
+/**
+ * Best-effort rescue of GFM tables that follow a non-blank line.
+ *
+ * marked (CommonMark) only recognizes a table when the delimiter row
+ * (`| --- |`) is separated from the preceding block by a blank line. Agent
+ * reports frequently paste a table directly after a prose sentence or a JSON
+ * fragment, which makes marked emit the raw `|` lines as a paragraph. This
+ * pre-pass inserts a blank line between a non-table, non-blank line and a
+ * following line that starts a table (contains `|` and the next line looks
+ * like a delimiter row).
+ */
+function rescueTables(content: string): string {
+  const lines = content.split("\n");
+  const isTableish = (s: string) => {
+    const t = s.trim();
+    return t.includes("|") && (t.startsWith("|") || t.endsWith("|"));
+  };
+  const isDelimiter = (s: string) =>
+    /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(s);
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const prev = out.length ? out[out.length - 1] : "";
+    const prevIsTable = isTableish(prev);
+    const curIsTable = isTableish(lines[i]);
+    const nextIsDelimiter =
+      i + 1 < lines.length && isDelimiter(lines[i + 1]);
+    if (
+      prev.trim() !== "" &&
+      !prevIsTable &&
+      curIsTable &&
+      nextIsDelimiter
+    ) {
+      out.push("");
+    }
+    out.push(lines[i]);
+  }
+  return out.join("\n");
+}
+
 async function renderMarkdown(content: string): Promise<string> {
   const [marked, DOMPurify] = await Promise.all([ensureMarked(), ensureDOMPurify()]);
 
@@ -69,9 +108,19 @@ async function renderMarkdown(content: string): Promise<string> {
     return `<div class="hk-md-code">${langLabel}<pre><code class="hljs${langAttr}">${highlighted}</code></pre></div>`;
   };
 
-  const raw = marked.parse(content, { renderer, async: false });
-  const html = typeof raw === "string" ? raw : "";
-  return DOMPurify.sanitize(html);
+  // Wrap tables in a horizontally scrollable container so a wide table
+  // scrolls inside the card instead of stretching the card past the
+  // viewport on mobile. Done as post-processing on the sanitized HTML
+  // rather than a renderer override: marked 18's table renderer receives
+  // structured cell tokens, and re-implementing cell rendering (inline
+  // tokens, alignment) would drift from upstream.
+  const raw = marked.parse(rescueTables(content), { renderer, async: false });
+  const parsed = typeof raw === "string" ? raw : "";
+  const html = DOMPurify.sanitize(parsed);
+  const wrapped = html
+    .replace(/<table>/g, '<div class="hk-md-table-wrap"><table>')
+    .replace(/<\/table>/g, "</table></div>");
+  return wrapped;
 }
 
 export default defineComponent({

--- a/packages/vue/src/components/HkMarkdownRenderer.tsx
+++ b/packages/vue/src/components/HkMarkdownRenderer.tsx
@@ -72,11 +72,38 @@ function rescueTables(content: string): string {
   };
   const isDelimiter = (s: string) =>
     /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(s);
+  const isFence = (s: string) => /^\s*(`{3,}|~{3,})/.test(s);
   const out: string[] = [];
+  // Track fenced code blocks: table-shaped lines inside a fence are literal
+  // content and must never be touched.
+  let fenceOpen = false;
+  let fenceMarker = "";
   for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (fenceOpen) {
+      out.push(line);
+      // Closing fence: same character, at least as many, nothing after.
+      if (line.trimStart().startsWith(fenceMarker[0].repeat(3))) {
+        const t = line.trim();
+        if (
+          (fenceMarker[0] === "`" && /^`{3,}`*\s*$/.test(t)) ||
+          (fenceMarker[0] === "~" && /^~{3,}~*\s*$/.test(t))
+        ) {
+          fenceOpen = false;
+          fenceMarker = "";
+        }
+      }
+      continue;
+    }
+    if (isFence(line)) {
+      fenceMarker = line.trimStart().slice(0, 3);
+      fenceOpen = true;
+      out.push(line);
+      continue;
+    }
     const prev = out.length ? out[out.length - 1] : "";
     const prevIsTable = isTableish(prev);
-    const curIsTable = isTableish(lines[i]);
+    const curIsTable = isTableish(line);
     const nextIsDelimiter =
       i + 1 < lines.length && isDelimiter(lines[i + 1]);
     if (
@@ -87,7 +114,7 @@ function rescueTables(content: string): string {
     ) {
       out.push("");
     }
-    out.push(lines[i]);
+    out.push(line);
   }
   return out.join("\n");
 }


### PR DESCRIPTION
## Problem (reported from dev.celestia.world mobile)
1. Report cards exceeded the phone viewport width — the markdown renderer had no `min-width: 0`/`overflow-wrap` containment, so a single long token (URL, JSON fragment leaked from agent reports) stretched its flex card past the screen.
2. Tables stayed as raw `| --- |` text — (a) agent reports often paste a GFM table directly after a prose line (no blank line), which marked emits as a plain paragraph; (b) even when parsed, a wide table stretched the card instead of scrolling.

## Changes (`HkMarkdownRenderer`)
- Container: `min-width: 0; max-width: 100%; overflow-wrap: break-word; word-break: break-word` (+ body inheritance) — the flex-child shrink fix.
- `rescueTables()` pre-pass: inserts the missing blank line when a table header + delimiter row follows a non-table line, so marked's GFM tokenizer recognizes it.
- Table wrap: post-processes the sanitized HTML to wrap every `<table>` in `.hk-md-table-wrap` (horizontal scroll container, `-webkit-overflow-scrolling: touch`). Post-processing instead of a renderer override because marked 18's table renderer receives structured cell tokens; re-implementing cell rendering would drift from upstream.
- Wide-table CSS: wrapper scrolls; inner table keeps a `min-width` so narrow tables still look like tables.

## Consumers
Every `HMarkdownRenderer` use site benefits automatically — shittim-chest report cards + report detail modal (both render through this component).

## Verification
- `vue-tsc --noEmit` (packages/vue): 0 errors
- Manual table-rescue unit verified against the raw agent-report sample (JSON envelope + table adjacency) from the live incident