### PR TITLE
🐛 Make the global closeAll actually close modal and drawer overlays.

### DIFF
--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -39,7 +39,13 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const { t } = useI18n();
     const manager = usePopupManager();
-    const overlayHook = useOverlay({ name: "hk-drawer" });
+    const overlayHook = useOverlay({
+      name: "hk-drawer",
+      // A global closeAll() must be able to actually close this drawer
+      // (not just untrack it) — route it through the same closable
+      // guard as the user-initiated paths.
+      onCloseRequested: () => { if (props.closable) close(); },
+    });
 
     const handle = ref<{ id: string; zIndex: number } | null>(null);
     const panelRef = ref<HTMLElement>();

--- a/packages/vue/src/components/HkModal.test.tsx
+++ b/packages/vue/src/components/HkModal.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkModal from "./HkModal";
+import { closeAll } from "../runtime/useOverlay";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(async () => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("HkModal overlay integration", () => {
+  it("closeAll() closes an open closable modal through its update:modelValue", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const emitted: boolean[] = [];
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: open.value,
+            closable: true,
+            "onUpdate:modelValue": (v: boolean) => { emitted.push(v); open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await nextTick();
+
+    closeAll();
+    await nextTick();
+    expect(emitted).toEqual([false]);
+  });
+
+  it("closeAll() leaves a non-closable modal alone", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const emitted: boolean[] = [];
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: open.value,
+            closable: false,
+            "onUpdate:modelValue": (v: boolean) => { emitted.push(v); open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await nextTick();
+
+    closeAll();
+    await nextTick();
+    expect(emitted).toEqual([]);
+  });
+});

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -53,7 +53,13 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const { t } = useI18n();
     const manager = usePopupManager();
-    const overlay = useOverlay({ name: "hk-modal" });
+    const overlay = useOverlay({
+      name: "hk-modal",
+      // A global closeAll() must be able to actually close this modal
+      // (not just untrack it) — route it through the same closable
+      // guard as the user-initiated paths.
+      onCloseRequested: () => { if (props.closable) close(); },
+    });
 
     const handle = ref<{ id: string; zIndex: number } | null>(null);
     const bodyRef = ref<HTMLElement>();

--- a/packages/vue/src/components/HkPasswordInput.tsx
+++ b/packages/vue/src/components/HkPasswordInput.tsx
@@ -318,7 +318,7 @@ export default defineComponent({
       // JS-driven animation. The draw callback clamps the delta exactly
       // like the old self-scheduling rAF loop did.
       loopHandle = onFrame((ctx) => {
-        draw(Math.min(0.1, ctx.delta));
+        draw(ctx.delta); // the bus already clamps per-entry delta to MAX_DELTA
       }, "normal");
     }
 

--- a/packages/vue/src/runtime/animationBus.ts
+++ b/packages/vue/src/runtime/animationBus.ts
@@ -16,7 +16,9 @@ type Callback = (ctx: FrameContext) => void;
  *  real time elapsed since the entry's OWN last run (clamped to MAX_DELTA),
  *  so motion speed is independent of both the display refresh rate and the
  *  tier's frame budget — only the call cadence differs:
- *  - "sync"  — every animation frame: fine-grained per-frame control, most CPU.
+ *  - "sync"  — every animation frame: fine-grained per-frame control, most
+ *    CPU. Exception: its delta is the raw per-tick inter-frame gap, NOT
+ *    per-entry and NOT clamped — it already runs every frame.
  *  - "normal" — ≈30fps (33ms budget): balanced default for visible motion.
  *  - "idle"  — ≈0.5fps (2000ms budget): cheap background sampling. */
 type Priority = "sync" | "normal" | "idle";


### PR DESCRIPTION
收口统一浮层管理的最后一块：closeAll() 此前对已开的 HkModal/HkDrawer 只做登记注销、不真正关闭。本 PR 给两者接上 onCloseRequested（走与用户关闭相同的 closable 守卫），并顺手清掉 HkPasswordInput 里与总线钳制重复的内部钳制、补全 animationBus sync 档的文档例外说明。验证：vue-tsc 全绿、30 文件 269/269 测试（新增 HkModal closeAll 两项）。