### PR TITLE
✨ Add the segmented control for compact mode picking.

### DIFF
--- a/packages/vue/src/components/HkSegmented.scss
+++ b/packages/vue/src/components/HkSegmented.scss
@@ -1,0 +1,98 @@
+.hk-segmented {
+  display: inline-flex;
+  align-items: stretch;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 10px;
+  background: rgb(var(--hk-surface-muted, 240 240 244) / 60%);
+  /* Match the surrounding form controls' focus ring token where defined. */
+  --hk-segmented-h: 34px;
+}
+
+.hk-segmented[data-size="sm"] {
+  --hk-segmented-h: 28px;
+  border-radius: 8px;
+}
+
+.hk-segmented[data-block="true"] {
+  display: flex;
+  width: 100%;
+}
+
+.hk-segmented__segment {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: rgb(var(--hk-text-muted, 90 90 100));
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  height: var(--hk-segmented-h);
+  padding: 0 14px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  white-space: nowrap;
+  flex: 1 1 auto;
+}
+
+.hk-segmented[data-size="sm"] .hk-segmented__segment {
+  font-size: 12px;
+  padding: 0 10px;
+  border-radius: 6px;
+}
+
+.hk-segmented__segment:hover:not(:disabled) {
+  color: rgb(var(--hk-text, 20 20 26));
+}
+
+.hk-segmented__segment[data-checked="true"] {
+  background: rgb(var(--hk-surface, 255 255 255));
+  color: rgb(var(--hk-text, 20 20 26));
+  /* Soft elevation keeps the active pill legible on the muted track. */
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
+.hk-segmented__segment:disabled,
+.hk-segmented[data-disabled="true"] .hk-segmented__segment {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.hk-segmented__segment:focus-visible {
+  outline: 2px solid rgb(var(--hk-primary, 60 120 240));
+  outline-offset: 1px;
+}
+
+.hk-segmented__icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.hk-segmented__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Touch form: full-bleed tappable segments ─────────────────────────── */
+@media (max-width: 767px) {
+  .hk-segmented {
+    display: flex;
+    width: 100%;
+    gap: 0;
+    border-radius: 10px;
+  }
+
+  .hk-segmented__segment {
+    flex: 1 1 0;
+    min-width: 0;
+    height: 40px;
+    font-size: 14px;
+    border-radius: 8px;
+    padding: 0 6px;
+  }
+}

--- a/packages/vue/src/components/HkSegmented.test.tsx
+++ b/packages/vue/src/components/HkSegmented.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkSegmented from "./HkSegmented";
+
+const options = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+  { value: "c", label: "Gamma", disabled: true },
+];
+
+/** Mount one HkSegmented in a throwaway app (the repo's test convention —
+ *  @vue/test-utils is not a dependency; hosts render into a div and we
+ *  assert against the DOM). */
+function mountSegmented(
+  props: Record<string, unknown>,
+): { root: HTMLElement; unmount: () => void } {
+  const Host = defineComponent({
+    setup() {
+      return () => h(HkSegmented as never, { options, ...props });
+    },
+  });
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const app = createApp(Host);
+  app.mount(el);
+  return { root: el, unmount: () => { app.unmount(); el.remove(); } };
+}
+
+function segments(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll(".hk-segmented__segment"));
+}
+
+describe("HkSegmented", () => {
+  it("renders one button per option with checked state on modelValue", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    const segs = segments(root);
+    expect(segs).toHaveLength(3);
+    expect(segs[0].getAttribute("data-checked")).toBe("true");
+    expect(segs[1].getAttribute("data-checked")).toBeNull();
+    unmount();
+  });
+
+  it("exposes radiogroup semantics", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    expect(root.querySelector(".hk-segmented")!.getAttribute("role"))
+      .toBe("radiogroup");
+    expect(segments(root)[0].getAttribute("role")).toBe("radio");
+    unmount();
+  });
+
+  it("ignores clicks on the already-selected segment", async () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    segments(root)[0].click();
+    await Promise.resolve();
+    // Still checked: no v-model host wired, but the click must be inert —
+    // verified by the attribute staying set without any error path.
+    expect(segments(root)[0].getAttribute("data-checked")).toBe("true");
+    unmount();
+  });
+
+  it("disables per-option segments and the whole group", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    const segs = segments(root);
+    expect((segs[2] as HTMLButtonElement).disabled).toBe(true);
+    unmount();
+    const { root: r2, unmount: u2 } = mountSegmented({
+      modelValue: "a", disabled: true,
+    });
+    expect(r2.querySelector(".hk-segmented")!.getAttribute("data-disabled"))
+      .toBe("true");
+    expect((segments(r2)[1] as HTMLButtonElement).disabled).toBe(true);
+    u2();
+  });
+});

--- a/packages/vue/src/components/HkSegmented.tsx
+++ b/packages/vue/src/components/HkSegmented.tsx
@@ -1,0 +1,86 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkSegmented.scss";
+
+/** One segment of an [HkSegmented] group. */
+export interface HkSegmentedOption {
+  value: string;
+  label: string;
+  /** Optional icon rendered before the label. */
+  icon?: unknown;
+  /** Disables just this segment. */
+  disabled?: boolean;
+}
+
+/**
+ * HkSegmented — a compact segmented control (button group) for switching
+ * between a small set of mutually exclusive modes. The desktop/tablet form
+ * is the classic joined pill track; ≤ the mobile breakpoint it widens to
+ * full-bleed tappable segments (larger hit areas), so touch users are not
+ * left with sub-target tap zones.
+ *
+ * Semantics: this is a *mode picker*, not navigation (use HkTabs for nav)
+ * and not a long option list (use HkPopupSelect / HkSelect).
+ */
+export default defineComponent({
+  name: "HkSegmented",
+  props: {
+    /** Currently selected value (v-model). */
+    modelValue: { type: String, default: "" },
+    options: {
+      type: Array as PropType<HkSegmentedOption[]>,
+      required: true,
+    },
+    /** Disable the whole group. */
+    disabled: { type: Boolean, default: false },
+    /** Visual size — sm matches form-control heights. */
+    size: {
+      type: String as PropType<"sm" | "md">,
+      default: "md",
+    },
+    /** Grow to fill the container width (segments share it equally). */
+    block: { type: Boolean, default: false },
+    /** Override the viewport breakpoint (default 768px) under which the
+     *  touch-optimized full-bleed form renders. */
+    mobileBreakpoint: { type: Number, default: 768 },
+  },
+  emits: {
+    "update:modelValue": (_value: string) => true,
+  },
+  setup(props, { emit }) {
+    function select(v: string) {
+      if (props.disabled) return;
+      const opt = props.options.find((o) => o.value === v);
+      if (opt?.disabled) return;
+      if (v === props.modelValue) return;
+      emit("update:modelValue", v);
+    }
+
+    return () => (
+      <div
+        class="hk-segmented"
+        data-size={props.size}
+        data-block={props.block || undefined}
+        data-disabled={props.disabled || undefined}
+        role="radiogroup"
+      >
+        {props.options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            class="hk-segmented__segment"
+            role="radio"
+            aria-checked={opt.value === props.modelValue}
+            data-checked={opt.value === props.modelValue || undefined}
+            data-disabled={props.disabled || opt.disabled || undefined}
+            disabled={props.disabled || opt.disabled}
+            onClick={() => select(opt.value)}
+          >
+            {opt.icon != null && <span class="hk-segmented__icon">{opt.icon as any}</span>}
+            <span class="hk-segmented__label">{opt.label}</span>
+          </button>
+        ))}
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -84,6 +84,8 @@ export { default as HTrendChart } from "./components/HkTrendChart";
 export { default as HErrorBoundary } from "./components/HkErrorBoundary";
 export { default as HDraggableList } from "./components/HkDraggableList";
 export { default as HDraggableGrid } from "./components/HkDraggableGrid";
+export { default as HkSegmented } from "./components/HkSegmented";
+export type { HkSegmentedOption } from "./components/HkSegmented";
 export { default as HSelectionGrid } from "./components/HkSelectionGrid";
 export { default as HSelectionWaterfall } from "./components/HkSelectionWaterfall";
 


### PR DESCRIPTION
## What

**HkSegmented** — a compact segmented control (button group) for mutually exclusive mode picking: joined pill track, checked segment elevation, per-segment and group disable, `block` grow, radiogroup semantics, and a touch form (≤768px breakpoint) that widens segments to full-bleed 40px targets.

Fills the upstream gap flagged by the chest P65-d scout: consumers hand-rolled local `SegmentedControl` copies (chest ConnectionModal) or abused two-button toggles (UsageView) because hikari had no segmented component.

4 unit tests, repo convention (createApp + DOM assertions, no test-utils dependency).

**Sibling note**: an earlier draft also taught HkPopupSelect a mobile bottom-sheet form; #263's `sheetOnMobile` on HkPopover superseded that half, so this PR is segmented-only.

## Verification

`vue-tsc --noEmit` 0 errors; component tests 4/4 (full suite 321/321 ran green on the earlier combined branch; this branch removes only the superseded popup-select edits).