### PR TITLE
✨ Re-land the adaptive dialog shell and blocking toast orphaned by the master rewrite.

### DIFF
--- a/packages/vue/src/components/HkAdaptiveDialog.scss
+++ b/packages/vue/src/components/HkAdaptiveDialog.scss
@@ -1,0 +1,22 @@
+// HkAdaptiveDialog — only the seams the two shells cannot provide
+// themselves: the composed drawer header (title + sub-header stacked in
+// HkDrawer's header slot, which otherwise replaces the title) and the
+// footerActions HButton row rendered inside HkDrawer's footer (HkModal
+// already renders that row itself; HkDrawer has no footerActions prop).
+// Everything visual (overlay, panel, transitions, footer padding and
+// divider) comes from HkModal.scss / HkDrawer.scss.
+
+.hk-adaptive-dialog-drawer-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--hi-space-4, 4px);
+  flex: 1;
+  min-width: 0;
+}
+
+.hk-adaptive-dialog-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--hi-space-8, 8px);
+}

--- a/packages/vue/src/components/HkAdaptiveDialog.test.tsx
+++ b/packages/vue/src/components/HkAdaptiveDialog.test.tsx
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkAdaptiveDialog from "./HkAdaptiveDialog";
+import { setLocale } from "../i18n/context";
+import { usePopupManager } from "../runtime/usePopupManager";
+
+/**
+ * HkAdaptiveDialog contract tests:
+ * - desktop width renders the HkModal shell, mobile width renders the
+ *   HkDrawer side="bottom" shell, and the shell flips live on resize
+ * - the v-model / update:modelValue contract round-trips in both shells
+ * - footerActions render in both shells (same order/labels/handlers)
+ * - the footer slot wins over footerActions (HkModal's precedence)
+ * - afterLeave is forwarded from the active shell
+ *
+ * (Repo test convention: raw createApp + document queries, no
+ * @vue/test-utils dependency.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+const originalWidth = window.innerWidth;
+
+const setWidth = (w: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: w,
+  });
+  window.dispatchEvent(new Event("resize"));
+};
+
+interface DialogHarness {
+  container: HTMLElement;
+  open: ReturnType<typeof ref<boolean>>;
+  emitted: Array<string | null>;
+  afterLeaveCount: () => number;
+  unmount: () => void;
+}
+
+function mountDialog(
+  props: Record<string, unknown> = {},
+  slots: Record<string, unknown> = {},
+): DialogHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+
+  const open = ref(true);
+  const emitted: Array<string | null> = [];
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkAdaptiveDialog, {
+          title: "Test dialog",
+          ...props,
+          modelValue: open.value,
+          "onUpdate:modelValue": (v: boolean) => {
+            emitted.push(String(v));
+            open.value = v;
+          },
+          "onAfterLeave": () => {
+            emitted.push("afterLeave");
+          },
+        } as never, slots as never);
+    },
+  });
+
+  const app = createApp(Wrapper);
+  const entry = { app, container };
+  mounts.push(entry);
+  app.mount(container);
+  return {
+    container,
+    open,
+    emitted,
+    afterLeaveCount: () => emitted.filter((e) => e === "afterLeave").length,
+    unmount: () => {
+      const idx = mounts.indexOf(entry);
+      if (idx !== -1) mounts.splice(idx, 1);
+      app.unmount();
+      container.remove();
+    },
+  };
+}
+
+/** Let Vue's enter/leave transitions (frame/timeout based) settle in happy-dom. */
+async function settle() {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 30));
+  await nextTick();
+}
+
+function modalContent(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".hk-modal-content");
+}
+
+function drawerPanel(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".hk-drawer-panel");
+}
+
+function footerButtons(root: ParentNode): HTMLButtonElement[] {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>("button")).filter(
+    (b) => !b.classList.contains("hk-modal-close") && !b.classList.contains("hk-drawer-close"),
+  );
+}
+
+afterEach(async () => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.querySelectorAll(".hk-modal-root, .hk-drawer-overlay, [class^='hk-drawer-panel']").forEach((el) => el.remove());
+  setWidth(originalWidth);
+  await setLocale("en");
+});
+
+describe("HkAdaptiveDialog", () => {
+  it("renders the modal shell at desktop width and registers kind modal", () => {
+    setWidth(1280);
+    mountDialog();
+    expect(modalContent()).toBeTruthy();
+    expect(drawerPanel()).toBeNull();
+
+    const entries = [...usePopupManager().registry.value.values()];
+    expect(entries.some((e) => e.kind === "modal" && e.title === "Test dialog")).toBe(true);
+    expect(entries.some((e) => e.kind === "drawer")).toBe(false);
+  });
+
+  it("renders the bottom drawer shell at mobile width and registers kind drawer", () => {
+    setWidth(375);
+    mountDialog();
+    const panel = drawerPanel();
+    expect(panel).toBeTruthy();
+    expect(panel!.classList.contains("hk-drawer-bottom")).toBe(true);
+    expect(modalContent()).toBeNull();
+    // No footer slot and no footerActions -> no empty footer band.
+    expect(document.querySelector(".hk-drawer-footer")).toBeNull();
+
+    const entries = [...usePopupManager().registry.value.values()];
+    expect(entries.some((e) => e.kind === "drawer")).toBe(true);
+    expect(entries.some((e) => e.kind === "modal")).toBe(false);
+  });
+
+  it("flips the shell live when the viewport crosses the breakpoint", async () => {
+    setWidth(1280);
+    mountDialog();
+    expect(modalContent()).toBeTruthy();
+    expect(drawerPanel()).toBeNull();
+
+    setWidth(375);
+    await nextTick();
+    await settle();
+    expect(drawerPanel()).toBeTruthy();
+    expect(modalContent()).toBeNull();
+
+    setWidth(1280);
+    await nextTick();
+    await settle();
+    expect(modalContent()).toBeTruthy();
+    expect(drawerPanel()).toBeNull();
+  });
+
+  it("round-trips v-model through the modal shell (close button + reopen)", async () => {
+    setWidth(1280);
+    const harness = mountDialog();
+    expect(modalContent()).toBeTruthy();
+
+    document.querySelector<HTMLElement>(".hk-modal-close")!.click();
+    await settle();
+    expect(harness.emitted).toContain("false");
+    expect(modalContent()).toBeNull();
+
+    harness.open.value = true;
+    await settle();
+    expect(modalContent()).toBeTruthy();
+  });
+
+  it("round-trips v-model through the drawer shell and forwards afterLeave", async () => {
+    setWidth(375);
+    const harness = mountDialog();
+    expect(drawerPanel()).toBeTruthy();
+
+    document.querySelector<HTMLElement>(".hk-drawer-close")!.click();
+    await settle();
+    expect(harness.emitted).toContain("false");
+    expect(drawerPanel()).toBeNull();
+    expect(harness.afterLeaveCount()).toBeGreaterThan(0);
+
+    harness.open.value = true;
+    await settle();
+    expect(drawerPanel()).toBeTruthy();
+  });
+
+  it("closes on Escape through the drawer shell", async () => {
+    setWidth(375);
+    const harness = mountDialog();
+    const panel = drawerPanel()!;
+    panel.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await settle();
+    expect(harness.emitted).toContain("false");
+  });
+
+  it("renders footerActions in the modal footer", () => {
+    setWidth(1280);
+    mountDialog({
+      footerActions: [
+        { label: "Keep", variant: "secondary" },
+        { label: "Delete", variant: "danger" },
+      ],
+    });
+    const labels = footerButtons(document).map((b) => b.textContent?.trim());
+    expect(labels).toEqual(["Keep", "Delete"]);
+  });
+
+  it("renders footerActions as an equivalent button row in the drawer footer", () => {
+    setWidth(375);
+    const clicked: string[] = [];
+    mountDialog({
+      footerActions: [
+        { label: "Keep", variant: "secondary", onClick: () => clicked.push("keep") },
+        { label: "Delete", variant: "danger", onClick: () => clicked.push("delete") },
+      ],
+    });
+    const footer = document.querySelector<HTMLElement>(".hk-drawer-footer");
+    expect(footer).toBeTruthy();
+    const row = footer!.querySelector<HTMLElement>(".hk-adaptive-dialog-footer");
+    expect(row).toBeTruthy();
+
+    const labels = footerButtons(footer!).map((b) => b.textContent?.trim());
+    expect(labels).toEqual(["Keep", "Delete"]);
+
+    footerButtons(footer!)[1].click();
+    expect(clicked).toEqual(["delete"]);
+  });
+
+  it("lets the footer slot win over footerActions in both shells", () => {
+    const slots = { footer: () => h("div", { class: "custom-footer" }, "CUSTOM") };
+    const actions = [{ label: "SlotShouldWin" }];
+
+    setWidth(1280);
+    const desktop = mountDialog({ footerActions: actions }, slots);
+    expect(document.querySelector(".hk-modal-footer .custom-footer")).toBeTruthy();
+    expect(footerButtons(document).map((b) => b.textContent?.trim())).toEqual([]);
+    desktop.unmount();
+
+    setWidth(375);
+    const mobile = mountDialog({ footerActions: actions }, slots);
+    const footer = document.querySelector<HTMLElement>(".hk-drawer-footer")!;
+    expect(footer.querySelector(".custom-footer")).toBeTruthy();
+    expect(footerButtons(footer).map((b) => b.textContent?.trim())).toEqual([]);
+    mobile.unmount();
+  });
+
+  it("maps the header slot to the modal sub-header and keeps the drawer title bar", () => {
+    const slots = { header: () => h("div", { class: "custom-header" }, "SUB") };
+
+    setWidth(1280);
+    const desktop = mountDialog({}, slots);
+    expect(document.querySelector(".hk-modal-subheader .custom-header")).toBeTruthy();
+    expect(document.querySelector<HTMLElement>(".hk-modal-title")!.textContent).toContain("Test dialog");
+    desktop.unmount();
+
+    setWidth(375);
+    const mobile = mountDialog({}, slots);
+    const composed = document.querySelector<HTMLElement>(".hk-adaptive-dialog-drawer-header");
+    expect(composed).toBeTruthy();
+    expect(composed!.querySelector(".hk-drawer-title")!.textContent).toContain("Test dialog");
+    expect(composed!.querySelector(".custom-header")).toBeTruthy();
+    mobile.unmount();
+  });
+});

--- a/packages/vue/src/components/HkAdaptiveDialog.tsx
+++ b/packages/vue/src/components/HkAdaptiveDialog.tsx
@@ -1,0 +1,167 @@
+/**
+ * HkAdaptiveDialog — one dialog contract, two shells.
+ *
+ * Renders HkModal on desktop viewports and HkDrawer side="bottom" on
+ * mobile (switched by `useBreakpoint().isMobile`, i.e. width < 768), so
+ * one `v-model` component gives a centered dialog on wide screens and a
+ * slide-up sheet on phones. The shell only picks which inner component
+ * renders and normalizes props/slots — overlay, teleport, z-index
+ * stacking, body scroll lock, focus handling and Escape-to-close all
+ * come from the inner components via usePopupManager and are never
+ * re-implemented here.
+ *
+ * Slot mapping:
+ *   default -> body of whichever shell renders
+ *   header  -> HkModal sub-header (below the title bar); on mobile the
+ *              drawer header is composed so the title stays in the title
+ *              bar and the slot content rides under it (visual parity
+ *              with the modal)
+ *   footer  -> footer slot of either shell; wins over footerActions,
+ *              matching HkModal's own precedence
+ *
+ * footerActions pass straight into HkModal's prop on desktop; HkDrawer
+ * has no footerActions prop, so on mobile the shell renders the
+ * equivalent HButton row inside the drawer's footer slot (same order,
+ * variants, loading, disabled and onClick handlers).
+ *
+ * Caveat: if the viewport crosses the mobile breakpoint while a leave
+ * transition is still in flight, the inner Transition unmounts without
+ * firing its after-leave hook — the forwarded `afterLeave` emit and
+ * HkModal's focus restore are skipped for that close (no resource leak:
+ * popup handle and scroll lock are released on unmount). Consumers
+ * relying on afterLeave (e.g. focus hand-off) should not depend on it
+ * firing during a live shell flip.
+ */
+import { defineComponent, type PropType } from "vue";
+
+import { useBreakpoint } from "../runtime/useBreakpoint";
+import "./HkAdaptiveDialog.scss";
+import HButton from "./HkButton";
+import HDrawer from "./HkDrawer";
+import HModal, { type ModalAction } from "./HkModal";
+
+export default defineComponent({
+  name: "HkAdaptiveDialog",
+  props: {
+    modelValue: { type: Boolean, required: true },
+    title: { type: String, default: undefined },
+    closable: { type: Boolean, default: true },
+    /** Desktop modal width (HkModal `width`). */
+    width: { type: String, default: "32rem" },
+    /** Mobile drawer height (HkDrawer `size`). HkDrawer's bottom-side CSS
+     *  clamps panels at maxHeight 70vh, so the default equals the cap;
+     *  pass `panelClass` with a custom max-height for taller sheets. */
+    mobileSize: { type: String, default: "70vh" },
+    footerActions: {
+      type: Array as PropType<ModalAction[]>,
+      default: undefined,
+    },
+    /** Extra classes for the mobile drawer panel — same escape hatch as
+     *  HkDrawer.panelClass (attrs fallthrough cannot reach a teleported
+     *  panel). Desktop has no equivalent hook on HkModal. */
+    panelClass: { type: String, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_value: boolean) => true,
+    afterLeave: () => true,
+  },
+  setup(props, { emit, slots }) {
+    const { isMobile } = useBreakpoint();
+
+    function onUpdate(v: boolean) {
+      emit("update:modelValue", v);
+    }
+
+    function onAfterLeave() {
+      emit("afterLeave");
+    }
+
+    /** Drawer footer: the footer slot wins over footerActions (same
+     *  precedence HkModal applies); with no slot, the actions render as
+     *  the same HButton row the modal would show. Returns undefined when
+     *  there is nothing to render so the drawer skips its footer band. */
+    function renderDrawerFooter() {
+      if (slots.footer) return slots.footer();
+      if (props.footerActions && props.footerActions.length > 0) {
+        return (
+          <div class="hk-adaptive-dialog-footer">
+            {props.footerActions.map((action, i) => (
+              <HButton
+                key={i}
+                variant={action.variant ?? "secondary"}
+                size="sm"
+                loading={action.loading}
+                disabled={action.disabled}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </HButton>
+            ))}
+          </div>
+        );
+      }
+      return undefined;
+    }
+
+    /** True when the drawer should render a footer band at all. */
+    function hasDrawerFooter() {
+      return Boolean(slots.footer) || Boolean(props.footerActions && props.footerActions.length > 0);
+    }
+
+    /** HkDrawer's header slot replaces the title span, so on mobile the
+     *  shell composes title + slot content itself — keeping the title in
+     *  the title bar with the slot under it, like the modal sub-header. */
+    function renderDrawerHeader() {
+      if (!slots.header) return undefined;
+      return () => (
+        <div class="hk-adaptive-dialog-drawer-header">
+          {props.title ? (
+            <span class="hk-drawer-title">{props.title}</span>
+          ) : null}
+          {slots.header!()}
+        </div>
+      );
+    }
+
+    return () => {
+      if (isMobile.value) {
+        return (
+          <HDrawer
+            modelValue={props.modelValue}
+            onUpdate:modelValue={onUpdate}
+            onAfterLeave={onAfterLeave}
+            side="bottom"
+            size={props.mobileSize}
+            title={props.title}
+            closable={props.closable}
+            panelClass={props.panelClass}
+          >
+            {{
+              default: () => slots.default?.(),
+              header: renderDrawerHeader(),
+              footer: hasDrawerFooter() ? () => renderDrawerFooter() : undefined,
+            }}
+          </HDrawer>
+        );
+      }
+
+      return (
+        <HModal
+          modelValue={props.modelValue}
+          onUpdate:modelValue={onUpdate}
+          onAfterLeave={onAfterLeave}
+          title={props.title}
+          closable={props.closable}
+          width={props.width}
+          footerActions={props.footerActions}
+        >
+          {{
+            default: () => slots.default?.(),
+            header: slots.header ? () => slots.header!() : undefined,
+            footer: slots.footer ? () => slots.footer!() : undefined,
+          }}
+        </HModal>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -1,0 +1,120 @@
+// HkBlockingToast — the blocking confirmation card host. The container
+// mirrors .hk-toast-container (same fixed top-right column, same
+// --hk-z-toast ceiling, same column gap) so blocking cards and
+// transient toasts read as one stack; the card itself follows the toast
+// item conventions (variant background, icon column, clamped message)
+// with a button row appended. Pointer events pass through the column
+// and re-enable on the card, exactly like toasts.
+
+.hk-blocking-toast-container {
+  position: fixed;
+  top: 4rem;
+  right: 1rem;
+  z-index: var(--hk-z-toast, 9999);
+  max-width: 24rem;
+  pointer-events: none;
+}
+
+.hk-blocking-toast-container > div {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--hi-space-12, 12px);
+}
+
+.hk-blocking-toast-slot {
+  position: relative;
+  pointer-events: auto;
+}
+
+.hk-blocking-toast-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--hi-space-8, 8px);
+  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  border-radius: var(--hi-radius-sm, 4px);
+  font-size: var(--hi-text-base, 0.875rem);
+  line-height: 1.4;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  pointer-events: auto;
+  backdrop-filter: blur(12px);
+}
+
+.hk-blocking-toast-icon {
+  display: flex;
+  align-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
+.hk-blocking-toast-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--hi-space-8, 8px);
+}
+
+.hk-blocking-toast-title {
+  font-size: 1em;
+  font-weight: 700;
+}
+
+.hk-blocking-toast-message {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  white-space: normal;
+}
+
+.hk-blocking-toast-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--hi-space-8, 8px);
+}
+
+// Variant backgrounds follow the HkToast conventions (including the
+// dark-on-amber warning text for contrast).
+.hk-blocking-toast-info {
+  background: var(--hi-color-info, #58a6ff);
+  color: #fff;
+}
+
+.hk-blocking-toast-warning {
+  background: var(--hi-color-warning, #d29922);
+  color: #1c1c1e;
+}
+
+.hk-blocking-toast-danger {
+  background: var(--hi-color-danger, #f85149);
+  color: #fff;
+}
+
+// Enter/leave mirrors the toast slide (settle, no bounce); leaving
+// cards go absolute so the remaining ones glide up (hk-toast pattern).
+.hk-blocking-toast-enter-active {
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform;
+  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.hk-blocking-toast-leave-active {
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform;
+  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-timing-function: cubic-bezier(0.36, 0, 0.66, 1);
+  position: absolute;
+  width: 100%;
+}
+
+.hk-blocking-toast-enter-from,
+.hk-blocking-toast-leave-to {
+  opacity: 0;
+  transform: translateX(1rem);
+}
+
+.hk-blocking-toast-move {
+  transition: transform var(--hi-duration-normal, 0.3s) ease;
+}

--- a/packages/vue/src/components/HkBlockingToast.test.tsx
+++ b/packages/vue/src/components/HkBlockingToast.test.tsx
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import HkBlockingToast from "./HkBlockingToast";
+import { setLocale } from "../i18n/context";
+import { usePopupManager } from "../runtime/usePopupManager";
+import {
+  clearBlockingToasts,
+  showBlockingToast,
+} from "../runtime/useBlockingToast";
+
+/**
+ * HkBlockingToast + useBlockingToast contract tests:
+ * - showBlockingToast renders a card in the toast stack host
+ * - confirm resolves true, cancel resolves false, and the card leaves
+ * - no auto-dismiss by default (the gate is truly blocking)
+ * - timeoutMs resolves false on expiry
+ * - the open card registers with the popup manager (kind "toast") and
+ *   unregisters when answered
+ * - multiple prompts stack and resolve independently
+ *
+ * (Repo test convention: raw createApp + document queries, no
+ * @vue/test-utils dependency.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountHost() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkBlockingToast) });
+  mounts.push({ app, container });
+  app.mount(container);
+  return container;
+}
+
+async function settle() {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 30));
+  await nextTick();
+}
+
+function cards(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".hk-blocking-toast-card"));
+}
+
+function actionButtons(card: HTMLElement): HTMLButtonElement[] {
+  return Array.from(card.querySelectorAll<HTMLButtonElement>(".hk-blocking-toast-actions button"));
+}
+
+function toastRegistryTitles(): Array<{ kind: string; title?: string }> {
+  return [...usePopupManager().registry.value.values()].map((e) => ({ kind: e.kind, title: e.title }));
+}
+
+afterEach(async () => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  clearBlockingToasts();
+  document.querySelectorAll(".hk-blocking-toast-container").forEach((el) => el.remove());
+  await setLocale("en");
+});
+
+describe("HkBlockingToast", () => {
+  it("shows a card on showBlockingToast with title, message and default labels", async () => {
+    mountHost();
+    const gate = showBlockingToast("Admins can view your usage.", { title: "Join group?" });
+    await settle();
+
+    expect(cards().length).toBe(1);
+    const card = cards()[0];
+    expect(card.querySelector(".hk-blocking-toast-title")!.textContent).toContain("Join group?");
+    expect(card.querySelector(".hk-blocking-toast-message")!.textContent).toContain("Admins can view your usage.");
+    const labels = actionButtons(card).map((b) => b.textContent?.trim());
+    expect(labels).toEqual(["Cancel", "Confirm"]);
+
+    actionButtons(card)[1].click();
+    await expect(gate).resolves.toBe(true);
+    await settle();
+    expect(cards().length).toBe(0);
+  });
+
+  it("resolves false on cancel and removes the card", async () => {
+    mountHost();
+    const gate = showBlockingToast("Cancel me");
+    await settle();
+    const card = cards()[0];
+
+    actionButtons(card)[0].click();
+    await expect(gate).resolves.toBe(false);
+    await settle();
+    expect(cards().length).toBe(0);
+  });
+
+  it("does not auto-dismiss by default", async () => {
+    mountHost();
+    const gate = showBlockingToast("Blocks forever");
+    await settle();
+    expect(cards().length).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 120));
+    expect(cards().length).toBe(1);
+
+    // Clean up the deliberately unanswered gate.
+    actionButtons(cards()[0])[1].click();
+    await expect(gate).resolves.toBe(true);
+  });
+
+  it("registers with the popup manager while open and unregisters when answered", async () => {
+    mountHost();
+    expect(toastRegistryTitles().some((e) => e.kind === "toast")).toBe(false);
+
+    const gate = showBlockingToast("Register me", { title: "Consent" });
+    await settle();
+    expect(toastRegistryTitles().some((e) => e.kind === "toast" && e.title === "Consent")).toBe(true);
+
+    actionButtons(cards()[0])[0].click();
+    await expect(gate).resolves.toBe(false);
+    await settle();
+    expect(toastRegistryTitles().some((e) => e.kind === "toast")).toBe(false);
+  });
+
+  it("resolves false when timeoutMs expires", async () => {
+    mountHost();
+    const gate = showBlockingToast("Times out", { timeoutMs: 40 });
+    await settle();
+    expect(cards().length).toBe(1);
+
+    await expect(gate).resolves.toBe(false);
+    await settle();
+    expect(cards().length).toBe(0);
+  });
+
+  it("stacks multiple prompts that resolve independently", async () => {
+    mountHost();
+    const first = showBlockingToast("First prompt", { title: "One" });
+    const second = showBlockingToast("Second prompt", { title: "Two" });
+    await settle();
+
+    expect(cards().length).toBe(2);
+    const [cardOne, cardTwo] = cards();
+    expect(cardOne.querySelector(".hk-blocking-toast-title")!.textContent).toContain("One");
+    expect(cardTwo.querySelector(".hk-blocking-toast-title")!.textContent).toContain("Two");
+
+    // Answer only the second; the first keeps blocking.
+    actionButtons(cardTwo)[1].click();
+    await expect(second).resolves.toBe(true);
+    await settle();
+    expect(cards().length).toBe(1);
+    expect(cards()[0].querySelector(".hk-blocking-toast-title")!.textContent).toContain("One");
+
+    actionButtons(cards()[0])[0].click();
+    await expect(first).resolves.toBe(false);
+  });
+
+  it("honors custom labels and the danger variant", async () => {
+    mountHost();
+    const gate = showBlockingToast("Danger zone", {
+      confirmLabel: "Join",
+      cancelLabel: "Back out",
+      variant: "danger",
+    });
+    await settle();
+
+    const card = cards()[0];
+    expect(card.classList.contains("hk-blocking-toast-danger")).toBe(true);
+    const labels = actionButtons(card).map((b) => b.textContent?.trim());
+    expect(labels).toEqual(["Back out", "Join"]);
+
+    actionButtons(card)[1].click();
+    await expect(gate).resolves.toBe(true);
+  });
+
+  it("uses localized default labels when the locale provides them", async () => {
+    await setLocale("zh-Hans");
+    mountHost();
+    const gate = showBlockingToast("本地化");
+    await settle();
+
+    const labels = actionButtons(cards()[0]).map((b) => b.textContent?.trim());
+    expect(labels).toEqual(["取消", "确认"]);
+
+    actionButtons(cards()[0])[1].click();
+    await expect(gate).resolves.toBe(true);
+    await setLocale("en");
+  });
+});

--- a/packages/vue/src/components/HkBlockingToast.tsx
+++ b/packages/vue/src/components/HkBlockingToast.tsx
@@ -1,0 +1,160 @@
+/**
+ * HkBlockingToast — renderer/host for the blocking-toast gate
+ * (`useBlockingToast` / `showBlockingToast`).
+ *
+ * Toast-shaped but flow-blocking consent prompts: a compact floating
+ * card in the toast stack area (not a centered modal, no scroll lock)
+ * with explicit Confirm/Cancel buttons — e.g. "joining this group lets
+ * its admins view your personal workspace usage — confirm?". Unlike a
+ * normal toast it never auto-dismisses; the caller's promise settles
+ * only when the user answers (or an optional timeoutMs expires).
+ *
+ * Mount once at the shell level, next to `<HToast />`. Self-contained
+ * Teleport-to-body host: cards sit in the same fixed top-right column
+ * HkToast uses (`--hk-z-toast`), so transient toasts and blocking cards
+ * share one visual stack; mount it after `<HToast />` so the blocking
+ * host paints above the transient stack and stays clickable when both
+ * are visible. While a card is visible it registers with
+ * usePopupManager (kind "toast", no scroll lock, with its title) so
+ * z-index ordering and popup introspection stay coherent with
+ * modals/drawers; the popup handle also fixes card-vs-card stacking
+ * (newer cards paint above older ones).
+ */
+import { AlertTriangle, CircleX as XCircle, Info } from "lucide-vue-next";
+import {
+  defineComponent,
+  onBeforeUnmount,
+  Teleport,
+  TransitionGroup,
+  watchEffect,
+} from "vue";
+
+import { useI18n } from "../i18n/context";
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import {
+  resolveBlockingToast,
+  useBlockingToast,
+  type BlockingToastItem,
+  type BlockingToastVariant,
+} from "../runtime/useBlockingToast";
+import "./HkBlockingToast.scss";
+import HButton from "./HkButton";
+
+const ICON_SIZE = 18;
+
+function renderIcon(variant: BlockingToastVariant) {
+  if (variant === "danger") return <XCircle size={ICON_SIZE} />;
+  if (variant === "warning") return <AlertTriangle size={ICON_SIZE} />;
+  return <Info size={ICON_SIZE} />;
+}
+
+const HkBlockingToastCard = defineComponent({
+  name: "HkBlockingToastCard",
+  props: {
+    item: { type: Object as () => BlockingToastItem, required: true },
+  },
+  emits: {
+    confirm: () => true,
+    cancel: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    return () => {
+      const item = props.item;
+      return (
+        <div
+          class={["hk-blocking-toast-card", `hk-blocking-toast-${item.variant}`]}
+          role="alertdialog"
+          aria-label={item.title ?? item.message}
+        >
+          <span class="hk-blocking-toast-icon">{renderIcon(item.variant)}</span>
+          <div class="hk-blocking-toast-body">
+            {item.title ? (
+              <strong class="hk-blocking-toast-title">{item.title}</strong>
+            ) : null}
+            <p class="hk-blocking-toast-message">{item.message}</p>
+            <div class="hk-blocking-toast-actions">
+              <HButton
+                variant="secondary"
+                size="sm"
+                onClick={() => emit("cancel")}
+              >
+                {item.cancelLabel ?? t("hikari::blockingToast.cancel", "Cancel")}
+              </HButton>
+              <HButton
+                variant={item.variant === "danger" ? "danger" : "primary"}
+                size="sm"
+                onClick={() => emit("confirm")}
+              >
+                {item.confirmLabel ?? t("hikari::blockingToast.confirm", "Confirm")}
+              </HButton>
+            </div>
+          </div>
+        </div>
+      );
+    };
+  },
+});
+
+export default defineComponent({
+  name: "HkBlockingToast",
+  setup() {
+    const { queue } = useBlockingToast();
+    const manager = usePopupManager();
+    const handles = new Map<number, PopupHandle>();
+
+    // Keep one popup-manager entry (kind "toast") per visible card so
+    // registry introspection and stacking stay coherent; unregister on
+    // removal. Cards register in queue order, so newer prompts get the
+    // higher z-index and paint above older ones.
+    watchEffect(() => {
+      const live = new Set(queue.map((item) => item.id));
+      for (const [id, handle] of [...handles]) {
+        if (!live.has(id)) {
+          manager.unregister(handle.id);
+          handles.delete(id);
+        }
+      }
+      for (const item of queue) {
+        if (!handles.has(item.id)) {
+          handles.set(
+            item.id,
+            manager.register("toast", false, item.title ?? item.message),
+          );
+        }
+      }
+    });
+
+    onBeforeUnmount(() => {
+      for (const [, handle] of handles) manager.unregister(handle.id);
+      handles.clear();
+    });
+
+    function zIndexOf(item: BlockingToastItem): number {
+      return handles.get(item.id)?.zIndex ?? 0;
+    }
+
+    return () => (
+      <Teleport to="body">
+        <div class="hk-blocking-toast-container">
+          <TransitionGroup tag="div" name="hk-blocking-toast">
+            {queue.map((item) => (
+              <div
+                key={item.id}
+                class="hk-blocking-toast-slot"
+                style={{ zIndex: zIndexOf(item) }}
+              >
+                <HkBlockingToastCard
+                  item={item}
+                  onConfirm={() => resolveBlockingToast(item.id, true)}
+                  onCancel={() => resolveBlockingToast(item.id, false)}
+                />
+              </div>
+            ))}
+          </TransitionGroup>
+        </div>
+      </Teleport>
+    );
+  },
+});

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -34,6 +34,8 @@ export default defineComponent({
   },
   emits: {
     "update:modelValue": (_value: boolean) => true,
+    // Mirrors HkModal.afterLeave so adaptive shells (HkAdaptiveDialog)
+    // can forward a uniform "the panel finished leaving" signal.
     afterLeave: () => true,
   },
   setup(props, { emit, slots }) {

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "لا توجد بيانات",
     "hikari::confirmDialog.cancel": "إلغاء",
     "hikari::confirmDialog.confirm": "تأكيد",
+    "hikari::blockingToast.cancel": "إلغاء",
+    "hikari::blockingToast.confirm": "تأكيد",
     "hikari::passwordInput.passwordEntered": "تم الإدخال، انقر للتركيز ومسح كلمة المرور الحالية",
     "hikari::passwordInput.allSelected": "تم تحديد الكل",
     "hikari::passwordInput.capsLock": "مفتاح Caps Lock مُفعّل",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "Keine Daten",
     "hikari::confirmDialog.cancel": "Abbrechen",
     "hikari::confirmDialog.confirm": "Bestätigen",
+    "hikari::blockingToast.cancel": "Abbrechen",
+    "hikari::blockingToast.confirm": "Bestätigen",
     "hikari::passwordInput.passwordEntered": "Eingegeben, Klicken fokussiert und löscht das vorhandene Passwort",
     "hikari::passwordInput.allSelected": "Alle ausgewählt",
     "hikari::passwordInput.capsLock": "Feststelltaste ist aktiviert",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "No data",
     "hikari::confirmDialog.cancel": "Cancel",
     "hikari::confirmDialog.confirm": "Confirm",
+    "hikari::blockingToast.cancel": "Cancel",
+    "hikari::blockingToast.confirm": "Confirm",
     "hikari::passwordInput.passwordEntered": "Entered, click to focus and clear the existing password",
     "hikari::passwordInput.allSelected": "All selected",
     "hikari::passwordInput.capsLock": "Caps Lock is on",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "Sin datos",
     "hikari::confirmDialog.cancel": "Cancelar",
     "hikari::confirmDialog.confirm": "Confirmar",
+    "hikari::blockingToast.cancel": "Cancelar",
+    "hikari::blockingToast.confirm": "Confirmar",
     "hikari::passwordInput.passwordEntered": "Introducida, al hacer clic se enfoca y borra la contraseña existente",
     "hikari::passwordInput.allSelected": "Todo seleccionado",
     "hikari::passwordInput.capsLock": "Bloq Mayús está activado",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "Aucune donnée",
     "hikari::confirmDialog.cancel": "Annuler",
     "hikari::confirmDialog.confirm": "Confirmer",
+    "hikari::blockingToast.cancel": "Annuler",
+    "hikari::blockingToast.confirm": "Confirmer",
     "hikari::passwordInput.passwordEntered": "Saisi, un clic active le champ et efface le mot de passe existant",
     "hikari::passwordInput.allSelected": "Tout est sélectionné",
     "hikari::passwordInput.capsLock": "Verr. Maj est activé",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "データなし",
     "hikari::confirmDialog.cancel": "キャンセル",
     "hikari::confirmDialog.confirm": "確認",
+    "hikari::blockingToast.cancel": "キャンセル",
+    "hikari::blockingToast.confirm": "確認",
     "hikari::passwordInput.passwordEntered": "入力済み、クリックでフォーカスし既存のパスワードを消去します",
     "hikari::passwordInput.allSelected": "全選択",
     "hikari::passwordInput.capsLock": "CapsLock オン",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "데이터 없음",
     "hikari::confirmDialog.cancel": "취소",
     "hikari::confirmDialog.confirm": "확인",
+    "hikari::blockingToast.cancel": "취소",
+    "hikari::blockingToast.confirm": "확인",
     "hikari::passwordInput.passwordEntered": "입력됨, 클릭하여 포커스하면 기존 비밀번호가 지워집니다",
     "hikari::passwordInput.allSelected": "전체 선택",
     "hikari::passwordInput.capsLock": "CapsLock 켜짐",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "Sem dados",
     "hikari::confirmDialog.cancel": "Cancelar",
     "hikari::confirmDialog.confirm": "Confirmar",
+    "hikari::blockingToast.cancel": "Cancelar",
+    "hikari::blockingToast.confirm": "Confirmar",
     "hikari::passwordInput.passwordEntered": "Inserida, clique para focar e apagar a senha existente",
     "hikari::passwordInput.allSelected": "Tudo selecionado",
     "hikari::passwordInput.capsLock": "Caps Lock está ativado",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "Нет данных",
     "hikari::confirmDialog.cancel": "Отмена",
     "hikari::confirmDialog.confirm": "Подтвердить",
+    "hikari::blockingToast.cancel": "Отмена",
+    "hikari::blockingToast.confirm": "Подтвердить",
     "hikari::passwordInput.passwordEntered": "Введён, клик сфокусирует и очистит текущий пароль",
     "hikari::passwordInput.allSelected": "Выделено всё",
     "hikari::passwordInput.capsLock": "Включён Caps Lock",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "暂无数据",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "确认",
+    "hikari::blockingToast.cancel": "取消",
+    "hikari::blockingToast.confirm": "确认",
     "hikari::passwordInput.passwordEntered": "已输入，点击聚焦将清空已有密码",
     "hikari::passwordInput.allSelected": "已全选",
     "hikari::passwordInput.capsLock": "大写锁定已开启",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -30,6 +30,8 @@
     "hikari::table.noData": "暫無數據",
     "hikari::confirmDialog.cancel": "取消",
     "hikari::confirmDialog.confirm": "確認",
+    "hikari::blockingToast.cancel": "取消",
+    "hikari::blockingToast.confirm": "確認",
     "hikari::passwordInput.passwordEntered": "已輸入，點擊聚焦將清空已有密碼",
     "hikari::passwordInput.allSelected": "已全選",
     "hikari::passwordInput.capsLock": "大寫鎖定已開啟",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,7 +1,9 @@
 export { default as HActionBar } from "./components/HkActionBar";
+export { default as HAdaptiveDialog } from "./components/HkAdaptiveDialog";
 export { default as HAlert } from "./components/HkAlert";
 export { default as HAvatar } from "./components/HkAvatar";
 export { default as HBadge } from "./components/HkBadge";
+export { default as HBlockingToast } from "./components/HkBlockingToast";
 export { default as HBreadcrumb } from "./components/HkBreadcrumb";
 export { default as HButton } from "./components/HkButton";
 export { default as HCard } from "./components/HkCard";
@@ -125,6 +127,13 @@ export {
   usePopupManager,
   useToast,
   useConfirm,
+  useBlockingToast,
+  showBlockingToast,
+  resolveBlockingToast,
+  clearBlockingToasts,
+  type BlockingToastItem,
+  type BlockingToastOptions,
+  type BlockingToastVariant,
   useBreakpoint,
   useClipboard,
   useMediaQuery,

--- a/packages/vue/src/runtime/index.ts
+++ b/packages/vue/src/runtime/index.ts
@@ -7,6 +7,7 @@ export { useOverlay, closeAll, isOverlayOpen, type OverlayHandle, type UseOverla
 export { usePopupManager, type PopupHandle, type PopupKind } from "./usePopupManager";
 export { useToast, TOAST_DURATION, type ToastItem, type ToastMessage, type ToastType } from "./useToast";
 export { useConfirm } from "./useConfirm";
+export { useBlockingToast, showBlockingToast, resolveBlockingToast, clearBlockingToasts, type BlockingToastItem, type BlockingToastOptions, type BlockingToastVariant } from "./useBlockingToast";
 export { useBreakpoint } from "./useBreakpoint";
 export { useClipboard } from "./useClipboard";
 export { provideScrollWindow, useScrollWindow, type ScrollWindowContext } from "../composables/useScrollWindow";

--- a/packages/vue/src/runtime/useBlockingToast.ts
+++ b/packages/vue/src/runtime/useBlockingToast.ts
@@ -1,0 +1,112 @@
+import { reactive } from "vue";
+
+import { scheduleCronAfter, type CronHandle } from "./cronBus";
+
+export type BlockingToastVariant = "info" | "warning" | "danger";
+
+export interface BlockingToastOptions {
+  /** Bold lead-in line (e.g. "Join group?"). */
+  title?: string;
+  /** Confirm button label; defaults to the i18n "Confirm" string. */
+  confirmLabel?: string;
+  /** Cancel button label; defaults to the i18n "Cancel" string. */
+  cancelLabel?: string;
+  /** Visual tone of the card. */
+  variant?: BlockingToastVariant;
+  /** Milliseconds before the gate auto-resolves `false`. Default: no
+   *  timeout — the prompt blocks until explicitly answered. */
+  timeoutMs?: number;
+}
+
+export interface BlockingToastItem {
+  id: number;
+  message: string;
+  title?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant: BlockingToastVariant;
+  timeoutMs?: number;
+}
+
+/**
+ * Blocking-toast gate — toast-shaped, flow-blocking confirmation prompts.
+ *
+ * Primary use case: consent gates such as "joining this group lets its
+ * admins view your personal workspace usage — confirm?" — less chrome
+ * than HkConfirmDialog (no centered modal, no scroll lock), but unlike a
+ * normal toast the prompt never auto-dismisses: the returned promise
+ * settles only on an explicit confirm/cancel (or an optional timeout).
+ *
+ * Rendering lives in `components/HkBlockingToast.tsx` — mount
+ * `<HBlockingToast />` once (next to `<HToast />`) at the shell level;
+ * calls made while no host is mounted queue up and resolve once the
+ * host appears (same contract as useToast/HkToast).
+ *
+ * Queue model: pending prompts are STACKED, not serialized — every
+ * `showBlockingToast` call renders its own card simultaneously and
+ * resolves independently (matching how normal toasts stack). A prompt
+ * does not wait for earlier ones to be answered.
+ */
+const state = reactive<{ queue: BlockingToastItem[] }>({ queue: [] });
+
+const resolvers = new Map<number, (value: boolean) => void>();
+const timers = new Map<number, CronHandle>();
+let nextId = 0;
+
+function settle(id: number, value: boolean) {
+  const resolve = resolvers.get(id);
+  if (!resolve) return;
+  resolvers.delete(id);
+  const timer = timers.get(id);
+  if (timer !== undefined) {
+    timer.disconnect();
+    timers.delete(id);
+  }
+  const idx = state.queue.findIndex((item) => item.id === id);
+  if (idx !== -1) state.queue.splice(idx, 1);
+  resolve(value);
+}
+
+/** Show a blocking confirmation toast. Resolves `true` on confirm,
+ *  `false` on cancel (or timeout expiry). */
+export function showBlockingToast(
+  message: string,
+  opts: BlockingToastOptions = {},
+): Promise<boolean> {
+  const id = ++nextId;
+  const item: BlockingToastItem = {
+    id,
+    message,
+    title: opts.title,
+    confirmLabel: opts.confirmLabel,
+    cancelLabel: opts.cancelLabel,
+    variant: opts.variant ?? "info",
+    timeoutMs: opts.timeoutMs,
+  };
+  return new Promise<boolean>((resolve) => {
+    state.queue.push(item);
+    resolvers.set(id, resolve);
+    const timeout = opts.timeoutMs ?? 0;
+    if (timeout > 0) {
+      timers.set(id, scheduleCronAfter(() => settle(id, false), timeout));
+    }
+  });
+}
+
+/** Resolve one prompt programmatically (value: confirm=true). */
+export function resolveBlockingToast(id: number, value: boolean): void {
+  settle(id, value);
+}
+
+/** Resolve every pending prompt as `false` (test/teardown helper). */
+export function clearBlockingToasts(): void {
+  for (const item of [...state.queue]) settle(item.id, false);
+}
+
+export function useBlockingToast() {
+  return {
+    /** Reactive stack of pending prompts rendered by HkBlockingToast. */
+    queue: state.queue,
+    show: showBlockingToast,
+  };
+}


### PR DESCRIPTION
# Summary

Re-lands the adaptive modal-drawer dialog shell and blocking toast confirmations (#249) that the 2026-08-22 org-wide master history rewrite orphaned (the #253 re-apply wave restored the picker/i18n/context waves but not this one).

Content is the e3e0515 squash cherry-picked onto current master:

- `HkAdaptiveDialog` (`HAdaptiveDialog`): desktop renders HkModal, mobile renders a bottom HkDrawer; overlay/teleport/z-index/scroll-lock/focus/Escape delegated to the inner components.
- `HkBlockingToast` (`HBlockingToast`) + `useBlockingToast`: promise-gated blocking toasts (`showBlockingToast(message, opts) → Promise<boolean>`), stacking, optional timeout, variant + i18n button labels.
- `HkDrawer` emits `afterLeave` mirroring HkModal so adaptive shells can forward a uniform leave signal.
- i18n keys for the toast buttons across all 11 locales; exports from the root and runtime entry points.

Conflict resolution against the post-rewrite overlay work (#254/#255): HkDrawer keeps the new focus-restoration in `onDrawerAfterLeave` alongside the `afterLeave` emit.

# Verification

- Scoped: HkAdaptiveDialog (10) + HkBlockingToast (8) vitest suites green.
- Full package vitest + vue-tsc typecheck run by the external round verifier (see PLAN.md §0 ledger).
