### PR TITLE
♻️ Re-land the one-shot health-endpoint probe orphaned by the master rewrite.

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -193,6 +193,8 @@ export {
 export type { CssAnimationOptions, RegisteredCssAnimation } from "./animation/registerAnimations";
 export { probeOrigin, probeOriginWithBody } from "./utils/connectivity";
 export type { OriginProbe } from "./utils/connectivity";
+export { probeHealthEndpoint } from "./utils/healthProbe";
+export type { HealthProbeBody, HealthProbeResult } from "./utils/healthProbe";
 
 export { highlight, useHighlight } from "./composables/useHighlight";
 export { LANGUAGE_LOADERS } from "./composables/highlightLanguages";

--- a/packages/vue/src/utils/healthProbe.ts
+++ b/packages/vue/src/utils/healthProbe.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared one-shot health-endpoint probe (P59-W2).
+ *
+ * `/api/health` (or any health-style endpoint) was fetched independently
+ * by every app with its own timeout/body handling — shittim-chest's
+ * useHealthProbe, plana-legacy's useEngineHealth, erp's status poll —
+ * drifting apart in policy. This is the single primitive they all call:
+ * one fetch, one AbortSignal timeout, one canonical minimal body shape.
+ * Pure function, no app config — callers bring the URL.
+ */
+
+/** Minimal subset shared by all `/api/health` consumers. */
+export interface HealthProbeBody {
+  status: string;
+  version: string;
+  product: string;
+  engine_version: string | null;
+  build_hash: string | null;
+  network?: unknown;
+  [key: string]: unknown;
+}
+
+export interface HealthProbeResult {
+  ok: boolean;
+  /** HTTP round-trip latency in ms (present even when the body is not ok). */
+  latencyMs: number;
+  body: HealthProbeBody | null;
+  /** Human-readable failure reason when !ok. */
+  reason: string | null;
+}
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+/**
+ * Probe a health endpoint once. Never throws — returns a result.
+ * `ok` means: HTTP 2xx AND parseable body (callers decide how to treat
+ * `status` values like "degraded").
+ */
+export async function probeHealthEndpoint(
+  url: string,
+  opts: { timeoutMs?: number; fetchFn?: typeof fetch } = {},
+): Promise<HealthProbeResult> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const started = performance.now();
+  try {
+    const resp = await fetchFn(url, {
+      method: "GET",
+      credentials: "include",
+      signal: AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    const latencyMs = Math.round(performance.now() - started);
+    if (!resp.ok) {
+      return { ok: false, latencyMs, body: null, reason: `HTTP ${resp.status}` };
+    }
+    const body = (await resp.json()) as HealthProbeBody;
+    return { ok: true, latencyMs, body, reason: null };
+  } catch (e) {
+    const latencyMs = Math.round(performance.now() - started);
+    const reason = e instanceof DOMException && e.name === "TimeoutError"
+      ? "timeout"
+      : e instanceof Error ? e.message : String(e);
+    return { ok: false, latencyMs, body: null, reason };
+  }
+}


### PR DESCRIPTION
chest 恢复后 master 已消费 probeHealthEndpoint（#245），但 hikari master 尚无该导出——重建 demo/dev 前的前置。cherry-pick 原 squash f212740（2 文件：utils/healthProbe.ts + index 导出），vue-tsc 全绿、269/269 测试。