### PR TITLE
🔥 Drop the dead auth protocol label rules and their customization classes.

### DIFF
--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -603,41 +603,6 @@
   color: var(--hi-color-muted, #666);
 }
 
-.s-auth-protocol-link {
-  color: var(--hi-color-primary, #58a6ff);
-  cursor: pointer;
-  text-decoration: none;
-  font-weight: 500;
-}
-
-.s-auth-protocol-link:hover {
-  text-decoration: underline;
-}
-
-.s-auth-protocol-agree {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-8, 0.5rem);
-  flex-wrap: wrap;
-  padding: var(--space-4, 0.25rem) 0;
-}
-
-.s-auth-protocol-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-8, 0.5rem);
-  margin-bottom: var(--space-12, 0.75rem);
-  text-align: center;
-}
-
-.s-auth-protocol-text {
-  font-size: var(--text-xs, 0.75rem);
-  color: var(--hi-color-text-secondary, color-mix(in srgb, #000 60%, transparent));
-  line-height: 1.5;
-}
-
 .s-auth-link {
   font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-text-secondary, #999);


### PR DESCRIPTION
## Summary
`admin-tokens.scss` still ships the `.s-auth-protocol-link/agree/row/text` rules from the old plana auth card. After the P57 de-customization the chest auth forms were their only consumer, and chest has stopped using them — yet the leftover `.s-auth-protocol-text` rule kept overriding the HkLabel shell font size (12px vs the 14px default). Removing the rules fixes the size mismatch at the root and completes the label unification.

## Changes
- Remove `.s-auth-protocol-link`, `.s-auth-protocol-link:hover`, `.s-auth-protocol-agree`, `.s-auth-protocol-row`, `.s-auth-protocol-text` from `packages/vue/src/styles/admin-tokens.scss` (35 lines).
- No version bump needed: this wave's bump to 0.5.1 already landed with #262, which this branch is rebased onto.

## Verification
- Grepped all family repos (shittim-chest / plana / arona / entelecheia / kirino): zero remaining references to the removed classes.
- `vue-tsc --noEmit` green locally.
- Companion chest PR #440 drops the last usages of these classes from the auth views; a hermetic chest webui build against this branch produced a dist whose CSS contains no `s-auth-protocol` rules, and the two checkbox labels both render 14px.

Note: this replaces the earlier closed PR #264, which was automatically closed when the branch was rebased onto master (8732134) after #262 merged.