### PR TITLE
🔧 Route component timers and overlays through the shared animation, interval and overlay contexts.

### DIFF
--- a/packages/vue/src/components/HkCheckbox.tsx
+++ b/packages/vue/src/components/HkCheckbox.tsx
@@ -1,6 +1,7 @@
 import { Check } from "lucide-vue-next";
-import { defineComponent, ref, type PropType } from "vue";
+import { defineComponent, onUnmounted, ref, type PropType } from "vue";
 
+import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
 import HkLabel from "./HkLabel";
 import "./HkCheckbox.scss";
 
@@ -24,12 +25,16 @@ export default defineComponent({
   },
   setup(props, { emit, slots }) {
     const animating = ref(false);
-    let animTimer: ReturnType<typeof setTimeout> | null = null;
+    let animTimer: CronHandle | null = null;
 
     function markActive() {
       animating.value = true;
-      if (animTimer) clearTimeout(animTimer);
-      animTimer = setTimeout(() => {
+      // cronBus one-shot (not the rAF-driven animationBus one): the
+      // flag must always clear, even while the animation bus is parked
+      // under reduced motion.
+      animTimer?.disconnect();
+      animTimer = scheduleCronAfter(() => {
+        animTimer = null;
         animating.value = false;
       }, 300);
     }
@@ -39,6 +44,11 @@ export default defineComponent({
       emit("update:modelValue", (e.target as HTMLInputElement).checked);
       markActive();
     }
+
+    onUnmounted(() => {
+      animTimer?.disconnect();
+      animTimer = null;
+    });
 
     return () => {
       const inputType = props.type === "radio" ? "radio" : "checkbox";

--- a/packages/vue/src/components/HkColorPicker.tsx
+++ b/packages/vue/src/components/HkColorPicker.tsx
@@ -1,6 +1,7 @@
-import { computed, defineComponent, ref, type PropType } from "vue";
+import { computed, defineComponent, onBeforeUnmount, ref, watch, type PropType } from "vue";
 
 import { clampRgbToBands, hueDelta, rgbToHsl, wrapHue, type HueClamp } from "../theme/tokenGroups";
+import { useOverlay } from "../runtime/useOverlay";
 import HInput from "./HkInput";
 import HPopover from "./HkPopover";
 import "./HkColorPicker.scss";
@@ -122,6 +123,20 @@ export default defineComponent({
   setup(props, { emit }) {
     const isOpen = ref(false);
     const triggerRef = ref<HTMLElement>();
+
+    // Registered with the overlay registry so closeAll()/isOverlayOpen()
+    // see the open popout; the popover inside handles z-stacking via the
+    // popup manager.
+    const overlay = useOverlay({ name: "hk-color-picker" });
+
+    watch(isOpen, (open) => {
+      if (open) overlay.open();
+      else overlay.close();
+    });
+
+    onBeforeUnmount(() => {
+      overlay.close();
+    });
 
     const hex = computed(() => rgbToHex(props.r, props.g, props.b));
     const hexDisplay = computed(() => hex.value.replace(/^#/, ""));

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -1,7 +1,6 @@
 import {
   computed,
   defineComponent,
-  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -13,6 +12,7 @@ import {
 
 import { useI18n } from "../i18n/context";
 import "./HkDrawer.scss";
+import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 
@@ -46,6 +46,7 @@ export default defineComponent({
     const handle = ref<{ id: string; zIndex: number } | null>(null);
     const panelRef = ref<HTMLElement>();
     let unmounted = false;
+    let previouslyFocused: HTMLElement | null = null;
 
     const isVertical = computed(
       () => props.side === "left" || props.side === "right",
@@ -75,8 +76,17 @@ export default defineComponent({
       if (props.closable) close();
     }
 
+    function onDrawerAfterEnter() {
+      const el = panelRef.value;
+      if (el) focusFirst(el);
+    }
+
     function onDrawerAfterLeave() {
       cleanup();
+      if (previouslyFocused) {
+        previouslyFocused.focus();
+        previouslyFocused = null;
+      }
       emit("afterLeave");
     }
 
@@ -95,9 +105,7 @@ export default defineComponent({
           cleanup();
           handle.value = manager.register("drawer", true);
           overlayHook.open();
-          nextTick(() => {
-            panelRef.value?.focus();
-          });
+          previouslyFocused = document.activeElement as HTMLElement | null;
         }
       },
       { immediate: true },
@@ -123,7 +131,7 @@ export default defineComponent({
             />
           ) : null}
         </Transition>
-        <Transition name={`hk-drawer-${props.side}`} appear onAfterLeave={onDrawerAfterLeave}>
+        <Transition name={`hk-drawer-${props.side}`} appear onAfterEnter={onDrawerAfterEnter} onAfterLeave={onDrawerAfterLeave}>
           {props.modelValue ? (
             <div
               ref={panelRef}
@@ -135,6 +143,7 @@ export default defineComponent({
               tabindex={-1}
               onKeydown={(e: KeyboardEvent) => {
                 if (e.key === "Escape") onEscape();
+                else if (e.key === "Tab" && panelRef.value) trapFocus(panelRef.value, e);
               }}
             >
               {props.title || slots.header ? (

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -153,6 +153,15 @@ export default defineComponent({
       emit("update:open", false);
     }
 
+    /** Escape collapses the whole cascade — mirrors HkPopover's close-on-
+     *  Escape so keyboard users can dismiss the menu without clicking. */
+    function onMenuKeydown(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeAll();
+      }
+    }
+
     function onPopState(e: PopStateEvent): void {
       if (suppressPop > 0) {
         // Our own restore traversal landing — not a user back gesture.
@@ -586,7 +595,11 @@ export default defineComponent({
         ];
         return (
           <Teleport to="body">
-            <div class="hk-menu-mobile-stack" style={{ zIndex: menuZ.value }}>{sheets}</div>
+            <div
+              class="hk-menu-mobile-stack"
+              style={{ zIndex: menuZ.value }}
+              onKeydown={onMenuKeydown}
+            >{sheets}</div>
           </Teleport>
         );
       }
@@ -609,7 +622,11 @@ export default defineComponent({
       }
       return (
         <Teleport to="body">
-          <div class="hk-menu-desktop" style={{ zIndex: menuZ.value }}>
+          <div
+            class="hk-menu-desktop"
+            style={{ zIndex: menuZ.value }}
+            onKeydown={onMenuKeydown}
+          >
             <div class="hk-menu-backdrop" onClick={() => closeAll()} />
             {panels}
           </div>

--- a/packages/vue/src/components/HkNumberInput.tsx
+++ b/packages/vue/src/components/HkNumberInput.tsx
@@ -1,4 +1,5 @@
 import { computed, defineComponent, onUnmounted, ref, type PropType } from "vue";
+import { scheduleAfter, scheduleEvery, type AnimationHandle } from "../runtime/animationBus";
 import "./HkNumberInput.scss";
 
 export default defineComponent({
@@ -19,8 +20,8 @@ export default defineComponent({
     "update:modelValue": (_value: number) => true,
   },
   setup(props, { emit, slots }) {
-    let holdInterval: ReturnType<typeof setInterval> | null = null;
-    let holdTimeout: ReturnType<typeof setTimeout> | null = null;
+    let holdDelay: AnimationHandle | null = null;
+    let holdRepeat: AnimationHandle | null = null;
     const inputRef = ref<HTMLInputElement | null>(null);
 
     const canIncrement = computed(() =>
@@ -54,8 +55,12 @@ export default defineComponent({
 
     function startHold(dir: "up" | "down") {
       stopHold();
-      holdTimeout = setTimeout(() => {
-        holdInterval = setInterval(() => {
+      // 300ms press threshold, then a 50ms repeat — both on the shared
+      // animation bus so the hold cadence parks with the reduced-motion
+      // switch like every other JS-driven animation.
+      holdDelay = scheduleAfter(() => {
+        holdDelay = null;
+        holdRepeat = scheduleEvery(() => {
           if (dir === "up") increment();
           else decrement();
         }, 50);
@@ -63,10 +68,10 @@ export default defineComponent({
     }
 
     function stopHold() {
-      if (holdTimeout) clearTimeout(holdTimeout);
-      if (holdInterval) clearInterval(holdInterval);
-      holdTimeout = null;
-      holdInterval = null;
+      holdDelay?.disconnect();
+      holdDelay = null;
+      holdRepeat?.disconnect();
+      holdRepeat = null;
     }
 
     onUnmounted(stopHold);

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -10,6 +10,10 @@ import {
 
 import { useI18n } from "../i18n/context";
 
+import { onFrame, onceFrame, type AnimationHandle } from "../runtime/animationBus";
+import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
+import { scheduleInterval, type IntervalHandle } from "../runtime/intervalBus";
+
 import HListTransition from "./HkListTransition";
 import { HkPlaceholderMarquee, type PlaceholderVariant } from "./HkPlaceholderMarquee";
 import "./HkPasswordInput.scss";
@@ -193,7 +197,6 @@ export default defineComponent({
     rebuildGrid(11);
 
     const ripples: Ripple[] = [];
-    let rafId: number | null = null;
     let ro: ResizeObserver | null = null;
 
     function syncColor() {
@@ -306,29 +309,22 @@ export default defineComponent({
       }
     }
 
-    let running = false;
-    let lastTime = 0;
-
-    function loop(ts: number) {
-      if (!lastTime) lastTime = ts;
-      const dt = Math.min(0.1, (ts - lastTime) / 1000);
-      lastTime = ts;
-      draw(dt);
-      rafId = requestAnimationFrame(loop);
-    }
+    let loopHandle: AnimationHandle | null = null;
 
     function startLoop() {
-      if (running) return;
-      running = true;
-      loop(performance.now());
+      if (loopHandle) return;
+      // The ripple canvas runs on the shared animation bus at "normal"
+      // priority so the reduced-motion switch parks it like every other
+      // JS-driven animation. The draw callback clamps the delta exactly
+      // like the old self-scheduling rAF loop did.
+      loopHandle = onFrame((ctx) => {
+        draw(Math.min(0.1, ctx.delta));
+      }, "normal");
     }
 
     function stopLoop() {
-      running = false;
-      if (rafId != null) {
-        cancelAnimationFrame(rafId);
-        rafId = null;
-      }
+      loopHandle?.disconnect();
+      loopHandle = null;
     }
 
     function kickRipple() {
@@ -341,13 +337,22 @@ export default defineComponent({
       inputRef.value?.focus();
     }
 
+    let flashHandle: CronHandle | null = null;
+
     function flash() {
       const el = boxRef.value;
       if (!el) return;
       el.removeAttribute("data-flash");
       void el.offsetWidth;
       el.setAttribute("data-flash", "");
-      setTimeout(() => el.removeAttribute("data-flash"), 320);
+      // cronBus one-shot (not the rAF-driven animationBus one) so the
+      // attribute cleanup always fires — the animation bus is parked
+      // under reduced motion and the flash must never stick.
+      flashHandle?.disconnect();
+      flashHandle = scheduleCronAfter(() => {
+        flashHandle = null;
+        el.removeAttribute("data-flash");
+      }, 320);
       kickRipple();
     }
 
@@ -408,7 +413,7 @@ export default defineComponent({
     function onKeydown(e: KeyboardEvent) {
       if (e.getModifierState) capsLock.value = e.getModifierState("CapsLock");
       if (e.ctrlKey || e.metaKey) {
-        requestAnimationFrame(() => checkSelection());
+        onceFrame(() => checkSelection());
       }
       if (
         e.key === "Enter" &&
@@ -480,7 +485,15 @@ export default defineComponent({
         !e.relatedTarget
       ) {
         const el = inputRef.value;
-        if (el) setTimeout(() => el.focus(), 0);
+        if (el) {
+          // cronBus one-shot: the reclaim must run even under reduced
+          // motion, where the animation bus is parked.
+          focusReclaimHandle?.disconnect();
+          focusReclaimHandle = scheduleCronAfter(() => {
+            focusReclaimHandle = null;
+            el.focus();
+          }, 0);
+        }
       }
       capsLock.value = false;
       fullWidthPaused.value = false;
@@ -571,10 +584,11 @@ export default defineComponent({
     }
 
     function onPointerup() {
-      requestAnimationFrame(() => checkSelection());
+      onceFrame(() => checkSelection());
     }
 
-    let autofillInterval: ReturnType<typeof setInterval> | null = null;
+    let autofillHandle: IntervalHandle | null = null;
+    let focusReclaimHandle: CronHandle | null = null;
 
     watch(() => props.modelValue, (v) => {
       // An external clear (or the blur hint's clear-and-focus) must drop
@@ -589,14 +603,21 @@ export default defineComponent({
       ro = new ResizeObserver(resize);
       if (boxRef.value) ro.observe(boxRef.value);
       startLoop();
-      autofillInterval = setInterval(() => {
+      // Visibility-aware poll (intervalBus parks while hidden, unlike a
+      // raw setInterval that keeps burning in background tabs).
+      autofillHandle = scheduleInterval(() => {
         if (!focused.value) checkAutofill();
       }, 500);
     });
 
     onUnmounted(() => {
       stopLoop();
-      if (autofillInterval) clearInterval(autofillInterval);
+      autofillHandle?.disconnect();
+      autofillHandle = null;
+      flashHandle?.disconnect();
+      flashHandle = null;
+      focusReclaimHandle?.disconnect();
+      focusReclaimHandle = null;
       if (ro) ro.disconnect();
       endReveal();
     });

--- a/packages/vue/src/components/HkPopupSelect.tsx
+++ b/packages/vue/src/components/HkPopupSelect.tsx
@@ -3,6 +3,7 @@ import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch, type 
 
 import HkPopover from "./HkPopover";
 import HkScrollContainer from "./HkScrollContainer";
+import { useOverlay } from "../runtime/useOverlay";
 import "./HkPopupSelect.scss";
 
 export interface HkPopupSelectOption {
@@ -49,17 +50,26 @@ export default defineComponent({
     const triggerRef = ref<HTMLElement>();
     const highlightedIndex = ref(-1);
 
+    // Registered with the overlay registry so closeAll()/isOverlayOpen()
+    // see the open popout. The popover inside handles z-stacking via the
+    // popup manager; the legacy module singleton (activePopupId) stays as
+    // the cross-instance close coordination.
+    const overlay = useOverlay({ name: "hk-popup-select" });
+
     watch(isOpen, (open) => {
       if (open) {
         activePopupId.value = instanceId;
+        overlay.open();
       } else {
         if (activePopupId.value === instanceId) {
           activePopupId.value = null;
         }
+        overlay.close();
       }
     });
 
     onBeforeUnmount(() => {
+      overlay.close();
       if (activePopupId.value === instanceId) {
         activePopupId.value = null;
       }

--- a/packages/vue/src/components/HkRollingNumber.test.ts
+++ b/packages/vue/src/components/HkRollingNumber.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+
+import HkRollingNumber from "./HkRollingNumber";
+
+interface Mounted {
+  model: ReturnType<typeof ref<string>>;
+  app: ReturnType<typeof createApp>;
+  container: HTMLElement;
+}
+
+const mounts: Mounted[] = [];
+
+function mountRollingNumber(initial: string): Mounted {
+  const model = ref(initial);
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render() {
+      return h(HkRollingNumber, { value: model.value });
+    },
+  });
+  app.mount(container);
+  const mounted = { model, app, container };
+  mounts.push(mounted);
+  return mounted;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkRollingNumber roll fallback", () => {
+  it("renders the value as plain chars when not animating", async () => {
+    const { container } = mountRollingNumber("42");
+    await nextTick();
+    expect(container.querySelector('[data-el="roll"]')).toBeNull();
+    expect(container.textContent).toBe("42");
+  });
+
+  it("commits the final digit via the fallback when animationend never fires", async () => {
+    vi.useFakeTimers();
+    const { container, model } = mountRollingNumber("5");
+    await nextTick();
+
+    model.value = "7";
+    await nextTick();
+
+    // Rolling: the slot shows both the old and the new digit.
+    const roll = container.querySelector('[data-el="roll"]');
+    expect(roll).not.toBeNull();
+    expect(container.querySelector('[data-el="digit"][data-variant="old"]')?.textContent).toBe("5");
+    expect(container.querySelector('[data-el="digit"][data-variant="new"]')?.textContent).toBe("7");
+
+    // Under the global animation switch the CSS roll is paused at 0% and
+    // animationend never fires — the ~350ms cronBus fallback commits.
+    vi.advanceTimersByTime(400);
+    await nextTick();
+
+    expect(container.querySelector('[data-el="roll"]')).toBeNull();
+    expect(container.textContent).toBe("7");
+  });
+
+  it("cancels the fallback when animationend does fire", async () => {
+    vi.useFakeTimers();
+    const { container, model } = mountRollingNumber("5");
+    await nextTick();
+
+    model.value = "7";
+    await nextTick();
+
+    const roll = container.querySelector('[data-el="roll"]') as HTMLElement | null;
+    expect(roll).not.toBeNull();
+    roll!.dispatchEvent(new AnimationEvent("animationend"));
+    await nextTick();
+
+    // Committed immediately by the event — the pending fallback must not
+    // double-commit (no error, state already final).
+    expect(container.querySelector('[data-el="roll"]')).toBeNull();
+    expect(container.textContent).toBe("7");
+
+    vi.advanceTimersByTime(400);
+    await nextTick();
+    expect(container.textContent).toBe("7");
+  });
+});

--- a/packages/vue/src/components/HkRollingNumber.tsx
+++ b/packages/vue/src/components/HkRollingNumber.tsx
@@ -1,6 +1,7 @@
 import { defineComponent, onBeforeUnmount, ref, watch, type PropType } from "vue";
 
 import { useReportedTransition } from "../composables/useReportedTransition";
+import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
 import "./HkRollingNumber.scss";
 
 export default defineComponent({
@@ -19,6 +20,38 @@ export default defineComponent({
 
     const ROLL_ANIM_MS = 100;
     const rollAnim = useReportedTransition(ROLL_ANIM_MS);
+
+    // Fallback commit: under the global animation switch
+    // (`html[data-css-animations="0"]`, driven by reduced motion /
+    // performance suspension) the roll keyframes are paused at 0% and
+    // `animationend` never fires — the OLD digit would stay visible
+    // forever. A cronBus one-shot always fires (the rAF-driven animation
+    // bus is parked in exactly that situation) and force-commits the
+    // final digit if `animationend` has not fired yet.
+    const ROLL_COMMIT_MS = 350;
+    const fallbacks = new Map<number, CronHandle>();
+
+    function cancelFallback(i: number) {
+      const h = fallbacks.get(i);
+      if (h) {
+        h.disconnect();
+        fallbacks.delete(i);
+      }
+    }
+
+    function armFallback(i: number) {
+      cancelFallback(i);
+      const handle = scheduleCronAfter(() => {
+        fallbacks.delete(i);
+        if (chars.value[i]) chars.value[i].animating = false;
+      }, ROLL_COMMIT_MS);
+      fallbacks.set(i, handle);
+    }
+
+    function cancelAllFallbacks() {
+      for (const h of fallbacks.values()) h.disconnect();
+      fallbacks.clear();
+    }
 
     function update(newStr: string): boolean {
       const newChars = newStr.split("");
@@ -43,6 +76,7 @@ export default defineComponent({
             prev,
             animating: true,
           };
+          armFallback(i);
           anyRolled = true;
         }
       }
@@ -56,9 +90,13 @@ export default defineComponent({
       },
       { immediate: true },
     );
-    onBeforeUnmount(stopWatch);
+    onBeforeUnmount(() => {
+      stopWatch();
+      cancelAllFallbacks();
+    });
 
     function onAnimEnd(i: number) {
+      cancelFallback(i);
       if (chars.value[i]) {
         chars.value[i].animating = false;
       }

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -12,6 +12,7 @@ import {
 
 import { ChevronDown, Search } from "lucide-vue-next";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import { useOverlay } from "../runtime/useOverlay";
 import "./HkSelect.scss";
 
 export interface HkSelectOption {
@@ -50,6 +51,11 @@ export default defineComponent({
     const handle = ref<PopupHandle | null>(null);
     const popoutZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
 
+    // Registered with the overlay registry too so closeAll()/isOverlayOpen()
+    // see the open popout (unique per-instance ids — multiple selects can
+    // share the "hk-select" name without corrupting the registry).
+    const overlay = useOverlay({ name: "hk-select" });
+
     function onDocumentClick(e: MouseEvent) {
       if (!isOpen.value) return;
       const target = e.target as Node;
@@ -61,6 +67,7 @@ export default defineComponent({
     watch(isOpen, (open) => {
       if (open) {
         handle.value = manager.register("dropdown", false);
+        overlay.open();
         document.addEventListener("click", onDocumentClick, true);
       } else {
         document.removeEventListener("click", onDocumentClick, true);
@@ -68,11 +75,13 @@ export default defineComponent({
           manager.unregister(handle.value.id);
           handle.value = null;
         }
+        overlay.close();
       }
     });
 
     onBeforeUnmount(() => {
       document.removeEventListener("click", onDocumentClick, true);
+      overlay.close();
       if (handle.value) {
         manager.unregister(handle.value.id);
         handle.value = null;

--- a/packages/vue/src/components/HkToast.tsx
+++ b/packages/vue/src/components/HkToast.tsx
@@ -1,10 +1,11 @@
 import { CircleX as XCircle, X } from "lucide-vue-next";
-import { computed, defineComponent, ref, Teleport, Transition, TransitionGroup, watch } from "vue";
+import { computed, defineComponent, onMounted, onUnmounted, ref, Teleport, Transition, TransitionGroup, watch } from "vue";
 import { AlertTriangle, CheckCircle, Copy, Info } from "lucide-vue-next";
 
 
 import { useToast, type ToastItem, type ToastMessage, type ToastType } from "../runtime/useToast";
 import { useClipboard } from "../runtime/useClipboard";
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useI18n } from "../i18n/context";
 import "./HkToast.scss";
 
@@ -155,10 +156,34 @@ export default defineComponent({
   name: "HkToast",
   setup() {
     const { toasts, remove } = useToast();
+    // The toast stack registers with the popup manager so it takes part
+    // in the unified z-band ladder instead of a hardcoded z that later
+    // modals could overtake.
+    const manager = usePopupManager();
+    let popupHandle: PopupHandle | null = null;
+    const containerZ = ref<number | null>(null);
+
+    onMounted(() => {
+      popupHandle = manager.register("toast", false);
+      containerZ.value = popupHandle.zIndex;
+    });
+
+    onUnmounted(() => {
+      if (popupHandle) {
+        manager.unregister(popupHandle.id);
+        popupHandle = null;
+      }
+    });
+
+    const containerStyle = computed<Record<string, string> | undefined>(() =>
+      containerZ.value != null
+        ? { "--hk-z-toast": String(containerZ.value) }
+        : undefined,
+    );
 
     return () => (
       <Teleport to="body">
-        <div class="hk-toast-container">
+        <div class="hk-toast-container" style={containerStyle.value}>
           <TransitionGroup
             tag="div"
             name="hk-toast"

--- a/packages/vue/src/components/HkTooltip.scss
+++ b/packages/vue/src/components/HkTooltip.scss
@@ -12,7 +12,7 @@
 
 .hk-tooltip-popup {
   position: fixed;
-  z-index: var(--z-tooltip);
+  z-index: var(--hi-z-tooltip, 10000);
   padding: var(--space-4) var(--space-8);
   border: none;
   border-radius: var(--radius-sm);

--- a/packages/vue/src/components/HkTooltip.tsx
+++ b/packages/vue/src/components/HkTooltip.tsx
@@ -1,4 +1,5 @@
-import { computed, defineComponent, onBeforeUnmount, ref, Teleport, type CSSProperties, type PropType } from "vue";
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, Teleport, type CSSProperties, type PropType } from "vue";
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import "./HkTooltip.scss";
 
 export default defineComponent({
@@ -14,6 +15,18 @@ export default defineComponent({
     const wrapperRef = ref<HTMLElement | null>(null);
     const tooltipStyle = ref<CSSProperties>({});
     let showTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Registers with the popup manager (kind "tooltip") so tooltips take
+    // part in the unified z-band ladder; the zIndex lands on the popup
+    // element and overrides the --hi-z-tooltip fallback in the SCSS.
+    const manager = usePopupManager();
+    let popupHandle: PopupHandle | null = null;
+    const zIndex = ref<number | null>(null);
+
+    onMounted(() => {
+      popupHandle = manager.register("tooltip", false);
+      zIndex.value = popupHandle.zIndex;
+    });
 
     function updatePosition() {
       if (!wrapperRef.value) return;
@@ -73,6 +86,10 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       clearShowTimer();
+      if (popupHandle) {
+        manager.unregister(popupHandle.id);
+        popupHandle = null;
+      }
     });
 
     const tooltipCls = computed(() => [
@@ -80,6 +97,11 @@ export default defineComponent({
       `hk-tooltip-${props.placement}`,
       visible.value ? "hk-tooltip-visible" : "",
     ]);
+
+    const popupStyle = computed<CSSProperties>(() => ({
+      ...tooltipStyle.value,
+      ...(zIndex.value != null ? { zIndex: zIndex.value } : {}),
+    }));
 
     return () => (
       <span
@@ -97,7 +119,7 @@ export default defineComponent({
         <Teleport to="body">
           <div
             class={tooltipCls.value}
-            style={tooltipStyle.value}
+            style={popupStyle.value}
           >
             <div class="hk-tooltip-content">{props.text}</div>
           </div>

--- a/packages/vue/src/composables/useConnectionProbe.ts
+++ b/packages/vue/src/composables/useConnectionProbe.ts
@@ -1,5 +1,7 @@
 import { onMounted, onUnmounted, ref, type Ref } from "vue";
 
+import { scheduleInterval, scheduleIntervalAfter, type IntervalHandle } from "../runtime/intervalBus";
+
 /** Fetch-based connectivity probe — the hikari-local successor of the
  *  plana-ui probe. Polls `/api/health` (or a custom endpoint set via
  *  `setProbeEndpoint`) and derives the same ProbeResult shape consumers
@@ -53,8 +55,8 @@ export function useConnectionProbe(): {
     countdown: 0,
   });
 
-  let pollTimer: ReturnType<typeof setTimeout> | null = null;
-  let tickTimer: ReturnType<typeof setInterval> | null = null;
+  let pollHandle: IntervalHandle | null = null;
+  let tickHandle: IntervalHandle | null = null;
   let nextAttemptAt = 0;
   let consecutiveFailures = 0;
 
@@ -64,7 +66,8 @@ export function useConnectionProbe(): {
   }
 
   async function probeOnce(): Promise<void> {
-    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+    pollHandle?.disconnect();
+    pollHandle = null;
     const attempt = result.value.attemptNumber + 1;
     result.value = {
       ...result.value,
@@ -104,8 +107,15 @@ export function useConnectionProbe(): {
   }
 
   function schedulePoll(): void {
-    if (pollTimer) { clearTimeout(pollTimer); }
-    pollTimer = setTimeout(() => { void probeOnce(); }, DEFAULT_POLL_MS);
+    // Visibility-aware one-shot: the 15s retry window holds while the
+    // page is hidden instead of burning down on a throttled background
+    // timer (intervalBus — this is its designed case: data polling, not
+    // animation).
+    pollHandle?.disconnect();
+    pollHandle = scheduleIntervalAfter(() => {
+      pollHandle = null;
+      void probeOnce();
+    }, DEFAULT_POLL_MS);
   }
 
   function retryNow(): void {
@@ -114,12 +124,14 @@ export function useConnectionProbe(): {
 
   onMounted(() => {
     void probeOnce();
-    tickTimer = setInterval(applyCountdown, 1000);
+    tickHandle = scheduleInterval(applyCountdown, 1000);
   });
 
   onUnmounted(() => {
-    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
-    if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+    pollHandle?.disconnect();
+    pollHandle = null;
+    tickHandle?.disconnect();
+    tickHandle = null;
   });
 
   return { result, retryNow };

--- a/packages/vue/src/runtime/useOverlay.test.ts
+++ b/packages/vue/src/runtime/useOverlay.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, type Component } from "vue";
+
+import { closeAll, isOverlayOpen, useOverlay, type OverlayHandle } from "./useOverlay";
+
+interface Mounted {
+  app: ReturnType<typeof createApp>;
+  container: HTMLElement;
+  overlay: OverlayHandle;
+}
+
+const mounts: Mounted[] = [];
+
+function mountOverlay(name: string, group?: string): Mounted {
+  // Plain variable, not a ref: storing the handle in a ref would
+  // deep-convert the object and unwrap the nested `isOpen` ref.
+  let handle: OverlayHandle | null = null;
+  const Comp = defineComponent({
+    setup() {
+      const overlay = useOverlay({ name, group });
+      handle = overlay;
+      return () => null;
+    },
+  });
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(Comp as Component) });
+  app.mount(container);
+  const mounted = { app, container, overlay: handle! };
+  mounts.push(mounted);
+  return mounted;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  closeAll();
+});
+
+describe("useOverlay registry", () => {
+  it("registers two instances sharing a name without overwriting each other", () => {
+    const a = mountOverlay("hk-select");
+    const b = mountOverlay("hk-select");
+
+    a.overlay.open();
+    expect(isOverlayOpen("hk-select")).toBe(true);
+
+    b.overlay.open();
+    // Both stay open under the unique per-instance ids — the old
+    // name-keyed registry would have dropped `a` here.
+    expect(a.overlay.isOpen.value).toBe(true);
+    expect(b.overlay.isOpen.value).toBe(true);
+
+    closeAll();
+    expect(a.overlay.isOpen.value).toBe(false);
+    expect(b.overlay.isOpen.value).toBe(false);
+    expect(isOverlayOpen("hk-select")).toBe(false);
+  });
+
+  it("closing one instance leaves the other registered", () => {
+    const a = mountOverlay("hk-popout");
+    const b = mountOverlay("hk-popout");
+
+    a.overlay.open();
+    b.overlay.open();
+    a.overlay.close();
+
+    expect(a.overlay.isOpen.value).toBe(false);
+    expect(b.overlay.isOpen.value).toBe(true);
+    expect(isOverlayOpen("hk-popout")).toBe(true);
+
+    b.overlay.close();
+    expect(isOverlayOpen("hk-popout")).toBe(false);
+  });
+
+  it("opening an overlay closes previously open overlays in the same group", () => {
+    const a = mountOverlay("hk-a", "picker");
+    const b = mountOverlay("hk-b", "picker");
+
+    a.overlay.open();
+    b.overlay.open();
+
+    expect(a.overlay.isOpen.value).toBe(false);
+    expect(b.overlay.isOpen.value).toBe(true);
+    expect(isOverlayOpen("hk-a")).toBe(false);
+    expect(isOverlayOpen("hk-b")).toBe(true);
+  });
+
+  it("unmounting an open overlay unregisters it", () => {
+    const a = mountOverlay("hk-modal");
+    a.overlay.open();
+    expect(isOverlayOpen("hk-modal")).toBe(true);
+
+    a.app.unmount();
+    a.container.remove();
+    mounts.splice(mounts.indexOf(a), 1);
+
+    expect(isOverlayOpen("hk-modal")).toBe(false);
+  });
+
+  it("isOverlayOpen reports per-name across same-named instances", () => {
+    const a = mountOverlay("hk-drawer");
+    mountOverlay("hk-drawer");
+    a.overlay.open();
+    expect(isOverlayOpen("hk-drawer")).toBe(true);
+    a.overlay.close();
+    expect(isOverlayOpen("hk-drawer")).toBe(false);
+  });
+});

--- a/packages/vue/src/runtime/useOverlay.ts
+++ b/packages/vue/src/runtime/useOverlay.ts
@@ -1,27 +1,41 @@
 import { onUnmounted, ref, type Ref } from "vue";
 
 interface OverlayRegistryEntry {
+  id: string;
+  name: string;
   close: () => void;
   group?: string;
 }
 
+/** Registry keyed by a per-instance unique id — NOT the display name. Two
+ *  instances sharing a name (e.g. two open selects both named "hk-select")
+ *  used to overwrite each other's entry in the name-keyed map, corrupting
+ *  closeAll()/isOverlayOpen() and leaking the first instance's open state.
+ *  The name/group metadata is retained for lookups and group closing. */
 const registry = new Map<string, OverlayRegistryEntry>();
 
+function uid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2) + Date.now().toString(36);
+}
+
 function closeGroup(group: string) {
-  for (const [name, entry] of registry) {
+  for (const [, entry] of registry) {
     if (entry.group === group) {
       entry.close();
-      registry.delete(name);
+      registry.delete(entry.id);
     }
   }
 }
 
-function register(name: string, close: () => void, group?: string) {
-  registry.set(name, { close, group });
+function register(id: string, name: string, close: () => void, group?: string) {
+  registry.set(id, { id, name, close, group });
 }
 
-function unregister(name: string) {
-  registry.delete(name);
+function unregister(id: string) {
+  registry.delete(id);
 }
 
 export function closeAll() {
@@ -32,7 +46,10 @@ export function closeAll() {
 }
 
 export function isOverlayOpen(name: string): boolean {
-  return registry.has(name);
+  for (const entry of registry.values()) {
+    if (entry.name === name) return true;
+  }
+  return false;
 }
 
 export interface UseOverlayOptions {
@@ -50,18 +67,19 @@ export interface OverlayHandle {
 
 export function useOverlay(opts: UseOverlayOptions): OverlayHandle {
   const isOpen = ref(false);
+  const id = uid();
 
   function open(): void {
     if (isOpen.value) return;
     if (opts.group) closeGroup(opts.group);
     isOpen.value = true;
-    register(opts.name, close, opts.group);
+    register(id, opts.name, close, opts.group);
   }
 
   function close(): void {
     if (!isOpen.value) return;
     isOpen.value = false;
-    unregister(opts.name);
+    unregister(id);
   }
 
   function toggle(): void {
@@ -75,7 +93,7 @@ export function useOverlay(opts: UseOverlayOptions): OverlayHandle {
   }
 
   onUnmounted(() => {
-    if (isOpen.value) unregister(opts.name);
+    if (isOpen.value) unregister(id);
   });
 
   return { isOpen, open, close, toggle, onUpdate };

--- a/packages/vue/src/runtime/useToast.test.ts
+++ b/packages/vue/src/runtime/useToast.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  MAX_TOASTS_PER_SLOT,
+  useToast,
+} from "./useToast";
+
+function clearAll() {
+  const { toasts, remove } = useToast();
+  for (const t of [...toasts]) remove(t.id);
+}
+
+describe("useToast stacking and dedupe", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    clearAll();
+  });
+  afterEach(() => {
+    clearAll();
+    vi.useRealTimers();
+  });
+
+  it("dedupes identical consecutive messages in the same slot", () => {
+    const toast = useToast();
+    const firstId = toast.error("backend unreachable");
+    const secondId = toast.error("backend unreachable");
+
+    expect(toast.toasts).toHaveLength(1);
+    expect(toast.toasts[0]!.messages).toHaveLength(1);
+    // Replace semantics: the second push returns the existing entry id.
+    expect(secondId).toBe(firstId);
+    expect(toast.toasts[0]!.messages[0]!.text).toBe("backend unreachable");
+  });
+
+  it("keeps distinct consecutive messages", () => {
+    const toast = useToast();
+    toast.error("first");
+    toast.error("second");
+
+    expect(toast.toasts[0]!.messages.map((m) => m.text)).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("dedupes only consecutive duplicates", () => {
+    const toast = useToast();
+    toast.error("a");
+    toast.error("b");
+    toast.error("b");
+
+    expect(toast.toasts[0]!.messages.map((m) => m.text)).toEqual(["a", "b"]);
+  });
+
+  it("caps messages per slot at MAX_TOASTS_PER_SLOT, dropping the oldest", () => {
+    const toast = useToast();
+    for (let i = 0; i < MAX_TOASTS_PER_SLOT + 3; i++) {
+      toast.error(`msg-${i}`);
+    }
+
+    expect(toast.toasts[0]!.messages).toHaveLength(MAX_TOASTS_PER_SLOT);
+    const texts = toast.toasts[0]!.messages.map((m) => m.text);
+    expect(texts[0]).toBe("msg-3"); // 0..2 dropped (oldest)
+    expect(texts[texts.length - 1]).toBe(`msg-${MAX_TOASTS_PER_SLOT + 2}`);
+  });
+
+  it("caps each slot independently", () => {
+    const toast = useToast();
+    for (let i = 0; i < MAX_TOASTS_PER_SLOT + 2; i++) toast.error(`e-${i}`);
+    for (let i = 0; i < MAX_TOASTS_PER_SLOT + 2; i++) toast.success(`s-${i}`);
+
+    const errorSlot = toast.toasts.find((t) => t.type === "error")!;
+    const successSlot = toast.toasts.find((t) => t.type === "success")!;
+    expect(errorSlot.messages).toHaveLength(MAX_TOASTS_PER_SLOT);
+    expect(successSlot.messages).toHaveLength(MAX_TOASTS_PER_SLOT);
+  });
+
+  it("dedupe still restarts the auto-dismiss clock (loading never dismisses)", () => {
+    const toast = useToast();
+    toast.info("pulse");
+    const first = toast.toasts[0]!;
+    // info duration is 3000ms — after 1000ms a duplicate push keeps a
+    // single entry; the slot is still present at 2500ms (timer restarted).
+    vi.advanceTimersByTime(1000);
+    toast.info("pulse");
+    expect(toast.toasts[0]!.messages).toHaveLength(1);
+    vi.advanceTimersByTime(2499);
+    expect(toast.toasts.some((t) => t.type === "info")).toBe(true);
+  });
+});

--- a/packages/vue/src/runtime/useToast.ts
+++ b/packages/vue/src/runtime/useToast.ts
@@ -34,6 +34,11 @@ export interface ToastItem {
   copyable?: boolean;
 }
 
+/** Hard cap on stacked messages per toast slot. Beyond it the oldest
+ *  messages are dropped so a noisy caller cannot bury the surface in
+ *  unbounded history. */
+export const MAX_TOASTS_PER_SLOT = 5;
+
 const state = reactive<{ toasts: ToastItem[] }>({ toasts: [] });
 
 let nextSlotId = 0;
@@ -93,8 +98,21 @@ function push(
   } else if (options.copyable === true && !slot.copyable) {
     slot.copyable = true;
   }
-  const msgId = ++nextMsgId;
-  slot.messages.push({ id: msgId, text });
+  let msgId: number;
+  const last = slot.messages[slot.messages.length - 1];
+  if (last && last.text === text) {
+    // Dedupe: an identical consecutive message (same slot + same text in
+    // the current stack) replaces the previous entry instead of appending —
+    // the surface keeps a single entry and the auto-dismiss clock restarts.
+    msgId = last.id;
+  } else {
+    msgId = ++nextMsgId;
+    slot.messages.push({ id: msgId, text });
+  }
+  // Cap: drop the oldest messages beyond the per-slot cap.
+  while (slot.messages.length > MAX_TOASTS_PER_SLOT) {
+    slot.messages.shift();
+  }
   scheduleAutoDismiss(slot);
   // Unified visibility behavior (P59-W5): every actionable toast — not just
   // the ones that went through useMessaging — also lands as an OS


### PR DESCRIPTION
Routes component timers and overlays through hikari's shared animation/interval/overlay/popup contexts so reduced-motion, hidden-tab and z-band behavior is uniform.

- **HkPasswordInput**: ripple canvas loop via `onFrame(..., "normal")` (parks under reduced motion), autofill poll via `scheduleInterval` (hidden-tab aware), one-shot rAFs via `onceFrame`, flash/focus-reclaim timeouts via `scheduleCronAfter` (must fire even when the rAF bus is parked).
- **useConnectionProbe**: 15s retry window (`scheduleIntervalAfter`) and 1s countdown ticker (`scheduleInterval`) — the intervalBus designed case (data polling, not animation).
- **HkNumberInput**: press-and-hold 300ms delay + 50ms repeat via `scheduleAfter`/`scheduleEvery` (animationBus), `stopHold` semantics kept.
- **HkCheckbox**: `animTimer` now cleared on unmount and runs on a cronBus one-shot (always clears, even under reduced motion).
- **HkRollingNumber**: 350ms cronBus fallback commit applies the final digit when `animationend` never fires (keyframes paused at 0% under `data-css-animations="0"` / reduced motion); cancelled on `animationend` or unmount.
- **useOverlay**: registry keyed by per-instance unique ids instead of display name — same-named instances no longer overwrite each other; name/group metadata retained (`isOverlayOpen`/`closeAll`/group semantics unchanged, API backward compatible).
- **HkSelect / HkColorPicker / HkPopupSelect**: popouts register with `useOverlay` on open and unregister on close/unmount so `closeAll()`/`isOverlayOpen()` see them (HkPopupSelect keeps its legacy module singleton).
- **useToast**: per-slot cap (default 5, oldest dropped) and consecutive-duplicate dedupe (same slot + same text replaces instead of appends, dismiss clock restarts).
- **HkToast**: stack registers with `usePopupManager` (kind `"toast"`) — participates in the unified z-band ladder.
- **HkTooltip**: registers with `usePopupManager` (kind `"tooltip"`); SCSS z fallback fixed to `var(--hi-z-tooltip, 10000)` (theme.scss defines 10000 at `:root`).
- **HkMenu**: Escape closes the whole cascade (desktop panels + mobile sheets), mirroring HkPopover.
- **HkDrawer**: focus trap + focus restore mirroring HkModal (`focusFirst`/`trapFocus`).

Tests added: useOverlay unique-id registry, useToast cap/dedupe, HkRollingNumber fallback commit. Full vitest suite green (33 files / 295 tests). `vue-tsc --noEmit` shows zero new errors — one pre-existing TS2416 in `toastMirror.test.ts` (verified identical at baseline HEAD with changes stashed; file outside this PR's scope).