### PR TITLE
✨ Mirror actionable toasts to OS notifications while the page is hidden.

### DIFF
--- a/packages/vue/src/composables/messaging/browserTransport.ts
+++ b/packages/vue/src/composables/messaging/browserTransport.ts
@@ -1,5 +1,5 @@
 import { defaultDurationFor, defaultRequireInteraction, type MessagePayload, type MessageTransport } from "./types";
-import { scheduleCronAfter } from "@celestia-island/hikari";
+import { scheduleCronAfter } from "../../runtime/cronBus";
 
 /**
  * Browser Notifications API transport.
@@ -77,6 +77,40 @@ export const browserTransport: MessageTransport = {
     }
   },
 };
+
+/**
+ * Mirror an in-app toast to the OS notification surface when the page is
+ * hidden and the severity is actionable off-page (P59-W5 unification).
+ * Shared by useToast's push path so DIRECT toast callers get the same
+ * hidden-page behavior as useMessaging callers — one routing policy for
+ * both notification entry points. Silently no-ops when permission is
+ * missing or the page is visible (the toast itself is the surface then).
+ */
+export function mirrorToBrowserIfHidden(
+  severity: "error" | "success" | "warning" | "info" | "loading",
+  message: string,
+  duration?: number,
+  copyable?: boolean,
+): void {
+  if (typeof document !== "undefined" && !document.hidden) return;
+  if (
+    severity !== "error" &&
+    severity !== "warning" &&
+    severity !== "success"
+  ) {
+    return; // info/loading pings don't earn an OS interruption
+  }
+  if (!browserTransport.available()) return;
+  browserTransport.send({
+    id: -1,
+    severity,
+    message,
+    duration,
+    copyable,
+    timestamp: Date.now(),
+    pageHidden: true,
+  });
+}
 
 /**
  * Request browser notification permission. Must be invoked from a user

--- a/packages/vue/src/composables/messaging/toastMirror.test.ts
+++ b/packages/vue/src/composables/messaging/toastMirror.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useToast } from "../../runtime/useToast";
+import { mirrorToBrowserIfHidden } from "./browserTransport";
+import { toastTransport } from "./toastTransport";
+
+type NotificationCtor = new (title: string, options?: NotificationOptions) => Notification;
+
+class FakeNotification implements Notification {
+  static instances: FakeNotification[] = [];
+  static permission: NotificationPermission = "granted";
+  onclick: ((this: Notification, ev: Event) => void) | null = null;
+  onclose: ((this: Notification, ev: Event) => void) | null = null;
+  onerror: ((this: Notification, ev: Event) => void) | null = null;
+  onshow: ((this: Notification, ev: Event) => void) | null = null;
+  tag: string;
+  title: string;
+  body: string | undefined;
+  constructor(title: string, options?: NotificationOptions & { body?: string; requireInteraction?: boolean }) {
+    this.title = title;
+    this.tag = options?.tag ?? "";
+    this.body = options?.body;
+    FakeNotification.instances.push(this);
+  }
+  close(): void { /* recorded by instances list */ }
+  addEventListener(): void { /* noop */ }
+  removeEventListener(): void { /* noop */
+  }
+  dispatchEvent(): boolean { return false; }
+}
+
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", { value: hidden, configurable: true });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("toast → browser mirroring (P59-W5)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeNotification.instances = [];
+    FakeNotification.permission = "granted";
+    vi.stubGlobal("Notification", FakeNotification as unknown as NotificationCtor);
+    setHidden(false);
+    const toast = useToast();
+    for (const t of [...toast.toasts]) toast.remove(t.id);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    setHidden(false);
+  });
+
+  it("direct toast errors mirror to a browser notification while hidden", () => {
+    setHidden(true);
+    const toast = useToast();
+    toast.error("backend unreachable");
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0]!.title).toContain("backend unreachable");
+  });
+
+  it("visible pages never mirror (the toast is the surface)", () => {
+    const toast = useToast();
+    toast.error("backend unreachable");
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(toast.toasts.length).toBeGreaterThan(0);
+  });
+
+  it("info/loading severities never mirror", () => {
+    setHidden(true);
+    const toast = useToast();
+    toast.info("tick");
+    toast.loading("loading…");
+    expect(FakeNotification.instances).toHaveLength(0);
+  });
+
+  it("messaging-routed payloads do not double-notify while hidden", async () => {
+    setHidden(true);
+    // Full router path: useMessaging fires toast + browser transports for
+    // actionable payloads when hidden; the toast transport must not mirror
+    // a second notification on top of the router's browser fire.
+    const { useMessaging } = await import("./index");
+    const msg = useMessaging();
+    msg.error("routed error");
+    // One notification: the router's browser-transport fire. A mirrored
+    // copy from the toast push would make this 2.
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0]!.title).toContain("routed error");
+    // And the toast still landed (the returning user sees it).
+    const toast = useToast();
+    expect(toast.toasts.some((t) => t.messages.some((m) => m.text === "routed error"))).toBe(true);
+  });
+
+  it("mirror no-ops without granted permission", () => {
+    FakeNotification.permission = "denied";
+    setHidden(true);
+    const toast = useToast();
+    toast.error("backend unreachable");
+    expect(FakeNotification.instances).toHaveLength(0);
+  });
+
+  it("mirrorToBrowserIfHidden is a silent no-op while visible", () => {
+    mirrorToBrowserIfHidden("error", "x", 1000, true);
+    expect(FakeNotification.instances).toHaveLength(0);
+  });
+});

--- a/packages/vue/src/composables/messaging/toastTransport.ts
+++ b/packages/vue/src/composables/messaging/toastTransport.ts
@@ -1,4 +1,4 @@
-import { useToast } from "@celestia-island/hikari";
+import { pushViaTransport } from "../../runtime/useToast";
 import type { MessagePayload, MessageTransport } from "./types";
 
 /**
@@ -16,9 +16,7 @@ export const toastTransport: MessageTransport = {
   name: "toast",
   available: () => true,
   send(payload: MessagePayload) {
-    const toast = useToast();
-    toast.show(payload.message, {
-      type: payload.severity,
+    pushViaTransport(payload.severity, payload.message, {
       duration: payload.duration,
       copyable: payload.copyable,
     });

--- a/packages/vue/src/runtime/useToast.ts
+++ b/packages/vue/src/runtime/useToast.ts
@@ -1,6 +1,7 @@
 import { reactive } from "vue";
 
 import { scheduleCronAfter, type CronHandle } from "./cronBus";
+import { mirrorToBrowserIfHidden } from "../composables/messaging/browserTransport";
 
 export type ToastType = "error" | "success" | "warning" | "info" | "loading";
 
@@ -38,6 +39,11 @@ const state = reactive<{ toasts: ToastItem[] }>({ toasts: [] });
 let nextSlotId = 0;
 let nextMsgId = 0;
 
+/** Re-entrancy guard: the messaging router already covers the browser
+ *  surface for payloads it routed, so its toast-transport calls must not
+ *  mirror again (double notification). */
+let suppressMirror = false;
+
 const timers = new Map<number, CronHandle>();
 
 function clearTimer(slotId: number) {
@@ -73,6 +79,7 @@ function push(
   text: string,
   options: { duration?: number; copyable?: boolean } = {},
 ): number {
+  const mirror = !suppressMirror;
   let slot = findSlot(type);
   if (!slot) {
     slot = {
@@ -89,7 +96,30 @@ function push(
   const msgId = ++nextMsgId;
   slot.messages.push({ id: msgId, text });
   scheduleAutoDismiss(slot);
+  // Unified visibility behavior (P59-W5): every actionable toast — not just
+  // the ones that went through useMessaging — also lands as an OS
+  // notification while the page is hidden, so direct useToast callers
+  // (error handlers, RPC layers) are no longer silently dropped when the
+  // user is in another tab. No-op without granted permission.
+  if (mirror) {
+    mirrorToBrowserIfHidden(type, text, slot.duration, slot.copyable);
+  }
   return msgId;
+}
+
+/** Internal: wrap a push in the mirror-suppression guard (used by the
+ *  messaging toast transport so router-routed payloads don't double-fire). */
+export function pushViaTransport(
+  type: ToastType,
+  text: string,
+  options: { duration?: number; copyable?: boolean } = {},
+): number {
+  suppressMirror = true;
+  try {
+    return push(type, text, options);
+  } finally {
+    suppressMirror = false;
+  }
 }
 
 export function useToast() {


### PR DESCRIPTION
## Summary
P59-W5 — closes the scan's "toast vs messaging" unification item at the right layer: **one visibility policy for both notification entry points**.

Direct `useToast` callers (chest's error handlers, the RPC layer) were silently dropped when the user was in another tab — only `useMessaging` callers got browser-notification routing. Now `push()` mirrors actionable severities (error/warning/success) through the browser transport while the page is hidden, with the same permission gate the router uses:

- visible page → toast only (unchanged); hidden + permission granted + actionable → toast + OS notification (identical to the messaging path).
- messaging-routed payloads still fire exactly one notification: the toast transport pushes through a suppression guard, so the router's own browser fire is never duplicated.
- `browserTransport`'s cron import goes straight to the runtime bus instead of the self-barrel, breaking the new useToast→browserTransport cycle.

## Test plan
- `vue-tsc` 0; `vitest` **256/256** (6 new: hidden-mirror, visible-no-mirror, info/loading-never-mirror, router-no-double-fire + toast-still-lands, permission-denied no-op, visible helper no-op).