### PR TITLE
✨ Expose the embeddable color scheme editor and an external customize hook on the theme toggle.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorSchemeDialog.tsx
+++ b/packages/vue/src/components/HkColorSchemeDialog.tsx
@@ -1,137 +1,37 @@
-import { computed, defineComponent, nextTick, reactive, ref, watch, type PropType } from "vue";
+import { computed, defineComponent, ref, watch, type PropType } from "vue";
 import {
-  HColorPicker,
-  HExpansionPanel,
-  HInput,
   HModal,
-  HMorphingTabs,
-
   useI18n,
-  useTheme,
-  allGroupSlots,
-  clampToSlot,
-  getTokenGroups,
-  resolveGroupTokens,
-  resolveLocalizedText,
-  tokenGroupsVersion,
   type ModalAction,
   type ThemeSchemeTokens,
   type ThemeTokenGroupModes,
-  type ThemeTokenGroupValues,
-  type TokenGroupDefinition,
-  type TokenGroupSection,
-  type TokenGroupSlot,
 } from "@celestia-island/hikari";
 
-import "./HkColorSchemeDialog.scss";
+import { HkColorSchemeEditor, type HCustomTheme } from "./HkColorSchemeEditor";
 
 
-const defaultDark: ThemeSchemeTokens = {
-  primary: { r: 255, g: 107, b: 157 },
-  secondary: { r: 199, g: 146, b: 234 },
-  accent: { r: 253, g: 235, b: 139 },
-  text: { r: 228, g: 228, b: 231 },
-  muted: { r: 180, g: 180, b: 180 },
-  border: { r: 255, g: 255, b: 255 },
-  focusedBorder: { r: 255, g: 107, b: 157 },
-  background: { r: 14, g: 14, b: 30 },
-  surface: { r: 24, g: 24, b: 42 },
-  selectedBackground: { r: 70, g: 70, b: 85 },
-  selectedText: { r: 240, g: 240, b: 240 },
-  statusBarBackground: { r: 24, g: 24, b: 42 },
-  success: { r: 114, g: 241, b: 184 },
-  error: { r: 255, g: 107, b: 107 },
-  warning: { r: 253, g: 235, b: 139 },
-  info: { r: 110, g: 231, b: 239 },
-};
+export { type HCustomTheme } from "./HkColorSchemeEditor";
 
-const defaultLight: ThemeSchemeTokens = {
-  primary: { r: 214, g: 51, b: 132 },
-  secondary: { r: 156, g: 106, b: 222 },
-  accent: { r: 230, g: 167, b: 0 },
-  text: { r: 30, g: 30, b: 30 },
-  muted: { r: 80, g: 80, b: 80 },
-  border: { r: 0, g: 0, b: 0 },
-  focusedBorder: { r: 214, g: 51, b: 132 },
-  background: { r: 245, g: 245, b: 240 },
-  surface: { r: 255, g: 255, b: 255 },
-  selectedBackground: { r: 200, g: 200, b: 205 },
-  selectedText: { r: 40, g: 40, b: 45 },
-  statusBarBackground: { r: 230, g: 230, b: 225 },
-  success: { r: 16, g: 185, b: 129 },
-  error: { r: 239, g: 68, b: 68 },
-  warning: { r: 245, g: 158, b: 11 },
-  info: { r: 6, g: 182, b: 212 },
-};
-
-type ColorTokenKey = keyof ThemeSchemeTokens;
-
-const editableTokens: ColorTokenKey[] = ["primary", "secondary", "accent", "success", "error", "warning", "info"];
-const derivedTokens: ColorTokenKey[] = ["background", "surface", "text", "muted", "border", "focusedBorder", "selectedBackground", "selectedText", "statusBarBackground"];
-
-function clamp(v: number): number {
-  return Math.max(0, Math.min(255, v));
-}
-
-function deriveSurface(tokens: ThemeSchemeTokens, isDark: boolean): ThemeSchemeTokens {
-  const p = tokens.primary;
-  const base = isDark ? 14 : 245;
-  return {
-    ...tokens,
-    background: { r: clamp(base), g: clamp(base), b: clamp(base + (isDark ? 16 : -5)) },
-    surface: { r: clamp(base + (isDark ? 10 : 10)), g: clamp(base + (isDark ? 10 : 10)), b: clamp(base + (isDark ? 18 : 5)) },
-    text: { r: clamp(isDark ? 228 : 30), g: clamp(isDark ? 228 : 30), b: clamp(isDark ? 231 : 30) },
-    muted: { r: clamp(isDark ? 180 : 80), g: clamp(isDark ? 180 : 80), b: clamp(isDark ? 180 : 80) },
-    border: { r: clamp(isDark ? 255 : 0), g: clamp(isDark ? 255 : 0), b: clamp(isDark ? 255 : 0) },
-    focusedBorder: { r: p.r, g: p.g, b: p.b },
-    selectedBackground: { r: clamp(p.r * 0.27), g: clamp(p.g * 0.27), b: clamp(p.b * 0.35) },
-    selectedText: { r: clamp(isDark ? 240 : 40), g: clamp(isDark ? 240 : 40), b: clamp(isDark ? 240 : 45) },
-    statusBarBackground: { r: clamp(base + (isDark ? 10 : -15)), g: clamp(base + (isDark ? 10 : -15)), b: clamp(base + (isDark ? 18 : -5)) },
-  };
-}
-
-interface HkTabItem {
-  key: string;
-  label: string;
-}
-
-/**
- * HCustomTheme — custom color scheme payload, structurally identical to
- * hikari's `CustomThemePreset` (which hikari does not re-export from its
- * root yet). `useTheme().addCustomTheme(theme)` accepts it directly.
- */
-export interface HCustomTheme {
-  id: string;
-  name: string;
-  dark: ThemeSchemeTokens;
-  light: ThemeSchemeTokens;
-  /** Extension token group values (both modes), present when groups are registered. */
-  groups?: ThemeTokenGroupModes;
-}
 
 /**
  * HColorSchemeDialog — custom color scheme editor over hikari's theme
  * presets/custom themes.
  *
- * Edits the seven accent tokens (primary/secondary/accent/success/error/
- * warning/info) per mode (dark/light); surface tokens are derived. When
- * extension token groups are registered (`registerTokenGroup` /
- * `registerTokenGroupConfig`), the "Extended colors" section renders one
- * Material expansion panel per group — sub-sectioned groups (config-file
- * palettes like chest's scada set) get one panel per section — with the
- * slots laid out on a 2–3 column grid of hue-clamped pickers showing
- * full localized color names. Emits `confirm` with a `HCustomTheme`
- * (a hikari `CustomThemePreset`); the caller persists it via
- * `useTheme().addCustomTheme()` and applies it with `setTheme()`.
+ * Thin modal wrapper around HkColorSchemeEditor: it owns only the modal
+ * chrome (title, footer actions) and the open→re-seed→save lifecycle,
+ * delegating the actual token/group editing form to the editor.
+ * Emits `confirm` with a `HCustomTheme` (a hikari `CustomThemePreset`);
+ * the caller persists it via `useTheme().addCustomTheme()` and applies it
+ * with `setTheme()`.
  */
 export const HColorSchemeDialog = defineComponent({
   name: "HkColorSchemeDialog",
   props: {
     modelValue: { type: Boolean, required: true },
     /** Prefill dark tokens; defaults to the hikari synthwave dark scheme. */
-    initialDark: { type: Object, default: undefined },
+    initialDark: { type: Object as PropType<ThemeSchemeTokens>, default: undefined },
     /** Prefill light tokens; defaults to the hikari synthwave light scheme. */
-    initialLight: { type: Object, default: undefined },
+    initialLight: { type: Object as PropType<ThemeSchemeTokens>, default: undefined },
     /** Prefill extension token groups (per mode); defaults to registry defaults. */
     initialGroups: { type: Object as PropType<ThemeTokenGroupModes>, default: undefined },
   },
@@ -141,120 +41,25 @@ export const HColorSchemeDialog = defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
-    // Reactive locale: `locale` from useI18n() is a snapshot string, but
-    // runtime setLocale() swaps messages reactively — resolve LocalizedText
-    // through a computed so config-file labels follow the live locale.
-    const activeLocale = computed(() => useI18n().locale);
-    const { effectiveMode } = useTheme();
-    const modeTab = ref<string>(effectiveMode.value);
-    const themeName = ref("");
+    // The editor exposes { reset, getDraft } via defineExpose; those are
+    // runtime-only and not part of InstanceType, so type the ref explicitly.
+    const editorRef = ref<{ reset: () => void; getDraft: () => HCustomTheme } | null>(null);
 
-    const dark = reactive<ThemeSchemeTokens>({ ...defaultDark });
-    const light = reactive<ThemeSchemeTokens>({ ...defaultLight });
-
-    // Extension token groups, edited per mode like the accent tokens.
-    // Seeded from the prefilled custom theme (if any) falling back to the
-    // registry defaults; empty (and rendered nowhere) while no downstream
-    // app has registered a group.
-    const groupDark = reactive<ThemeTokenGroupValues>({});
-    const groupLight = reactive<ThemeTokenGroupValues>({});
-    // Depends on the registry's reactive version so groups registered
-    // after this dialog first rendered appear without a remount.
-    const registeredGroups = computed<readonly TokenGroupDefinition[]>(() => {
-      void tokenGroupsVersion.value;
-      return getTokenGroups();
-    });
-
-    const currentTokens = computed(() => (modeTab.value === "dark" ? dark : light));
-    const currentGroupValues = computed(() => (modeTab.value === "dark" ? groupDark : groupLight));
-
-    function seedGroups(
-      target: ThemeTokenGroupValues,
-      mode: "dark" | "light",
-      overrides?: ThemeTokenGroupValues,
-    ) {
-      const resolved = resolveGroupTokens(mode, overrides);
-      for (const key of Object.keys(target)) delete target[key];
-      for (const [groupId, slots] of Object.entries(resolved)) {
-        target[groupId] = slots;
-      }
-    }
-
-    function rederiveSurface() {
-      const target = modeTab.value === "dark" ? dark : light;
-      const derived = deriveSurface(target, modeTab.value === "dark");
-      derivedTokens.forEach((k) => {
-        target[k] = { ...derived[k] };
-      });
-    }
-
-    watch(
-      () => [
-        dark.primary, dark.secondary, dark.accent, dark.success, dark.error, dark.warning, dark.info,
-        light.primary, light.secondary, light.accent, light.success, light.error, light.warning, light.info,
-      ],
-      () => rederiveSurface(),
-      { deep: true },
-    );
-
-    watch(modeTab, () => nextTick(() => rederiveSurface()));
-
+    // Re-seed the editor each time the dialog opens so it reflects the
+    // current effective mode and any (updated) prefills — same timing the
+    // old inline watch had.
     watch(
       () => props.modelValue,
       (open) => {
         if (!open) return;
-        modeTab.value = effectiveMode.value;
-        themeName.value = t("hikari::theme.customThemeName");
-        const initialDark = props.initialDark as ThemeSchemeTokens | undefined;
-        const initialLight = props.initialLight as ThemeSchemeTokens | undefined;
-        Object.assign(dark, initialDark ?? defaultDark);
-        Object.assign(light, initialLight ?? defaultLight);
-        const initialGroups = props.initialGroups as ThemeTokenGroupModes | undefined;
-        seedGroups(groupDark, "dark", initialGroups?.dark);
-        seedGroups(groupLight, "light", initialGroups?.light);
-        rederiveSurface();
+        editorRef.value?.reset();
       },
     );
 
-    function updateToken(key: ColorTokenKey, rgb: { r: number; g: number; b: number }) {
-      const target = modeTab.value === "dark" ? dark : light;
-      target[key] = { ...rgb };
-    }
-
-    function updateGroupToken(groupId: string, slot: TokenGroupSlot, rgb: { r: number; g: number; b: number }) {
-      const values = currentGroupValues.value;
-      const group = values[groupId] ?? (values[groupId] = {});
-      // Defense in depth: the picker already clamps, clamp again on write.
-      group[slot.key] = clampToSlot(slot, rgb);
-    }
-
-    function clampGroups(
-      source: ThemeTokenGroupValues,
-      mode: "dark" | "light",
-    ): ThemeTokenGroupValues {
-      const out: ThemeTokenGroupValues = {};
-      for (const group of registeredGroups.value) {
-        const slots: Record<string, { r: number; g: number; b: number }> = {};
-        for (const slot of allGroupSlots(group)) {
-          const value = source[group.id]?.[slot.key] ?? slot.defaults[mode];
-          slots[slot.key] = clampToSlot(slot, value);
-        }
-        out[group.id] = slots;
-      }
-      return out;
-    }
-
     function handleConfirm() {
-      const id = `custom-theme-${Date.now()}`;
-      emit("confirm", {
-        id,
-        name: themeName.value || t("hikari::theme.customThemeName"),
-        dark: { ...dark },
-        light: { ...light },
-        ...(registeredGroups.value.length > 0
-          ? { groups: { dark: clampGroups(groupDark, "dark"), light: clampGroups(groupLight, "light") } }
-          : {}),
-      });
+      const draft = editorRef.value?.getDraft();
+      if (!draft) return;
+      emit("confirm", draft);
       emit("update:modelValue", false);
     }
 
@@ -271,94 +76,6 @@ export const HColorSchemeDialog = defineComponent({
       },
     ]);
 
-    const modeTabs = computed<HkTabItem[]>(() => [
-      { key: "dark", label: t("hikari::theme.modeDark") },
-      { key: "light", label: t("hikari::theme.modeLight") },
-    ]);
-
-    // ── Extension group rendering ────────────────────────────────────
-    // Label resolution order: hikari i18n message (apps may override via
-    // mergeMessages) → LocalizedText entry for the active locale → the
-    // definition's `en` → first defined locale.
-
-    function slotLabel(groupId: string, slot: TokenGroupSlot): string {
-      return t(
-        `hikari::theme.groups.${groupId}.${slot.key}`,
-        resolveLocalizedText(slot.label, activeLocale.value),
-      );
-    }
-
-    function sectionLabel(groupId: string, section: TokenGroupSection): string {
-      return t(
-        `hikari::theme.groups.${groupId}.sections.${section.key}`,
-        resolveLocalizedText(section.label, activeLocale.value),
-      );
-    }
-
-    function groupLabel(group: TokenGroupDefinition): string {
-      return t(
-        `hikari::theme.groups.${group.id}.title`,
-        resolveLocalizedText(group.label, activeLocale.value),
-      );
-    }
-
-    function countLabel(count: number): string {
-      return t("hikari::theme.groupCount", "{count} colors").replace("{count}", String(count));
-    }
-
-    function renderGroupSlot(group: TokenGroupDefinition, slot: TokenGroupSlot) {
-      const mode = modeTab.value === "dark" ? "dark" : "light";
-      const rgb = currentGroupValues.value[group.id]?.[slot.key] ?? slot.defaults[mode];
-      return (
-        <HColorPicker
-          key={slot.key}
-          r={rgb.r}
-          g={rgb.g}
-          b={rgb.b}
-          label={slotLabel(group.id, slot)}
-          layout="row"
-          hueClamp={slot.hueClamp}
-          sRange={slot.sRange}
-          lRange={slot.lRange}
-          onChange={(next: { r: number; g: number; b: number }) => updateGroupToken(group.id, slot, next)}
-        />
-      );
-    }
-
-    function renderSlotGrid(group: TokenGroupDefinition, slots: TokenGroupSlot[]) {
-      return (
-        <div class="s-scheme-group-grid">
-          {slots.map((slot) => renderGroupSlot(group, slot))}
-        </div>
-      );
-    }
-
-    /** One expansion panel per section, then one for any flat slots. */
-    function renderGroup(group: TokenGroupDefinition) {
-      const panels = (group.sections ?? []).map((section) => (
-        <HExpansionPanel
-          key={`${group.id}--${section.key}`}
-          title={sectionLabel(group.id, section)}
-          subtitle={countLabel(section.slots.length)}
-        >
-          {renderSlotGrid(group, section.slots)}
-        </HExpansionPanel>
-      ));
-      const flat = group.slots ?? [];
-      if (flat.length > 0) {
-        panels.push(
-          <HExpansionPanel
-            key={`${group.id}--flat`}
-            title={groupLabel(group)}
-            subtitle={countLabel(flat.length)}
-          >
-            {renderSlotGrid(group, flat)}
-          </HExpansionPanel>,
-        );
-      }
-      return panels;
-    }
-
     return () => (
       <HModal
         modelValue={props.modelValue}
@@ -367,43 +84,12 @@ export const HColorSchemeDialog = defineComponent({
         width="36rem"
         footerActions={footerActions.value}
       >
-        <div class="s-scheme-dialog">
-          <HInput
-            modelValue={themeName.value}
-            onUpdate:modelValue={(v: string) => { themeName.value = v; }}
-            label={t("hikari::theme.themeName")}
-            placeholder={t("hikari::theme.customThemeName")}
-          />
-          <HMorphingTabs
-            tag="div"
-            class="s-scheme-mode-switch"
-            modelValue={modeTab.value}
-            onUpdate:modelValue={(v: string) => { modeTab.value = v; }}
-            tabs={modeTabs.value}
-          />
-          <div class="s-scheme-colors">
-            {editableTokens.map((key) => (
-              <HColorPicker
-                key={key}
-                r={currentTokens.value[key].r}
-                g={currentTokens.value[key].g}
-                b={currentTokens.value[key].b}
-                label={t(`hikari::theme.tokens.${key}`)}
-                onChange={(rgb: { r: number; g: number; b: number }) => updateToken(key, rgb)}
-              />
-            ))}
-          </div>
-          {registeredGroups.value.length > 0 && (
-            <div class="s-scheme-groups">
-              <div class="s-scheme-groups-title">
-                {t("hikari::theme.extendedColors", "Extended colors")}
-              </div>
-              <div class="s-scheme-group-panels">
-                {registeredGroups.value.map((group) => renderGroup(group))}
-              </div>
-            </div>
-          )}
-        </div>
+        <HkColorSchemeEditor
+          ref={editorRef}
+          initialDark={props.initialDark}
+          initialLight={props.initialLight}
+          initialGroups={props.initialGroups}
+        />
       </HModal>
     );
   },

--- a/packages/vue/src/components/HkColorSchemeEditor.test.ts
+++ b/packages/vue/src/components/HkColorSchemeEditor.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref, type Ref } from "vue";
+
+import { registerTokenGroup, useTheme, type TokenGroupDefinition } from "../theme";
+import { HkColorSchemeEditor, type HCustomTheme } from "./HkColorSchemeEditor";
+
+// Fresh file = fresh registry module instance: no groups are registered
+// until a test registers one, mirroring an app that registers late.
+const EDITOR_GROUP: TokenGroupDefinition = {
+  id: "editor-wires",
+  label: "Editor wires",
+  slots: [
+    {
+      key: "a",
+      label: "A",
+      defaults: { dark: { r: 1, g: 2, b: 3 }, light: { r: 4, g: 5, b: 6 } },
+    },
+    {
+      key: "b",
+      label: "B",
+      defaults: { dark: { r: 7, g: 8, b: 9 }, light: { r: 10, g: 11, b: 12 } },
+      pairWith: "a",
+    },
+  ],
+};
+
+const SECTIONED_GROUP: TokenGroupDefinition = {
+  id: "editor-sectioned",
+  label: { en: "Sectioned palette", "zh-Hans": "分区调色板" },
+  sections: [
+    {
+      key: "power",
+      label: { en: "Electrical power", "zh-Hans": "电力" },
+      slots: [
+        {
+          key: "l1",
+          label: { en: "Phase L1 (yellow)", "zh-Hans": "L1 相（黄）" },
+          defaults: { dark: { r: 234, g: 179, b: 8 }, light: { r: 161, g: 98, b: 7 } },
+          hueClamp: { center: 45, range: 20 },
+        },
+        {
+          key: "l2",
+          label: { en: "Phase L2 (green)", "zh-Hans": "L2 相（绿）" },
+          defaults: { dark: { r: 34, g: 197, b: 94 }, light: { r: 21, g: 128, b: 61 } },
+        },
+      ],
+    },
+    {
+      key: "media",
+      label: { en: "Process media", "zh-Hans": "工艺介质" },
+      slots: [
+        {
+          key: "h2",
+          label: { en: "Hydrogen", "zh-Hans": "氢气" },
+          defaults: { dark: { r: 20, g: 184, b: 166 }, light: { r: 15, g: 118, b: 110 } },
+        },
+      ],
+    },
+  ],
+};
+
+interface EditorExpose {
+  reset: () => void;
+  getDraft: () => HCustomTheme;
+}
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountEditor(initial?: {
+  initialDark?: HCustomTheme["dark"];
+  initialLight?: HCustomTheme["light"];
+}): { ref: Ref<EditorExpose | null>; container: HTMLElement } {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const editorRef = ref<EditorExpose | null>(null);
+  const app = createApp({
+    render: () =>
+      h(HkColorSchemeEditor, {
+        ref: editorRef,
+        ...(initial?.initialDark ? { initialDark: initial.initialDark } : {}),
+        ...(initial?.initialLight ? { initialLight: initial.initialLight } : {}),
+      }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { ref: editorRef, container };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+/** Set the first accent token (primary) of the active mode to a hex color. */
+async function setPrimaryHex(hex: string): Promise<void> {
+  const swatch = document.body.querySelector(
+    ".s-scheme-colors .hk-color-picker-swatch-btn",
+  ) as HTMLButtonElement | null;
+  swatch!.click();
+  await settle();
+  const input = document.body.querySelector(
+    ".hk-color-picker-hex-row input.hk-input-element",
+  ) as HTMLInputElement | null;
+  input!.value = hex;
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+}
+
+beforeEach(() => {
+  // Pin the effective mode so edits deterministically target the dark side.
+  useTheme().setMode("dark");
+});
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkColorSchemeEditor", () => {
+  it("renders the seven accent pickers on initial render", async () => {
+    const { container } = mountEditor();
+    await nextTick();
+
+    const pickers = container.querySelectorAll(".s-scheme-colors .hk-color-picker");
+    expect(pickers).toHaveLength(7);
+    // No groups registered in this file yet: the extension section is absent.
+    expect(container.querySelector(".s-scheme-groups")).toBeNull();
+  });
+
+  it("editing a token updates getDraft() with the edited RGB", async () => {
+    const { ref } = mountEditor();
+    await nextTick();
+
+    await setPrimaryHex("ff0000");
+    const draft = ref.value!.getDraft();
+    expect(draft.dark.primary).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("getDraft() includes clamped group values", async () => {
+    registerTokenGroup(EDITOR_GROUP);
+    registerTokenGroup(SECTIONED_GROUP);
+    const { ref } = mountEditor();
+    await nextTick();
+
+    const draft = ref.value!.getDraft();
+    expect(draft.groups).toBeTruthy();
+    const darkGroups = draft.groups!.dark!;
+    const lightGroups = draft.groups!.light!;
+    // Flat group defaults, clamped per slot (no bands → passthrough).
+    expect(darkGroups["editor-wires"]).toEqual({
+      a: { r: 1, g: 2, b: 3 },
+      b: { r: 7, g: 8, b: 9 },
+    });
+    // Sectioned group slots also land under their group id.
+    expect(darkGroups["editor-sectioned"].l1.r).toBe(234);
+    expect(lightGroups["editor-sectioned"].l2).toEqual({ r: 21, g: 128, b: 61 });
+  });
+
+  it("reset() restores the defaults after edits", async () => {
+    const { ref } = mountEditor();
+    await nextTick();
+
+    const before = ref.value!.getDraft();
+    expect(before.dark.primary).toEqual({ r: 255, g: 107, b: 157 });
+
+    await setPrimaryHex("00ff00");
+    expect(ref.value!.getDraft().dark.primary).toEqual({ r: 0, g: 255, b: 0 });
+
+    ref.value!.reset();
+    await nextTick();
+    expect(ref.value!.getDraft().dark.primary).toEqual({ r: 255, g: 107, b: 157 });
+  });
+});

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -1,0 +1,378 @@
+import { computed, defineComponent, nextTick, onMounted, reactive, ref, watch, type PropType } from "vue";
+import {
+  HColorPicker,
+  HExpansionPanel,
+  HInput,
+  HMorphingTabs,
+
+  useI18n,
+  useTheme,
+  allGroupSlots,
+  clampToSlot,
+  getTokenGroups,
+  resolveGroupTokens,
+  resolveLocalizedText,
+  tokenGroupsVersion,
+  type ThemeSchemeTokens,
+  type ThemeTokenGroupModes,
+  type ThemeTokenGroupValues,
+  type TokenGroupDefinition,
+  type TokenGroupSection,
+  type TokenGroupSlot,
+} from "@celestia-island/hikari";
+
+import "./HkColorSchemeDialog.scss";
+
+
+const defaultDark: ThemeSchemeTokens = {
+  primary: { r: 255, g: 107, b: 157 },
+  secondary: { r: 199, g: 146, b: 234 },
+  accent: { r: 253, g: 235, b: 139 },
+  text: { r: 228, g: 228, b: 231 },
+  muted: { r: 180, g: 180, b: 180 },
+  border: { r: 255, g: 255, b: 255 },
+  focusedBorder: { r: 255, g: 107, b: 157 },
+  background: { r: 14, g: 14, b: 30 },
+  surface: { r: 24, g: 24, b: 42 },
+  selectedBackground: { r: 70, g: 70, b: 85 },
+  selectedText: { r: 240, g: 240, b: 240 },
+  statusBarBackground: { r: 24, g: 24, b: 42 },
+  success: { r: 114, g: 241, b: 184 },
+  error: { r: 255, g: 107, b: 107 },
+  warning: { r: 253, g: 235, b: 139 },
+  info: { r: 110, g: 231, b: 239 },
+};
+
+const defaultLight: ThemeSchemeTokens = {
+  primary: { r: 214, g: 51, b: 132 },
+  secondary: { r: 156, g: 106, b: 222 },
+  accent: { r: 230, g: 167, b: 0 },
+  text: { r: 30, g: 30, b: 30 },
+  muted: { r: 80, g: 80, b: 80 },
+  border: { r: 0, g: 0, b: 0 },
+  focusedBorder: { r: 214, g: 51, b: 132 },
+  background: { r: 245, g: 245, b: 240 },
+  surface: { r: 255, g: 255, b: 255 },
+  selectedBackground: { r: 200, g: 200, b: 205 },
+  selectedText: { r: 40, g: 40, b: 45 },
+  statusBarBackground: { r: 230, g: 230, b: 225 },
+  success: { r: 16, g: 185, b: 129 },
+  error: { r: 239, g: 68, b: 68 },
+  warning: { r: 245, g: 158, b: 11 },
+  info: { r: 6, g: 182, b: 212 },
+};
+
+type ColorTokenKey = keyof ThemeSchemeTokens;
+
+const editableTokens: ColorTokenKey[] = ["primary", "secondary", "accent", "success", "error", "warning", "info"];
+const derivedTokens: ColorTokenKey[] = ["background", "surface", "text", "muted", "border", "focusedBorder", "selectedBackground", "selectedText", "statusBarBackground"];
+
+function clamp(v: number): number {
+  return Math.max(0, Math.min(255, v));
+}
+
+function deriveSurface(tokens: ThemeSchemeTokens, isDark: boolean): ThemeSchemeTokens {
+  const p = tokens.primary;
+  const base = isDark ? 14 : 245;
+  return {
+    ...tokens,
+    background: { r: clamp(base), g: clamp(base), b: clamp(base + (isDark ? 16 : -5)) },
+    surface: { r: clamp(base + (isDark ? 10 : 10)), g: clamp(base + (isDark ? 10 : 10)), b: clamp(base + (isDark ? 18 : 5)) },
+    text: { r: clamp(isDark ? 228 : 30), g: clamp(isDark ? 228 : 30), b: clamp(isDark ? 231 : 30) },
+    muted: { r: clamp(isDark ? 180 : 80), g: clamp(isDark ? 180 : 80), b: clamp(isDark ? 180 : 80) },
+    border: { r: clamp(isDark ? 255 : 0), g: clamp(isDark ? 255 : 0), b: clamp(isDark ? 255 : 0) },
+    focusedBorder: { r: p.r, g: p.g, b: p.b },
+    selectedBackground: { r: clamp(p.r * 0.27), g: clamp(p.g * 0.27), b: clamp(p.b * 0.35) },
+    selectedText: { r: clamp(isDark ? 240 : 40), g: clamp(isDark ? 240 : 40), b: clamp(isDark ? 240 : 45) },
+    statusBarBackground: { r: clamp(base + (isDark ? 10 : -15)), g: clamp(base + (isDark ? 10 : -15)), b: clamp(base + (isDark ? 18 : -5)) },
+  };
+}
+
+interface HkTabItem {
+  key: string;
+  label: string;
+}
+
+/**
+ * HCustomTheme — custom color scheme payload, structurally identical to
+ * hikari's `CustomThemePreset` (which hikari does not re-export from its
+ * root yet). `useTheme().addCustomTheme(theme)` accepts it directly.
+ */
+export interface HCustomTheme {
+  id: string;
+  name: string;
+  dark: ThemeSchemeTokens;
+  light: ThemeSchemeTokens;
+  /** Extension token group values (both modes), present when groups are registered. */
+  groups?: ThemeTokenGroupModes;
+}
+
+/**
+ * HkColorSchemeEditor — the editable body of the custom color scheme form,
+ * extracted from HkColorSchemeDialog so downstream apps can host it inside
+ * their own surface (tabs, drawers, panels) instead of the built-in modal.
+ *
+ * Edits the seven accent tokens (primary/secondary/accent/success/error/
+ * warning/info) per mode (dark/light); surface tokens are derived. When
+ * extension token groups are registered (`registerTokenGroup` /
+ * `registerTokenGroupConfig`), the "Extended colors" section renders one
+ * Material expansion panel per group — sub-sectioned groups get one panel
+ * per section — with the slots laid out on a 2–3 column grid of
+ * hue-clamped pickers showing full localized color names.
+ *
+ * Exposes `reset()` (re-seed from props + current effective mode) and
+ * `getDraft()` (snapshot the current edits as a `HCustomTheme`) for the
+ * host surface to wire to its own save/close controls.
+ */
+export const HkColorSchemeEditor = defineComponent({
+  name: "HkColorSchemeEditor",
+  props: {
+    /** Prefill dark tokens; defaults to the hikari synthwave dark scheme. */
+    initialDark: { type: Object as PropType<ThemeSchemeTokens>, default: undefined },
+    /** Prefill light tokens; defaults to the hikari synthwave light scheme. */
+    initialLight: { type: Object as PropType<ThemeSchemeTokens>, default: undefined },
+    /** Prefill extension token groups (per mode); defaults to registry defaults. */
+    initialGroups: { type: Object as PropType<ThemeTokenGroupModes>, default: undefined },
+  },
+  setup(props, { expose }) {
+    const { t } = useI18n();
+    // Reactive locale: `locale` from useI18n() is a snapshot string, but
+    // runtime setLocale() swaps messages reactively — resolve LocalizedText
+    // through a computed so config-file labels follow the live locale.
+    const activeLocale = computed(() => useI18n().locale);
+    const modeTab = ref<string>("dark");
+    const themeName = ref("");
+
+    const dark = reactive<ThemeSchemeTokens>({ ...defaultDark });
+    const light = reactive<ThemeSchemeTokens>({ ...defaultLight });
+
+    // Extension token groups, edited per mode like the accent tokens.
+    // Seeded from the prefilled custom theme (if any) falling back to the
+    // registry defaults; empty (and rendered nowhere) while no downstream
+    // app has registered a group.
+    const groupDark = reactive<ThemeTokenGroupValues>({});
+    const groupLight = reactive<ThemeTokenGroupValues>({});
+    // Depends on the registry's reactive version so groups registered
+    // after this editor first rendered appear without a remount.
+    const registeredGroups = computed<readonly TokenGroupDefinition[]>(() => {
+      void tokenGroupsVersion.value;
+      return getTokenGroups();
+    });
+
+    const currentTokens = computed(() => (modeTab.value === "dark" ? dark : light));
+    const currentGroupValues = computed(() => (modeTab.value === "dark" ? groupDark : groupLight));
+
+    function seedGroups(
+      target: ThemeTokenGroupValues,
+      mode: "dark" | "light",
+      overrides?: ThemeTokenGroupValues,
+    ) {
+      const resolved = resolveGroupTokens(mode, overrides);
+      for (const key of Object.keys(target)) delete target[key];
+      for (const [groupId, slots] of Object.entries(resolved)) {
+        target[groupId] = slots;
+      }
+    }
+
+    function rederiveSurface() {
+      const target = modeTab.value === "dark" ? dark : light;
+      const derived = deriveSurface(target, modeTab.value === "dark");
+      derivedTokens.forEach((k) => {
+        target[k] = { ...derived[k] };
+      });
+    }
+
+    function reset(): void {
+      modeTab.value = useTheme().effectiveMode.value;
+      themeName.value = t("hikari::theme.customThemeName");
+      Object.assign(dark, props.initialDark ?? defaultDark);
+      Object.assign(light, props.initialLight ?? defaultLight);
+      seedGroups(groupDark, "dark", props.initialGroups?.dark);
+      seedGroups(groupLight, "light", props.initialGroups?.light);
+      rederiveSurface();
+    }
+
+    onMounted(() => reset());
+
+    expose({ reset, getDraft });
+
+    watch(
+      () => [
+        dark.primary, dark.secondary, dark.accent, dark.success, dark.error, dark.warning, dark.info,
+        light.primary, light.secondary, light.accent, light.success, light.error, light.warning, light.info,
+      ],
+      () => rederiveSurface(),
+      { deep: true },
+    );
+
+    watch(modeTab, () => nextTick(() => rederiveSurface()));
+
+    function updateToken(key: ColorTokenKey, rgb: { r: number; g: number; b: number }) {
+      const target = modeTab.value === "dark" ? dark : light;
+      target[key] = { ...rgb };
+    }
+
+    function updateGroupToken(groupId: string, slot: TokenGroupSlot, rgb: { r: number; g: number; b: number }) {
+      const values = currentGroupValues.value;
+      const group = values[groupId] ?? (values[groupId] = {});
+      // Defense in depth: the picker already clamps, clamp again on write.
+      group[slot.key] = clampToSlot(slot, rgb);
+    }
+
+    function clampGroups(
+      source: ThemeTokenGroupValues,
+      mode: "dark" | "light",
+    ): ThemeTokenGroupValues {
+      const out: ThemeTokenGroupValues = {};
+      for (const group of registeredGroups.value) {
+        const slots: Record<string, { r: number; g: number; b: number }> = {};
+        for (const slot of allGroupSlots(group)) {
+          const value = source[group.id]?.[slot.key] ?? slot.defaults[mode];
+          slots[slot.key] = clampToSlot(slot, value);
+        }
+        out[group.id] = slots;
+      }
+      return out;
+    }
+
+    function getDraft(): HCustomTheme {
+      return {
+        id: `custom-theme-${Date.now()}`,
+        name: themeName.value || t("hikari::theme.customThemeName"),
+        dark: { ...dark },
+        light: { ...light },
+        ...(registeredGroups.value.length > 0
+          ? { groups: { dark: clampGroups(groupDark, "dark"), light: clampGroups(groupLight, "light") } }
+          : {}),
+      };
+    }
+
+    const modeTabs = computed<HkTabItem[]>(() => [
+      { key: "dark", label: t("hikari::theme.modeDark") },
+      { key: "light", label: t("hikari::theme.modeLight") },
+    ]);
+
+    // ── Extension group rendering ────────────────────────────────────
+    // Label resolution order: hikari i18n message (apps may override via
+    // mergeMessages) → LocalizedText entry for the active locale → the
+    // definition's `en` → first defined locale.
+
+    function slotLabel(groupId: string, slot: TokenGroupSlot): string {
+      return t(
+        `hikari::theme.groups.${groupId}.${slot.key}`,
+        resolveLocalizedText(slot.label, activeLocale.value),
+      );
+    }
+
+    function sectionLabel(groupId: string, section: TokenGroupSection): string {
+      return t(
+        `hikari::theme.groups.${groupId}.sections.${section.key}`,
+        resolveLocalizedText(section.label, activeLocale.value),
+      );
+    }
+
+    function groupLabel(group: TokenGroupDefinition): string {
+      return t(
+        `hikari::theme.groups.${group.id}.title`,
+        resolveLocalizedText(group.label, activeLocale.value),
+      );
+    }
+
+    function countLabel(count: number): string {
+      return t("hikari::theme.groupCount", "{count} colors").replace("{count}", String(count));
+    }
+
+    function renderGroupSlot(group: TokenGroupDefinition, slot: TokenGroupSlot) {
+      const mode = modeTab.value === "dark" ? "dark" : "light";
+      const rgb = currentGroupValues.value[group.id]?.[slot.key] ?? slot.defaults[mode];
+      return (
+        <HColorPicker
+          key={slot.key}
+          r={rgb.r}
+          g={rgb.g}
+          b={rgb.b}
+          label={slotLabel(group.id, slot)}
+          layout="row"
+          hueClamp={slot.hueClamp}
+          sRange={slot.sRange}
+          lRange={slot.lRange}
+          onChange={(next: { r: number; g: number; b: number }) => updateGroupToken(group.id, slot, next)}
+        />
+      );
+    }
+
+    function renderSlotGrid(group: TokenGroupDefinition, slots: TokenGroupSlot[]) {
+      return (
+        <div class="s-scheme-group-grid">
+          {slots.map((slot) => renderGroupSlot(group, slot))}
+        </div>
+      );
+    }
+
+    /** One expansion panel per section, then one for any flat slots. */
+    function renderGroup(group: TokenGroupDefinition) {
+      const panels = (group.sections ?? []).map((section) => (
+        <HExpansionPanel
+          key={`${group.id}--${section.key}`}
+          title={sectionLabel(group.id, section)}
+          subtitle={countLabel(section.slots.length)}
+        >
+          {renderSlotGrid(group, section.slots)}
+        </HExpansionPanel>
+      ));
+      const flat = group.slots ?? [];
+      if (flat.length > 0) {
+        panels.push(
+          <HExpansionPanel
+            key={`${group.id}--flat`}
+            title={groupLabel(group)}
+            subtitle={countLabel(flat.length)}
+          >
+            {renderSlotGrid(group, flat)}
+          </HExpansionPanel>,
+        );
+      }
+      return panels;
+    }
+
+    return () => (
+      <div class="s-scheme-dialog">
+        <HInput
+          modelValue={themeName.value}
+          onUpdate:modelValue={(v: string) => { themeName.value = v; }}
+          label={t("hikari::theme.themeName")}
+          placeholder={t("hikari::theme.customThemeName")}
+        />
+        <HMorphingTabs
+          tag="div"
+          class="s-scheme-mode-switch"
+          modelValue={modeTab.value}
+          onUpdate:modelValue={(v: string) => { modeTab.value = v; }}
+          tabs={modeTabs.value}
+        />
+        <div class="s-scheme-colors">
+          {editableTokens.map((key) => (
+            <HColorPicker
+              key={key}
+              r={currentTokens.value[key].r}
+              g={currentTokens.value[key].g}
+              b={currentTokens.value[key].b}
+              label={t(`hikari::theme.tokens.${key}`)}
+              onChange={(rgb: { r: number; g: number; b: number }) => updateToken(key, rgb)}
+            />
+          ))}
+        </div>
+        {registeredGroups.value.length > 0 && (
+          <div class="s-scheme-groups">
+            <div class="s-scheme-groups-title">
+              {t("hikari::theme.extendedColors", "Extended colors")}
+            </div>
+            <div class="s-scheme-group-panels">
+              {registeredGroups.value.map((group) => renderGroup(group))}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HkThemeToggle } from "./HkThemeToggle";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+interface Mounted {
+  container: HTMLElement;
+  openCustomize: () => number;
+}
+
+function mountToggle(externalCustomize: boolean): Mounted {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let openCount = 0;
+  const app = createApp({
+    render: () =>
+      h(HkThemeToggle, {
+        externalCustomize,
+        "onOpen-customize": () => {
+          openCount += 1;
+        },
+      }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { container, openCustomize: () => openCount };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+function openMenu(container: HTMLElement): void {
+  const arrow = container.querySelector(
+    '.s-theme-toggle-btn[data-variant="arrow"]',
+  ) as HTMLButtonElement | null;
+  arrow!.click();
+}
+
+function paletteButton(): HTMLButtonElement {
+  const btn = [...document.body.querySelectorAll<HTMLButtonElement>(".s-theme-menu .s-theme-item-btn")].find(
+    (b) => b.textContent?.includes("Customize"),
+  );
+  return btn!;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkThemeToggle external customization", () => {
+  it("emits open-customize and keeps the dialog closed when externalCustomize is true", async () => {
+    const { container, openCustomize } = mountToggle(true);
+    await settle();
+
+    openMenu(container);
+    await settle();
+
+    paletteButton().click();
+    await settle();
+
+    expect(openCustomize()).toBe(1);
+    // The internal dialog is never rendered in external mode.
+    expect(document.body.querySelector(".s-scheme-dialog")).toBeNull();
+  });
+
+  it("opens the built-in dialog when externalCustomize defaults to false", async () => {
+    const { container, openCustomize } = mountToggle(false);
+    await settle();
+
+    openMenu(container);
+    await settle();
+
+    paletteButton().click();
+    await settle();
+
+    expect(openCustomize()).toBe(0);
+    expect(document.body.querySelector(".s-scheme-dialog")).toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -21,9 +21,17 @@ export const HkThemeToggle = defineComponent({
   props: {
     /** Popover placement. */
     popoverPlacement: { type: String as PropType<PopupPlacement>, default: "bottom-end" },
+    /**
+     * When true, the "Customize" button emits `open-customize` and closes
+     * the popover instead of opening the built-in HColorSchemeDialog — the
+     * host app then owns the customization surface (e.g. its own tabs
+     * dialog). The internal dialog is not rendered in this mode.
+     */
+    externalCustomize: { type: Boolean, default: false },
   },
   emits: {
     "update:scheme": (_theme: HCustomTheme) => true,
+    "open-customize": () => true,
   },
   setup(props, { emit, slots }) {
     const { t } = useI18n();
@@ -140,20 +148,29 @@ export const HkThemeToggle = defineComponent({
             <button
               type="button"
               class="s-theme-item-btn"
-              onClick={() => { schemeDialogOpen.value = true; menuOpen.value = false; }}
+              onClick={() => {
+                menuOpen.value = false;
+                if (props.externalCustomize) {
+                  emit("open-customize");
+                } else {
+                  schemeDialogOpen.value = true;
+                }
+              }}
             >
               <Palette size={14} />
-              <span>{t("hikari::theme.editScheme")}</span>
+              <span>{t("hikari::theme.customize")}</span>
             </button>
           </div>
           {slots["menu-extra"]?.()}
         </HPopover>
 
-        <HColorSchemeDialog
-          modelValue={schemeDialogOpen.value}
-          onUpdate:modelValue={(v: boolean) => { schemeDialogOpen.value = v; }}
-          onConfirm={onConfirmScheme}
-        />
+        {!props.externalCustomize && (
+          <HColorSchemeDialog
+            modelValue={schemeDialogOpen.value}
+            onUpdate:modelValue={(v: boolean) => { schemeDialogOpen.value = v; }}
+            onConfirm={onConfirmScheme}
+          />
+        )}
       </div>
     );
   },

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "تلقائي",
     "hikari::theme.themes": "سمات الألوان",
     "hikari::theme.editScheme": "تعديل نظام الألوان…",
+    "hikari::theme.customize": "تخصيص",
     "hikari::theme.themeName": "اسم السمة",
     "hikari::theme.customThemeName": "سمة مخصصة",
     "hikari::theme.save": "حفظ",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Automatisch",
     "hikari::theme.themes": "Farbschemata",
     "hikari::theme.editScheme": "Farbschema bearbeiten…",
+    "hikari::theme.customize": "Anpassen",
     "hikari::theme.themeName": "Designname",
     "hikari::theme.customThemeName": "Benutzerdefiniertes Design",
     "hikari::theme.save": "Speichern",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Color themes",
     "hikari::theme.editScheme": "Edit color scheme…",
+    "hikari::theme.customize": "Customize",
     "hikari::theme.themeName": "Theme name",
     "hikari::theme.customThemeName": "Custom theme",
     "hikari::theme.save": "Save",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de color",
     "hikari::theme.editScheme": "Editar esquema de color…",
+    "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nombre del tema",
     "hikari::theme.customThemeName": "Tema personalizado",
     "hikari::theme.save": "Guardar",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Thèmes de couleurs",
     "hikari::theme.editScheme": "Modifier le schéma de couleurs…",
+    "hikari::theme.customize": "Personnaliser",
     "hikari::theme.themeName": "Nom du thème",
     "hikari::theme.customThemeName": "Thème personnalisé",
     "hikari::theme.save": "Enregistrer",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色テーマ",
     "hikari::theme.editScheme": "配色を編集…",
+    "hikari::theme.customize": "カスタマイズ",
     "hikari::theme.themeName": "テーマ名",
     "hikari::theme.customThemeName": "カスタムテーマ",
     "hikari::theme.save": "保存",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "자동",
     "hikari::theme.themes": "색상 테마",
     "hikari::theme.editScheme": "색 구성표 편집…",
+    "hikari::theme.customize": "사용자 지정",
     "hikari::theme.themeName": "테마 이름",
     "hikari::theme.customThemeName": "사용자 지정 테마",
     "hikari::theme.save": "저장",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de cores",
     "hikari::theme.editScheme": "Editar esquema de cores…",
+    "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nome do tema",
     "hikari::theme.customThemeName": "Tema personalizado",
     "hikari::theme.save": "Salvar",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "Авто",
     "hikari::theme.themes": "Цветовые темы",
     "hikari::theme.editScheme": "Изменить цветовую схему…",
+    "hikari::theme.customize": "Настроить",
     "hikari::theme.themeName": "Название темы",
     "hikari::theme.customThemeName": "Пользовательская тема",
     "hikari::theme.save": "Сохранить",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "自动",
     "hikari::theme.themes": "配色主题",
     "hikari::theme.editScheme": "编辑配色方案…",
+    "hikari::theme.customize": "自定义",
     "hikari::theme.themeName": "主题名称",
     "hikari::theme.customThemeName": "自定义主题",
     "hikari::theme.save": "保存",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -22,6 +22,7 @@
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色主題",
     "hikari::theme.editScheme": "編輯配色方案…",
+    "hikari::theme.customize": "自訂",
     "hikari::theme.themeName": "主題名稱",
     "hikari::theme.customThemeName": "自訂主題",
     "hikari::theme.save": "儲存",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -12,6 +12,7 @@ export { default as HCheckbox } from "./components/HkCheckbox";
 // broken max-height animation never met the MD3 bar. Use HExpansionPanel.
 export { default as HColorPicker } from "./components/HkColorPicker";
 export { HColorSchemeDialog, type HCustomTheme } from "./components/HkColorSchemeDialog";
+export { HkColorSchemeEditor } from "./components/HkColorSchemeEditor";
 export { default as HConfirmDialog } from "./components/HkConfirmDialog";
 export { default as HDivider } from "./components/HkDivider";
 export { default as HDrawer } from "./components/HkDrawer";


### PR DESCRIPTION
## Summary
Upstream foundation for the chest theme-customization dialog (colors / wallpaper / style tabs).

- **HkColorSchemeEditor** — the color-scheme editing form extracted from `HkColorSchemeDialog` as a standalone, embeddable component (props `initialDark`/`initialLight`/`initialGroups`, exposes `reset()` + `getDraft()`), keeping the full extension token-group surface (SCADA palettes, sections, hue-clamped pickers).
- **HkColorSchemeDialog** — now a thin modal wrapper with the exact same public API and behavior.
- **HkThemeToggle** — new `externalCustomize` prop + `open-customize` emit so host apps can own the customization entry point; entry relabeled via new `hikari::theme.customize` (all 11 locales).
- Version 0.5.0 → 0.5.1.

## Verification
- vitest: 35 files / 317 tests passed (existing dialog test unchanged).
- `vue-tsc --noEmit`: clean.
- lint: ok.