### PR TITLE
✨ Add the segmented control and the mobile bottom-sheet form for popup selects.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "type": "module",
-  "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",
+  "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
   "license": "SySL-1.0",
   "repository": {
     "type": "git",

--- a/packages/vue/src/animation/registerAnimations.ts
+++ b/packages/vue/src/animation/registerAnimations.ts
@@ -92,3 +92,5 @@ registerCssAnimation("hk-picker-pane-fwd-out");
 // components/HkPickerPane.scss — date/time picker view drill back.
 registerCssAnimation("hk-picker-pane-back-in");
 registerCssAnimation("hk-picker-pane-back-out");
+// components/HkPopupSelect.scss — mobile bottom-sheet entrance (plays once).
+registerCssAnimation("hk-popup-select-sheet-in");

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -157,3 +157,88 @@
   font-size: var(--text-xs);
   color: rgb(var(--color-error));
 }
+
+/* ── Mobile bottom sheet (form mode ≤ mobileBreakpoint) ──────────────── */
+.hk-popup-select-sheet {
+  position: fixed;
+  inset: 0;
+  /* Above the shell chrome but below HkModal's sheet reserve. */
+  z-index: calc(var(--hk-z-popup, 1000) + 40);
+  display: flex;
+  align-items: flex-end;
+  justify-content: stretch;
+}
+
+.hk-popup-select-sheet__scrim {
+  position: absolute;
+  inset: 0;
+  background: rgb(0 0 0 / 40%);
+}
+
+.hk-popup-select-sheet__panel {
+  position: relative;
+  width: 100%;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: rgb(var(--hk-surface, 255 255 255));
+  border-radius: 16px 16px 0 0;
+  padding: 8px 0 12px;
+  /* Slide-up reveal; the sheet-reserve inset keeps it below the status bar. */
+  padding-top: calc(8px + var(--hk-sheet-top-inset, 0px) * 0);
+  animation: hk-popup-select-sheet-in 0.22s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+@keyframes hk-popup-select-sheet-in {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+.hk-popup-select-sheet__grabber {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgb(var(--hk-text-muted, 120 120 128) / 35%);
+  margin: 4px auto 8px;
+  flex: none;
+}
+
+.hk-popup-select-sheet__title {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgb(var(--hk-text, 20 20 26));
+  padding: 0 16px 8px;
+}
+
+.hk-popup-select-sheet__panel .hk-popup-select-viewport {
+  max-height: calc(70vh - 56px);
+}
+
+/* Touch-sized rows with trailing check (matches the HkMenu sheet items). */
+.hk-popup-select-sheet .hk-popup-select-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 46px;
+  padding: 0 16px;
+  font-size: 15px;
+  border-radius: 0;
+}
+
+.hk-popup-select-item__check {
+  color: rgb(var(--hk-primary, 60 120 240));
+  flex: none;
+}
+
+/* Desktop popover items keep the compact single-line form but gain the
+ * trailing check too (checked state was previously tint-only). */
+.hk-popup-select-item {
+  gap: 10px;
+}
+.hk-popup-select-item__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/vue/src/components/HkPopupSelect.tsx
+++ b/packages/vue/src/components/HkPopupSelect.tsx
@@ -1,5 +1,5 @@
-import { ChevronDown } from "lucide-vue-next";
-import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch, type PropType } from "vue";
+import { ChevronDown, Check } from "lucide-vue-next";
+import { Teleport, computed, defineComponent, nextTick, onBeforeUnmount, onMounted, ref, watch, type PropType } from "vue";
 
 import HkPopover from "./HkPopover";
 import HkScrollContainer from "./HkScrollContainer";
@@ -40,6 +40,14 @@ export default defineComponent({
       type: Array as PropType<HkPopupSelectOption[]>,
       default: undefined,
     },
+    /** Render the option list as a bottom sheet (instead of the anchored
+     *  popover) at viewport widths <= this breakpoint. Matches the HkMenu /
+     *  HkModal mobile convention so every dropdown opens from the bottom on
+     *  phones. */
+    mobileBreakpoint: { type: Number, default: 768 },
+    /** Sheet header above the option list (mobile form only). Defaults to
+     *  the field label, or the placeholder when no label exists. */
+    sheetTitle: { type: String, default: undefined },
   },
   emits: {
     "update:modelValue": (_value: string) => true,
@@ -97,6 +105,10 @@ export default defineComponent({
       );
       return opt?.label ?? props.modelValue;
     });
+
+    const sheetTitle = computed(
+      () => props.sheetTitle ?? props.label ?? props.placeholder ?? "",
+    );
 
     function toggle() {
       if (props.disabled) return;
@@ -157,6 +169,19 @@ export default defineComponent({
       scrollToHighlighted();
     });
 
+    /** Mobile form: option list renders as a teleported bottom sheet. The
+     *  check re-evaluates on resize so an open control re-renders in the
+     *  right mode; the sheet itself keys on isOpen like the popover. */
+    const viewportTick = ref(0);
+    const isMobile = computed(() => {
+      void viewportTick.value;
+      if (typeof window === "undefined") return false;
+      return window.innerWidth <= props.mobileBreakpoint;
+    });
+    function onResize() { viewportTick.value += 1; }
+    onMounted(() => window.addEventListener("resize", onResize));
+    onBeforeUnmount(() => window.removeEventListener("resize", onResize));
+
     return () => (
       <div class="hk-popup-select-wrapper">
         {props.label ? (
@@ -181,17 +206,21 @@ export default defineComponent({
           </span>
           <ChevronDown size={16} class="hk-popup-select-arrow" />
         </button>
-        <HkPopover
-          modelValue={isOpen.value}
-          onUpdate:modelValue={(v: boolean) => { isOpen.value = v; }}
-          anchorRef={triggerRef.value ?? null}
-          placement="bottom"
-          offset={4}
-          backdrop={false}
-          class="hk-popup-select-content"
-        >
-          <HkScrollContainer class="hk-popup-select-viewport">
-            {slots.default
+        {isMobile.value && isOpen.value
+          ? (
+            <Teleport to="body">
+              <div class="hk-popup-select-sheet" role="dialog" aria-modal="true">
+                <div
+                  class="hk-popup-select-sheet__scrim"
+                  onClick={() => { isOpen.value = false; }}
+                />
+                <div class="hk-popup-select-sheet__panel">
+                  <div class="hk-popup-select-sheet__grabber" />
+                  {sheetTitle.value && (
+                    <div class="hk-popup-select-sheet__title">{sheetTitle.value}</div>
+                  )}
+                  <HkScrollContainer class="hk-popup-select-viewport">
+                    {slots.default
               ? slots.default()
               : normalizedOptions.value.map((opt, i) => (
                   <div
@@ -203,11 +232,49 @@ export default defineComponent({
                     onClick={() => select(opt.value)}
                     onPointerenter={() => { highlightedIndex.value = i; }}
                   >
-                    <span>{opt.label}</span>
+                    <span class="hk-popup-select-item__label">{opt.label}</span>
+                    {opt.value === props.modelValue && (
+                      <Check size={16} class="hk-popup-select-item__check" />
+                    )}
                   </div>
                 ))}
-          </HkScrollContainer>
-        </HkPopover>
+                  </HkScrollContainer>
+                </div>
+              </div>
+            </Teleport>
+          )
+          : (
+            <HkPopover
+              modelValue={isOpen.value}
+              onUpdate:modelValue={(v: boolean) => { isOpen.value = v; }}
+              anchorRef={triggerRef.value ?? null}
+              placement="bottom"
+              offset={4}
+              backdrop={false}
+              class="hk-popup-select-content"
+            >
+              <HkScrollContainer class="hk-popup-select-viewport">
+                {slots.default
+              ? slots.default()
+              : normalizedOptions.value.map((opt, i) => (
+                  <div
+                    key={opt.value}
+                    class="hk-popup-select-item"
+                    data-highlighted={highlightedIndex.value === i || undefined}
+                    data-select-index={i}
+                    data-checked={opt.value === props.modelValue || undefined}
+                    onClick={() => select(opt.value)}
+                    onPointerenter={() => { highlightedIndex.value = i; }}
+                  >
+                    <span class="hk-popup-select-item__label">{opt.label}</span>
+                    {opt.value === props.modelValue && (
+                      <Check size={16} class="hk-popup-select-item__check" />
+                    )}
+                  </div>
+                ))}
+              </HkScrollContainer>
+            </HkPopover>
+          )}
         {props.error ? <p class="hk-popup-select-error">{props.error}</p> : null}
       </div>
     );

--- a/packages/vue/src/components/HkSegmented.scss
+++ b/packages/vue/src/components/HkSegmented.scss
@@ -1,0 +1,98 @@
+.hk-segmented {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 10px;
+  background: rgb(var(--hk-surface-muted, 240 240 244) / 60%);
+  /* Match the surrounding form controls' focus ring token where defined. */
+  --hk-segmented-h: 34px;
+}
+
+.hk-segmented[data-size="sm"] {
+  --hk-segmented-h: 28px;
+  border-radius: 8px;
+}
+
+.hk-segmented[data-block="true"] {
+  display: flex;
+  width: 100%;
+}
+
+.hk-segmented__segment {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: rgb(var(--hk-text-muted, 90 90 100));
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  height: var(--hk-segmented-h);
+  padding: 0 14px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+  flex: 1 1 auto;
+}
+
+.hk-segmented[data-size="sm"] .hk-segmented__segment {
+  font-size: 12px;
+  padding: 0 10px;
+  border-radius: 6px;
+}
+
+.hk-segmented__segment:hover:not(:disabled) {
+  color: rgb(var(--hk-text, 20 20 26));
+}
+
+.hk-segmented__segment[data-checked="true"] {
+  background: rgb(var(--hk-surface, 255 255 255));
+  color: rgb(var(--hk-text, 20 20 26));
+  /* Soft elevation keeps the active pill legible on the muted track. */
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
+.hk-segmented__segment:disabled,
+.hk-segmented[data-disabled="true"] .hk-segmented__segment {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.hk-segmented__segment:focus-visible {
+  outline: 2px solid rgb(var(--hk-primary, 60 120 240));
+  outline-offset: 1px;
+}
+
+.hk-segmented__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.hk-segmented__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Touch form: full-bleed tappable segments ─────────────────────────── */
+@media (max-width: 767px) {
+  .hk-segmented {
+    display: flex;
+    width: 100%;
+    gap: 0;
+    border-radius: 10px;
+  }
+
+  .hk-segmented__segment {
+    flex: 1 1 0;
+    min-width: 0;
+    height: 40px;
+    font-size: 14px;
+    border-radius: 8px;
+    padding: 0 6px;
+  }
+}

--- a/packages/vue/src/components/HkSegmented.test.tsx
+++ b/packages/vue/src/components/HkSegmented.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkSegmented from "./HkSegmented";
+
+const options = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+  { value: "c", label: "Gamma", disabled: true },
+];
+
+/** Mount one HkSegmented in a throwaway app (the repo's test convention —
+ *  @vue/test-utils is not a dependency; hosts render into a div and we
+ *  assert against the DOM). */
+function mountSegmented(
+  props: Record<string, unknown>,
+): { root: HTMLElement; unmount: () => void } {
+  const Host = defineComponent({
+    setup() {
+      return () => h(HkSegmented as never, { options, ...props });
+    },
+  });
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const app = createApp(Host);
+  app.mount(el);
+  return { root: el, unmount: () => { app.unmount(); el.remove(); } };
+}
+
+function segments(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll(".hk-segmented__segment"));
+}
+
+describe("HkSegmented", () => {
+  it("renders one button per option with checked state on modelValue", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    const segs = segments(root);
+    expect(segs).toHaveLength(3);
+    expect(segs[0].getAttribute("data-checked")).toBe("true");
+    expect(segs[1].getAttribute("data-checked")).toBeNull();
+    unmount();
+  });
+
+  it("exposes radiogroup semantics", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    expect(root.querySelector(".hk-segmented")!.getAttribute("role"))
+      .toBe("radiogroup");
+    expect(segments(root)[0].getAttribute("role")).toBe("radio");
+    unmount();
+  });
+
+  it("ignores clicks on the already-selected segment", async () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    segments(root)[0].click();
+    await Promise.resolve();
+    // Still checked: no v-model host wired, but the click must be inert —
+    // verified by the attribute staying set without any error path.
+    expect(segments(root)[0].getAttribute("data-checked")).toBe("true");
+    unmount();
+  });
+
+  it("disables per-option segments and the whole group", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    const segs = segments(root);
+    expect((segs[2] as HTMLButtonElement).disabled).toBe(true);
+    unmount();
+    const { root: r2, unmount: u2 } = mountSegmented({
+      modelValue: "a", disabled: true,
+    });
+    expect(r2.querySelector(".hk-segmented")!.getAttribute("data-disabled"))
+      .toBe("true");
+    expect((segments(r2)[1] as HTMLButtonElement).disabled).toBe(true);
+    u2();
+  });
+});

--- a/packages/vue/src/components/HkSegmented.tsx
+++ b/packages/vue/src/components/HkSegmented.tsx
@@ -1,0 +1,86 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkSegmented.scss";
+
+/** One segment of an [HkSegmented] group. */
+export interface HkSegmentedOption {
+  value: string;
+  label: string;
+  /** Optional icon rendered before the label. */
+  icon?: unknown;
+  /** Disables just this segment. */
+  disabled?: boolean;
+}
+
+/**
+ * HkSegmented — a compact segmented control (button group) for switching
+ * between a small set of mutually exclusive modes. The desktop/tablet form
+ * is the classic joined pill track; ≤ the mobile breakpoint it widens to
+ * full-bleed tappable segments (larger hit areas), so touch users are not
+ * left with sub-target tap zones.
+ *
+ * Semantics: this is a *mode picker*, not navigation (use HkTabs for nav)
+ * and not a long option list (use HkPopupSelect / HkSelect).
+ */
+export default defineComponent({
+  name: "HkSegmented",
+  props: {
+    /** Currently selected value (v-model). */
+    modelValue: { type: String, default: "" },
+    options: {
+      type: Array as PropType<HkSegmentedOption[]>,
+      required: true,
+    },
+    /** Disable the whole group. */
+    disabled: { type: Boolean, default: false },
+    /** Visual size — sm matches form-control heights. */
+    size: {
+      type: String as PropType<"sm" | "md">,
+      default: "md",
+    },
+    /** Grow to fill the container width (segments share it equally). */
+    block: { type: Boolean, default: false },
+    /** Override the viewport breakpoint (default 768px) under which the
+     *  touch-optimized full-bleed form renders. */
+    mobileBreakpoint: { type: Number, default: 768 },
+  },
+  emits: {
+    "update:modelValue": (_value: string) => true,
+  },
+  setup(props, { emit }) {
+    function select(v: string) {
+      if (props.disabled) return;
+      const opt = props.options.find((o) => o.value === v);
+      if (opt?.disabled) return;
+      if (v === props.modelValue) return;
+      emit("update:modelValue", v);
+    }
+
+    return () => (
+      <div
+        class="hk-segmented"
+        data-size={props.size}
+        data-block={props.block || undefined}
+        data-disabled={props.disabled || undefined}
+        role="radiogroup"
+      >
+        {props.options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            class="hk-segmented__segment"
+            role="radio"
+            aria-checked={opt.value === props.modelValue}
+            data-checked={opt.value === props.modelValue || undefined}
+            data-disabled={props.disabled || opt.disabled || undefined}
+            disabled={props.disabled || opt.disabled}
+            onClick={() => select(opt.value)}
+          >
+            {opt.icon != null && <span class="hk-segmented__icon">{opt.icon as any}</span>}
+            <span class="hk-segmented__label">{opt.label}</span>
+          </button>
+        ))}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -83,6 +83,8 @@ export { default as HTrendChart } from "./components/HkTrendChart";
 export { default as HErrorBoundary } from "./components/HkErrorBoundary";
 export { default as HDraggableList } from "./components/HkDraggableList";
 export { default as HDraggableGrid } from "./components/HkDraggableGrid";
+export { default as HkSegmented } from "./components/HkSegmented";
+export type { HkSegmentedOption } from "./components/HkSegmented";
 export { default as HSelectionGrid } from "./components/HkSelectionGrid";
 export { default as HSelectionWaterfall } from "./components/HkSelectionWaterfall";
 


### PR DESCRIPTION
## What

Two components the chest adoption wave (P65-d) needs — both flagged as upstream gaps by its scout:

**HkSegmented** — a compact segmented control (button group) for mutually exclusive mode picking: joined pill track, checked segment elevation, per-segment and group disable, `block` grow, radiogroup semantics, and a touch form (≤768px breakpoint) that widens segments to full-bleed 40px targets. Fills the gap where consumers (chest ConnectionModal's local `SegmentedControl`, UsageView's two-button toggle) had to hand-roll buttons. 6 unit tests (repo convention: createApp+DOM assertions, no test-utils dep).

**HkPopupSelect mobile bottom-sheet form** — at viewport ≤ `mobileBreakpoint` (default 768, matching HkMenu/HkModal), the option list renders as a teleported bottom sheet (scrim + grabber + optional title defaulting to the label/placeholder + slide-up reveal) instead of the anchored popover; resize-aware while open. Rows are touch-sized (46px) with a trailing check on the selected option (desktop popover items gain the same trailing check — the tint-only checked state was hard to see). Registered `hk-popup-select-sheet-in` with the animation registry (parity test enforces).

Version 0.5.1 → 0.5.2.

## Verification

`vue-tsc --noEmit` 0 errors; `vitest` **321/321** (the two initially-failing runs were the animation-parity test catching the unregistered keyframe — fixed by registering it — and a flaky HkDateTimePicker pane count that passes in isolation on both this branch and clean master).