### PR TITLE
✨ Add a below slot to the auth cards for in-card alternate sign-in methods.

### DIFF
--- a/packages/vue/src/components/HkAuthCard.tsx
+++ b/packages/vue/src/components/HkAuthCard.tsx
@@ -30,6 +30,11 @@ export const HkAuthCard = defineComponent({
             {slots.footer()}
           </div>
         )}
+        {slots.below && (
+          <div class="s-auth-below">
+            {slots.below()}
+          </div>
+        )}
       </div>
     );
   },

--- a/packages/vue/src/components/HkSignInCard.tsx
+++ b/packages/vue/src/components/HkSignInCard.tsx
@@ -30,6 +30,9 @@ import HkAuthSubmitButton from "./HkAuthSubmitButton";
  *   `hikari::signIn.usernamePlaceholder` locale when unset.
  * - `footer` slot — content below the submit button (remember-me,
  *   protocol links, …).
+ * - `below` slot — content at the very bottom INSIDE the card, after the
+ *   footer (alternate sign-in methods with a divider, …). Rendered inside
+ *   the card shell so it never escapes the card's width.
  *
  * ```tsx
  * <HSignInCard
@@ -148,6 +151,7 @@ export const HkSignInCard = defineComponent({
             </>
           ),
           footer: () => slots.footer?.(),
+          below: () => slots.below?.(),
         }}
       </HkAuthCard>
     );

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -603,6 +603,15 @@
   color: var(--hi-color-muted, #666);
 }
 
+/* Bottom-of-card extension point (HkAuthCard `below` slot): alternate
+   sign-in methods and similar flows stay INSIDE the card width. The footer
+   already carries the bottom inset, so this block only needs the side
+   padding to align with the footer's text column. */
+.s-auth-below {
+  padding: 0 var(--space-32, 2rem) var(--space-24, 1.5rem);
+  margin-top: calc(-1 * var(--space-8, 0.5rem));
+}
+
 .s-auth-protocol-link {
   color: var(--hi-color-primary, #58a6ff);
   cursor: pointer;


### PR DESCRIPTION
Extends HkAuthCard/HkSignInCard with a `below` slot rendered at the very bottom INSIDE the card (after the footer). Alternate sign-in methods (third-party redirect logins) can now live inside the card instead of escaping it — the chest login page currently renders them as a sibling of the card, which the auth layout places beside/outside it.

- HkAuthCard renders `below` in a new `.s-auth-below` block (side padding aligned with the footer column).
- HkSignInCard forwards the slot; existing consumers are unaffected (slot is optional).
- Local verify: vue-tsc clean.