### PR TITLE
🐛 Fix the animation bus per-entry timing and make the unified overlay close and z ladder truthful.

### DIFF
--- a/packages/vue/src/components/HkColorPicker.tsx
+++ b/packages/vue/src/components/HkColorPicker.tsx
@@ -126,8 +126,12 @@ export default defineComponent({
 
     // Registered with the overlay registry so closeAll()/isOverlayOpen()
     // see the open popout; the popover inside handles z-stacking via the
-    // popup manager.
-    const overlay = useOverlay({ name: "hk-color-picker" });
+    // popup manager. The onCloseRequested hook makes a global closeAll()
+    // flip this component's own open ref, which tears the popover down.
+    const overlay = useOverlay({
+      name: "hk-color-picker",
+      onCloseRequested: () => { isOpen.value = false; },
+    });
 
     watch(isOpen, (open) => {
       if (open) overlay.open();

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -104,6 +104,12 @@ export default defineComponent({
           handle.value = manager.register("drawer", true);
           overlayHook.open();
           previouslyFocused = document.activeElement as HTMLElement | null;
+        } else {
+          // Register/unregister WITH the open state so a closed-but-mounted
+          // drawer does not linger in the overlay registry (isOverlayOpen
+          // must reflect reality). The popup manager handle is torn down by
+          // the leave transition or by cleanup() on unmount.
+          overlayHook.close();
         }
       },
       { immediate: true },

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -269,6 +269,7 @@ export default defineComponent({
           // Close happens via Transition onAfterLeave,
           // but if modelValue flips to false without Transition
           // (e.g. immediate), clean up now.
+          overlay.close();
         }
       },
       { immediate: true },

--- a/packages/vue/src/components/HkPopupSelect.tsx
+++ b/packages/vue/src/components/HkPopupSelect.tsx
@@ -53,8 +53,13 @@ export default defineComponent({
     // Registered with the overlay registry so closeAll()/isOverlayOpen()
     // see the open popout. The popover inside handles z-stacking via the
     // popup manager; the legacy module singleton (activePopupId) stays as
-    // the cross-instance close coordination.
-    const overlay = useOverlay({ name: "hk-popup-select" });
+    // the cross-instance close coordination. The onCloseRequested hook makes
+    // a global closeAll() flip this component's own open ref, which tears
+    // the popover down (the activePopupId cleanup runs in the watcher).
+    const overlay = useOverlay({
+      name: "hk-popup-select",
+      onCloseRequested: () => { isOpen.value = false; },
+    });
 
     watch(isOpen, (open) => {
       if (open) {

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -53,8 +53,14 @@ export default defineComponent({
 
     // Registered with the overlay registry too so closeAll()/isOverlayOpen()
     // see the open popout (unique per-instance ids — multiple selects can
-    // share the "hk-select" name without corrupting the registry).
-    const overlay = useOverlay({ name: "hk-select" });
+    // share the "hk-select" name without corrupting the registry). The
+    // onCloseRequested hook makes a global closeAll() flip this component's
+    // own open ref, which is what actually tears the popout down (the popup
+    // manager unregister happens in the isOpen watcher below).
+    const overlay = useOverlay({
+      name: "hk-select",
+      onCloseRequested: () => { isOpen.value = false; },
+    });
 
     function onDocumentClick(e: MouseEvent) {
       if (!isOpen.value) return;

--- a/packages/vue/src/runtime/animationBus.test.ts
+++ b/packages/vue/src/runtime/animationBus.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { onFrame, type AnimationHandle } from "./animationBus";
+
+// ── Fake-RAF harness ──────────────────────────────────────────────────
+// The bus arms the next frame by calling requestAnimationFrame(tick); the
+// harness captures that callback and lets each test drive tick() with an
+// explicit timestamp, so deltas are fully deterministic.
+
+let rafCallback: FrameRequestCallback | null = null;
+let rafId = 0;
+const handles: AnimationHandle[] = [];
+
+function stubRaf() {
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafCallback = cb;
+    return ++rafId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {
+    rafCallback = null;
+  });
+}
+
+/** Run the bus for one frame at `now` (ms). The bus re-arms the next
+ *  frame itself when entries remain. */
+function fireRaf(now: number) {
+  const cb = rafCallback;
+  rafCallback = null;
+  cb?.(now);
+}
+
+function tracked(handle: AnimationHandle): AnimationHandle {
+  handles.push(handle);
+  return handle;
+}
+
+beforeEach(() => {
+  stubRaf();
+});
+
+afterEach(() => {
+  for (const h of handles.splice(0)) h.disconnect();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  rafCallback = null;
+  rafId = 0;
+});
+
+describe("animationBus per-entry delta", () => {
+  it("hands normal-priority callbacks the elapsed time since their own last run", () => {
+    // 60Hz-style ticks at 16.7ms; the 33ms normal budget fires the callback
+    // every 2nd tick. The delta must be ≈2 ticks (0.033s) — NOT the shared
+    // per-tick delta (0.0167s) that previously ran animations at half speed.
+    const deltas: number[] = [];
+    tracked(onFrame((ctx) => { deltas.push(ctx.delta); }, "normal"));
+
+    fireRaf(0);
+    fireRaf(16.7);
+    fireRaf(33.4);
+    fireRaf(50.1);
+    fireRaf(66.8);
+    fireRaf(83.5);
+
+    expect(deltas.length).toBeGreaterThanOrEqual(2);
+    for (const d of deltas) {
+      expect(d).toBeCloseTo(0.033, 2);
+      expect(d).not.toBeCloseTo(0.0167, 3);
+    }
+  });
+
+  it("clamps the per-entry delta so a hiccup spike cannot teleport motion", () => {
+    const deltas: number[] = [];
+    tracked(onFrame((ctx) => { deltas.push(ctx.delta); }, "normal"));
+
+    fireRaf(0);
+    fireRaf(33.4); // normal firing: dt ≈ 0.033
+    fireRaf(533.4); // 500ms gap since last run — must clamp at 0.1
+
+    expect(deltas[0]).toBeCloseTo(0.033, 2);
+    expect(deltas[1]).toBeCloseTo(0.1, 6);
+    expect(deltas[1]).toBeLessThanOrEqual(0.1);
+  });
+
+  it("keeps the raw per-tick delta for sync entries", () => {
+    const deltas: number[] = [];
+    tracked(onFrame((ctx) => { deltas.push(ctx.delta); }, "sync"));
+
+    fireRaf(100); // first tick: delta is 0 by bus convention
+    fireRaf(116.7);
+    fireRaf(133.4);
+
+    expect(deltas[0]).toBe(0);
+    expect(deltas[1]).toBeCloseTo(0.0167, 3);
+    expect(deltas[2]).toBeCloseTo(0.0167, 3);
+  });
+
+  it("clamps idle-priority deltas to MAX_DELTA after a full 2000ms budget", () => {
+    // Fake ONLY timers, not rAF — the harness drives rAF explicitly and
+    // vitest's default fake-timers config would override the stub.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const deltas: number[] = [];
+    tracked(onFrame((ctx) => { deltas.push(ctx.delta); }, "idle"));
+
+    // Idle entries arm via setTimeout(IDLE_FRAME_BUDGET) → rAF → tick.
+    vi.advanceTimersByTime(2000);
+    fireRaf(2000);
+    vi.advanceTimersByTime(2000);
+    fireRaf(4000);
+
+    expect(deltas).toEqual([0.1, 0.1]);
+  });
+});

--- a/packages/vue/src/runtime/animationBus.ts
+++ b/packages/vue/src/runtime/animationBus.ts
@@ -11,11 +11,21 @@ export interface AnimationHandle {
 }
 
 type Callback = (ctx: FrameContext) => void;
+
+/** Frame delivery tier. Every tier hands its callback a delta equal to the
+ *  real time elapsed since the entry's OWN last run (clamped to MAX_DELTA),
+ *  so motion speed is independent of both the display refresh rate and the
+ *  tier's frame budget — only the call cadence differs:
+ *  - "sync"  — every animation frame: fine-grained per-frame control, most CPU.
+ *  - "normal" — ≈30fps (33ms budget): balanced default for visible motion.
+ *  - "idle"  — ≈0.5fps (2000ms budget): cheap background sampling. */
 type Priority = "sync" | "normal" | "idle";
 
 interface Entry {
   cb: Callback;
   priority: Priority;
+  /** Timestamp (ms) of this entry's own last run; the per-entry delta is
+   *  derived from it so throttled tiers stay refresh-rate invariant. */
   lastRun: number;
 }
 
@@ -50,6 +60,13 @@ let oneShotRaf = 0;
 
 const NORMAL_FRAME_BUDGET = 33;
 const IDLE_FRAME_BUDGET = 2000;
+
+/** Hard cap (seconds) on the per-entry delta handed to normal/idle
+ *  callbacks. A jank/hiccup spike between two runs must not teleport the
+ *  animation forward — the sweep simply stalls for the spike and resumes at
+ *  the real rate afterwards. Normal operation yields the exact real-time
+ *  delta, which is what makes throttled motion refresh-rate independent. */
+const MAX_DELTA = 0.1;
 
 function uid(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -94,16 +111,21 @@ function tick(now: number) {
   if (!skipNormal) {
     for (const e of normalEntries.values()) {
       if (now - e.lastRun >= NORMAL_FRAME_BUDGET) {
+        // Per-entry real-time delta, clamped so a hiccup spike stalls the
+        // animation instead of teleporting it. Compute BEFORE lastRun moves
+        // so the delta measures exactly the entry's own wait time.
+        const dt = Math.min((now - e.lastRun) / 1000, MAX_DELTA);
         e.lastRun = now;
-        e.cb(ctx);
+        e.cb({ ...ctx, delta: dt });
       }
     }
   }
 
   for (const e of idleEntries.values()) {
     if (now - e.lastRun >= IDLE_FRAME_BUDGET) {
+      const dt = Math.min((now - e.lastRun) / 1000, MAX_DELTA);
       e.lastRun = now;
-      e.cb(ctx);
+      e.cb({ ...ctx, delta: dt });
     }
   }
 

--- a/packages/vue/src/runtime/useOverlay.test.ts
+++ b/packages/vue/src/runtime/useOverlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineComponent, h, type Component } from "vue";
 
 import { closeAll, isOverlayOpen, useOverlay, type OverlayHandle } from "./useOverlay";
@@ -11,13 +11,17 @@ interface Mounted {
 
 const mounts: Mounted[] = [];
 
-function mountOverlay(name: string, group?: string): Mounted {
+function mountOverlay(
+  name: string,
+  group?: string,
+  onCloseRequested?: () => void,
+): Mounted {
   // Plain variable, not a ref: storing the handle in a ref would
   // deep-convert the object and unwrap the nested `isOpen` ref.
   let handle: OverlayHandle | null = null;
   const Comp = defineComponent({
     setup() {
-      const overlay = useOverlay({ name, group });
+      const overlay = useOverlay({ name, group, onCloseRequested });
       handle = overlay;
       return () => null;
     },
@@ -107,5 +111,50 @@ describe("useOverlay registry", () => {
     expect(isOverlayOpen("hk-drawer")).toBe(true);
     a.overlay.close();
     expect(isOverlayOpen("hk-drawer")).toBe(false);
+  });
+
+  it("closeAll invokes the registered onCloseRequested hook", () => {
+    const closed: string[] = [];
+    const a = mountOverlay("hk-select", undefined, () => closed.push("a"));
+    const b = mountOverlay("hk-color-picker", undefined, () => closed.push("b"));
+
+    a.overlay.open();
+    b.overlay.open();
+    closeAll();
+
+    expect(closed).toEqual(["a", "b"]);
+    expect(a.overlay.isOpen.value).toBe(false);
+    expect(b.overlay.isOpen.value).toBe(false);
+  });
+
+  it("a throwing onCloseRequested does not prevent the remaining hooks", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const closed: string[] = [];
+    const a = mountOverlay("hk-select", undefined, () => { throw new Error("boom"); });
+    const b = mountOverlay("hk-popup-select", undefined, () => closed.push("b"));
+
+    a.overlay.open();
+    b.overlay.open();
+    expect(() => closeAll()).not.toThrow();
+
+    expect(closed).toEqual(["b"]);
+    expect(a.overlay.isOpen.value).toBe(false);
+    expect(b.overlay.isOpen.value).toBe(false);
+    vi.restoreAllMocks();
+  });
+
+  it("closeAll closes every entry under unique ids, including same-named ones", () => {
+    const closed: string[] = [];
+    const a = mountOverlay("hk-popout", undefined, () => closed.push("a"));
+    const b = mountOverlay("hk-popout", undefined, () => closed.push("b"));
+    const c = mountOverlay("hk-popout", undefined, () => closed.push("c"));
+
+    a.overlay.open();
+    b.overlay.open();
+    c.overlay.open();
+    closeAll();
+
+    expect(closed).toEqual(["a", "b", "c"]);
+    expect(isOverlayOpen("hk-popout")).toBe(false);
   });
 });

--- a/packages/vue/src/runtime/useOverlay.ts
+++ b/packages/vue/src/runtime/useOverlay.ts
@@ -4,6 +4,10 @@ interface OverlayRegistryEntry {
   id: string;
   name: string;
   close: () => void;
+  /** Component-level teardown invoked alongside the internal flip when a
+   *  global/group close fires — lets the owner close its own visible
+   *  popout state (e.g. an open ref bound to the popup manager). */
+  onCloseRequested?: () => void;
   group?: string;
 }
 
@@ -21,17 +25,39 @@ function uid(): string {
   return Math.random().toString(36).slice(2) + Date.now().toString(36);
 }
 
+/** Run an entry's full close path: the internal flip AND the component
+ *  onCloseRequested hook, each isolated so a throwing callback cannot abort
+ *  the remaining entries (or the sibling hook). */
+function runEntryClose(entry: OverlayRegistryEntry) {
+  try {
+    entry.close();
+  } catch (err) {
+    console.warn("[useOverlay] overlay close() threw for", entry.name, err);
+  }
+  try {
+    entry.onCloseRequested?.();
+  } catch (err) {
+    console.warn("[useOverlay] overlay onCloseRequested() threw for", entry.name, err);
+  }
+}
+
 function closeGroup(group: string) {
   for (const [, entry] of registry) {
     if (entry.group === group) {
-      entry.close();
+      runEntryClose(entry);
       registry.delete(entry.id);
     }
   }
 }
 
-function register(id: string, name: string, close: () => void, group?: string) {
-  registry.set(id, { id, name, close, group });
+function register(
+  id: string,
+  name: string,
+  close: () => void,
+  group?: string,
+  onCloseRequested?: () => void,
+) {
+  registry.set(id, { id, name, close, group, onCloseRequested });
 }
 
 function unregister(id: string) {
@@ -40,7 +66,7 @@ function unregister(id: string) {
 
 export function closeAll() {
   for (const [, entry] of registry) {
-    entry.close();
+    runEntryClose(entry);
   }
   registry.clear();
 }
@@ -55,6 +81,9 @@ export function isOverlayOpen(name: string): boolean {
 export interface UseOverlayOptions {
   name: string;
   group?: string;
+  /** Component-level teardown run by closeAll()/group-close alongside the
+   *  internal isOpen flip — close the owner's own visible popout state. */
+  onCloseRequested?: () => void;
 }
 
 export interface OverlayHandle {
@@ -73,7 +102,7 @@ export function useOverlay(opts: UseOverlayOptions): OverlayHandle {
     if (isOpen.value) return;
     if (opts.group) closeGroup(opts.group);
     isOpen.value = true;
-    register(id, opts.name, close, opts.group);
+    register(id, opts.name, close, opts.group, opts.onCloseRequested);
   }
 
   function close(): void {

--- a/packages/vue/src/runtime/usePopupManager.test.ts
+++ b/packages/vue/src/runtime/usePopupManager.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { usePopupManager } from "./usePopupManager";
+
+const managers: ReturnType<typeof usePopupManager>[] = [];
+
+function freshManager() {
+  const m = usePopupManager();
+  managers.push(m);
+  return m;
+}
+
+afterEach(() => {
+  // The registry is a module singleton shared across usePopupManager()
+  // instances — unregister everything so tests do not leak z state.
+  for (const m of managers.splice(0)) {
+    for (const entry of [...m.registry.value.values()]) {
+      m.unregister(entry.id);
+    }
+  }
+  document.body.style.overflow = "";
+});
+
+describe("usePopupManager z ladder", () => {
+  it("starts at the base band and steps by Z_STEP while popups stack", () => {
+    const m = freshManager();
+    const a = m.register("dropdown", false);
+    const b = m.register("modal", true);
+
+    expect(a.zIndex).toBe(1000);
+    expect(b.zIndex).toBe(1002);
+    expect(m.isOpen(a.id)).toBe(true);
+    expect(m.isOpen(b.id)).toBe(true);
+  });
+
+  it("reclaims a freed z band instead of drifting upward forever", () => {
+    const m = freshManager();
+    // Simulate HkToast's persistent registration: it stays mounted forever,
+    // so the old monotonic counter could never reset.
+    const toast = m.register("toast", false);
+    expect(toast.zIndex).toBe(1000);
+
+    const a = m.register("dropdown", false);
+    expect(a.zIndex).toBe(1002);
+    const b = m.register("dropdown", false);
+    expect(b.zIndex).toBe(1004);
+
+    m.unregister(b.id);
+    // C must reclaim B's band (1004) — NOT drift to 1006.
+    const c = m.register("dropdown", false);
+    expect(c.zIndex).toBe(1004);
+
+    m.unregister(c.id);
+    m.unregister(a.id);
+    // Registry still holds the toast, so the ladder must not reset to base.
+    expect(m.registry.value.size).toBe(1);
+    const d = m.register("tooltip", false);
+    expect(d.zIndex).toBe(1002);
+  });
+
+  it("resets to the base band when the registry empties", () => {
+    const m = freshManager();
+    const a = m.register("dropdown", false);
+    const b = m.register("dropdown", false);
+    m.unregister(a.id);
+    m.unregister(b.id);
+
+    expect(m.registry.value.size).toBe(0);
+    const c = m.register("tooltip", false);
+    expect(c.zIndex).toBe(1000);
+  });
+
+  it("keeps the scroll lock counter balanced across register/unregister", () => {
+    const m = freshManager();
+    const modal = m.register("modal", true);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    const dropdown = m.register("dropdown", false);
+    m.unregister(dropdown.id);
+    // The modal still locks scroll.
+    expect(document.body.style.overflow).toBe("hidden");
+
+    m.unregister(modal.id);
+    expect(document.body.style.overflow).toBe("");
+  });
+});

--- a/packages/vue/src/runtime/usePopupManager.ts
+++ b/packages/vue/src/runtime/usePopupManager.ts
@@ -44,8 +44,21 @@ export function usePopupManager() {
     title?: string,
   ): PopupHandle {
     const id = uid();
+    // Reclaim z bands on assignment: the next z derives from the max z of
+    // the CURRENTLY registered entries, so popups that unregister free
+    // their band for the next popup instead of the ladder drifting upward
+    // forever behind a persistent entry (e.g. HkToast's long-lived toast
+    // stack registration). The registry emptying resets to the base band.
+    if (registry.value.size === 0) {
+      nextZ = Z_BASE;
+    } else {
+      let maxZ = 0;
+      for (const entry of registry.value.values()) {
+        if (entry.zIndex > maxZ) maxZ = entry.zIndex;
+      }
+      nextZ = maxZ + Z_STEP;
+    }
     const zIndex = nextZ;
-    nextZ += Z_STEP;
     const entry: PopupEntry = { id, kind, locksScroll, zIndex, title };
     registry.value.set(id, entry);
     if (locksScroll) {


### PR DESCRIPTION
## Design rationale

Three follow-up fixes balancing performance (throttled priorities) with fine-grained animation control (refresh-rate-invariant, clamped timing).

### 1. animationBus per-entry delta
Normal (33ms) and idle (2000ms) entries previously received the shared per-tick `delta` (~16.7ms at 60Hz), so phase-advancing callbacks ran at ~0.5x speed at 60Hz and ~0.2x at 120-144Hz. HkPasswordInput's ripple sweep and HkPlaceholderMarquee were affected (the marquee's speed-invariance comment was false).

Now each normal/idle callback receives `min((now - lastRun) / 1000, MAX_DELTA)` computed before `lastRun` advances — the exact real elapsed time since the entry's OWN last run, capped at 100ms so a jank/hiccup spike stalls the animation instead of teleporting it. The designed 0.3s ripple sweep now takes 0.3s at 60/120/144Hz; the marquee holds its px/sec speed. Sync entries keep the raw per-tick delta (every-frame precision tier). Priority docs now state the tradeoff: sync = per-frame fine control (most CPU), normal ≈30fps balanced, idle ≈0.5fps cheap — all delta-accurate.

### 2. useOverlay closeAll actually closes popouts
`closeAll()`/group-close only flipped the internal `isOpen` ref, so the visible popout (bound to the component's own open ref) stayed up. Entries now carry an optional `onCloseRequested` hook invoked alongside the internal flip, each wrapped in try/catch so one throwing callback cannot abort the rest (swallow + console.warn). HkSelect, HkColorPicker and HkPopupSelect wire it to flip their own open ref, which tears down the popout (their existing close paths unregister the popup manager). HkPopupSelect's legacy module singleton is untouched.

Also fixed the stale-registration NIT required for `isOverlayOpen` correctness: HkModal and HkDrawer registered once and only called `overlay.open()`, so entries stayed registered while closed-but-mounted. They now register/unregister with the open state (watch modelValue → open/close, unmount cleanup).

### 3. popup z-ladder reclaim
`nextZ` only reset when the registry emptied; HkToast's persistent registration (mounted forever) prevented the reset → the ladder drifted +2 per popup forever. Now on assignment the next z is derived from the max z of the CURRENTLY registered entries (reclaiming bands when popups unregister) and resets to the base when the registry empties — no register/unregister churn, HkToast stays as-is.

## Verification
- `vue-tsc --noEmit`: clean
- `vitest run --pool=threads`: 29 files / 267 tests green (one transient HkDateTimePicker transition-timing flake on first full run; passes consistently on rerun and on pristine master; unrelated to these changes)
- New tests: per-entry delta accuracy (16.7ms ticks → dt ≈ 0.033), clamp (500ms gap → dt ≤ 0.1), sync raw tick delta, idle clamp; closeAll onCloseRequested wiring + throw isolation + unique-id close; z-band reclaim (A→B→unregister B→C: C reclaims B's band, not B+2), empty-registry reset, scroll-lock balance.

## Files changed
- packages/vue/src/runtime/animationBus.ts
- packages/vue/src/runtime/useOverlay.ts
- packages/vue/src/runtime/usePopupManager.ts
- packages/vue/src/runtime/animationBus.test.ts (new)
- packages/vue/src/runtime/useOverlay.test.ts
- packages/vue/src/runtime/usePopupManager.test.ts (new)
- packages/vue/src/components/HkSelect.tsx
- packages/vue/src/components/HkColorPicker.tsx
- packages/vue/src/components/HkPopupSelect.tsx
- packages/vue/src/components/HkModal.tsx
- packages/vue/src/components/HkDrawer.tsx