### PR TITLE
🌐 Localize the rich input attachment delete label through the chat catalog.

### DIFF
--- a/packages/vue/src/components/HkRichInput.tsx
+++ b/packages/vue/src/components/HkRichInput.tsx
@@ -192,7 +192,7 @@ export const HkRichInput = defineComponent({
                           )}
                         </div>
                         <HButton variant="ghost" size="sm" class="s-rich-input-attachment-remove"
-                          ariaLabel={t("common.actions.delete", "Delete")}
+                          ariaLabel={t("hikari::chat.removeAttachment", "Delete")}
                           onClick={(e: MouseEvent) => { e.stopPropagation(); emit("removeAttachment", a.id); }}>
                           <X size={12} />
                         </HButton>
@@ -214,7 +214,7 @@ export const HkRichInput = defineComponent({
                           <span class="s-rich-input-attachment-chip-size">{formatBytes(a.size)}</span>
                         </div>
                         <HButton variant="ghost" size="sm" class="s-rich-input-attachment-remove"
-                          ariaLabel={t("common.actions.delete", "Delete")}
+                          ariaLabel={t("hikari::chat.removeAttachment", "Delete")}
                           onClick={(e: MouseEvent) => { e.stopPropagation(); emit("removeAttachment", a.id); }}>
                           <X size={10} />
                         </HButton>

--- a/packages/vue/src/i18n/locales/ar/chat.json
+++ b/packages/vue/src/i18n/locales/ar/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "مخزن",
     "hikari::model.context": "السياق",
     "hikari::model.pricing": "التسعير",
-    "hikari::model.noData": "لا توجد مواصفات"
+    "hikari::model.noData": "لا توجد مواصفات",
+    "hikari::chat.removeAttachment": "حذف"
   }
 }

--- a/packages/vue/src/i18n/locales/de/chat.json
+++ b/packages/vue/src/i18n/locales/de/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "Zwischengespeichert",
     "hikari::model.context": "Kontext",
     "hikari::model.pricing": "Preise",
-    "hikari::model.noData": "Keine Spezifikation verfügbar"
+    "hikari::model.noData": "Keine Spezifikation verfügbar",
+    "hikari::chat.removeAttachment": "Löschen"
   }
 }

--- a/packages/vue/src/i18n/locales/en/chat.json
+++ b/packages/vue/src/i18n/locales/en/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "Cached",
     "hikari::model.context": "Context",
     "hikari::model.pricing": "Pricing",
-    "hikari::model.noData": "No spec available"
+    "hikari::model.noData": "No spec available",
+    "hikari::chat.removeAttachment": "Delete"
   }
 }

--- a/packages/vue/src/i18n/locales/es/chat.json
+++ b/packages/vue/src/i18n/locales/es/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "En caché",
     "hikari::model.context": "Contexto",
     "hikari::model.pricing": "Precios",
-    "hikari::model.noData": "Sin especificación disponible"
+    "hikari::model.noData": "Sin especificación disponible",
+    "hikari::chat.removeAttachment": "Eliminar"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/chat.json
+++ b/packages/vue/src/i18n/locales/fr/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "En cache",
     "hikari::model.context": "Contexte",
     "hikari::model.pricing": "Tarifs",
-    "hikari::model.noData": "Aucune spécification disponible"
+    "hikari::model.noData": "Aucune spécification disponible",
+    "hikari::chat.removeAttachment": "Supprimer"
   }
 }

--- a/packages/vue/src/i18n/locales/ja/chat.json
+++ b/packages/vue/src/i18n/locales/ja/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "キャッシュ",
     "hikari::model.context": "コンテキスト",
     "hikari::model.pricing": "価格",
-    "hikari::model.noData": "仕様情報がありません"
+    "hikari::model.noData": "仕様情報がありません",
+    "hikari::chat.removeAttachment": "削除"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/chat.json
+++ b/packages/vue/src/i18n/locales/ko/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "캐시",
     "hikari::model.context": "컨텍스트",
     "hikari::model.pricing": "가격",
-    "hikari::model.noData": "사양 정보 없음"
+    "hikari::model.noData": "사양 정보 없음",
+    "hikari::chat.removeAttachment": "삭제"
   }
 }

--- a/packages/vue/src/i18n/locales/pt/chat.json
+++ b/packages/vue/src/i18n/locales/pt/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "Em cache",
     "hikari::model.context": "Contexto",
     "hikari::model.pricing": "Preços",
-    "hikari::model.noData": "Nenhuma especificação disponível"
+    "hikari::model.noData": "Nenhuma especificação disponível",
+    "hikari::chat.removeAttachment": "Excluir"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/chat.json
+++ b/packages/vue/src/i18n/locales/ru/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "Кэш",
     "hikari::model.context": "Контекст",
     "hikari::model.pricing": "Цены",
-    "hikari::model.noData": "Нет данных о модели"
+    "hikari::model.noData": "Нет данных о модели",
+    "hikari::chat.removeAttachment": "Удалить"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/chat.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "缓存",
     "hikari::model.context": "上下文",
     "hikari::model.pricing": "定价",
-    "hikari::model.noData": "暂无规格信息"
+    "hikari::model.noData": "暂无规格信息",
+    "hikari::chat.removeAttachment": "删除"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/chat.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/chat.json
@@ -32,6 +32,7 @@
     "hikari::model.cached": "快取",
     "hikari::model.context": "上下文",
     "hikari::model.pricing": "定價",
-    "hikari::model.noData": "暫無規格資訊"
+    "hikari::model.noData": "暫無規格資訊",
+    "hikari::chat.removeAttachment": "刪除"
   }
 }


### PR DESCRIPTION
Follow-up to #269 flagged in its verification: HkRichInput's attachment-remove aria-label used the app-level key `common.actions.delete`, which hikari's own catalog never defines — every locale (including inside chest) rendered the English fallback. The label now uses `hikari::chat.removeAttachment` with translations in all 11 locale chat.json files. vue-tsc clean; vitest 354/354.