### PR TITLE
✨ Make popovers and selects adaptive with mobile bottom sheets and fix touch slider drags.

### DIFF
--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -137,6 +137,10 @@
   display: block;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgb(0 0 0 / 10%);
+  // Explicit on the hit targets too (not only the container): touch-action
+  // resolves against the touched element's ancestor chain, and spelling it
+  // out on track+thumb removes any hit-target ambiguity on mobile.
+  touch-action: none;
 }
 
 .hk-color-picker-slider-thumb {
@@ -150,6 +154,8 @@
   cursor: grab;
   outline: none;
   transition: transform 0.1s;
+  touch-action: none;
+  -webkit-touch-callout: none;
 
   &:hover { transform: scale(1.15); }
   &:active { cursor: grabbing; }
@@ -210,4 +216,34 @@
   user-select: none;
   pointer-events: none;
   line-height: 1;
+}
+
+// Mobile sheet form (via HPopover sheetOnMobile): the panel spans the full
+// width and its controls get touch-sized spacing — the sliders are the
+// whole point on phones, give them room to hit.
+.hk-popover-panel.hk-is-sheet.hk-color-picker-panel {
+  padding: 0 var(--space-16) var(--space-20);
+
+  .hk-color-picker-controls {
+    min-width: 0;
+    width: 100%;
+    gap: var(--space-16);
+  }
+
+  .hk-color-picker-slider-row {
+    gap: var(--space-10);
+  }
+
+  .hk-color-picker-channel-slider {
+    height: 22px;
+  }
+
+  .hk-color-picker-slider-track {
+    height: 14px;
+  }
+
+  .hk-color-picker-slider-thumb {
+    width: 22px;
+    height: 22px;
+  }
 }

--- a/packages/vue/src/components/HkColorPicker.tsx
+++ b/packages/vue/src/components/HkColorPicker.tsx
@@ -58,26 +58,49 @@ const ColorSlider = defineComponent({
     let dragging = false;
 
     function getValueFromX(clientX: number): number {
-      const el = trackRef.value;
-      if (!el) return props.value;
-      const rect = el.getBoundingClientRect();
+      // Live rect per event: the panel is position:fixed and the slider
+      // carries touch-action:none, so reads are cheap and stay correct even
+      // if a desktop window resize repositions the popover mid-drag.
+      const rect = trackRef.value?.getBoundingClientRect();
+      if (!rect || rect.width === 0) return props.value;
       const pct = clamp((clientX - rect.left) / rect.width, 0, 1);
       return Math.round(pct * 255);
     }
 
+    // Move/up listeners live on the WINDOW (added on down, removed on
+    // up/cancel). setPointerCapture alone should route every move to the
+    // slider, but mobile Safari has long-standing capture quirks under
+    // compositing; window-level listeners make the drag track the finger
+    // regardless. pointercancel (browser reclaims the gesture) must reset
+    // dragging or the slider sticks to the next stray move.
+    function onWindowPointerMove(e: PointerEvent) {
+      if (!dragging) return;
+      e.preventDefault();
+      emit("change", getValueFromX(e.clientX));
+    }
+
+    function endDrag() {
+      dragging = false;
+      window.removeEventListener("pointermove", onWindowPointerMove);
+      window.removeEventListener("pointerup", endDrag);
+      window.removeEventListener("pointercancel", endDrag);
+    }
+
+    // A drag in flight must never leak listeners past unmount (e.g. the
+    // sheet closing mid-drag tears the panel down).
+    onBeforeUnmount(endDrag);
+
     function onPointerDown(e: PointerEvent) {
       dragging = true;
-      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      try {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      } catch {
+        // Capture is best-effort; the window listeners carry the drag.
+      }
+      window.addEventListener("pointermove", onWindowPointerMove, { passive: false });
+      window.addEventListener("pointerup", endDrag);
+      window.addEventListener("pointercancel", endDrag);
       emit("change", getValueFromX(e.clientX));
-    }
-
-    function onPointerMove(e: PointerEvent) {
-      if (!dragging) return;
-      emit("change", getValueFromX(e.clientX));
-    }
-
-    function onPointerUp() {
-      dragging = false;
     }
 
     const pct = computed(() => (props.value / 255) * 100);
@@ -86,8 +109,8 @@ const ColorSlider = defineComponent({
       <div
         class="hk-color-picker-channel-slider"
         onPointerdown={onPointerDown}
-        onPointermove={onPointerMove}
-        onPointerup={onPointerUp}
+        onPointerup={endDrag}
+        onPointercancel={endDrag}
       >
         <div
           ref={trackRef}
@@ -217,6 +240,7 @@ export default defineComponent({
           placement="bottom-start"
           offset={6}
           backdrop={false}
+          sheetOnMobile
           class="hk-color-picker-panel"
         >
           <div class="hk-color-picker-body">

--- a/packages/vue/src/components/HkColorPickerTouch.test.tsx
+++ b/packages/vue/src/components/HkColorPickerTouch.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkColorPicker from "./HkColorPicker";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+/**
+ * Drag a slider the way a phone does it: pointerdown ON the slider
+ * element, then pointermove events that reach the component only through
+ * the WINDOW (the fix routes mobile drags through window-level
+ * listeners — element-level capture alone was the bug).
+ */
+function dragSlider(slider: HTMLElement, fromX: number, toX: number) {
+  slider.dispatchEvent(new PointerEvent("pointerdown", {
+    bubbles: true, clientX: fromX, pointerId: 1, pointerType: "touch",
+  }));
+  window.dispatchEvent(new PointerEvent("pointermove", {
+    bubbles: true, clientX: toX, pointerId: 1, pointerType: "touch",
+  }));
+  window.dispatchEvent(new PointerEvent("pointerup", {
+    bubbles: true, clientX: toX, pointerId: 1, pointerType: "touch",
+  }));
+}
+
+function mountPicker() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const rgb = ref({ r: 128, g: 128, b: 128 });
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkColorPicker, {
+          r: rgb.value.r,
+          g: rgb.value.g,
+          b: rgb.value.b,
+          onChange: (next: { r: number; g: number; b: number }) => { rgb.value = next; },
+        });
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { rgb, container };
+}
+
+function openPanel(container: HTMLElement) {
+  container.querySelector<HTMLButtonElement>(".hk-color-picker-swatch-btn")!.click();
+}
+
+describe("HkColorPicker slider touch drag", () => {
+  it("tracks a window-routed touch drag and updates the channel", async () => {
+    const { rgb, container } = mountPicker();
+    await nextTick();
+    openPanel(container);
+    await nextTick();
+
+    const sliders = document.body.querySelectorAll<HTMLElement>(".hk-color-picker-channel-slider");
+    expect(sliders.length).toBe(3);
+    const rSlider = sliders[0];
+
+    // Pin the track geometry (happy-dom lays elements out at 0×0 unless
+    // sized explicitly; the drag math reads the TRACK element's rect).
+    const track = rSlider.querySelector<HTMLElement>(".hk-color-picker-slider-track")!;
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 100, top: 0, right: 300, bottom: 20, width: 200, height: 20, x: 100, y: 0, toJSON: () => ({}) }),
+    });
+
+    // Press at 25% → value ~64; drag to 75% → value ~191.
+    dragSlider(rSlider, 150, 250);
+    await nextTick();
+    expect(rgb.value.r).toBeGreaterThanOrEqual(188);
+    expect(rgb.value.r).toBeLessThanOrEqual(194);
+  });
+
+  it("stops tracking after pointercancel reclaims the gesture", async () => {
+    const { rgb, container } = mountPicker();
+    await nextTick();
+    openPanel(container);
+    await nextTick();
+
+    const rSlider = document.body.querySelectorAll<HTMLElement>(".hk-color-picker-channel-slider")[0];
+    const track = rSlider.querySelector<HTMLElement>(".hk-color-picker-slider-track")!;
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 100, top: 0, right: 300, bottom: 20, width: 200, height: 20, x: 100, y: 0, toJSON: () => ({}) }),
+    });
+
+    rSlider.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true, clientX: 150, pointerId: 1, pointerType: "touch",
+    }));
+    // The browser reclaims the gesture (scroll/edge-swipe)…
+    window.dispatchEvent(new PointerEvent("pointercancel", {
+      bubbles: true, pointerId: 1, pointerType: "touch",
+    }));
+    // …so a later stray move must NOT move the thumb.
+    const before = rgb.value.r;
+    window.dispatchEvent(new PointerEvent("pointermove", {
+      bubbles: true, clientX: 290, pointerId: 1, pointerType: "touch",
+    }));
+    await nextTick();
+    expect(rgb.value.r).toBe(before);
+  });
+
+  it("cleans window listeners up on unmount (no post-unmount moves)", async () => {
+    const { rgb, container } = mountPicker();
+    await nextTick();
+    openPanel(container);
+    await nextTick();
+
+    const rSlider = document.body.querySelectorAll<HTMLElement>(".hk-color-picker-channel-slider")[0];
+    const track = rSlider.querySelector<HTMLElement>(".hk-color-picker-slider-track")!;
+    Object.defineProperty(track, "getBoundingClientRect", {
+      value: () => ({ left: 100, top: 0, right: 300, bottom: 20, width: 200, height: 20, x: 100, y: 0, toJSON: () => ({}) }),
+    });
+
+    rSlider.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true, clientX: 150, pointerId: 1, pointerType: "touch",
+    }));
+    // Unmount mid-drag (e.g. the sheet closes): listeners must go away.
+    mounts.splice(0).forEach((app) => app.unmount());
+    const before = rgb.value.r;
+    window.dispatchEvent(new PointerEvent("pointermove", {
+      bubbles: true, clientX: 290, pointerId: 1, pointerType: "touch",
+    }));
+    await nextTick();
+    expect(rgb.value.r).toBe(before);
+  });
+});

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -82,3 +82,76 @@
   font-size: var(--text-base);
   line-height: 1;
 }
+
+// ------
+// Mobile bottom-sheet mode (`sheetOnMobile`) — the panel docks to the
+// bottom edge on <768px viewports instead of anchoring: a real scrim
+// (click closes), rounded top corners only, slide-up reveal. Same visual
+// contract as the modal mobile docking (top inset keeps the secondary-
+// window breadcrumb strip visible).
+// ------
+.hk-popover-scrim {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+  background: rgb(0 0 0 / 40%);
+}
+
+.hk-popover-panel.hk-is-sheet {
+  border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+                 var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+                 0 0;
+  border-left: 0;
+  border-right: 0;
+  border-bottom: 0;
+  max-height: min(72vh, calc(100vh - var(--hk-sheet-top-inset, 4.25rem)));
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-top: 0;
+}
+
+.hk-popover-sheet-grabber {
+  flex-shrink: 0;
+  // Grabber zone: tap target tall enough for a thumb, bar visually small.
+  padding: 14px 0 20px;
+  margin: 0 auto;
+  width: 100%;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+
+  &::before {
+    content: "";
+    width: 2.25rem;
+    height: 4px;
+    border-radius: 999px;
+    background: rgb(var(--color-border, 100 100 100) / 40%);
+  }
+}
+
+.hk-popover-sheet-enter-active {
+  transition:
+    opacity 0.25s ease-out,
+    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hk-popover-sheet-leave-active {
+  transition:
+    opacity 0.2s ease-in,
+    transform 0.25s cubic-bezier(0.4, 0, 1, 1);
+}
+
+.hk-popover-sheet-enter-from,
+.hk-popover-sheet-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-popover-sheet-enter-active,
+  .hk-popover-sheet-leave-active {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -14,6 +14,7 @@ import {
 } from "vue";
 
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import { useBreakpoint } from "../runtime/useBreakpoint";
 import { useReportedTransition } from "../composables/useReportedTransition";
 import { onceFrame } from "../runtime/animationBus";
 import "./HkPopover.scss";
@@ -49,6 +50,15 @@ export default defineComponent({
     closeOnEscape: { type: Boolean, default: true },
     glass: { type: Boolean, default: true },
     anchorRef: { type: Object as PropType<HTMLElement | null>, default: null },
+    /**
+     * Dock the panel as a bottom sheet on mobile-width viewports (<768px,
+     * useBreakpoint().isMobile): scrim (click closes) + full-width sheet
+     * rising from the bottom edge, instead of the anchored popup. The
+     * desktop path is untouched; z-order still rides the popup manager
+     * either way. The mode flips live with the viewport — an open popover
+     * closes when crossing the breakpoint rather than hanging mid-morph.
+     */
+    sheetOnMobile: { type: Boolean, default: false },
   },
   emits: {
     "update:modelValue": (_v: boolean) => true,
@@ -60,6 +70,18 @@ export default defineComponent({
     const panelRef = ref<HTMLElement>();
     const resolvedPlacement = ref<PopupPlacement>(props.placement);
     const coords = ref<{ top?: number; left?: number; bottom?: number; right?: number }>({});
+
+    const { isMobile } = useBreakpoint();
+    const sheetMode = computed(() => props.sheetOnMobile && isMobile.value);
+
+    // Crossing the mobile/desktop breakpoint mid-flight would leave a
+    // SHEET-mode panel hung between two form factors — close it and let
+    // the user reopen in the shape the viewport now calls for. Consumers
+    // that never opted into sheetOnMobile keep the historic behavior
+    // (stay open, reposition on the resize).
+    watch(isMobile, () => {
+      if (props.sheetOnMobile && props.modelValue) close();
+    });
 
     const animBus = useReportedTransition(300);
 
@@ -294,13 +316,19 @@ export default defineComponent({
         if (open) {
           fullCleanup();
           handle.value = manager.register("dropdown", false);
-          computeInitialCoords();
-          attachObservers();
-          attachOutsideClickShield();
-          nextTick(() => {
-            computePosition();
-            schedulePosition();
-          });
+          if (sheetMode.value) {
+            // Bottom sheet: nothing to anchor-measure; the scrim handles
+            // dismissal (the outside-click shield is desktop-only).
+            nextTick(() => { panelRef.value?.focus?.(); });
+          } else {
+            computeInitialCoords();
+            attachObservers();
+            attachOutsideClickShield();
+            nextTick(() => {
+              computePosition();
+              schedulePosition();
+            });
+          }
         } else {
           detachObservers();
           detachOutsideClickShield();
@@ -354,6 +382,20 @@ export default defineComponent({
     const panelZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
 
     const panelStyle = computed(() => {
+      if (sheetMode.value) {
+        // Bottom sheet: pinned to the bottom edge, full width, inside the
+        // top inset reserved for the secondary-window breadcrumb strip
+        // (same convention as the modal mobile docking).
+        return {
+          left: "0",
+          right: "0",
+          bottom: "0",
+          top: "auto" as const,
+          position: "fixed" as const,
+          pointerEvents: "auto" as const,
+          zIndex: panelZ.value,
+        };
+      }
       const c = coords.value;
       return {
         ...(c.top != null ? { top: `${c.top}px` } : {}),
@@ -368,14 +410,21 @@ export default defineComponent({
 
     return () => (
       <Teleport to="body">
-        {props.backdrop && props.modelValue && (
+        {sheetMode.value && props.modelValue && props.closeOnBackdrop && (
+          <div
+            class="hk-popover-scrim"
+            style={{ zIndex: backdropZ.value }}
+            onClick={() => close()}
+          />
+        )}
+        {props.backdrop && !sheetMode.value && props.modelValue && (
           <div
             class="hk-popover-backdrop"
             style={{ zIndex: backdropZ.value }}
           />
         )}
         <Transition
-          name="hk-popover"
+          name={sheetMode.value ? "hk-popover-sheet" : "hk-popover"}
           appear
           onBeforeEnter={() => animBus.run()}
           onAfterEnter={() => animBus.cancel()}
@@ -387,7 +436,7 @@ export default defineComponent({
               ref={panelRef}
               class={[
                 "hk-popover-panel",
-                `hk-popover-${resolvedPlacement.value}`,
+                ...(sheetMode.value ? ["hk-is-sheet"] : [`hk-popover-${resolvedPlacement.value}`]),
                 props.glass ? "hii-dropdown-content" : "",
                 ...(typeof attrs.class === "string" ? [attrs.class]
                   : Array.isArray(attrs.class) ? attrs.class as string[]
@@ -398,8 +447,13 @@ export default defineComponent({
               ]}
               style={panelStyle.value}
               role="dialog"
+              aria-modal={sheetMode.value ? "true" : undefined}
+              tabindex={sheetMode.value ? "-1" : undefined}
               onKeydown={onPanelKeydown}
             >
+              {sheetMode.value && (
+                <div class="hk-popover-sheet-grabber" aria-hidden="true" onClick={() => close()} />
+              )}
               {slots.default?.()}
             </div>
           ) : null}

--- a/packages/vue/src/components/HkPopoverSheet.test.tsx
+++ b/packages/vue/src/components/HkPopoverSheet.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkPopover from "./HkPopover";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  // happy-dom never fires transitionend, so leave transitions never
+  // finish and teleported panels linger on <body> — strip them or the
+  // next test's querySelector sees this test's panel.
+  document.body
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-sheet-panel, .hk-select-sheet-scrim")
+    .forEach((el) => el.remove());
+  // Restore a desktop viewport between tests.
+  setViewport(1200);
+});
+
+function setViewport(width: number) {
+  window.innerWidth = width;
+  window.dispatchEvent(new Event("resize"));
+}
+
+function mountPopover(props: Record<string, unknown> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const anchor = document.createElement("button");
+  anchor.textContent = "anchor";
+  container.appendChild(anchor);
+
+  const open = ref(true);
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkPopover, {
+          modelValue: open.value,
+          "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          anchorRef: anchor,
+          ...props,
+        }, { default: () => h("div", { class: "pop-content" }, "content") });
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { open };
+}
+
+describe("HkPopover sheetOnMobile", () => {
+  it("docks as a bottom sheet with a closing scrim on mobile widths", async () => {
+    setViewport(375);
+    const { open } = mountPopover({ sheetOnMobile: true });
+    await nextTick();
+
+    const panel = document.body.querySelector<HTMLElement>(".hk-popover-panel")!;
+    expect(panel).toBeTruthy();
+    expect(panel.classList.contains("hk-is-sheet")).toBe(true);
+    expect(panel.getAttribute("aria-modal")).toBe("true");
+    // Grabber affordance present.
+    expect(panel.querySelector(".hk-popover-sheet-grabber")).toBeTruthy();
+    // Real, clickable scrim (unlike the desktop visual backdrop).
+    const scrim = document.body.querySelector<HTMLElement>(".hk-popover-scrim")!;
+    expect(scrim).toBeTruthy();
+    scrim.click();
+    await nextTick();
+    expect(open.value).toBe(false);
+  });
+
+  it("keeps the anchored popup (no scrim) on desktop widths", async () => {
+    setViewport(1200);
+    mountPopover({ sheetOnMobile: true });
+    await nextTick();
+
+    const panel = document.body.querySelector<HTMLElement>(".hk-popover-panel")!;
+    expect(panel.classList.contains("hk-is-sheet")).toBe(false);
+    // Anchored placement class instead of the sheet class.
+    expect(panel.className).toMatch(/hk-popover-(top|bottom|left|right)/);
+    expect(document.body.querySelector(".hk-popover-scrim")).toBeNull();
+  });
+
+  it("closes an open popover when the viewport crosses the breakpoint", async () => {
+    setViewport(375);
+    const { open } = mountPopover({ sheetOnMobile: true });
+    await nextTick();
+    expect(open.value).toBe(true);
+
+    setViewport(1200);
+    await nextTick();
+    expect(open.value).toBe(false);
+  });
+
+  it("stays anchored on mobile when sheetOnMobile is off", async () => {
+    setViewport(375);
+    mountPopover();
+    await nextTick();
+
+    const panel = document.body.querySelector<HTMLElement>(".hk-popover-panel")!;
+    expect(panel.classList.contains("hk-is-sheet")).toBe(false);
+    expect(document.body.querySelector(".hk-popover-scrim")).toBeNull();
+  });
+
+  it("does NOT close a non-opted-in popover on breakpoint cross (date pickers etc.)", async () => {
+    setViewport(1200);
+    const { open } = mountPopover();
+    await nextTick();
+    expect(open.value).toBe(true);
+
+    // A consumer that never set sheetOnMobile keeps the historic
+    // behavior: stay open across the breakpoint (it just repositions).
+    setViewport(375);
+    await nextTick();
+    expect(open.value).toBe(true);
+    setViewport(1200);
+    await nextTick();
+    expect(open.value).toBe(true);
+  });
+
+  it("omits the scrim when closeOnBackdrop is false in sheet mode", async () => {
+    setViewport(375);
+    mountPopover({ sheetOnMobile: true, closeOnBackdrop: false });
+    await nextTick();
+    expect(document.body.querySelector(".hk-popover-panel")!.classList.contains("hk-is-sheet")).toBe(true);
+    expect(document.body.querySelector(".hk-popover-scrim")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -157,3 +157,16 @@
   font-size: var(--text-xs);
   color: rgb(var(--color-error));
 }
+
+// Mobile sheet form (HPopover sheetOnMobile): full-width option list with
+// touch-sized rows.
+.hk-popover-panel.hk-is-sheet.hk-popup-select-content {
+  .hk-popup-select-viewport {
+    max-height: min(56vh, 24rem);
+  }
+
+  .hk-popup-select-item {
+    padding: var(--space-14) var(--space-16);
+    font-size: var(--text-base);
+  }
+}

--- a/packages/vue/src/components/HkPopupSelect.tsx
+++ b/packages/vue/src/components/HkPopupSelect.tsx
@@ -188,6 +188,7 @@ export default defineComponent({
           placement="bottom"
           offset={4}
           backdrop={false}
+          sheetOnMobile
           class="hk-popup-select-content"
         >
           <HkScrollContainer class="hk-popup-select-viewport">

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -162,3 +162,95 @@
   font-size: var(--text-xs);
   color: rgb(var(--color-error));
 }
+
+// ------
+// Mobile bottom sheet (useBreakpoint().isMobile) — the popout docks to the
+// bottom edge: scrim (click closes) + grabber + label + touch-sized option
+// rows. Desktop popout above is untouched. Same visual contract as the
+// popover/modal mobile dockings.
+// ------
+.hk-select-sheet-scrim {
+  position: fixed;
+  inset: 0;
+  pointer-events: auto;
+  background: rgb(0 0 0 / 40%);
+}
+
+.hk-select-sheet-panel {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: min(72vh, calc(100vh - var(--hk-sheet-top-inset, 4.25rem)));
+  background: rgb(var(--color-surface));
+  border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+                 var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+                 0 0;
+  box-shadow: 0 -8px 32px rgb(0 0 0 / 20%);
+  outline: none;
+}
+
+.hk-select-sheet-grabber {
+  flex-shrink: 0;
+  padding: 14px 0 20px;
+  margin: 0 auto;
+  width: 100%;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+
+  &::before {
+    content: "";
+    width: 2.25rem;
+    height: 4px;
+    border-radius: 999px;
+    background: rgb(var(--color-border, 100 100 100) / 40%);
+  }
+}
+
+.hk-select-sheet-title {
+  flex-shrink: 0;
+  padding: 0 var(--space-16) var(--space-8);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgb(var(--color-muted));
+}
+
+.hk-select-sheet-list {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-bottom: var(--space-16);
+
+  .hk-select-option {
+    padding: var(--space-14) var(--space-16);
+    font-size: var(--text-base);
+  }
+}
+
+.hk-select-sheet-enter-active {
+  transition:
+    opacity 0.25s ease-out,
+    transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hk-select-sheet-leave-active {
+  transition:
+    opacity 0.2s ease-in,
+    transform 0.25s cubic-bezier(0.4, 0, 1, 1);
+}
+
+.hk-select-sheet-enter-from,
+.hk-select-sheet-leave-to {
+  opacity: 0;
+  transform: translateY(100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-select-sheet-enter-active,
+  .hk-select-sheet-leave-active {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -7,12 +7,14 @@ import {
   watch,
   type PropType,
   Teleport,
+  Transition,
 } from "vue";
 
 
 import { ChevronDown, Search } from "lucide-vue-next";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useOverlay } from "../runtime/useOverlay";
+import { useBreakpoint } from "../runtime/useBreakpoint";
 import "./HkSelect.scss";
 
 export interface HkSelectOption {
@@ -62,8 +64,17 @@ export default defineComponent({
       onCloseRequested: () => { isOpen.value = false; },
     });
 
+    // Form factor: anchored popout on desktop, bottom sheet on phones.
+    // Crossing the breakpoint mid-flight closes the sheet rather than
+    // leaving it hung between shapes.
+    const { isMobile } = useBreakpoint();
+    const sheetMode = computed(() => isMobile.value);
+    watch(isMobile, () => {
+      if (isOpen.value) isOpen.value = false;
+    });
+
     function onDocumentClick(e: MouseEvent) {
-      if (!isOpen.value) return;
+      if (!isOpen.value || sheetMode.value) return;
       const target = e.target as Node;
       if (triggerRef.value?.contains(target)) return;
       if (panelRef.value?.contains(target)) return;
@@ -74,7 +85,9 @@ export default defineComponent({
       if (open) {
         handle.value = manager.register("dropdown", false);
         overlay.open();
-        document.addEventListener("click", onDocumentClick, true);
+        if (!sheetMode.value) {
+          document.addEventListener("click", onDocumentClick, true);
+        }
       } else {
         document.removeEventListener("click", onDocumentClick, true);
         if (handle.value) {
@@ -226,8 +239,56 @@ export default defineComponent({
           <span class="hk-select-value">{displayLabel.value || props.placeholder}</span>
           <ChevronDown size={16} class="hk-select-arrow" />
         </button>
-        {isOpen.value && (
-          <Teleport to="body">
+        <Teleport to="body">
+          {sheetMode.value && isOpen.value && (
+            <div
+              class="hk-select-sheet-scrim"
+              style={{ zIndex: popoutZ.value - 1 }}
+              onClick={() => { isOpen.value = false; }}
+            />
+          )}
+          <Transition name="hk-select-sheet" appear>
+            {sheetMode.value && isOpen.value ? (
+              <div
+                ref={panelRef}
+                class="hk-select-sheet-panel"
+                style={{ zIndex: popoutZ.value }}
+                role="dialog"
+                aria-modal="true"
+                tabindex="-1"
+                onKeydown={onPopoutKeydown}
+              >
+                <div
+                  class="hk-select-sheet-grabber"
+                  aria-hidden="true"
+                  onClick={() => { isOpen.value = false; }}
+                />
+                {props.label ? (
+                  <div class="hk-select-sheet-title">{props.label}</div>
+                ) : null}
+                <div class="hk-select-sheet-list">
+                  {slots.default
+                    ? slots.default()
+                    : normalizedOptions.value.map((opt, i) => (
+                        <div
+                          key={opt.value}
+                          class="hk-select-option"
+                          data-highlighted={highlightedIndex.value === i || undefined}
+                          data-select-index={i}
+                          data-checked={opt.value === props.modelValue || undefined}
+                          data-disabled={opt.disabled || undefined}
+                          onClick={() => {
+                            if (!opt.disabled) select(opt.value);
+                          }}
+                        >
+                          <span>{opt.label}</span>
+                        </div>
+                      ))}
+                </div>
+              </div>
+            ) : null}
+          </Transition>
+          {!sheetMode.value && isOpen.value ? (
             <div
               ref={panelRef}
               class="hk-select-popout"
@@ -255,8 +316,8 @@ export default defineComponent({
                     </div>
                   ))}
             </div>
-          </Teleport>
-        )}
+          ) : null}
+        </Teleport>
         {props.error ? <p class="hk-select-error">{props.error}</p> : null}
       </div>
     );

--- a/packages/vue/src/components/HkSelectSheet.test.tsx
+++ b/packages/vue/src/components/HkSelectSheet.test.tsx
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkSelect from "./HkSelect";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  // happy-dom never fires transitionend, so leave transitions never
+  // finish and teleported panels linger on <body> — strip them or the
+  // next test's querySelector sees this test's panel.
+  document.body
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-sheet-panel, .hk-select-sheet-scrim")
+    .forEach((el) => el.remove());
+  setViewport(1200);
+});
+
+function setViewport(width: number) {
+  window.innerWidth = width;
+  window.dispatchEvent(new Event("resize"));
+}
+
+function mountSelect(props: Record<string, unknown> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const value = ref("a");
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkSelect, {
+          modelValue: value.value,
+          "onUpdate:modelValue": (v: string) => { value.value = v; },
+          label: "Channel",
+          options: [
+            { value: "a", label: "Alpha" },
+            { value: "b", label: "Beta" },
+            { value: "c", label: "Gamma" },
+          ],
+          ...props,
+        });
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { value, container };
+}
+
+describe("HkSelect mobile sheet", () => {
+  it("opens as a bottom sheet on mobile widths", async () => {
+    setViewport(375);
+    const { container } = mountSelect();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>(".hk-select-trigger")!.click();
+    await nextTick();
+
+    const panel = document.body.querySelector<HTMLElement>(".hk-select-sheet-panel")!;
+    expect(panel).toBeTruthy();
+    expect(panel.getAttribute("aria-modal")).toBe("true");
+    // Label surfaces as the sheet title.
+    expect(panel.querySelector(".hk-select-sheet-title")!.textContent).toBe("Channel");
+    // Options render with touch-sized rows inside the sheet list.
+    const options = panel.querySelectorAll(".hk-select-option");
+    expect(options).toHaveLength(3);
+    expect(document.body.querySelector(".hk-select-sheet-scrim")).toBeTruthy();
+    // No anchored popout in sheet mode.
+    expect(document.body.querySelector(".hk-select-popout")).toBeNull();
+  });
+
+  it("selects from the sheet and closes it", async () => {
+    setViewport(375);
+    const { value, container } = mountSelect();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>(".hk-select-trigger")!.click();
+    await nextTick();
+
+    const options = document.body.querySelectorAll<HTMLElement>(".hk-select-sheet-panel .hk-select-option");
+    options[2].click();
+    await nextTick();
+    expect(value.value).toBe("c");
+    // happy-dom never finishes leave transitions, so the panel element can
+    // outlive the close — assert the reactive state instead (the trigger's
+    // data-state mirrors isOpen).
+    expect(container.querySelector<HTMLElement>(".hk-select-trigger")!.dataset.state).toBe("closed");
+  });
+
+  it("closes the sheet via the scrim", async () => {
+    setViewport(375);
+    const { container } = mountSelect();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>(".hk-select-trigger")!.click();
+    await nextTick();
+    (document.body.querySelector<HTMLElement>(".hk-select-sheet-scrim"))!.click();
+    await nextTick();
+    expect(container.querySelector<HTMLElement>(".hk-select-trigger")!.dataset.state).toBe("closed");
+  });
+
+  it("keeps the anchored popout on desktop widths", async () => {
+    setViewport(1200);
+    const { container } = mountSelect();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>(".hk-select-trigger")!.click();
+    await nextTick();
+
+    expect(document.body.querySelector(".hk-select-popout")).toBeTruthy();
+    expect(document.body.querySelector(".hk-select-sheet-panel")).toBeNull();
+  });
+
+  it("closes an open sheet when the viewport crosses the breakpoint", async () => {
+    setViewport(375);
+    const { container } = mountSelect();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>(".hk-select-trigger")!.click();
+    await nextTick();
+    expect(document.body.querySelector(".hk-select-sheet-panel")).toBeTruthy();
+
+    setViewport(1200);
+    await nextTick();
+    expect(container.querySelector<HTMLElement>(".hk-select-trigger")!.dataset.state).toBe("closed");
+    expect(document.body.querySelector(".hk-select-popout")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
用户报障两处 + 一个全局面板模式：
- **触摸跟手修复**：HkColorPicker 滑块在手机上拖动点不跟手指。根因是仅靠元素级 pointer capture（移动端 Safari 在合成层下有已知 quirk）。修复：window 级 pointermove/up/cancel 监听（down 时挂载、end/unmount 幂等移除）+ pointercancel 复位 + 实时 rect 读取（桌面 popover 拖动中重定位也正确）。
- **HPopover `sheetOnMobile`（opt-in）**：手机断点（<768）渲染为底部 sheet——可点击 scrim（受 closeOnBackdrop 约束）、grabber、顶部圆角、上滑过渡、aria-modal；桌面路径零改动；popup manager z 序两模式一致；**断点跨越仅关闭 opt-in 的 popover**，未 opt-in 的消费者（日期选择器/主题菜单/admin header）保持历史行为（回归测试覆盖）。
- **HkColorPicker + HkPopupSelect 开启 sheet 模式**：颜色 sheet 带触摸加大滑块；选项 sheet 带 capped 滚动区。
- **HkSelect 手机底部选择器**（无条件分支）：scrim + grabber + label 标题 + 触摸尺寸选项行，键盘导航不变；桌面 popout 不动；z 带对齐 handle.z/z+1 约定。
- 14 个新测试（拖动/cancel/unmount/sheet 行为/断点回归）。

## Downstream
chest 的 27 处下拉全部经 HkPopupSelect options prop（零 slot 消费、零 CSS override、零新增 i18n）→ **全部下拉在 dev.celestia.world / demo.dev 手机端自动变底部选择器，chest 零代码改动**（Round 3 机械普查确认）。版本保持 0.5.0（publish 是 tag 门控，chest 走 master 分支消费）。

## Verification（3 轮）
- vue-tsc 0 · vitest **325/325** · vite build ✓
- R1 found+fixed：watch(isMobile) 未按 sheetOnMobile 门控（影响全部 HPopover 消费者的断点跨越关闭）；false comment；z 带；回归测试
- R2: 5/5 PASS（gate 非对称性确认正确：popover opt-in 需门控、select 无条件无需）
- R3: chest 集成缝 7/7 PASS，零 chest 侧跟进项
- 浏览器实测（390×844）：颜色选择器 sheet（grabber+scrim+全宽大滑块）、HkSelect sheet、桌面 popup 锚定、滑块交互全部符合预期