### PR TITLE
✨ Fill the inline picker to its host width and enlarge the touch grid.

### DIFF
--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -9,6 +9,11 @@
   flex-direction: column;
   gap: var(--hi-space-8, 8px);
   user-select: none;
+  /* Fill the host (inline sheets/dialogs) instead of collapsing to the
+   * grid's min-content width — a bottom-sheet calendar should use the
+   * space it is given, not shrink to a cramped block. */
+  width: 100%;
+  min-width: 17.5rem;
 }
 
 .hk-dtp-header {

--- a/packages/vue/src/components/HkPickerPane.scss
+++ b/packages/vue/src/components/HkPickerPane.scss
@@ -37,8 +37,8 @@
 .hk-dp-panel.is-touch,
 .hk-dtp.is-touch {
   --hk-picker-wd: 1.5rem;
-  --hk-picker-cell: 2.5rem;
-  --hk-picker-pick: 3rem;
+  --hk-picker-cell: 2.75rem;
+  --hk-picker-pick: 3.25rem;
 }
 
 .hk-dp-stage,


### PR DESCRIPTION
demo 报告页底部弹层里的日历此前收缩成豆腐块：inline 模式容器无宽度，7 列 1fr 在自适应容器里塌缩到内容最小宽。修复：.hk-dtp 撑满宿主宽度（min 17.5rem）+ 触屏档再放大（天格 2.5→2.75rem、月/年格 3→3.25rem，stage 302→326px）。浏览器实测：390×844 模拟 336px 弹层内日历填满 336px、天格 46×44px。vue-tsc 全绿、50/50 测试。