### PR TITLE
✨ Add the unified HkLabel shell to every control label position.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -95,8 +95,3 @@
 .hk-checkbox[data-animating] .hk-checkbox-box {
   will-change: border-color, background;
 }
-
-.hk-checkbox-label-text {
-  font-size: var(--hi-text-sm, 0.8125rem);
-  color: var(--hi-color-text-primary, #333);
-}

--- a/packages/vue/src/components/HkCheckbox.tsx
+++ b/packages/vue/src/components/HkCheckbox.tsx
@@ -1,6 +1,7 @@
 import { Check } from "lucide-vue-next";
 import { defineComponent, ref, type PropType } from "vue";
 
+import HkLabel from "./HkLabel";
 import "./HkCheckbox.scss";
 
 export default defineComponent({
@@ -75,9 +76,9 @@ export default defineComponent({
             ) : null}
           </span>
           {props.label || slots.default ? (
-            <span class="hk-checkbox-label-text">
+            <HkLabel size={props.size}>
               {slots.default?.() ?? props.label}
-            </span>
+            </HkLabel>
           ) : null}
         </label>
       );

--- a/packages/vue/src/components/HkLabel.scss
+++ b/packages/vue/src/components/HkLabel.scss
@@ -1,0 +1,34 @@
+/* HkLabel — unified label shell for control label positions.
+ *
+ * One typography source for every control label (checkbox / radio / switch /
+ * …): plain text via the `text` prop or rich content via the default slot
+ * both render inside this shell, so mixed plain/rich label lists read with
+ * the same font. Links inside a label are the one sanctioned rich-text
+ * element: they get the primary accent so a clickable agreement link is
+ * obviously interactive without any consumer-side styling. */
+
+.hk-label {
+  display: inline;
+  font-size: var(--hi-text-base, 0.875rem);
+  line-height: 1.5;
+  color: var(--hi-color-text-primary, #333);
+
+  &.hk-label-sm {
+    font-size: var(--hi-text-xs, 0.75rem);
+  }
+
+  &.hk-label-lg {
+    font-size: var(--hi-text-md, 1rem);
+  }
+
+  a {
+    color: var(--hi-color-primary, #58a6ff);
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/packages/vue/src/components/HkLabel.test.tsx
+++ b/packages/vue/src/components/HkLabel.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import HkLabel from "./HkLabel";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkLabel", () => {
+  it("renders plain text through the text prop inside the label shell", () => {
+    const c = mount(h(HkLabel, { text: "Remember login" }));
+    const label = c.querySelector(".hk-label") as HTMLElement;
+    expect(label).not.toBeNull();
+    expect(label.textContent).toBe("Remember login");
+    expect(label.className).toContain("hk-label-md");
+  });
+
+  it("renders rich content through the default slot", () => {
+    const c = mount(
+      h(HkLabel, () => [
+        "I have read and agree to the ",
+        h("a", { onClick: () => {} }, "User Agreement"),
+      ]),
+    );
+    const label = c.querySelector(".hk-label") as HTMLElement;
+    expect(label.textContent).toBe("I have read and agree to the User Agreement");
+    expect(label.querySelector("a")).not.toBeNull();
+  });
+
+  it("prefers the default slot over the text prop", () => {
+    const c = mount(
+      h(HkLabel, { text: "plain" }, () => ["rich"]),
+    );
+    expect((c.querySelector(".hk-label") as HTMLElement).textContent).toBe("rich");
+  });
+
+  it("maps the size prop to a shell modifier", () => {
+    const c = mount(h(HkLabel, { text: "x", size: "sm" }));
+    expect((c.querySelector(".hk-label") as HTMLElement).className).toContain("hk-label-sm");
+  });
+
+  it("renders nothing when there is no text and no slot", () => {
+    const c = mount(h(HkLabel));
+    expect(c.querySelector(".hk-label")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkLabel.tsx
+++ b/packages/vue/src/components/HkLabel.tsx
@@ -1,0 +1,45 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkLabel.scss";
+
+/**
+ * HkLabel — the unified label/text shell for every control that shows a
+ * label position (checkbox, radio, switch, …).
+ *
+ * Plain text goes through the `text` prop and is rendered as plain text
+ * inside the label shell. Rich content (clickable links inside an agreement
+ * line, icons, mixed emphasis, …) goes through the default slot — the shell
+ * and its typography stay identical either way, so a plain "Remember login"
+ * and an agreement line with a clickable link read with the same font.
+ *
+ * ```tsx
+ * <HkLabel text="Remember login" />
+ * <HkLabel size="sm">
+ *   I have read and agree to the{" "}
+ *   <a onClick={openProtocol}>User Agreement</a>
+ * </HkLabel>
+ * ```
+ */
+export default defineComponent({
+  name: "HkLabel",
+  props: {
+    /** Plain-text label; rendered as-is (escaped) inside the label shell. */
+    text: { type: String, default: undefined },
+    size: {
+      type: String as PropType<"sm" | "md" | "lg">,
+      default: "md",
+    },
+  },
+  setup(props, { slots }) {
+    return () => {
+      const hasText = !!props.text;
+      const hasSlot = !!slots.default;
+      if (!hasText && !hasSlot) return null;
+      return (
+        <span class={["hk-label", `hk-label-${props.size}`]}>
+          {hasSlot ? slots.default!() : props.text}
+        </span>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkRadio.scss
+++ b/packages/vue/src/components/HkRadio.scss
@@ -102,18 +102,3 @@
     height: 5px;
   }
 }
-
-/* --- Label --- */
-
-.hk-radio-label-text {
-  font-size: 0.875rem;
-  color: var(--hi-color-text-primary);
-
-  [data-size="sm"] & {
-    font-size: 0.75rem;
-  }
-
-  [data-size="lg"] & {
-    font-size: 1rem;
-  }
-}

--- a/packages/vue/src/components/HkRadio.tsx
+++ b/packages/vue/src/components/HkRadio.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, type PropType } from "vue";
+import HkLabel from "./HkLabel";
 import "./HkRadio.scss";
 
 export interface HkRadioOption {
@@ -31,7 +32,7 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_value: string | number) => true,
   },
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     return () => (
       <div
         class={[
@@ -65,7 +66,9 @@ export default defineComponent({
                 />
                 {isSelected && <span class="hk-radio-dot" />}
               </span>
-              <span class="hk-radio-label-text">{opt.label}</span>
+              <HkLabel size={props.size}>
+                {slots.label?.({ option: opt }) ?? opt.label}
+              </HkLabel>
             </label>
           );
         })}

--- a/packages/vue/src/components/HkSwitch.scss
+++ b/packages/vue/src/components/HkSwitch.scss
@@ -140,18 +140,3 @@
     color: var(--hi-color-text-on-primary, #fff);
   }
 }
-
-/* --- Label --- */
-
-.hk-switch-label-text {
-  font-size: 0.875rem;
-  color: var(--hi-color-text-primary);
-
-  .hk-switch-sm & {
-    font-size: 0.75rem;
-  }
-
-  .hk-switch-lg & {
-    font-size: 1rem;
-  }
-}

--- a/packages/vue/src/components/HkSwitch.tsx
+++ b/packages/vue/src/components/HkSwitch.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, type PropType } from "vue";
+import HkLabel from "./HkLabel";
 import "./HkSwitch.scss";
 
 export default defineComponent({
@@ -21,7 +22,7 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_value: boolean) => true,
   },
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     function toggle() {
       if (props.disabled) return;
       emit("update:modelValue", !props.modelValue);
@@ -63,8 +64,10 @@ export default defineComponent({
             </span>
           ) : null}
         </span>
-        {props.label ? (
-          <span class="hk-switch-label-text">{props.label}</span>
+        {props.label || slots.default ? (
+          <HkLabel size={props.size}>
+            {slots.default?.() ?? props.label}
+          </HkLabel>
         ) : null}
       </label>
     );

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -17,6 +17,7 @@ export { default as HIconButton } from "./components/HkIconButton";
 export { default as HInput } from "./components/HkInput";
 export { default as HPlaceholderMarquee, type PlaceholderVariant } from "./components/HkPlaceholderMarquee";
 export { default as HKbd } from "./components/HkKbd";
+export { default as HLabel } from "./components/HkLabel";
 export { default as HListTransition } from "./components/HkListTransition";
 export { default as HMarkdownRenderer } from "./components/HkMarkdownRenderer";
 export { default as HModal } from "./components/HkModal";

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -603,13 +603,6 @@
   color: var(--hi-color-muted, #666);
 }
 
-.s-auth-options {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: calc(-1 * var(--space-4, 0.25rem));
-}
-
 .s-auth-protocol-link {
   color: var(--hi-color-primary, #58a6ff);
   cursor: pointer;


### PR DESCRIPTION
Unify every control label position (checkbox / radio / switch) on one upstream label shell.

## What

- **New `HLabel` component** (`HkLabel`): renders plain text via the `text` prop inside a label shell, or rich content (clickable agreement links, icons, mixed emphasis) via the default slot. Links inside the shell are styled in the primary accent (500 weight, no underline, hover underline) so a clickable agreement link is obviously interactive without any consumer-side styling.
- **HkCheckbox / HkRadio / HkSwitch** now render their labels through HkLabel with size mapping sm/md/lg → 0.75/0.875/1rem; HkSwitch gains default-slot label support; HkRadio gains a `label` scoped slot (`{ option }`) for rich option labels.
- Per-component `.hk-*-label-text` rules removed (one typography source now). The dead `.s-auth-options` rule is dropped (its only consumer switched to the plain checkbox).
- `HLabel` exported; version 0.4.23 → 0.4.24.

## Consumer-visible deltas

- HkCheckbox md label typography aligns 0.8125rem → 0.875rem (intentional unification with radio/switch; sm/lg now scale instead of staying flat).
- Everything else renders identically for existing plain-`label` usages.

## Verify

- `vue-tsc --noEmit` exit 0; `vitest run` 239/239 (HkLabel suite 5/5); sass compiles all touched files.
- Follow-up chest PR consumes `HLabel`-backed checkboxes in the auth views (agreement link inside the checkbox label).