### PR TITLE
✨ Enlarge the picker calendars on touch viewports with a size variant.

### DIFF
--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -145,8 +145,8 @@
 
 .hk-dp-header {
   /* Fixed height keeps the header row — and therefore the shared stage
-   * height — identical in every view and locale. */
-  height: 1.75rem;
+   * height — identical in every view and locale (enlarged on touch). */
+  height: var(--hk-picker-header);
 }
 
 .hk-dp-header-side {
@@ -245,8 +245,8 @@
   font-size: var(--hi-text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
-  height: 1.25rem;
-  line-height: 1.25rem;
+  height: var(--hk-picker-wd);
+  line-height: var(--hk-picker-wd);
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
@@ -259,8 +259,8 @@
   border-radius: var(--hi-radius-sm, 4px);
   /* Fixed height keeps the six-row day grid — and therefore the shared
    * stage height — independent of the panel width, so drilling between
-   * views never changes the popup's size. */
-  height: 2rem;
+   * views never changes the popup's size (enlarged on touch). */
+  height: var(--hk-picker-cell);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -312,7 +312,7 @@
 
 /* Month/year pick cells: wider targets, still inside the fixed stage. */
 .hk-dp-cell[data-variant="pick"] {
-  height: 2.5rem;
+  height: var(--hk-picker-pick);
   font-weight: 500;
 }
 

--- a/packages/vue/src/components/HkDatePicker.test.ts
+++ b/packages/vue/src/components/HkDatePicker.test.ts
@@ -418,6 +418,8 @@ describe("HkDatePicker", () => {
     await nextTick();
     // The custom panel is portaled to the body, not the container.
     expect(panel()).not.toBeNull();
+    // Mobile custom calendar gets the enlarged touch geometry variant.
+    expect(panel()?.classList.contains("is-touch")).toBe(true);
   });
 
   it("passes min/max through to the native input", () => {

--- a/packages/vue/src/components/HkDatePicker.tsx
+++ b/packages/vue/src/components/HkDatePicker.tsx
@@ -87,6 +87,10 @@ export default defineComponent({
     // chrome for a native date input (the model already speaks its ISO wire
     // format) and keep the custom calendar on desktop widths only.
     const useNative = computed(() => props.nativeOnMobile && isMobile.value);
+    // The custom calendar renders on touch viewports only when the host
+    // opts out of the native input (e.g. bottom-sheet dialogs); enlarge
+    // the cells there via the `is-touch` geometry variant.
+    const isTouch = computed(() => isMobile.value && !useNative.value);
 
     const selected = computed(() => parseISODate(props.modelValue));
     const hasValue = computed(() => selected.value !== null);
@@ -537,7 +541,7 @@ export default defineComponent({
             backdrop={false}
             class="hk-dp-popover"
           >
-            <div class="hk-dp-panel">
+            <div class={["hk-dp-panel", isTouch.value ? "is-touch" : ""].filter(Boolean).join(" ")}>
               {/* The stage pins the day view's exact size in every view so
                   drilling into months/years never resizes the popup; the
                   drift direction drives the registered pane keyframes. */}

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -20,8 +20,8 @@
 
 .hk-dtp-header {
   /* Fixed height keeps the header row — and therefore the shared stage
-   * height — identical in every view and locale. */
-  height: 1.75rem;
+   * height — identical in every view and locale (enlarged on touch). */
+  height: var(--hk-picker-header);
 }
 
 .hk-dtp-header-side {
@@ -109,8 +109,8 @@
   font-size: var(--hi-text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
-  height: 1.25rem;
-  line-height: 1.25rem;
+  height: var(--hk-picker-wd);
+  line-height: var(--hk-picker-wd);
   text-transform: uppercase;
   letter-spacing: 0.02em;
 }
@@ -123,8 +123,8 @@
   border-radius: var(--hi-radius-sm, 4px);
   /* Fixed height keeps the six-row day grid — and therefore the shared
    * stage height — independent of the picker width, so drilling between
-   * views never changes the picker's size. */
-  height: 2rem;
+   * views never changes the picker's size (enlarged on touch). */
+  height: var(--hk-picker-cell);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -181,7 +181,7 @@
 }
 
 .hk-dtp-cell[data-variant="pick"] {
-  height: 2.5rem;
+  height: var(--hk-picker-pick);
   font-size: var(--hi-text-xs, 0.75rem);
   font-weight: 500;
 }

--- a/packages/vue/src/components/HkDateTimePicker.test.ts
+++ b/packages/vue/src/components/HkDateTimePicker.test.ts
@@ -287,6 +287,8 @@ describe("HkDateTimePicker", () => {
     expect(p.container.querySelector(".hk-dtp")).not.toBeNull();
     expect(dayCells().length).toBe(42);
     expect(nativeInput(p.container)).toBeNull();
+    // Mobile custom calendar gets the enlarged touch geometry variant.
+    expect(p.container.querySelector(".hk-dtp")?.classList.contains("is-touch")).toBe(true);
   });
 
   it("native input edits update the model as a local-time Date", async () => {

--- a/packages/vue/src/components/HkDateTimePicker.tsx
+++ b/packages/vue/src/components/HkDateTimePicker.tsx
@@ -110,6 +110,10 @@ export default defineComponent({
     // chrome for a native datetime-local input and keep the custom UI on
     // desktop widths only.
     const useNative = computed(() => props.nativeOnMobile && isMobile.value);
+    // The custom calendar renders on touch viewports only when the host
+    // opts out of the native input (e.g. bottom-sheet dialogs); enlarge
+    // the cells there via the `is-touch` geometry variant.
+    const isTouch = computed(() => isMobile.value && !useNative.value);
 
     const viewYear = ref(props.modelValue.getFullYear());
     const viewMonth = ref(props.modelValue.getMonth());
@@ -521,7 +525,7 @@ export default defineComponent({
       }
 
       const body = (
-        <div class="hk-dtp" role="group" aria-label={t("hikari::dateTimePicker.pickDate", "Pick a date and time")}>
+        <div class={["hk-dtp", isTouch.value ? "is-touch" : ""].filter(Boolean).join(" ")} role="group" aria-label={t("hikari::dateTimePicker.pickDate", "Pick a date and time")}>
           {renderBody()}
           {/* The time row lives outside the transitioned pane and stays in
               every view, so the picker's footprint never changes when the

--- a/packages/vue/src/components/HkPickerPane.scss
+++ b/packages/vue/src/components/HkPickerPane.scss
@@ -11,15 +11,40 @@
  * the global CSS-animation switch and reduced-motion both collapse the
  * transition to an instant swap. */
 
-/* Day-view geometry the stage height is derived from: a 1.75rem header
- * row (fixed on .hk-dp-header / .hk-dtp-header) + a 1.25rem weekday row +
- * six 2rem day rows + five 2px grid gaps. Keep the values in sync with
+/* Day-view geometry the stage height is derived from: a header row + a
+ * weekday row + six day rows + five 2px grid gaps. The individual metrics
+ * are CSS variables (--hk-picker-*) so the touch variant can enlarge the
+ * cells while the fixed-stage invariant holds per variant — the panel
+ * still never resizes when a sub-view opens. Keep the values in sync with
  * the .hk-dp-cell / .hk-dtp-cell and .hk-dp-wd / .hk-dtp-wd rules in each
  * component's stylesheet. */
+
+/* Geometry tokens. Defined on the panel/body roots because the popover
+ * teleports them away from the picker root (no var inheritance across the
+ * teleport boundary). */
+.hk-dp-panel,
+.hk-dtp {
+  --hk-picker-header: 1.75rem;
+  --hk-picker-wd: 1.25rem;
+  --hk-picker-cell: 2rem;
+  --hk-picker-pick: 2.5rem;
+}
+
+/* Touch variant: bigger cells for bottom-sheet / in-page mobile usage.
+ * Applied via the `is-touch` class when the custom calendar renders on a
+ * touch-sized viewport (nativeOnMobile=false hosts, e.g. the reports
+ * date-jump sheet). */
+.hk-dp-panel.is-touch,
+.hk-dtp.is-touch {
+  --hk-picker-wd: 1.5rem;
+  --hk-picker-cell: 2.5rem;
+  --hk-picker-pick: 3rem;
+}
+
 .hk-dp-stage,
 .hk-dtp-stage {
   position: relative;
-  height: calc(1.75rem + 1.25rem + 6 * 2rem + 10px);
+  height: calc(var(--hk-picker-header) + var(--hk-picker-wd) + 6 * var(--hk-picker-cell) + 10px);
 }
 
 .hk-dp-pane,


### PR DESCRIPTION
手机版底部弹出框里的日期日历偏小：给 HkDatePicker/HkDateTimePicker 的自定义日历加 `is-touch` 尺寸变体（移动端且 nativeOnMobile=false 时自动启用）——天格 2→2.5rem、月/年格 2.5→3rem、星期行 1.25→1.5rem，stage 250→302px，固定尺寸不变式按变体保持，桌面端与原生输入不受影响。浏览器实测：390×844 下两种 picker 均 is-touch、天格 40px、月/年格 48px、视图切换 stage 恒定 302px；桌面 1280×720 不变（250/32px）。验证：vue-tsc 全绿、30 文件 269/269 测试（新增 is-touch 断言）。chest 报告页对话框无需改动自动受益。