### PR TITLE
✨ Add the single-field localized input editor with a cascading language menu.

### DIFF
--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -1,0 +1,92 @@
+.s-about-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16, 1rem);
+}
+
+.s-about-modal-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12, 0.75rem);
+}
+
+.s-about-modal-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  flex-shrink: 0;
+  border-radius: var(--radius-lg, 12px);
+  background: rgb(var(--color-primary));
+  color: rgb(var(--color-on-primary));
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 700;
+}
+
+.s-about-modal-name {
+  margin: 0;
+  font-size: var(--text-lg, 1.125rem);
+  font-weight: 700;
+  color: rgb(var(--color-text));
+}
+
+.s-about-modal-version {
+  margin: var(--space-4, 0.25rem) 0 0;
+  font-size: var(--text-sm, 0.8125rem);
+  color: rgb(var(--color-muted));
+}
+
+.s-about-modal-rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8, 0.5rem);
+}
+
+.s-about-modal-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-8, 0.5rem);
+}
+
+.s-about-modal-row-label {
+  font-size: var(--text-sm, 0.8125rem);
+  color: rgb(var(--color-muted));
+}
+
+.s-about-modal-row-value {
+  font-size: var(--text-sm, 0.8125rem);
+  color: rgb(var(--color-text));
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+}
+
+.s-about-modal-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8, 0.5rem);
+}
+
+.s-about-modal-links-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-8, 0.5rem);
+}
+
+.s-about-modal-link {
+  padding: var(--space-4, 0.25rem) var(--space-8, 0.5rem);
+  border-radius: var(--radius-sm, 6px);
+  background: rgb(var(--color-primary) / 12%);
+  color: rgb(var(--color-primary));
+  font-size: var(--text-xs, 0.75rem);
+  text-decoration: none;
+}
+
+.s-about-modal-link:hover {
+  background: rgb(var(--color-primary) / 20%);
+}
+
+.s-about-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/packages/vue/src/components/HkAboutModal.tsx
+++ b/packages/vue/src/components/HkAboutModal.tsx
@@ -1,0 +1,114 @@
+import { defineComponent, type PropType } from "vue";
+import { HBadge, HModal } from "@celestia-island/hikari";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkAboutModal.scss";
+
+export interface HAboutLink {
+  label: string;
+  href: string;
+}
+
+/**
+ * HkAboutModal — version / about dialog.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Shows the app identity and version metadata plus optional external
+ * links. Version/build hashes render as short hashes when longer than 12
+ * chars (full value in `title` tooltip).
+ */
+export const HkAboutModal = defineComponent({
+  name: "HkAboutModal",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    /** Application display name. */
+    appName: { type: String, required: true },
+    /** Application version (e.g. "0.1.4"). */
+    version: { type: String, required: true },
+    /** Optional app build hash / commit. */
+    buildHash: { type: String, default: undefined },
+    /** Optional engine version (backend), e.g. "0.2.1". */
+    engineVersion: { type: String, default: undefined },
+    /** Optional engine build hash / commit. */
+    engineBuildHash: { type: String, default: undefined },
+    /** Optional external links (e.g. GitHub, docs). */
+    links: { type: Array as PropType<HAboutLink[]>, default: () => [] },
+    title: { type: String, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_v: boolean) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    function shortHash(hash: string): string {
+      return hash.length > 12 ? `${hash.slice(0, 12)}…` : hash;
+    }
+
+    return () => (
+      <HModal
+        modelValue={props.modelValue}
+        onUpdate:modelValue={(v: boolean) => emit("update:modelValue", v)}
+        title={props.title ?? t("hikari::about.title", "About")}
+        width="30rem"
+      >
+        <div class="s-about-modal">
+          <header class="s-about-modal-header">
+            <div class="s-about-modal-logo">{props.appName.slice(0, 1).toUpperCase()}</div>
+            <div>
+              <h2 class="s-about-modal-name">{props.appName}</h2>
+              <p class="s-about-modal-version">
+                {t("hikari::about.version", "Version")} {props.version}
+              </p>
+            </div>
+          </header>
+
+          <div class="s-about-modal-rows">
+            {props.buildHash && (
+              <div class="s-about-modal-row">
+                <span class="s-about-modal-row-label">{t("hikari::about.buildHash", "Build")}</span>
+                <span class="s-about-modal-row-value" title={props.buildHash}>
+                  {shortHash(props.buildHash)}
+                </span>
+              </div>
+            )}
+            {props.engineVersion && (
+              <div class="s-about-modal-row">
+                <span class="s-about-modal-row-label">{t("hikari::about.engineVersion", "Engine version")}</span>
+                <span class="s-about-modal-row-value">{props.engineVersion}</span>
+              </div>
+            )}
+            {props.engineBuildHash && (
+              <div class="s-about-modal-row">
+                <span class="s-about-modal-row-label">{t("hikari::about.engineBuildHash", "Engine build")}</span>
+                <span class="s-about-modal-row-value" title={props.engineBuildHash}>
+                  {shortHash(props.engineBuildHash)}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {props.links.length > 0 && (
+            <div class="s-about-modal-links">
+              <span class="s-about-modal-row-label">{t("hikari::about.links", "Links")}</span>
+              <div class="s-about-modal-links-list">
+                {props.links.map((link) => (
+                  <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer" class="s-about-modal-link">
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <footer class="s-about-modal-footer">
+            <HBadge variant="muted">
+              © {new Date().getFullYear()} {props.appName}
+            </HBadge>
+          </footer>
+        </div>
+      </HModal>
+    );
+  },
+});

--- a/packages/vue/src/components/HkAttachmentModal.scss
+++ b/packages/vue/src/components/HkAttachmentModal.scss
@@ -1,0 +1,49 @@
+.s-attachment-modal {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12, 0.75rem);
+}
+
+.s-attachment-modal-text {
+  max-height: 48vh;
+  padding: var(--space-12, 0.75rem);
+  border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
+  border-radius: var(--radius-md, 8px);
+  background: rgb(var(--color-surface) / 0.5);
+}
+
+.s-attachment-modal-text-empty {
+  margin: 0;
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-muted));
+  font-style: italic;
+}
+
+.s-attachment-modal-text-error {
+  margin: var(--space-8, 0.5rem) 0 0;
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-error));
+}
+
+.s-attachment-modal-file {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
+  padding: var(--space-24, 1.5rem);
+  color: rgb(var(--color-muted));
+}
+
+.s-attachment-modal-file-name {
+  margin: 0;
+  font-size: var(--text-sm, 0.8125rem);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.s-attachment-modal-meta {
+  display: flex;
+  gap: var(--space-8, 0.5rem);
+}

--- a/packages/vue/src/components/HkAttachmentModal.tsx
+++ b/packages/vue/src/components/HkAttachmentModal.tsx
@@ -1,0 +1,309 @@
+import { computed, defineComponent, ref, watch, type PropType } from "vue";
+import { Film, File as FileIcon, Image as ImageIcon, Music } from "lucide-vue-next";
+import {
+  HBadge,
+  HImageViewer,
+  HMarkdownRenderer,
+  HMediaPlayer,
+  HModal,
+  HScrollContainer,
+} from "@celestia-island/hikari";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkAttachmentModal.scss";
+
+const CODE_LANGS: Record<string, string> = {
+  ".ts": "typescript", ".tsx": "typescript", ".js": "javascript",
+  ".jsx": "javascript", ".json": "json", ".rs": "rust", ".go": "go",
+  ".py": "python", ".java": "java", ".c": "c", ".cpp": "cpp", ".h": "c",
+  ".cs": "csharp", ".sh": "bash", ".bash": "bash", ".yaml": "yaml",
+  ".yml": "yaml", ".toml": "toml", ".html": "html", ".css": "css",
+  ".scss": "scss", ".sql": "sql", ".xml": "xml", ".ini": "ini",
+};
+
+function codeLanguage(name: string): string | undefined {
+  const idx = name.lastIndexOf(".");
+  if (idx < 0) return undefined;
+  return CODE_LANGS[name.slice(idx).toLowerCase()];
+}
+
+const TEXT_EXTS = new Set([".md", ".markdown", ".txt", ".log", ".csv"]);
+const CODE_EXTS = new Set(Object.keys(CODE_LANGS));
+
+/** Attachment row in the HRichInput strip. Parent-owned upload state. */
+export interface HAttachmentItem {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  preview?: string;
+  /** Upload progress 0-100; omitted/100 = ready. */
+  progress?: number;
+  status?: "uploading" | "done" | "error";
+}
+
+/** Attachment payload for HAttachmentModal preview. */
+export interface HAttachmentDetail {
+  name: string;
+  type: string;
+  size: number;
+  preview?: string;
+  url?: string;
+  /** Original File handle — used to read text/code content for preview. */
+  file?: File;
+}
+
+/** Kind of rich preview to render; inferred from MIME unless hinted. */
+export type HAttachmentPreviewType = "image" | "video" | "audio" | "other";
+
+/** Resolve the preview kind: an explicit hint wins, MIME prefix otherwise. */
+export function previewKindFor(
+  att: Pick<HAttachmentDetail, "type"> | null | undefined,
+  hint?: HAttachmentPreviewType,
+): HAttachmentPreviewType {
+  if (hint) return hint;
+  const type = att?.type ?? "";
+  if (type.startsWith("image/")) return "image";
+  if (type.startsWith("video/")) return "video";
+  if (type.startsWith("audio/")) return "audio";
+  return "other";
+}
+
+function isTextFile(att: HAttachmentDetail): boolean {
+  const ext = att.name.slice(att.name.lastIndexOf(".")).toLowerCase();
+  return att.type.startsWith("text/") || TEXT_EXTS.has(ext) || CODE_EXTS.has(ext);
+}
+
+/** "512" -> "512B", "1536" -> "1.5KB", "2621440" -> "2.5MB". */
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0B";
+  if (bytes < 1024) return `${Math.floor(bytes)}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+}
+
+/**
+ * HkAttachmentModal — generic file-picker preview modal.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Renders an attachment by preview kind: image (HImageViewer), video/audio
+ * (HMediaPlayer), text/code (HMarkdownRenderer, with syntax fences for
+ * known code extensions) or a generic file chip.
+ *
+ * URL handling is transport-agnostic: when the attachment carries no
+ * `preview`/`url`, the consumer may pass `resolveUrl` (its own API client /
+ * transport knows how to turn a backend file name into an authed URL).
+ * The resolved URL is used for media previews, the text fetch and the
+ * download action. Text content is read via the attachment's `file` handle
+ * when provided.
+ */
+export const HkAttachmentModal = defineComponent({
+  name: "HkAttachmentModal",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    attachment: { type: Object as PropType<HAttachmentDetail | null>, default: null },
+    /** Transport-provided URL resolver; called with the file name when the
+     *  attachment has neither `preview` nor `url`. */
+    resolveUrl: { type: Function as PropType<(name: string) => Promise<string>>, default: undefined },
+    /** Preview kind hint; inferred from the MIME type when omitted. */
+    previewType: { type: String as PropType<HAttachmentPreviewType>, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_v: boolean) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    const kind = computed(() => previewKindFor(props.attachment, props.previewType));
+    const isText = computed(() => (props.attachment ? isTextFile(props.attachment) : false));
+
+    /* ── URL resolution ──────────────────────────────────────────── */
+    const resolvedSrc = ref("");
+    const srcLoading = ref(false);
+    const srcError = ref<string | null>(null);
+
+    async function resolveSrc() {
+      const att = props.attachment;
+      srcLoading.value = false;
+      srcError.value = null;
+      if (!att) {
+        resolvedSrc.value = "";
+        return;
+      }
+      if (att.preview || att.url) {
+        resolvedSrc.value = att.preview || att.url || "";
+        return;
+      }
+      if (props.resolveUrl) {
+        srcLoading.value = true;
+        try {
+          resolvedSrc.value = await props.resolveUrl(att.name);
+        } catch (e) {
+          resolvedSrc.value = "";
+          srcError.value = e instanceof Error ? e.message : String(e);
+        } finally {
+          srcLoading.value = false;
+        }
+        return;
+      }
+      resolvedSrc.value = "";
+    }
+
+    watch(
+      () => [props.attachment, props.resolveUrl, props.previewType] as const,
+      () => { void resolveSrc(); },
+      { immediate: true },
+    );
+
+    /* ── Text / code preview ─────────────────────────────────────── */
+    const textContent = ref("");
+    const textPlain = ref(false);
+    const textLoading = ref(false);
+    const textError = ref<string | null>(null);
+
+    async function loadText() {
+      const att = props.attachment;
+      if (!att) return;
+      textLoading.value = true;
+      textError.value = null;
+      try {
+        let raw: string;
+        if (att.file) {
+          raw = await att.file.text();
+        } else if (resolvedSrc.value) {
+          // The resolved URL comes from the consumer's transport (via
+          // `resolveUrl`) or was already a usable preview/object URL.
+          const res = await fetch(resolvedSrc.value);
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          raw = await res.text();
+        } else {
+          raw = "";
+        }
+        const lang = codeLanguage(att.name);
+        const isMd = /\.(md|markdown)$/i.test(att.name);
+        if (isMd) {
+          textContent.value = raw;
+          textPlain.value = false;
+        } else if (lang) {
+          textContent.value = "```" + lang + "\n" + raw + "\n```";
+          textPlain.value = false;
+        } else {
+          textContent.value = raw;
+          textPlain.value = true;
+        }
+      } catch (e) {
+        textError.value = e instanceof Error ? e.message : String(e);
+      } finally {
+        textLoading.value = false;
+      }
+    }
+
+    function startTextLoad() {
+      if (!props.modelValue || !props.attachment) return;
+      if (isText.value) void loadText();
+    }
+
+    watch(
+      () => [props.modelValue, props.attachment] as const,
+      () => startTextLoad(),
+      { immediate: true },
+    );
+
+    // Re-fetch text once the transport URL lands (resolveUrl is async).
+    watch(resolvedSrc, () => {
+      if (!props.attachment?.file) startTextLoad();
+    });
+
+    function download() {
+      if (!resolvedSrc.value) return;
+      const a = document.createElement("a");
+      a.href = resolvedSrc.value;
+      a.download = props.attachment?.name || "download";
+      a.click();
+    }
+
+    function fileIcon() {
+      const att = props.attachment;
+      if (!att) return <FileIcon size={40} />;
+      if (att.type.startsWith("image/")) return <ImageIcon size={40} />;
+      if (att.type.startsWith("video/")) return <Film size={40} />;
+      if (att.type.startsWith("audio/")) return <Music size={40} />;
+      return <FileIcon size={40} />;
+    }
+
+    return () => (
+      <HModal
+        modelValue={props.modelValue}
+        onUpdate:modelValue={(v: boolean) => emit("update:modelValue", v)}
+        title={props.attachment?.name}
+        width="44rem"
+        footerActions={[
+          { label: t("hikari::attachment.download", "Download"), onClick: download, disabled: !resolvedSrc.value },
+          { label: t("hikari::attachment.close", "Close"), variant: "secondary", onClick: () => emit("update:modelValue", false) },
+        ]}
+      >
+        <div class="s-attachment-modal">
+          {srcLoading.value && (
+            <p class="s-attachment-modal-text-empty">{t("hikari::attachment.loading", "Loading…")}</p>
+          )}
+
+          {/* Image — zoomable viewer with minimap navigator */}
+          {!srcLoading.value && kind.value === "image" && resolvedSrc.value && (
+            <HImageViewer src={resolvedSrc.value} alt={props.attachment?.name ?? ""} />
+          )}
+
+          {/* Video — hikari media player with control bar */}
+          {!srcLoading.value && kind.value === "video" && resolvedSrc.value && (
+            <HMediaPlayer type="video" src={resolvedSrc.value} />
+          )}
+
+          {/* Audio — hikari media player with visualizer + control bar */}
+          {!srcLoading.value && kind.value === "audio" && resolvedSrc.value && (
+            <HMediaPlayer type="audio" src={resolvedSrc.value} />
+          )}
+
+          {/* Text / code — markdown + highlight.js via HMarkdownRenderer */}
+          {isText.value && (
+            <HScrollContainer class="s-attachment-modal-text">
+              {props.attachment?.file || resolvedSrc.value ? (
+                <HMarkdownRenderer
+                  content={textContent.value}
+                  loading={textLoading.value}
+                  plain={textPlain.value}
+                />
+              ) : (
+                <p class="s-attachment-modal-text-empty">
+                  {srcError.value
+                    ? srcError.value
+                    : t("hikari::attachment.noPreview", "No preview available.")}
+                </p>
+              )}
+              {textError.value && (
+                <p class="s-attachment-modal-text-error">{textError.value}</p>
+              )}
+            </HScrollContainer>
+          )}
+
+          {/* Generic file */}
+          {!srcLoading.value && kind.value === "other" && !isText.value && (
+            <div class="s-attachment-modal-file">
+              {fileIcon()}
+              <p class="s-attachment-modal-file-name">{props.attachment?.name}</p>
+            </div>
+          )}
+
+          {srcError.value && kind.value !== "other" && (
+            <p class="s-attachment-modal-text-error">{srcError.value}</p>
+          )}
+
+          <div class="s-attachment-modal-meta">
+            <HBadge variant="muted">{props.attachment?.type || "unknown"}</HBadge>
+            <HBadge variant="muted">{formatBytes(props.attachment?.size ?? 0)}</HBadge>
+          </div>
+        </div>
+      </HModal>
+    );
+  },
+});

--- a/packages/vue/src/components/HkCaptchaModal.scss
+++ b/packages/vue/src/components/HkCaptchaModal.scss
@@ -1,0 +1,14 @@
+.s-captcha-modal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-12, 0.75rem);
+  padding: var(--space-8, 0.5rem) 0;
+}
+
+.s-captcha-modal-prompt {
+  margin: 0;
+  font-size: var(--text-sm, 0.8125rem);
+  color: rgb(var(--color-muted));
+  text-align: center;
+}

--- a/packages/vue/src/components/HkCaptchaModal.tsx
+++ b/packages/vue/src/components/HkCaptchaModal.tsx
@@ -1,0 +1,62 @@
+import { defineComponent, type PropType } from "vue";
+import { HModal } from "@celestia-island/hikari";
+
+import { useI18n } from "../i18n/context";
+
+import { HkCaptchaWidget, type HkCaptchaProvider } from "./HkCaptchaWidget";
+import "./HkCaptchaModal.scss";
+
+/**
+ * HkCaptchaModal — modal host for HkCaptchaWidget.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Opens on demand (at submit time), renders the provider widget, and emits
+ * the verification token once the challenge succeeds. Closes itself when
+ * the provider reports an error so the caller can surface its own message.
+ */
+export const HkCaptchaModal = defineComponent({
+  name: "HkCaptchaModal",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    siteKey: { type: String, required: true },
+    provider: { type: String as PropType<HkCaptchaProvider>, default: "turnstile" },
+    scriptUrl: { type: String, default: undefined },
+    attempt: { type: Number, default: 0 },
+    title: { type: String, default: undefined },
+    width: { type: String, default: "30rem" },
+  },
+  emits: {
+    "update:modelValue": (_v: boolean) => true,
+    verify: (_token: string) => true,
+    error: (_message: string) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    return () => (
+      <HModal
+        modelValue={props.modelValue}
+        onUpdate:modelValue={(v: boolean) => emit("update:modelValue", v)}
+        title={props.title ?? t("hikari::captcha.title", "Security check")}
+        width={props.width}
+      >
+        <div class="s-captcha-modal">
+          <p class="s-captcha-modal-prompt">{t("hikari::captcha.prompt", "Complete the verification below to continue.")}</p>
+          {props.modelValue && (
+            <HkCaptchaWidget
+              siteKey={props.siteKey}
+              provider={props.provider}
+              scriptUrl={props.scriptUrl}
+              attempt={props.attempt}
+              onVerify={(token: string) => emit("verify", token)}
+              onError={(message: string) => {
+                emit("error", message);
+                emit("update:modelValue", false);
+              }}
+            />
+          )}
+        </div>
+      </HModal>
+    );
+  },
+});

--- a/packages/vue/src/components/HkCaptchaWidget.scss
+++ b/packages/vue/src/components/HkCaptchaWidget.scss
@@ -1,0 +1,30 @@
+.s-captcha-widget {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
+  min-height: 4rem;
+}
+
+.s-captcha-widget-loading {
+  margin: 0;
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-muted));
+}
+
+.s-captcha-widget-host {
+  display: flex;
+  justify-content: center;
+}
+
+.s-captcha-widget-placeholder {
+  justify-content: center;
+  min-height: 4rem;
+  padding: var(--space-16, 1rem);
+  border: 1px dashed var(--border-faint, rgb(var(--color-border) / 15%));
+  border-radius: var(--radius-md, 8px);
+  color: rgb(var(--color-muted));
+  font-size: var(--text-xs, 0.75rem);
+  text-align: center;
+  max-width: 22rem;
+}

--- a/packages/vue/src/components/HkCaptchaWidget.tsx
+++ b/packages/vue/src/components/HkCaptchaWidget.tsx
@@ -1,0 +1,171 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue";
+import { ShieldAlert } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkCaptchaWidget.scss";
+
+/**
+ * HkCaptchaWidget — provider-agnostic silent-captcha widget.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Renders a third-party captcha widget (Cloudflare Turnstile or Google
+ * reCAPTCHA protocol) and emits the verification token once the challenge
+ * succeeds. The provider CDN script is loaded lazily, only once per URL,
+ * and never bundled locally.
+ *
+ * Provider-agnostic contract:
+ *  - `provider: "turnstile" | "recaptcha"` selects the render protocol.
+ *  - `scriptUrl` overrides the official CDN URL (defaults per provider),
+ *    so any platform compatible with one of those protocols — including a
+ *    self-hosted one — works by pointing `scriptUrl` at it.
+ *  - No-op placeholder mode: when `siteKey` is empty (or `disabled` is
+ *    true) the widget renders a placeholder box and emits nothing. This
+ *    lets deployments ship without a captcha provider; wire a real
+ *    `siteKey`/`scriptUrl` per deployment to enable verification.
+ *
+ * Tokens are single-use; bump `attempt` (e.g. after a failed submit) to
+ * force a reset so a fresh token is produced.
+ */
+export type HkCaptchaProvider = "turnstile" | "recaptcha";
+
+const DEFAULT_SCRIPT_URLS: Record<HkCaptchaProvider, string> = {
+  turnstile: "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit",
+  recaptcha: "https://www.google.com/recaptcha/api.js?render=explicit",
+};
+
+const SCRIPT_LOADERS: Record<string, Promise<unknown> | undefined> = {};
+
+function loadScript(src: string): Promise<unknown> {
+  if (SCRIPT_LOADERS[src]) return SCRIPT_LOADERS[src];
+  SCRIPT_LOADERS[src] = new Promise((resolve, reject) => {
+    const el = document.createElement("script");
+    el.src = src;
+    el.async = true;
+    el.defer = true;
+    el.onload = () => resolve(undefined);
+    el.onerror = () => {
+      delete SCRIPT_LOADERS[src];
+      reject(new Error(`failed to load ${src}`));
+    };
+    document.head.appendChild(el);
+  });
+  return SCRIPT_LOADERS[src];
+}
+
+type TurnstileApi = {
+  render: (el: HTMLElement, opts: Record<string, unknown>) => string;
+  reset: (id?: string) => void;
+  remove: (id: string) => void;
+};
+type GrecaptchaApi = {
+  ready: (cb: () => void) => void;
+  render: (el: HTMLElement, opts: Record<string, unknown>) => number;
+  reset: (id?: number) => void;
+};
+
+function getGlobal(name: string): unknown {
+  return (window as unknown as Record<string, unknown>)[name];
+}
+
+export const HkCaptchaWidget = defineComponent({
+  name: "HkCaptchaWidget",
+  props: {
+    /** Site key issued by the provider (empty = placeholder/no-op mode). */
+    siteKey: { type: String, required: true },
+    /** Provider protocol: "turnstile" (default) or "recaptcha". */
+    provider: { type: String as PropType<HkCaptchaProvider>, default: "turnstile" },
+    /** CDN script URL override (defaults to the official provider URL). */
+    scriptUrl: { type: String, default: undefined },
+    /** Bump to force a token refresh (e.g. after a failed submit). */
+    attempt: { type: Number, default: 0 },
+    /** Disables rendering and enters no-op placeholder mode. */
+    disabled: { type: Boolean, default: false },
+  },
+  emits: {
+    verify: (_token: string) => true,
+    error: (_message: string) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const container = ref<HTMLElement>();
+    const loading = ref(false);
+    let widgetId: string | number | null = null;
+
+    const placeholder = computed(() => !props.siteKey || props.disabled);
+
+    function reset() {
+      if (widgetId == null) return;
+      if (props.provider === "turnstile") {
+        (getGlobal("turnstile") as TurnstileApi | undefined)?.reset(widgetId as string);
+      } else {
+        (getGlobal("grecaptcha") as GrecaptchaApi | undefined)?.reset(widgetId as number);
+      }
+    }
+
+    async function render() {
+      if (!container.value || placeholder.value) return;
+      const onToken = (token: string) => emit("verify", token);
+
+      loading.value = true;
+      try {
+        const src = props.scriptUrl || DEFAULT_SCRIPT_URLS[props.provider];
+        if (props.provider === "turnstile") {
+          await loadScript(src);
+          const api = getGlobal("turnstile") as TurnstileApi | undefined;
+          if (!api) throw new Error("turnstile not available");
+          widgetId = api.render(container.value, {
+            sitekey: props.siteKey,
+            callback: onToken,
+            "error-callback": () => emit("error", "turnstile error"),
+          });
+        } else {
+          await loadScript(src);
+          const api = getGlobal("grecaptcha") as GrecaptchaApi | undefined;
+          if (!api) throw new Error("grecaptcha not available");
+          await new Promise<void>((resolve) => api.ready(() => resolve()));
+          widgetId = api.render(container.value, {
+            sitekey: props.siteKey,
+            callback: onToken,
+          });
+        }
+      } catch (e) {
+        emit("error", e instanceof Error ? e.message : String(e));
+      } finally {
+        loading.value = false;
+      }
+    }
+
+    onMounted(render);
+    watch(
+      () => props.attempt,
+      () => {
+        if (widgetId != null) reset();
+      },
+    );
+    onBeforeUnmount(() => {
+      if (widgetId == null) return;
+      if (props.provider === "turnstile") {
+        (getGlobal("turnstile") as TurnstileApi | undefined)?.remove(widgetId as string);
+      }
+      widgetId = null;
+    });
+
+    return () => {
+      if (placeholder.value) {
+        return (
+          <div class="s-captcha-widget s-captcha-widget-placeholder">
+            <ShieldAlert size={16} />
+            <span>{t("hikari::captcha.placeholder", "Verification is not configured for this deployment (no site key provided).")}</span>
+          </div>
+        );
+      }
+      return (
+        <div class="s-captcha-widget">
+          {loading.value && <p class="s-captcha-widget-loading">{t("hikari::captcha.loading", "Loading verification widget…")}</p>}
+          <div ref={container} class="s-captcha-widget-host" />
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkCookieConsent.scss
+++ b/packages/vue/src/components/HkCookieConsent.scss
@@ -1,0 +1,22 @@
+.s-cookie-consent {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.625rem;
+  color: rgb(var(--color-muted));
+}
+
+.s-cookie-consent-ok {
+  background: transparent;
+  border: none;
+  color: rgb(var(--color-primary));
+  cursor: pointer;
+  font-size: 0.625rem;
+  font-weight: 600;
+}
+
+.s-cookie-consent-icon {
+  color: rgb(var(--color-success));
+  opacity: 0.5;
+  cursor: default;
+}

--- a/packages/vue/src/components/HkCookieConsent.test.tsx
+++ b/packages/vue/src/components/HkCookieConsent.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HkCookieConsent } from "./HkCookieConsent";
+
+const STORAGE_KEY = "hikari-cookies-accepted";
+
+/** Stub the runtime timezone the component's Europe check reads. */
+function stubTimezone(tz: string | undefined) {
+  vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+    () =>
+      ({
+        resolvedOptions: () => ({ timeZone: tz }),
+      }) as unknown as Intl.DateTimeFormat,
+  );
+}
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountConsent() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkCookieConsent) });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+  localStorage.removeItem(STORAGE_KEY);
+  vi.restoreAllMocks();
+});
+
+describe("HkCookieConsent", () => {
+  it("renders nothing outside Europe before any choice is stored", async () => {
+    stubTimezone("Asia/Shanghai");
+    const container = mountConsent();
+    await nextTick();
+    expect(container.querySelector(".s-cookie-consent")).toBeNull();
+    expect(container.querySelector(".s-cookie-consent-icon")).toBeNull();
+  });
+
+  it("shows the notice text and OK button in a Europe timezone with no stored choice", async () => {
+    stubTimezone("Europe/Berlin");
+    const container = mountConsent();
+    await nextTick();
+    const notice = container.querySelector<HTMLElement>(".s-cookie-consent");
+    expect(notice, "notice span renders").toBeTruthy();
+    expect(notice!.textContent).toContain("This site uses cookies.");
+    const ok = container.querySelector<HTMLButtonElement>(".s-cookie-consent-ok");
+    expect(ok, "OK button renders").toBeTruthy();
+    expect(ok!.textContent).toBe("OK");
+  });
+
+  it("accepting stores the flag and collapses to the cookie icon", async () => {
+    stubTimezone("Europe/Paris");
+    const container = mountConsent();
+    await nextTick();
+    container.querySelector<HTMLButtonElement>(".s-cookie-consent-ok")!.click();
+    await nextTick();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("1");
+    expect(container.querySelector(".s-cookie-consent")).toBeNull();
+    expect(container.querySelector("svg.s-cookie-consent-icon")).toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/HkCookieConsent.tsx
+++ b/packages/vue/src/components/HkCookieConsent.tsx
@@ -1,0 +1,56 @@
+import { defineComponent, onMounted, ref } from "vue";
+import { Cookie } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkCookieConsent.scss";
+
+// Upstream namespace rename: the plana-legacy original stored the flag
+// under "plana-cookies-accepted"; hikari owns the key in its own
+// "hikari-cookies-accepted" namespace.
+const STORAGE_KEY = "hikari-cookies-accepted";
+
+/**
+ * HkCookieConsent — minimal GDPR cookie notice.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Only surfaces the notice in European timezones and only until the
+ * visitor accepts; afterwards a tiny cookie glyph remains as the
+ * acknowledgment marker. Outside Europe nothing renders at all.
+ */
+export const HkCookieConsent = defineComponent({
+  name: "HkCookieConsent",
+  setup() {
+    const { t } = useI18n();
+    const accepted = ref(false);
+    const show = ref(false);
+
+    onMounted(() => {
+      accepted.value = localStorage.getItem(STORAGE_KEY) === "1";
+      if (!accepted.value) {
+        const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        const eu = tz?.startsWith("Europe/") ?? false;
+        show.value = eu;
+      }
+    });
+
+    function accept() {
+      localStorage.setItem(STORAGE_KEY, "1");
+      accepted.value = true;
+      show.value = false;
+    }
+
+    return () => {
+      if (!show.value && !accepted.value) return null;
+      if (accepted.value) return <Cookie size={12} class="s-cookie-consent-icon" />;
+      return (
+        <span class="s-cookie-consent">
+          {t("hikari::cookie.text", "This site uses cookies.")}
+          <button type="button" class="s-cookie-consent-ok" onClick={accept}>
+            {t("hikari::cookie.ok", "OK")}
+          </button>
+        </span>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -1,0 +1,58 @@
+.hk-localized-input {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  width: 100%;
+}
+
+.hk-localized-input-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: rgb(var(--color-muted));
+}
+
+/* The wrapped language chip riding the input's right edge. A button so
+ * it is focusable/AT-reachable, but it must never steal the field's
+ * click-to-edit: pointer events stop at the chip boundary (handled in
+ * TSX) and mousedown is suppressed to keep focus inside the input. */
+.hk-localized-input-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgb(var(--color-muted));
+  cursor: pointer;
+  border-radius: var(--radius-sm, 999px);
+  transition: color 0.15s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    color: rgb(var(--color-text));
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
+  /* Dim while no translation exists yet — same affordance level as an
+   * empty field; brightens the moment content lands. */
+  &[data-empty] {
+    opacity: 0.6;
+  }
+}
+
+.hk-localized-input-chip-badge {
+  /* Keep the badge compact inside the field's suffix slot. */
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-localized-input-chip-caret {
+  flex: none;
+  opacity: 0.6;
+}

--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -5,12 +5,6 @@
   width: 100%;
 }
 
-.hk-localized-input-label {
-  font-size: 0.75rem;
-  font-weight: 500;
-  color: rgb(var(--color-muted));
-}
-
 /* The wrapped language chip riding the input's right edge. A button so
  * it is focusable/AT-reachable, but it must never steal the field's
  * click-to-edit: pointer events stop at the chip boundary (handled in

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -193,4 +193,51 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)?.en).toBeUndefined();
     expect(events.modelValue.at(-1)).toBe("工厂总览");
   });
+
+  it("focuses the field after switching languages", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const row = menuRows().find((r) => (r.textContent ?? "").includes("简体中文"));
+    row!.click();
+    await nextTick();
+    await nextTick();
+    await nextTick();
+    expect(document.activeElement).toBe(queryField(container));
+  });
+
+  it("edits the switched-to language: new keystrokes land on it", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview" },
+    });
+    await openMenu(container);
+    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
+    addRow!.click();
+    await nextTick();
+    await nextTick();
+    const jaRow = menuRows().find((r) => (r.textContent ?? "").includes("日本語"));
+    jaRow!.click();
+    await nextTick();
+    await nextTick();
+    const field = queryField(container);
+    field.value = "プラント概覧";
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(events.translations.at(-1)).toMatchObject({
+      en: "Plant overview",
+      ja: "プラント概覧",
+    });
+  });
+
+  it("trims values on commit so storage never diverges from display", async () => {
+    const { events, container } = mountInput({ modelValue: "" });
+    const field = queryField(container);
+    field.value = "  Plant overview  ";
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(events.translations.at(-1)?.en).toBe("Plant overview");
+  });
 });

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -240,4 +240,63 @@ describe("HkLocalizedInput", () => {
     await nextTick();
     expect(events.translations.at(-1)?.en).toBe("Plant overview");
   });
+
+  it("renders menu-row flags when the catalog provides them", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(HkLocalizedInput, {
+          modelValue: "Plant overview",
+          sourceLang: "en",
+          translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+          localeOptions: [
+            { code: "en", label: "English", flag: "🇬🇧" },
+            { code: "zh-Hans", label: "简体中文", flag: "🇨🇳" },
+          ],
+        }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    await openMenu(container);
+    const row = menuRows().find((r) => (r.textContent ?? "").includes("简体中文"));
+    expect(row?.querySelector(".hk-menu-flag")?.textContent).toBe("🇨🇳");
+  });
+
+  it("follows a sourceLang change without stealing focus", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const events: string[] = [];
+    const app = createApp({
+      data: () => ({
+        modelValue: "Plant overview",
+        sourceLang: "en",
+        translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+      }),
+      render() {
+        return h(HkLocalizedInput, {
+          modelValue: this.modelValue,
+          sourceLang: this.sourceLang,
+          translations: this.translations,
+          localeOptions: LOCALES,
+          "onUpdate:modelValue": (v: string) => {
+            this.modelValue = v;
+          },
+          onLanguagechange: (code: string) => events.push(code),
+        });
+      },
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    // Simulate an app-level locale switch mid-edit.
+    const state = app._instance?.proxy as unknown as {
+      sourceLang: string;
+    };
+    state.sourceLang = "zh-Hans";
+    await nextTick();
+    await nextTick();
+    expect(events.at(-1)).toBe("zh-Hans");
+    expect(queryField(container).value).toBe("工厂总览");
+    expect(document.activeElement).not.toBe(queryField(container));
+  });
 });

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HkLocalizedInput } from "./HkLocalizedInput";
+
+const LOCALES = [
+  { code: "en", label: "English" },
+  { code: "zh-Hans", label: "简体中文" },
+  { code: "ja", label: "日本語" },
+];
+
+interface MountOptions {
+  modelValue?: string;
+  sourceLang?: string;
+  translations?: Record<string, string>;
+}
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountInput(opts: MountOptions = {}) {
+  const events = {
+    modelValue: [] as string[],
+    translations: [] as Record<string, string>[],
+    languagechange: [] as string[],
+  };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(HkLocalizedInput, {
+        modelValue: opts.modelValue ?? "",
+        sourceLang: opts.sourceLang ?? "en",
+        translations: opts.translations ?? {},
+        localeOptions: LOCALES,
+        "onUpdate:modelValue": (v: string) => {
+          events.modelValue.push(v);
+        },
+        "onUpdate:translations": (v: Record<string, string>) => {
+          events.translations.push(v);
+        },
+        onLanguagechange: (code: string) => {
+          events.languagechange.push(code);
+        },
+      }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { events, container };
+}
+
+function queryChip(container: HTMLElement): HTMLButtonElement {
+  const chip = container.querySelector<HTMLButtonElement>(".hk-localized-input-chip");
+  expect(chip, "language chip renders inside the input suffix").toBeTruthy();
+  return chip!;
+}
+
+function queryField(container: HTMLElement): HTMLInputElement {
+  const field = container.querySelector<HTMLInputElement>(".hk-input-element");
+  expect(field).toBeTruthy();
+  return field!;
+}
+
+async function openMenu(container: HTMLElement) {
+  queryChip(container).click();
+  await nextTick();
+  await nextTick();
+}
+
+function menuRows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-row")];
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkLocalizedInput", () => {
+  it("shows the app-provided label plus code on the chip", () => {
+    const { container } = mountInput({ modelValue: "Plant overview" });
+    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(queryField(container).value).toBe("Plant overview");
+  });
+
+  it("commits the edited text into translations on every input", async () => {
+    const { events, container } = mountInput({ modelValue: "" });
+    const field = queryField(container);
+    field.value = "Plant overview";
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(events.modelValue.at(-1)).toBe("Plant overview");
+    expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
+  });
+
+  it("prunes empty values from the translations map", async () => {
+    const { events, container } = mountInput({ modelValue: "Plant overview" });
+    const field = queryField(container);
+    field.value = "  ";
+    field.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(events.translations.at(-1)?.en).toBeUndefined();
+  });
+
+  it("lists existing translations and an add-language cascade in the menu", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const labels = menuRows().map((r) => r.textContent ?? "");
+    expect(labels.some((l) => l.includes("简体中文"))).toBe(true);
+    // The currently edited language is not offered as a switch target.
+    expect(labels.some((l) => l.includes("English"))).toBe(false);
+    expect(labels.some((l) => l.includes("Add language"))).toBe(true);
+  });
+
+  it("switches to an existing language: commits text, loads its value, closes the menu", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const row = menuRows().find((r) => (r.textContent ?? "").includes("简体中文"));
+    expect(row).toBeTruthy();
+    row!.click();
+    await nextTick();
+    await nextTick();
+    expect(events.modelValue.at(-1)).toBe("工厂总览");
+    expect(events.languagechange.at(-1)).toBe("zh-Hans");
+    expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
+    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+    // Menu closed after the switch.
+    expect(menuRows().length).toBe(0);
+  });
+
+  it("adds a fresh language via the cascade: closes menu, empty field, chip follows", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview" },
+    });
+    await openMenu(container);
+    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
+    expect(addRow).toBeTruthy();
+    addRow!.click();
+    await nextTick();
+    await nextTick();
+    // Cascade child rows render for the not-yet-added languages.
+    const jaRow = menuRows().find((r) => (r.textContent ?? "").includes("日本語"));
+    expect(jaRow).toBeTruthy();
+    jaRow!.click();
+    await nextTick();
+    await nextTick();
+    expect(events.modelValue.at(-1)).toBe("");
+    expect(events.languagechange.at(-1)).toBe("ja");
+    expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
+    expect(queryChip(container).textContent).toContain("日本語 (ja)");
+    expect(menuRows().length).toBe(0);
+  });
+
+  it("disables the chip when the catalog is exhausted", () => {
+    // Single-language catalog with that language already being edited:
+    // nothing to switch to, nothing to add.
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(HkLocalizedInput, {
+          modelValue: "Plant overview",
+          sourceLang: "en",
+          translations: { en: "Plant overview" },
+          localeOptions: [{ code: "en", label: "English" }],
+        }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    expect(queryChip(container).disabled).toBe(true);
+  });
+
+  it("keeps edits on the switched-from language when the text is blank", async () => {
+    const { events, container } = mountInput({
+      modelValue: "",
+      translations: { "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const row = menuRows().find((r) => (r.textContent ?? "").includes("简体中文"));
+    row!.click();
+    await nextTick();
+    await nextTick();
+    // No empty "en" key is committed.
+    expect(events.translations.at(-1)?.en).toBeUndefined();
+    expect(events.modelValue.at(-1)).toBe("工厂总览");
+  });
+});

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -90,9 +90,11 @@ export const HkLocalizedInput = defineComponent({
     const chipRef = ref<HTMLElement | null>(null);
     const rootRef = ref<HTMLElement | null>(null);
 
-    // Follow the app locale while no explicit edit language has been
-    // picked: a locale switch mid-edit commits the current text and
-    // moves the field, exactly like a menu-driven switch.
+    // Follow the app locale: whenever the parent's sourceLang changes
+    // (the app-level language switch moved), commit the current text
+    // and move the field to the new language — same semantics as a
+    // menu-driven switch, minus the focus grab (the user is busy
+    // operating the app-level picker, not this field).
     watch(
       () => props.sourceLang,
       (lang) => {
@@ -189,9 +191,11 @@ export const HkLocalizedInput = defineComponent({
       commitTranslations(editLang.value, props.modelValue);
       editLang.value = code;
       emit("update:modelValue", (props.translations[code] ?? "").trim());
-      if (!opts.viaWatch) menuOpen.value = false;
+      if (!opts.viaWatch) {
+        menuOpen.value = false;
+        focusField();
+      }
       emit("languagechange", code);
-      focusField();
     }
 
     function onMenuSelect(key: string) {

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, nextTick, ref, type PropType } from "vue";
+import { computed, defineComponent, nextTick, ref, watch, type PropType } from "vue";
 
 import { ChevronDown } from "lucide-vue-next";
 
@@ -16,6 +16,9 @@ export interface HkLocaleOption {
    *  switcher shows (e.g. the autonym "简体中文" / "English"), so the
    *  chip and the system picker never disagree. */
   label: string;
+  /** Optional flag glyph rendered in the menu rows, matching the app's
+   *  language switcher rows when they carry one. */
+  flag?: string;
 }
 
 /** Marker key for the "Add language" cascade root (never a real locale). */
@@ -85,7 +88,17 @@ export const HkLocalizedInput = defineComponent({
     const editLang = ref(props.sourceLang);
     const menuOpen = ref(false);
     const chipRef = ref<HTMLElement | null>(null);
-    const inputRef = ref<{ focus: () => void } | HTMLElement | null>(null);
+    const rootRef = ref<HTMLElement | null>(null);
+
+    // Follow the app locale while no explicit edit language has been
+    // picked: a locale switch mid-edit commits the current text and
+    // moves the field, exactly like a menu-driven switch.
+    watch(
+      () => props.sourceLang,
+      (lang) => {
+        if (lang && lang !== editLang.value) switchLanguage(lang, { viaWatch: true });
+      },
+    );
 
     /** Non-empty translation codes, insertion-ordered. */
     const filledCodes = computed(() =>
@@ -123,6 +136,7 @@ export const HkLocalizedInput = defineComponent({
       ...switchableCodes.value.map((code) => ({
         key: code,
         label: localeLabel(code),
+        flag: props.localeOptions.find((o) => o.code === code)?.flag,
       })),
       ...(addableOptions.value.length > 0
         ? [
@@ -132,6 +146,7 @@ export const HkLocalizedInput = defineComponent({
               children: addableOptions.value.map((o) => ({
                 key: o.code,
                 label: o.label,
+                flag: o.flag,
               })),
             },
           ]
@@ -142,7 +157,9 @@ export const HkLocalizedInput = defineComponent({
       const next = { ...props.translations };
       const trimmed = value.trim();
       if (trimmed) {
-        next[code] = value;
+        // Store trimmed so the stored map and the field content can
+        // never diverge on whitespace-only padding.
+        next[code] = trimmed;
       } else {
         delete next[code];
       }
@@ -156,20 +173,23 @@ export const HkLocalizedInput = defineComponent({
 
     function focusField() {
       nextTick(() => {
-        const el = inputRef.value as HTMLElement | null;
-        el?.focus?.();
+        // HkInput does not expose a focus method; its element is the
+        // only input/textarea inside this component's root (the menu
+        // teleports to body), so a scoped query resolves it reliably.
+        const el = rootRef.value?.querySelector<HTMLElement>("input, textarea");
+        el?.focus();
       });
     }
 
     /** Switch the edited language (existing row or freshly added one):
      *  commit the current text, swap the field to the target language,
      *  close the menu, and resume editing focused. */
-    function switchLanguage(code: string) {
+    function switchLanguage(code: string, opts: { viaWatch?: boolean } = {}) {
       if (!code || code === editLang.value || code === ADD_LANGUAGE_KEY) return;
       commitTranslations(editLang.value, props.modelValue);
       editLang.value = code;
       emit("update:modelValue", (props.translations[code] ?? "").trim());
-      menuOpen.value = false;
+      if (!opts.viaWatch) menuOpen.value = false;
       emit("languagechange", code);
       focusField();
     }
@@ -179,17 +199,14 @@ export const HkLocalizedInput = defineComponent({
     }
 
     return () => (
-      <div class="hk-localized-input">
-        {props.label && (
-          <label class="hk-localized-input-label">{props.label}</label>
-        )}
+      <div class="hk-localized-input" ref={rootRef}>
         <HkInput
-          ref={inputRef}
           modelValue={props.modelValue}
           onUpdate:modelValue={onInput}
           placeholder={props.placeholder}
           disabled={props.disabled}
           size={props.size}
+          label={props.label}
         >
           {{
             suffix: () => (
@@ -201,6 +218,8 @@ export const HkLocalizedInput = defineComponent({
                 class="hk-localized-input-chip"
                 disabled={props.disabled || menuItems.value.length === 0}
                 data-empty={filledCodes.value.length === 0 || undefined}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen.value}
                 aria-label={t(
                   "hikari::localizedInput.chooseLanguage",
                   "Choose editing language",

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -1,0 +1,241 @@
+import { computed, defineComponent, nextTick, ref, type PropType } from "vue";
+
+import { ChevronDown } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import HkBadge from "./HkBadge";
+import HkInput from "./HkInput";
+import HkMenu, { type HkMenuItem } from "./HkMenu";
+import "./HkLocalizedInput.scss";
+
+/** One selectable language in the editor's language menu. */
+export interface HkLocaleOption {
+  code: string;
+  /** Display label — apps pass the SAME text their global language
+   *  switcher shows (e.g. the autonym "简体中文" / "English"), so the
+   *  chip and the system picker never disagree. */
+  label: string;
+}
+
+/** Marker key for the "Add language" cascade root (never a real locale). */
+const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
+
+/**
+ * HkLocalizedInput — single-field multilingual text editor.
+ *
+ * One input that edits ONE language at a time. The text is centered (the
+ * base `HkInput` element style) and a small badge-like language chip sits
+ * wrapped on the RIGHT edge of the field:
+ *
+ *   - Click the field itself → normal text editing for the chip's language.
+ *   - Click the chip → a cascading language menu (`HkMenu`, so desktop
+ *     gets an anchored submenu and mobile a bottom-up sheet — identical
+ *     behavior to the app-level language switcher):
+ *       · rows for every language that already has a translation
+ *         (click → switch the field to that language and keep editing);
+ *       · last row "Add language" cascades into the full locale catalog;
+ *         picking one closes the menu and drops the field straight into
+ *         edit state for the freshly added language.
+ *
+ * The chip label is `{label} ({code})` using the app-provided label, and
+ * the popup participates in the shared modal/dropdown stacking contexts
+ * via HkMenu's popup-manager integration — safe inside modals.
+ *
+ * Contract:
+ *   - `modelValue` is ALWAYS the text of the language being edited.
+ *   - every keystroke also emits `update:translations` with that
+ *     language's value merged in (empty values prune the key), so a
+ *     parent can persist drafts without listening to blur.
+ *   - switching languages commits the current text, swaps `modelValue`
+ *     to the target language's stored text ("" when none), and refocuses
+ *     the field.
+ */
+export const HkLocalizedInput = defineComponent({
+  name: "HkLocalizedInput",
+  props: {
+    modelValue: { type: String, default: "" },
+    /** Language the field edits until the user picks another from the
+     *  chip menu. Defaults to `sourceLang` (usually the app locale). */
+    sourceLang: { type: String, default: "en" },
+    /** Per-language values. Keys follow the app's locale codes. */
+    translations: {
+      type: Object as PropType<Record<string, string>>,
+      default: () => ({}),
+    },
+    /** The app's locale catalog — same list its language switcher uses. */
+    localeOptions: {
+      type: Array as PropType<HkLocaleOption[]>,
+      default: () => [],
+    },
+    label: { type: String, default: undefined },
+    placeholder: { type: String, default: "" },
+    disabled: { type: Boolean, default: false },
+    size: { type: String as PropType<"sm" | "md" | "lg">, default: "md" },
+  },
+  emits: {
+    "update:modelValue": (_value: string) => true,
+    "update:translations": (_value: Record<string, string>) => true,
+    /** Emitted after the edited language changes (switch or add). */
+    languagechange: (_code: string) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    const editLang = ref(props.sourceLang);
+    const menuOpen = ref(false);
+    const chipRef = ref<HTMLElement | null>(null);
+    const inputRef = ref<{ focus: () => void } | HTMLElement | null>(null);
+
+    /** Non-empty translation codes, insertion-ordered. */
+    const filledCodes = computed(() =>
+      Object.keys(props.translations).filter(
+        (k) => (props.translations[k] ?? "").trim().length > 0,
+      ),
+    );
+
+    function localeLabel(code: string): string {
+      return props.localeOptions.find((o) => o.code === code)?.label ?? code;
+    }
+
+    /** Chip text: app label + parenthesized code, e.g. "English (en)". */
+    const chipLabel = computed(
+      () => `${localeLabel(editLang.value)} (${editLang.value})`,
+    );
+
+    /** Languages with an existing translation, excluding the one being
+     *  edited — those are the switch targets in the menu's first level. */
+    const switchableCodes = computed(() =>
+      filledCodes.value.filter((c) => c !== editLang.value),
+    );
+
+    /** Catalog entries not yet present in the translations map (and not
+     *  currently being edited) — the "Add language" cascade children. */
+    const addableOptions = computed(() =>
+      props.localeOptions.filter(
+        (o) =>
+          o.code !== editLang.value &&
+          !filledCodes.value.includes(o.code),
+      ),
+    );
+
+    const menuItems = computed<HkMenuItem[]>(() => [
+      ...switchableCodes.value.map((code) => ({
+        key: code,
+        label: localeLabel(code),
+      })),
+      ...(addableOptions.value.length > 0
+        ? [
+            {
+              key: ADD_LANGUAGE_KEY,
+              label: t("hikari::localizedInput.addLanguage", "Add language"),
+              children: addableOptions.value.map((o) => ({
+                key: o.code,
+                label: o.label,
+              })),
+            },
+          ]
+        : []),
+    ]);
+
+    function commitTranslations(code: string, value: string) {
+      const next = { ...props.translations };
+      const trimmed = value.trim();
+      if (trimmed) {
+        next[code] = value;
+      } else {
+        delete next[code];
+      }
+      emit("update:translations", next);
+    }
+
+    function onInput(value: string) {
+      emit("update:modelValue", value);
+      commitTranslations(editLang.value, value);
+    }
+
+    function focusField() {
+      nextTick(() => {
+        const el = inputRef.value as HTMLElement | null;
+        el?.focus?.();
+      });
+    }
+
+    /** Switch the edited language (existing row or freshly added one):
+     *  commit the current text, swap the field to the target language,
+     *  close the menu, and resume editing focused. */
+    function switchLanguage(code: string) {
+      if (!code || code === editLang.value || code === ADD_LANGUAGE_KEY) return;
+      commitTranslations(editLang.value, props.modelValue);
+      editLang.value = code;
+      emit("update:modelValue", (props.translations[code] ?? "").trim());
+      menuOpen.value = false;
+      emit("languagechange", code);
+      focusField();
+    }
+
+    function onMenuSelect(key: string) {
+      switchLanguage(key);
+    }
+
+    return () => (
+      <div class="hk-localized-input">
+        {props.label && (
+          <label class="hk-localized-input-label">{props.label}</label>
+        )}
+        <HkInput
+          ref={inputRef}
+          modelValue={props.modelValue}
+          onUpdate:modelValue={onInput}
+          placeholder={props.placeholder}
+          disabled={props.disabled}
+          size={props.size}
+        >
+          {{
+            suffix: () => (
+              <button
+                ref={(el: unknown) => {
+                  chipRef.value = (el as HTMLElement) ?? null;
+                }}
+                type="button"
+                class="hk-localized-input-chip"
+                disabled={props.disabled || menuItems.value.length === 0}
+                data-empty={filledCodes.value.length === 0 || undefined}
+                aria-label={t(
+                  "hikari::localizedInput.chooseLanguage",
+                  "Choose editing language",
+                )}
+                title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
+                onClick={(e: MouseEvent) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  menuOpen.value = !menuOpen.value;
+                }}
+                onMousedown={(e: MouseEvent) => e.preventDefault()}
+              >
+                <HkBadge variant="primary" size="sm" class="hk-localized-input-chip-badge">
+                  {chipLabel.value}
+                </HkBadge>
+                <ChevronDown size={12} class="hk-localized-input-chip-caret" />
+              </button>
+            ),
+          }}
+        </HkInput>
+        <HkMenu
+          variant="popup"
+          items={menuItems.value}
+          open={menuOpen.value}
+          onUpdate:open={(v: boolean) => {
+            menuOpen.value = v;
+          }}
+          onSelect={onMenuSelect}
+          anchorRef={chipRef.value}
+          placement="bottom-end"
+          title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
+        />
+      </div>
+    );
+  },
+});
+
+export default HkLocalizedInput;

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -59,7 +59,7 @@ export const HkLocalizedInput = defineComponent({
   props: {
     modelValue: { type: String, default: "" },
     /** Language the field edits until the user picks another from the
-     *  chip menu. Defaults to `sourceLang` (usually the app locale). */
+     *  chip menu. Defaults to the app locale ("en" when unset). */
     sourceLang: { type: String, default: "en" },
     /** Per-language values. Keys follow the app's locale codes. */
     translations: {

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -1,0 +1,113 @@
+.s-log-viewer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8, 0.5rem);
+  min-height: 0;
+}
+
+.s-log-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-8, 0.5rem);
+  flex-wrap: wrap;
+}
+
+.s-log-tabs {
+  display: flex;
+  gap: var(--space-4, 0.25rem);
+}
+
+.s-log-tab {
+  padding: var(--space-4, 0.25rem) var(--space-10, 0.625rem);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-xs, 0.75rem);
+  cursor: pointer;
+}
+
+.s-log-tab:hover:not([data-active]) {
+  background: rgb(var(--color-primary) / 12%);
+  color: rgb(var(--color-text));
+}
+
+.s-log-tab[data-active] {
+  background: rgb(var(--color-primary));
+  color: rgb(var(--color-on-primary));
+  font-weight: 600;
+}
+
+.s-log-controls {
+  display: flex;
+  gap: var(--space-4, 0.25rem);
+}
+
+.s-log-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
+  border-radius: var(--radius-sm, 6px);
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-muted));
+  cursor: pointer;
+}
+
+.s-log-btn:hover:not([data-active]) {
+  background: rgb(var(--color-primary) / 12%);
+  color: rgb(var(--color-text));
+}
+
+.s-log-btn[data-active] {
+  background: rgb(var(--color-primary));
+  border-color: rgb(var(--color-primary));
+  color: rgb(var(--color-on-primary));
+}
+
+.s-log-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.s-log-viewer-scroll {
+  flex: 1;
+  min-height: 0;
+  padding: var(--space-8, 0.5rem);
+  border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
+  border-radius: var(--radius-md, 8px);
+  background: rgb(var(--color-background) / 0.5);
+  overflow-y: auto;
+}
+
+.s-log-empty {
+  padding: var(--space-16, 1rem);
+  text-align: center;
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-muted));
+}
+
+.s-log-entry {
+  padding: var(--space-2, 0.125rem) var(--space-4, 0.25rem);
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  font-size: var(--text-xs, 0.75rem);
+  line-height: 1.5;
+  color: rgb(var(--color-text));
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.s-log-entry-error {
+  color: rgb(var(--color-error));
+}
+
+.s-log-entry-warn {
+  color: rgb(var(--color-warning));
+}
+
+.s-log-entry-debug {
+  color: rgb(var(--color-muted));
+}

--- a/packages/vue/src/components/HkLogWindow.tsx
+++ b/packages/vue/src/components/HkLogWindow.tsx
@@ -1,0 +1,172 @@
+import { computed, defineComponent, ref, watch, type PropType } from "vue";
+import { Copy, Eraser, Pause, Play, ScrollText } from "lucide-vue-next";
+import { HModal, HScrollContainer, useClipboard } from "@celestia-island/hikari";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkLogWindow.scss";
+
+export interface HLogTab {
+  key: string;
+  title: string;
+  lines: string[];
+}
+
+function levelOf(line: string): "error" | "warn" | "debug" | "info" {
+  const upper = line.toUpperCase();
+  if (upper.includes("ERROR")) return "error";
+  if (upper.includes("WARN")) return "warn";
+  if (upper.includes("DEBUG") || upper.includes("TRACE")) return "debug";
+  return "info";
+}
+
+/**
+ * HkLogWindow — tabbed service log viewer.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Displays caller-provided `tabs` (each an ordered list of log lines) with
+ * pause, autoscroll, copy and clear controls. Line arrays are props: the
+ * caller keeps appending; `clearTab(key)` tells the caller to reset that
+ * tab's buffer. Pause is optional-controlled (`paused` + `update:paused`).
+ * Autoscroll delegates to HScrollContainer's `autoFollow` (pins to
+ * bottom while the user stays near the end, pauses when paused).
+ */
+export const HkLogWindow = defineComponent({
+  name: "HkLogWindow",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    tabs: { type: Array as PropType<HLogTab[]>, required: true },
+    /** Controlled pause state; when undefined the toggle is internal. */
+    paused: { type: Boolean, default: false },
+    /** Height of the log body (CSS length, e.g. "55vh"). */
+    height: { type: String, default: "55vh" },
+    title: { type: String, default: undefined },
+    width: { type: String, default: "60rem" },
+  },
+  emits: {
+    "update:modelValue": (_v: boolean) => true,
+    "update:paused": (_v: boolean) => true,
+    clearTab: (_key: string) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const clipboard = useClipboard();
+
+    const activeTab = ref<string>("");
+    const autoscroll = ref(true);
+    const paused = ref(props.paused);
+
+    watch(
+      () => props.paused,
+      (v) => { paused.value = v; },
+    );
+
+    watch(
+      () => props.tabs,
+      (tabs) => {
+        if (tabs.length === 0) {
+          activeTab.value = "";
+        } else if (!tabs.some((tab) => tab.key === activeTab.value)) {
+          activeTab.value = tabs[0].key;
+        }
+      },
+      { immediate: true },
+    );
+
+    const currentTab = computed(() => props.tabs.find((tab) => tab.key === activeTab.value) ?? null);
+    const currentLines = computed(() => currentTab.value?.lines ?? []);
+
+    function togglePause() {
+      paused.value = !paused.value;
+      emit("update:paused", paused.value);
+    }
+
+    function handleClear() {
+      if (!currentTab.value) return;
+      emit("clearTab", currentTab.value.key);
+    }
+
+    function handleCopy() {
+      if (currentLines.value.length === 0) return;
+      void clipboard.copy(currentLines.value.join("\n"));
+    }
+
+    const copied = computed(() => clipboard.copied.value);
+
+    return () => (
+      <HModal
+        modelValue={props.modelValue}
+        onUpdate:modelValue={(v: boolean) => emit("update:modelValue", v)}
+        title={props.title ?? t("hikari::log.title", "Logs")}
+        width={props.width}
+      >
+        <div class="s-log-viewer" style={{ height: props.height }}>
+          <div class="s-log-toolbar">
+            <div class="s-log-tabs">
+              {props.tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  class="s-log-tab"
+                  data-active={tab.key === activeTab.value || undefined}
+                  onClick={() => { activeTab.value = tab.key; }}
+                >
+                  {tab.title}
+                </button>
+              ))}
+            </div>
+            <div class="s-log-controls">
+              <button
+                type="button"
+                class="s-log-btn"
+                data-active={paused.value || undefined}
+                onClick={togglePause}
+                title={paused.value ? t("hikari::log.resume", "Resume") : t("hikari::log.pause", "Pause")}
+              >
+                {paused.value ? <Play size={12} /> : <Pause size={12} />}
+              </button>
+              <button
+                type="button"
+                class="s-log-btn"
+                data-active={autoscroll.value || undefined}
+                onClick={() => { autoscroll.value = !autoscroll.value; }}
+                title={t("hikari::log.autoscroll", "Autoscroll")}
+              >
+                <ScrollText size={12} />
+              </button>
+              <button
+                type="button"
+                class="s-log-btn"
+                disabled={currentLines.value.length === 0}
+                onClick={handleCopy}
+                title={copied.value ? t("hikari::log.copied", "Copied") : t("hikari::log.copy", "Copy")}
+              >
+                <Copy size={12} />
+              </button>
+              <button
+                type="button"
+                class="s-log-btn"
+                disabled={currentLines.value.length === 0}
+                onClick={handleClear}
+                title={t("hikari::log.clear", "Clear")}
+              >
+                <Eraser size={12} />
+              </button>
+            </div>
+          </div>
+          <HScrollContainer class="s-log-viewer-scroll" autoFollow={autoscroll.value && !paused.value}>
+            {currentLines.value.length === 0 ? (
+              <div class="s-log-empty">{t("hikari::log.empty", "No log lines yet.")}</div>
+            ) : (
+              currentLines.value.map((line, i) => (
+                <div key={i} class={["s-log-entry", `s-log-entry-${levelOf(line)}`]}>
+                  {line}
+                </div>
+              ))
+            )}
+          </HScrollContainer>
+        </div>
+      </HModal>
+    );
+  },
+});

--- a/packages/vue/src/components/HkProtocolModal.scss
+++ b/packages/vue/src/components/HkProtocolModal.scss
@@ -1,0 +1,15 @@
+.s-protocol-modal {
+  position: relative;
+}
+
+.s-protocol-modal-copied {
+  position: absolute;
+  top: -0.25rem;
+  right: 0;
+  margin: 0;
+  padding: var(--space-4, 0.25rem) var(--space-8, 0.5rem);
+  border-radius: var(--radius-sm, 6px);
+  background: rgb(var(--color-success) / 15%);
+  color: rgb(var(--color-success));
+  font-size: var(--text-xs, 0.75rem);
+}

--- a/packages/vue/src/components/HkProtocolModal.tsx
+++ b/packages/vue/src/components/HkProtocolModal.tsx
@@ -1,0 +1,86 @@
+import { computed, defineComponent } from "vue";
+import { HMarkdownRenderer, HModal, useClipboard, type ModalAction } from "@celestia-island/hikari";
+
+import { useI18n } from "../i18n/context";
+
+import "./HkProtocolModal.scss";
+
+/**
+ * HkProtocolModal — markdown EULA / privacy / terms modal.
+ * (Upstreamed from shittim-chest's plana-legacy layer.)
+ *
+ * Renders arbitrary markdown `content` (via HMarkdownRenderer) with
+ * a Decline/Accept footer. `accept`/`decline` are the caller's commit
+ * actions; closing (overlay click / ESC / X) only emits `update:modelValue`
+ * so the caller can decide whether close === decline.
+ */
+export const HkProtocolModal = defineComponent({
+  name: "HkProtocolModal",
+  props: {
+    modelValue: { type: Boolean, default: false },
+    /** Modal title (defaults to "Agreement"). */
+    title: { type: String, default: undefined },
+    /** Markdown content to render (or plain text when `plain`). */
+    content: { type: String, default: "" },
+    /** Render `content` as escaped plain text instead of markdown. */
+    plain: { type: Boolean, default: false },
+    /** Accept button label override. */
+    acceptLabel: { type: String, default: undefined },
+    /** Decline button label override. */
+    declineLabel: { type: String, default: undefined },
+    /** Allow dismissing without a decision (overlay/ESC/X). Default true. */
+    closable: { type: Boolean, default: true },
+    width: { type: String, default: "48rem" },
+    /** Cap the scroll body height (e.g. "60vh"). */
+    bodyHeight: { type: String, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_v: boolean) => true,
+    accept: () => true,
+    decline: () => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    const clipboard = useClipboard();
+    const copied = computed(() => clipboard.copied.value);
+
+    const footerActions = computed<ModalAction[]>(() => [
+      {
+        label: t("hikari::protocol.copy", "Copy"),
+        variant: "secondary" as const,
+        onClick: () => void clipboard.copy(props.content),
+        disabled: !props.content,
+      },
+      {
+        label: props.declineLabel ?? t("hikari::protocol.decline", "Decline"),
+        variant: "secondary" as const,
+        onClick: () => emit("decline"),
+      },
+      {
+        label: props.acceptLabel ?? t("hikari::protocol.accept", "Accept"),
+        variant: "primary" as const,
+        onClick: () => emit("accept"),
+        disabled: !props.content,
+      },
+    ]);
+
+    return () => (
+      <HModal
+        modelValue={props.modelValue}
+        onUpdate:modelValue={(v: boolean) => emit("update:modelValue", v)}
+        title={props.title ?? t("hikari::protocol.title", "Agreement")}
+        width={props.width}
+        closable={props.closable}
+        footerActions={footerActions.value}
+      >
+        <div
+          class="s-protocol-modal"
+          style={props.bodyHeight ? { maxHeight: props.bodyHeight, overflowY: "auto" } : undefined}
+        >
+          {copied.value && <p class="s-protocol-modal-copied">{t("hikari::protocol.copied", "Copied")}</p>}
+          <HMarkdownRenderer content={props.content} plain={props.plain} />
+        </div>
+      </HModal>
+    );
+  },
+});

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "الصورة الرمزية",
     "hikari::adminHeader.avatarTrigger": "قائمة الحساب",
     "hikari::adminHeader.language": "اللغة",
-    "hikari::adminHeader.adminGroup": "المسؤولون"
+    "hikari::adminHeader.adminGroup": "المسؤولون",
+    "hikari::localizedInput.addLanguage": "إضافة لغة",
+    "hikari::localizedInput.chooseLanguage": "اختر لغة التحرير"
   }
 }

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "تم النسخ",
     "hikari::log.clear": "مسح",
     "hikari::cookie.text": "يستخدم هذا الموقع ملفات تعريف الارتباط.",
-    "hikari::cookie.ok": "موافق"
+    "hikari::cookie.ok": "موافق",
+    "hikari::attachment.download": "تنزيل",
+    "hikari::attachment.close": "إغلاق",
+    "hikari::attachment.loading": "جارٍ التحميل…",
+    "hikari::attachment.noPreview": "لا تتوفر معاينة."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "جارٍ حل التحدّي…"

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "تمرير تلقائي",
     "hikari::log.copy": "نسخ",
     "hikari::log.copied": "تم النسخ",
-    "hikari::log.clear": "مسح"
+    "hikari::log.clear": "مسح",
+    "hikari::cookie.text": "يستخدم هذا الموقع ملفات تعريف الارتباط.",
+    "hikari::cookie.ok": "موافق"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "جارٍ حل التحدّي…"

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Avatar",
     "hikari::adminHeader.avatarTrigger": "Kontomenü",
     "hikari::adminHeader.language": "Sprache",
-    "hikari::adminHeader.adminGroup": "Administratoren"
+    "hikari::adminHeader.adminGroup": "Administratoren",
+    "hikari::localizedInput.addLanguage": "Sprache hinzufügen",
+    "hikari::localizedInput.chooseLanguage": "Bearbeitungssprache wählen"
   }
 }

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Kopiert",
     "hikari::log.clear": "Leeren",
     "hikari::cookie.text": "Diese Seite verwendet Cookies.",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "Herunterladen",
+    "hikari::attachment.close": "Schließen",
+    "hikari::attachment.loading": "Wird geladen…",
+    "hikari::attachment.noPreview": "Keine Vorschau verfügbar."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Proof-of-Work wird gelöst…"

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Autoscroll",
     "hikari::log.copy": "Kopieren",
     "hikari::log.copied": "Kopiert",
-    "hikari::log.clear": "Leeren"
+    "hikari::log.clear": "Leeren",
+    "hikari::cookie.text": "Diese Seite verwendet Cookies.",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Proof-of-Work wird gelöst…"

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Avatar",
     "hikari::adminHeader.avatarTrigger": "Account menu",
     "hikari::adminHeader.language": "Language",
-    "hikari::adminHeader.adminGroup": "Administrators"
+    "hikari::adminHeader.adminGroup": "Administrators",
+    "hikari::localizedInput.addLanguage": "Add language",
+    "hikari::localizedInput.chooseLanguage": "Choose editing language"
   }
 }

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Copied",
     "hikari::log.clear": "Clear",
     "hikari::cookie.text": "This site uses cookies.",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "Download",
+    "hikari::attachment.close": "Close",
+    "hikari::attachment.loading": "Loading…",
+    "hikari::attachment.noPreview": "No preview available."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Verifying challenge…"

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Autoscroll",
     "hikari::log.copy": "Copy",
     "hikari::log.copied": "Copied",
-    "hikari::log.clear": "Clear"
+    "hikari::log.clear": "Clear",
+    "hikari::cookie.text": "This site uses cookies.",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Verifying challenge…"

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Avatar",
     "hikari::adminHeader.avatarTrigger": "Menú de cuenta",
     "hikari::adminHeader.language": "Idioma",
-    "hikari::adminHeader.adminGroup": "Administradores"
+    "hikari::adminHeader.adminGroup": "Administradores",
+    "hikari::localizedInput.addLanguage": "Añadir idioma",
+    "hikari::localizedInput.chooseLanguage": "Elegir idioma de edición"
   }
 }

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Desplazamiento automático",
     "hikari::log.copy": "Copiar",
     "hikari::log.copied": "Copiado",
-    "hikari::log.clear": "Limpiar"
+    "hikari::log.clear": "Limpiar",
+    "hikari::cookie.text": "Este sitio utiliza cookies.",
+    "hikari::cookie.ok": "Aceptar"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Verificando el desafío…"

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Copiado",
     "hikari::log.clear": "Limpiar",
     "hikari::cookie.text": "Este sitio utiliza cookies.",
-    "hikari::cookie.ok": "Aceptar"
+    "hikari::cookie.ok": "Aceptar",
+    "hikari::attachment.download": "Descargar",
+    "hikari::attachment.close": "Cerrar",
+    "hikari::attachment.loading": "Cargando…",
+    "hikari::attachment.noPreview": "No hay vista previa disponible."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Verificando el desafío…"

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Avatar",
     "hikari::adminHeader.avatarTrigger": "Menu du compte",
     "hikari::adminHeader.language": "Langue",
-    "hikari::adminHeader.adminGroup": "Administrateurs"
+    "hikari::adminHeader.adminGroup": "Administrateurs",
+    "hikari::localizedInput.addLanguage": "Ajouter une langue",
+    "hikari::localizedInput.chooseLanguage": "Choisir la langue d’édition"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Défilement auto",
     "hikari::log.copy": "Copier",
     "hikari::log.copied": "Copié",
-    "hikari::log.clear": "Vider"
+    "hikari::log.clear": "Vider",
+    "hikari::cookie.text": "Ce site utilise des cookies.",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Résolution du défi de preuve de travail…"

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Copié",
     "hikari::log.clear": "Vider",
     "hikari::cookie.text": "Ce site utilise des cookies.",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "Télécharger",
+    "hikari::attachment.close": "Fermer",
+    "hikari::attachment.loading": "Chargement…",
+    "hikari::attachment.noPreview": "Aucun aperçu disponible."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Résolution du défi de preuve de travail…"

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "アバター",
     "hikari::adminHeader.avatarTrigger": "アカウントメニュー",
     "hikari::adminHeader.language": "言語",
-    "hikari::adminHeader.adminGroup": "管理者"
+    "hikari::adminHeader.adminGroup": "管理者",
+    "hikari::localizedInput.addLanguage": "言語を追加",
+    "hikari::localizedInput.chooseLanguage": "編集言語を選択"
   }
 }

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "コピーしました",
     "hikari::log.clear": "クリア",
     "hikari::cookie.text": "このサイトは Cookie を使用します。",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "ダウンロード",
+    "hikari::attachment.close": "閉じる",
+    "hikari::attachment.loading": "読み込み中…",
+    "hikari::attachment.noPreview": "プレビューは利用できません。"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "チャレンジを検証中…"

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "自動スクロール",
     "hikari::log.copy": "コピー",
     "hikari::log.copied": "コピーしました",
-    "hikari::log.clear": "クリア"
+    "hikari::log.clear": "クリア",
+    "hikari::cookie.text": "このサイトは Cookie を使用します。",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "チャレンジを検証中…"

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "아바타",
     "hikari::adminHeader.avatarTrigger": "계정 메뉴",
     "hikari::adminHeader.language": "언어",
-    "hikari::adminHeader.adminGroup": "관리자"
+    "hikari::adminHeader.adminGroup": "관리자",
+    "hikari::localizedInput.addLanguage": "언어 추가",
+    "hikari::localizedInput.chooseLanguage": "편집 언어 선택"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "복사됨",
     "hikari::log.clear": "지우기",
     "hikari::cookie.text": "이 사이트는 쿠키를 사용합니다.",
-    "hikari::cookie.ok": "확인"
+    "hikari::cookie.ok": "확인",
+    "hikari::attachment.download": "다운로드",
+    "hikari::attachment.close": "닫기",
+    "hikari::attachment.loading": "로드 중…",
+    "hikari::attachment.noPreview": "미리보기를 사용할 수 없습니다."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "챌린지 검증 중…"

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "자동 스크롤",
     "hikari::log.copy": "복사",
     "hikari::log.copied": "복사됨",
-    "hikari::log.clear": "지우기"
+    "hikari::log.clear": "지우기",
+    "hikari::cookie.text": "이 사이트는 쿠키를 사용합니다.",
+    "hikari::cookie.ok": "확인"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "챌린지 검증 중…"

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Avatar",
     "hikari::adminHeader.avatarTrigger": "Menu da conta",
     "hikari::adminHeader.language": "Idioma",
-    "hikari::adminHeader.adminGroup": "Administradores"
+    "hikari::adminHeader.adminGroup": "Administradores",
+    "hikari::localizedInput.addLanguage": "Adicionar idioma",
+    "hikari::localizedInput.chooseLanguage": "Escolher idioma de edição"
   }
 }

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Rolagem automática",
     "hikari::log.copy": "Copiar",
     "hikari::log.copied": "Copiado",
-    "hikari::log.clear": "Limpar"
+    "hikari::log.clear": "Limpar",
+    "hikari::cookie.text": "Este site usa cookies.",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "A verificar o desafio…"

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Copiado",
     "hikari::log.clear": "Limpar",
     "hikari::cookie.text": "Este site usa cookies.",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "Baixar",
+    "hikari::attachment.close": "Fechar",
+    "hikari::attachment.loading": "Carregando…",
+    "hikari::attachment.noPreview": "Nenhuma pré-visualização disponível."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "A verificar o desafio…"

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "Аватар",
     "hikari::adminHeader.avatarTrigger": "Меню учётной записи",
     "hikari::adminHeader.language": "Язык",
-    "hikari::adminHeader.adminGroup": "Администраторы"
+    "hikari::adminHeader.adminGroup": "Администраторы",
+    "hikari::localizedInput.addLanguage": "Добавить язык",
+    "hikari::localizedInput.chooseLanguage": "Выбрать язык редактирования"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "Автопрокрутка",
     "hikari::log.copy": "Копировать",
     "hikari::log.copied": "Скопировано",
-    "hikari::log.clear": "Очистить"
+    "hikari::log.clear": "Очистить",
+    "hikari::cookie.text": "Этот сайт использует файлы cookie.",
+    "hikari::cookie.ok": "OK"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Проверка задания…"

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "Скопировано",
     "hikari::log.clear": "Очистить",
     "hikari::cookie.text": "Этот сайт использует файлы cookie.",
-    "hikari::cookie.ok": "OK"
+    "hikari::cookie.ok": "OK",
+    "hikari::attachment.download": "Скачать",
+    "hikari::attachment.close": "Закрыть",
+    "hikari::attachment.loading": "Загрузка…",
+    "hikari::attachment.noPreview": "Предпросмотр недоступен."
   },
   "auth": {
     "hikari::auth.solvingChallenge": "Проверка задания…"

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "头像",
     "hikari::adminHeader.avatarTrigger": "账户菜单",
     "hikari::adminHeader.language": "语言",
-    "hikari::adminHeader.adminGroup": "管理员"
+    "hikari::adminHeader.adminGroup": "管理员",
+    "hikari::localizedInput.addLanguage": "添加新语言",
+    "hikari::localizedInput.chooseLanguage": "选择编辑语言"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "已复制",
     "hikari::log.clear": "清空",
     "hikari::cookie.text": "本站使用 Cookie。",
-    "hikari::cookie.ok": "确定"
+    "hikari::cookie.ok": "确定",
+    "hikari::attachment.download": "下载",
+    "hikari::attachment.close": "关闭",
+    "hikari::attachment.loading": "加载中…",
+    "hikari::attachment.noPreview": "没有可用的预览。"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "正在验证挑战…"

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "自动滚动",
     "hikari::log.copy": "复制",
     "hikari::log.copied": "已复制",
-    "hikari::log.clear": "清空"
+    "hikari::log.clear": "清空",
+    "hikari::cookie.text": "本站使用 Cookie。",
+    "hikari::cookie.ok": "确定"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "正在验证挑战…"

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -106,6 +106,8 @@
     "hikari::adminHeader.avatar": "頭像",
     "hikari::adminHeader.avatarTrigger": "帳戶選單",
     "hikari::adminHeader.language": "語言",
-    "hikari::adminHeader.adminGroup": "管理員"
+    "hikari::adminHeader.adminGroup": "管理員",
+    "hikari::localizedInput.addLanguage": "新增語言",
+    "hikari::localizedInput.chooseLanguage": "選擇編輯語言"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -50,7 +50,11 @@
     "hikari::log.copied": "已複製",
     "hikari::log.clear": "清空",
     "hikari::cookie.text": "本站使用 Cookie。",
-    "hikari::cookie.ok": "確定"
+    "hikari::cookie.ok": "確定",
+    "hikari::attachment.download": "下載",
+    "hikari::attachment.close": "關閉",
+    "hikari::attachment.loading": "載入中…",
+    "hikari::attachment.noPreview": "沒有可用的預覽。"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "正在驗證挑戰…"

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -48,7 +48,9 @@
     "hikari::log.autoscroll": "自動捲動",
     "hikari::log.copy": "複製",
     "hikari::log.copied": "已複製",
-    "hikari::log.clear": "清空"
+    "hikari::log.clear": "清空",
+    "hikari::cookie.text": "本站使用 Cookie。",
+    "hikari::cookie.ok": "確定"
   },
   "auth": {
     "hikari::auth.solvingChallenge": "正在驗證挑戰…"

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -253,3 +253,10 @@ export { HkProtocolModal as HProtocolModal } from "./components/HkProtocolModal"
 export { HkAboutModal as HAboutModal, type HAboutLink } from "./components/HkAboutModal";
 export { HkLogWindow as HLogWindow, type HLogTab } from "./components/HkLogWindow";
 export { HkCookieConsent as HCookieConsent } from "./components/HkCookieConsent";
+export {
+  HkAttachmentModal as HAttachmentModal,
+  previewKindFor,
+  type HAttachmentDetail,
+  type HAttachmentItem,
+  type HAttachmentPreviewType,
+} from "./components/HkAttachmentModal";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -41,6 +41,7 @@ export { default as HKeywordSearchModal } from "./components/HkKeywordSearchModa
 export { default as HModalBreadcrumb } from "./components/HkModalBreadcrumb";
 export { default as HPopover, type PopupPlacement } from "./components/HkPopover";
 export { default as HMenu, type HkMenuItem } from "./components/HkMenu";
+export { HkLocalizedInput as HLocalizedInput, type HkLocaleOption } from "./components/HkLocalizedInput";
 export { default as HPopupSelect, isAnyPopupOpen, closeAllPopups, type HkPopupSelectOption } from "./components/HkPopupSelect";
 export { default as HProgressBar } from "./components/HkProgressBar";
 export { default as HProgressDialog } from "./components/HkProgressDialog";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -247,3 +247,9 @@ export { HkStatCard as HStatCard, type StatTone } from "./components/HkStatCard"
 export { HkStatusPill as HStatusPill, type PillState } from "./components/HkStatusPill";
 export { HkShareBar as HShareBar } from "./components/HkShareBar";
 export { HkSecretRevealModal as HSecretRevealModal } from "./components/HkSecretRevealModal";
+export { HkCaptchaWidget as HCaptchaWidget, type HkCaptchaProvider } from "./components/HkCaptchaWidget";
+export { HkCaptchaModal as HCaptchaModal } from "./components/HkCaptchaModal";
+export { HkProtocolModal as HProtocolModal } from "./components/HkProtocolModal";
+export { HkAboutModal as HAboutModal, type HAboutLink } from "./components/HkAboutModal";
+export { HkLogWindow as HLogWindow, type HLogTab } from "./components/HkLogWindow";
+export { HkCookieConsent as HCookieConsent } from "./components/HkCookieConsent";


### PR DESCRIPTION
## What

New shared component `HkLocalizedInput` — a single-field multilingual text editor, designed to replace the legacy chip-based `PLocalizedInput` pattern and give every app one canonical "edit translations inline" affordance.

## Behavior (user spec)

- One input; text is **centered** (HikInput's element style).
- The **right edge carries a wrapped language chip** (HkBadge) showing the language currently being edited, labeled `{app label} ({code})` — the SAME label text the app's global language switcher shows.
- Clicking the field = normal editing for that language.
- Clicking the chip opens a **cascading menu (HkMenu)** — desktop anchored submenu, mobile bottom-up sheet, identical to the app-level language switcher, fully participant in the shared popup/modal stacking contexts (usePopupManager + Teleport).
- Menu lists every language that already has a translation (click → switch + keep editing); the last row **"Add language"** cascades into the full locale catalog; picking one closes the menu first, then drops the field into edit state with the chip following.

## Contract

- `modelValue` is always the text of the edited language; every keystroke also emits `update:translations` with that language merged (empty values prune; values trimmed on commit).
- Switching languages commits the current text, loads the target's stored text, refocuses the field.
- `sourceLang` changes (app-locale switch mid-edit) move the field WITHOUT stealing focus.

## Verification

3-round cycle complete: R1 implementation → adversarial review (1 blocker: focusField no-op because HkInput exposes nothing; 7 minors) → R2 fixes + fresh verifier (READY-FOR-PR) → R3 polish (no-focus-steal, flag rendering, doc nit) + final gate.

- vitest **300/300** (13 new component tests: chip label, live commit, prune, menu rows, switch, add-cascade, focus, typing-after-switch, trim, flags, sourceLang-follow)
- `vue-tsc --noEmit` clean
- 11 locale catalogs carry `hikari::localizedInput.addLanguage` / `.chooseLanguage`

Downstream consumer (shittim-chest panel/tab editors) lands in the chest PR.