### PR TITLE
✨ Add an auto-collapsing window mode to the horizontal timeline.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -195,6 +195,14 @@
     <section>
       <h2>HTimeline</h2>
       <HTimeline :steps="timelineSteps" current-key="v2" />
+      <h3>Narrow host → auto window (prev / current / next, edges fade)</h3>
+      <div style="max-width:280px;padding:8px;border:1px dashed var(--hi-color-border, #888);border-radius:8px">
+        <HTimeline :steps="wizardSteps" current-key="vendor" />
+      </div>
+      <h3>collapse="always" at the first step</h3>
+      <div style="max-width:280px;padding:8px;border:1px dashed var(--hi-color-border, #888);border-radius:8px">
+        <HTimeline :steps="wizardSteps" current-key="type" collapse="always" />
+      </div>
     </section>
 
     <section>
@@ -293,6 +301,12 @@ const timelineSteps = [
   { key: 'v1', label: 'v1.0 Released' },
   { key: 'v11', label: 'v1.1' },
   { key: 'v2', label: 'v2.0' },
+]
+const wizardSteps = [
+  { key: 'type', label: 'Type' },
+  { key: 'vendor', label: 'Vendor' },
+  { key: 'apiKey', label: 'API key' },
+  { key: 'models', label: 'Models' },
 ]
 
 const mediaSliderRatio = ref(0.42)

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -10,6 +10,48 @@
   align-items: flex-start;
 }
 
+// ── Compact window mode ────────────────────────────────────────────────
+// Engaged automatically (collapse="auto") when the full row cannot fit the
+// host: a three-cell grid keeps the current step dead-center, reveals at
+// most one neighbour per side, and fades the side outward where further
+// hidden steps continue — the connector gains the space the crowded full
+// row was denying it.
+.hk-timeline[data-mode="window"] {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+}
+
+.hk-timeline-window {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+
+  .hk-timeline-step {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+}
+
+// The trailing side mirrors the step so its connector leads from the center
+// node out to the neighbour: [—— connector ——][label][node].
+.hk-timeline-window[data-side="after"] .hk-timeline-step {
+  flex-direction: row-reverse;
+}
+
+// A side fades toward its outer edge only when hidden steps continue past
+// the window — the "about to disappear" hint that more steps lie beyond.
+.hk-timeline-window[data-side="before"][data-fade] {
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 55%);
+  mask-image: linear-gradient(to right, transparent 0, #000 55%);
+}
+
+.hk-timeline-window[data-side="after"][data-fade] {
+  -webkit-mask-image: linear-gradient(to left, transparent 0, #000 55%);
+  mask-image: linear-gradient(to left, transparent 0, #000 55%);
+}
+
+
 .hk-timeline-step {
   display: flex;
   align-items: center;

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -26,15 +26,20 @@
   display: flex;
   align-items: center;
   min-width: 0;
-
-  .hk-timeline-step {
-    flex: 1 1 auto;
-    min-width: 0;
-  }
 }
 
-// The trailing side mirrors the step so its connector leads from the center
-// node out to the neighbour: [—— connector ——][label][node].
+// Each side cell holds a single step that stretches across its whole 1fr
+// column so the connector fills the distance to the centre. The step must
+// NOT carry [data-last] (its flex:0 0 auto override would squash the
+// stretch and kill the fade) — the component only sets it in full mode.
+.hk-timeline-window .hk-timeline-step {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+// The after side mirrors the step so its connector leads from the centre
+// node out to the neighbour: [—— connector ——][label][node], node at the
+// outer edge — exactly where the fade mask sits.
 .hk-timeline-window[data-side="after"] .hk-timeline-step {
   flex-direction: row-reverse;
 }

--- a/packages/vue/src/components/HkTimeline.test.tsx
+++ b/packages/vue/src/components/HkTimeline.test.tsx
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkTimeline, { computeTimelineWindow } from "./HkTimeline";
+import type { TimelineStep } from "./HkTimeline";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+interface TimelineHarness {
+  container: HTMLElement;
+  setCurrent: (key: string) => void;
+}
+
+function mountTimeline(
+  props: Record<string, unknown> = {},
+  steps: TimelineStep[] = [
+    { key: "a", label: "Alpha" },
+    { key: "b", label: "Beta" },
+    { key: "c", label: "Gamma" },
+    { key: "d", label: "Delta" },
+    { key: "e", label: "Epsilon" },
+  ],
+): TimelineHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const current = ref((props.currentKey as string) ?? "a");
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkTimeline, {
+          ...props,
+          currentKey: current.value,
+          steps,
+        });
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { container, setCurrent: (key) => { current.value = key; } };
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("computeTimelineWindow", () => {
+  const steps = [
+    { key: "a", label: "1" },
+    { key: "b", label: "2" },
+    { key: "c", label: "3" },
+    { key: "d", label: "4" },
+    { key: "e", label: "5" },
+  ];
+
+  it("shows both neighbours in the middle of the row", () => {
+    expect(computeTimelineWindow(steps, "c")).toEqual({
+      beforeIndex: 1,
+      afterIndex: 3,
+      fadeBefore: true,
+      fadeAfter: true,
+    });
+  });
+
+  it("leaves the left cell empty and unfaded on the first step", () => {
+    expect(computeTimelineWindow(steps, "a")).toEqual({
+      beforeIndex: -1,
+      afterIndex: 1,
+      fadeBefore: false,
+      fadeAfter: true,
+    });
+  });
+
+  it("leaves the right cell empty and unfaded on the last step", () => {
+    expect(computeTimelineWindow(steps, "e")).toEqual({
+      beforeIndex: 3,
+      afterIndex: -1,
+      fadeBefore: true,
+      fadeAfter: false,
+    });
+  });
+
+  it("does not fade a side when the neighbour is the true edge step", () => {
+    // Four steps parked on the second: window is 1|2|3 — step 1 is the real
+    // start (left unfaded), step 4 hides beyond step 3 (right fades).
+    const four = steps.slice(0, 4);
+    expect(computeTimelineWindow(four, "b")).toEqual({
+      beforeIndex: 0,
+      afterIndex: 2,
+      fadeBefore: false,
+      fadeAfter: true,
+    });
+  });
+});
+
+describe("HkTimeline full mode", () => {
+  it("renders every step with statuses in a full row by default", () => {
+    const t = mountTimeline({ currentKey: "c" });
+    const root = t.container.querySelector(".hk-timeline");
+    expect(root?.getAttribute("data-mode")).toBe("full");
+    const els = t.container.querySelectorAll(".hk-timeline-step");
+    expect(els.length).toBe(5);
+    expect(els[0].getAttribute("data-status")).toBe("completed");
+    expect(els[2].getAttribute("data-status")).toBe("active");
+    expect(els[4].getAttribute("data-status")).toBe("pending");
+    expect(els[4].hasAttribute("data-last")).toBe(true);
+    expect(els[2].querySelector('[data-el="connector"]')).not.toBeNull();
+  });
+
+  it("stays full when collapse is never, even with many steps", () => {
+    const t = mountTimeline({ currentKey: "c", collapse: "never" });
+    expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
+    expect(t.container.querySelectorAll(".hk-timeline-step").length).toBe(5);
+  });
+
+  it("never windows a three-step row", () => {
+    const t = mountTimeline(
+      { currentKey: "b", collapse: "always" },
+      [
+        { key: "a", label: "Alpha" },
+        { key: "b", label: "Beta" },
+        { key: "c", label: "Gamma" },
+      ],
+    );
+    expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
+  });
+
+  it("keeps vertical orientation in full mode", () => {
+    const t = mountTimeline({ currentKey: "b", orientation: "vertical", collapse: "always" });
+    expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
+  });
+});
+
+describe("HkTimeline window mode", () => {
+  it("shows only the previous, current and next steps around the middle", () => {
+    const t = mountTimeline({ currentKey: "c", collapse: "always" });
+    const root = t.container.querySelector(".hk-timeline");
+    expect(root?.getAttribute("data-mode")).toBe("window");
+
+    const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
+    const current = t.container.querySelector('.hk-timeline-window[data-side="current"]');
+    const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
+
+    expect(before?.querySelector('[data-el="label"]')?.textContent).toBe("Beta");
+    expect(current?.querySelector('[data-el="label"]')?.textContent).toBe("Gamma");
+    expect(after?.querySelector('[data-el="label"]')?.textContent).toBe("Delta");
+
+    // Steps 1 and 5 are hidden entirely.
+    expect(t.container.textContent).not.toContain("Alpha");
+    expect(t.container.textContent).not.toContain("Epsilon");
+
+    // Both sides continue past the window, so both fade.
+    expect(before?.hasAttribute("data-fade")).toBe(true);
+    expect(after?.hasAttribute("data-fade")).toBe(true);
+
+    // Real ordinal numbers survive the collapse.
+    expect(current?.querySelector('[data-el="num"]')?.textContent).toBe("3");
+  });
+
+  it("keeps connectors drawn between the window cells", () => {
+    const t = mountTimeline({ currentKey: "c", collapse: "always" });
+    const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
+    const current = t.container.querySelector('.hk-timeline-window[data-side="current"]');
+    const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
+    // Previous step trails a connector toward the center; the current step
+    // trails one toward the neighbour; the last visible step does not.
+    expect(before?.querySelector('[data-el="connector"]')).not.toBeNull();
+    expect(current?.querySelector('[data-el="connector"]')).not.toBeNull();
+    expect(after?.querySelector('[data-el="connector"]')).toBeNull();
+  });
+
+  it("empties the left cell on the first step and the right cell on the last", async () => {
+    const t = mountTimeline({ currentKey: "a", collapse: "always" });
+    const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
+    expect(before?.querySelector(".hk-timeline-step")).toBeNull();
+    expect(before?.hasAttribute("data-fade")).toBe(false);
+    expect(
+      t.container.querySelector('.hk-timeline-window[data-side="after"] [data-el="label"]')
+        ?.textContent,
+    ).toBe("Beta");
+
+    t.setCurrent("e");
+    await nextTick();
+    const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
+    expect(after?.querySelector(".hk-timeline-step")).toBeNull();
+    expect(after?.hasAttribute("data-fade")).toBe(false);
+    expect(
+      t.container.querySelector('.hk-timeline-window[data-side="before"] [data-el="label"]')
+        ?.textContent,
+    ).toBe("Delta");
+  });
+
+  it("still emits select for a clickable completed neighbour in the window", () => {
+    const selected: string[] = [];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const app = createApp({
+      setup() {
+        return () =>
+          h(HkTimeline, {
+            steps: [
+              { key: "a", label: "Alpha" },
+              { key: "b", label: "Beta" },
+              { key: "c", label: "Gamma" },
+              { key: "d", label: "Delta" },
+            ],
+            currentKey: "c",
+            clickable: true,
+            collapse: "always",
+            onSelect: (key: string) => selected.push(key),
+          });
+      },
+    });
+    mounts.push(app);
+    app.mount(container);
+
+    const before = container.querySelector(
+      '.hk-timeline-window[data-side="before"] .hk-timeline-step',
+    ) as HTMLElement;
+    expect(before?.getAttribute("data-status")).toBe("completed");
+    before.dispatchEvent(new MouseEvent("click"));
+    expect(selected).toEqual(["b"]);
+  });
+});

--- a/packages/vue/src/components/HkTimeline.test.tsx
+++ b/packages/vue/src/components/HkTimeline.test.tsx
@@ -162,16 +162,21 @@ describe("HkTimeline window mode", () => {
     expect(current?.querySelector('[data-el="num"]')?.textContent).toBe("3");
   });
 
-  it("keeps connectors drawn between the window cells", () => {
+  it("draws the window connectors on the neighbour cells, never the center", () => {
     const t = mountTimeline({ currentKey: "c", collapse: "always" });
     const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
     const current = t.container.querySelector('.hk-timeline-window[data-side="current"]');
     const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
-    // Previous step trails a connector toward the center; the current step
-    // trails one toward the neighbour; the last visible step does not.
+    // The previous step trails its connector toward the centre; the next
+    // step (row-reversed) leads its connector back from the centre; the
+    // current step owns no connector at all — both bonds are drawn by the
+    // neighbours, and no [data-last] flex override may apply (the fade and
+    // the connector stretch live on these cells).
     expect(before?.querySelector('[data-el="connector"]')).not.toBeNull();
-    expect(current?.querySelector('[data-el="connector"]')).not.toBeNull();
-    expect(after?.querySelector('[data-el="connector"]')).toBeNull();
+    expect(after?.querySelector('[data-el="connector"]')).not.toBeNull();
+    expect(current?.querySelector('[data-el="connector"]')).toBeNull();
+    expect(current?.querySelector(".hk-timeline-step")?.hasAttribute("data-last")).toBe(false);
+    expect(after?.querySelector(".hk-timeline-step")?.hasAttribute("data-last")).toBe(false);
   });
 
   it("empties the left cell on the first step and the right cell on the last", async () => {

--- a/packages/vue/src/components/HkTimeline.tsx
+++ b/packages/vue/src/components/HkTimeline.tsx
@@ -66,6 +66,31 @@ export function computeTimelineWindow(
   };
 }
 
+/**
+ * Measure the row's natural (unshrunk) width.
+ *
+ * Summing the laid-out step rects is useless here: the steps are flex items
+ * with `min-width: 0`, so when the row overflows they simply shrink to the
+ * host's width and their rects always sum to ≈ `clientWidth` — the overflow
+ * only shows as overlapping labels. The reliable way is an offscreen clone
+ * sized to `max-content`, which lets the flex items keep their natural
+ * widths (labels are `white-space: nowrap; flex-shrink: 0`).
+ */
+function naturalRowWidth(el: HTMLElement): number {
+  const probe = el.cloneNode(true) as HTMLElement;
+  probe.style.position = "absolute";
+  probe.style.visibility = "hidden";
+  probe.style.pointerEvents = "none";
+  probe.style.width = "max-content";
+  probe.style.whiteSpace = "nowrap";
+  const parent = el.parentElement;
+  if (!parent) return el.scrollWidth;
+  parent.appendChild(probe);
+  const width = probe.getBoundingClientRect().width;
+  probe.remove();
+  return Math.ceil(width);
+}
+
 export default defineComponent({
   name: "HkTimeline",
   props: {
@@ -132,13 +157,7 @@ export default defineComponent({
         }
         return;
       }
-      const natural = Math.ceil(
-        Array.from(el.children).reduce(
-          (width, child) =>
-            width + (child as HTMLElement).getBoundingClientRect().width,
-          0,
-        ),
-      );
+      const natural = naturalRowWidth(el);
       if (natural > el.clientWidth + 1) {
         fullNaturalWidth = natural;
         collapsed.value = true;
@@ -174,7 +193,7 @@ export default defineComponent({
       },
     );
 
-    function renderStep(idx: number, connector: "trail" | "none") {
+    function renderStep(idx: number, opts: { connector: boolean; last: boolean }) {
       const step = props.steps[idx];
       const status: TimelineStepStatus =
         idx < currentIndex.value
@@ -183,14 +202,12 @@ export default defineComponent({
             ? "active"
             : "pending";
 
-      const showConnector = connector === "trail";
-
       return (
         <div
           key={step.key}
           class="hk-timeline-step"
           data-status={status}
-          data-last={!showConnector || undefined}
+          data-last={opts.last || undefined}
           data-clickable={(props.clickable && status === "completed") || undefined}
           role={props.clickable ? "button" : undefined}
           tabindex={props.clickable && status === "completed" ? 0 : undefined}
@@ -221,7 +238,7 @@ export default defineComponent({
             )}
           </span>
           <span data-el="label">{step.label}</span>
-          {showConnector && (
+          {opts.connector && (
             <div data-el="connector" />
           )}
         </div>
@@ -230,6 +247,13 @@ export default defineComponent({
 
     return () => {
       if (windowed.value) {
+        // Window-mode connector layout: the PREVIOUS step trails its
+        // connector rightward into the current node, and the NEXT step is
+        // row-reversed (see SCSS) so its connector leads leftward from the
+        // current node out to the neighbour — both fill their 1fr grid
+        // columns. The current step itself carries no connector (both sides
+        // are drawn by the neighbours), so no `data-last` flex override ever
+        // applies inside the window and every window step stretches.
         return (
           <div
             ref={host}
@@ -243,14 +267,11 @@ export default defineComponent({
               data-fade={win.value.fadeBefore || undefined}
             >
               {win.value.beforeIndex >= 0
-                ? renderStep(win.value.beforeIndex, "trail")
+                ? renderStep(win.value.beforeIndex, { connector: true, last: false })
                 : null}
             </div>
             <div class="hk-timeline-window" data-side="current">
-              {renderStep(
-                currentIndex.value,
-                win.value.afterIndex >= 0 ? "trail" : "none",
-              )}
+              {renderStep(currentIndex.value, { connector: false, last: false })}
             </div>
             <div
               class="hk-timeline-window"
@@ -258,7 +279,7 @@ export default defineComponent({
               data-fade={win.value.fadeAfter || undefined}
             >
               {win.value.afterIndex >= 0
-                ? renderStep(win.value.afterIndex, "none")
+                ? renderStep(win.value.afterIndex, { connector: true, last: false })
                 : null}
             </div>
           </div>
@@ -274,7 +295,7 @@ export default defineComponent({
         >
           {props.steps.map((_step, idx) => {
             const isLast = idx === props.steps.length - 1;
-            return renderStep(idx, isLast ? "none" : "trail");
+            return renderStep(idx, { connector: !isLast, last: isLast });
           })}
         </div>
       );

--- a/packages/vue/src/components/HkTimeline.tsx
+++ b/packages/vue/src/components/HkTimeline.tsx
@@ -1,5 +1,14 @@
 import { Check } from "lucide-vue-next";
-import { defineComponent, type PropType } from "vue";
+import {
+  computed,
+  defineComponent,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type PropType,
+} from "vue";
 
 
 import "./HkTimeline.scss";
@@ -12,6 +21,51 @@ export interface TimelineStep {
   icon?: string;
 }
 
+/**
+ * How the horizontal timeline behaves when there is not enough width to lay
+ * every step out in a row:
+ *
+ * - `"auto"` (default) — measure the host; when the full row would overflow,
+ *   collapse into the three-cell window (previous / current / next) with the
+ *   truncated edges fading out, and restore the full row once width returns.
+ * - `"always"` — always render the window form (useful for narrow cards and
+ *   for deterministic tests).
+ * - `"never"` — always render the full row, the classic behavior.
+ */
+export type TimelineCollapse = "auto" | "always" | "never";
+
+/** Which neighbours the compact window reveals around the current step. */
+export interface TimelineWindowState {
+  /** Index of the step shown left of the current one, or -1 at the start. */
+  beforeIndex: number;
+  /** Index of the step shown right of the current one, or -1 at the end. */
+  afterIndex: number;
+  /** Earlier steps exist beyond the window's left edge (fade that side). */
+  fadeBefore: boolean;
+  /** Later steps exist beyond the window's right edge (fade that side). */
+  fadeAfter: boolean;
+}
+
+/**
+ * Pure window computation for the compact mode so the layout logic is
+ * unit-testable without a layout engine. At most one neighbour is shown on
+ * each side of the current step; a side only fades when further hidden
+ * steps continue past it.
+ */
+export function computeTimelineWindow(
+  steps: TimelineStep[],
+  currentKey: string,
+): TimelineWindowState {
+  const currentIndex = steps.findIndex((s) => s.key === currentKey);
+  const has = (i: number): boolean => i >= 0 && i < steps.length;
+  return {
+    beforeIndex: has(currentIndex - 1) ? currentIndex - 1 : -1,
+    afterIndex: has(currentIndex + 1) ? currentIndex + 1 : -1,
+    fadeBefore: currentIndex - 1 > 0,
+    fadeAfter: currentIndex + 1 < steps.length - 1,
+  };
+}
+
 export default defineComponent({
   name: "HkTimeline",
   props: {
@@ -22,72 +76,205 @@ export default defineComponent({
       default: "horizontal",
     },
     clickable: { type: Boolean, default: false },
+    collapse: {
+      type: String as PropType<TimelineCollapse>,
+      default: "auto",
+    },
   },
   emits: {
     select: (_key: string) => true,
   },
   setup(props, { emit }) {
-    return () => {
-      const currentIndex = props.steps.findIndex(
-        (s) => s.key === props.currentKey,
+    const host = ref<HTMLElement | null>(null);
+    const collapsed = ref(false);
+    /** Full-row width captured right before collapsing; used as the
+     *  expand-again threshold (plus hysteresis) while windowed. */
+    let fullNaturalWidth = 0;
+    let observer: ResizeObserver | undefined;
+
+    const currentIndex = computed(() =>
+      props.steps.findIndex((s) => s.key === props.currentKey),
+    );
+
+    /** The window only makes sense for a horizontal row with more steps
+     *  than the window can show (a 3-step row is its own window). */
+    const windowable = computed(
+      () =>
+        props.orientation === "horizontal" &&
+        props.steps.length > 3 &&
+        currentIndex.value >= 0,
+    );
+
+    const windowed = computed(
+      () =>
+        windowable.value &&
+        (props.collapse === "always" ||
+          (props.collapse === "auto" && collapsed.value)),
+    );
+
+    const win = computed(() =>
+      computeTimelineWindow(props.steps, props.currentKey),
+    );
+
+    function measure(): void {
+      const el = host.value;
+      if (!el || !windowable.value || props.collapse !== "auto") {
+        collapsed.value = false;
+        return;
+      }
+      if (collapsed.value) {
+        // Expand again only once the host comfortably fits the full row it
+        // could not fit when we collapsed (16px hysteresis against flapping
+        // around the exact threshold).
+        if (fullNaturalWidth > 0 && el.clientWidth >= fullNaturalWidth + 16) {
+          collapsed.value = false;
+          fullNaturalWidth = 0;
+        }
+        return;
+      }
+      const natural = Math.ceil(
+        Array.from(el.children).reduce(
+          (width, child) =>
+            width + (child as HTMLElement).getBoundingClientRect().width,
+          0,
+        ),
       );
+      if (natural > el.clientWidth + 1) {
+        fullNaturalWidth = natural;
+        collapsed.value = true;
+      }
+    }
+
+    onMounted(() => {
+      if (typeof ResizeObserver !== "undefined") {
+        observer = new ResizeObserver(() => measure());
+        if (host.value) observer.observe(host.value);
+      }
+      void nextTick(measure);
+    });
+
+    onBeforeUnmount(() => {
+      observer?.disconnect();
+      observer = undefined;
+    });
+
+    // Labels and keys drive the row's natural width (locale switches rebuild
+    // the steps array), so re-measure from a clean full-mode render whenever
+    // they change.
+    watch(
+      () => [
+        props.steps.map((s) => `${s.key} ${s.label}`).join(" "),
+        props.orientation,
+        props.collapse,
+      ],
+      () => {
+        collapsed.value = false;
+        fullNaturalWidth = 0;
+        void nextTick(measure);
+      },
+    );
+
+    function renderStep(idx: number, connector: "trail" | "none") {
+      const step = props.steps[idx];
+      const status: TimelineStepStatus =
+        idx < currentIndex.value
+          ? "completed"
+          : idx === currentIndex.value
+            ? "active"
+            : "pending";
+
+      const showConnector = connector === "trail";
 
       return (
         <div
+          key={step.key}
+          class="hk-timeline-step"
+          data-status={status}
+          data-last={!showConnector || undefined}
+          data-clickable={(props.clickable && status === "completed") || undefined}
+          role={props.clickable ? "button" : undefined}
+          tabindex={props.clickable && status === "completed" ? 0 : undefined}
+          onClick={() => {
+            if (props.clickable && status === "completed")
+              emit("select", step.key);
+          }}
+          onKeydown={(e: KeyboardEvent) => {
+            if (
+              props.clickable &&
+              status === "completed" &&
+              (e.key === "Enter" || e.key === " ")
+            ) {
+              e.preventDefault();
+              emit("select", step.key);
+            }
+          }}
+        >
+          <span
+            data-el="indicator"
+            aria-hidden="true"
+          >
+            {status === "completed" && (
+              <Check size={12} data-el="check" strokeWidth={3} />
+            )}
+            {status !== "completed" && (
+              <span data-el="num">{idx + 1}</span>
+            )}
+          </span>
+          <span data-el="label">{step.label}</span>
+          {showConnector && (
+            <div data-el="connector" />
+          )}
+        </div>
+      );
+    }
+
+    return () => {
+      if (windowed.value) {
+        return (
+          <div
+            ref={host}
+            class="hk-timeline"
+            data-orientation={props.orientation}
+            data-mode="window"
+          >
+            <div
+              class="hk-timeline-window"
+              data-side="before"
+              data-fade={win.value.fadeBefore || undefined}
+            >
+              {win.value.beforeIndex >= 0
+                ? renderStep(win.value.beforeIndex, "trail")
+                : null}
+            </div>
+            <div class="hk-timeline-window" data-side="current">
+              {renderStep(
+                currentIndex.value,
+                win.value.afterIndex >= 0 ? "trail" : "none",
+              )}
+            </div>
+            <div
+              class="hk-timeline-window"
+              data-side="after"
+              data-fade={win.value.fadeAfter || undefined}
+            >
+              {win.value.afterIndex >= 0
+                ? renderStep(win.value.afterIndex, "none")
+                : null}
+            </div>
+          </div>
+        );
+      }
+
+      return (
+        <div
+          ref={host}
           class="hk-timeline"
           data-orientation={props.orientation}
+          data-mode="full"
         >
-          {props.steps.map((step, idx) => {
-            const status: TimelineStepStatus =
-              idx < currentIndex
-                ? "completed"
-                : idx === currentIndex
-                  ? "active"
-                  : "pending";
-
+          {props.steps.map((_step, idx) => {
             const isLast = idx === props.steps.length - 1;
-
-            return (
-              <div
-                key={step.key}
-                class="hk-timeline-step"
-                data-status={status}
-                data-last={isLast || undefined}
-                data-clickable={(props.clickable && status === "completed") || undefined}
-                role={props.clickable ? "button" : undefined}
-                tabindex={props.clickable && status === "completed" ? 0 : undefined}
-                onClick={() => {
-                  if (props.clickable && status === "completed")
-                    emit("select", step.key);
-                }}
-                onKeydown={(e: KeyboardEvent) => {
-                  if (
-                    props.clickable &&
-                    status === "completed" &&
-                    (e.key === "Enter" || e.key === " ")
-                  ) {
-                    e.preventDefault();
-                    emit("select", step.key);
-                  }
-                }}
-              >
-                <span
-                  data-el="indicator"
-                  aria-hidden="true"
-                >
-                  {status === "completed" && (
-                    <Check size={12} data-el="check" strokeWidth={3} />
-                  )}
-                  {status !== "completed" && (
-                    <span data-el="num">{idx + 1}</span>
-                  )}
-                </span>
-                <span data-el="label">{step.label}</span>
-                {!isLast && (
-                  <div data-el="connector" />
-                )}
-              </div>
-            );
+            return renderStep(idx, isLast ? "none" : "trail");
           })}
         </div>
       );


### PR DESCRIPTION
## What

Wizard-style steppers built on `HkTimeline` (e.g. the chest add-provider wizard's 4-step row) look broken on phones: the full row cannot fit the narrow width, labels collide and the connectors are starved.

This adds a **compact window mode**: when the full row cannot fit its host, the timeline collapses into a three-cell grid — previous / current / next — where:

- the current step stays dead-center and fully opaque,
- at most one neighbour shows per side,
- a side **fades toward its outer edge** when further hidden steps continue past it (the about-to-disappear hint), and shows no fade when the neighbour is the true first/last step,
- boundary positions render an empty side cell (first step → no left content; last step → no right content),
- connectors regain the horizontal space the crowded full row denied them.

## API

New `collapse` prop: `"auto" (default) | "always" | "never"`.

- `auto` measures the host with a ResizeObserver (sum of step widths vs host width, 16px expand hysteresis) and re-measures from a clean full render whenever labels change (locale switches).
- `always` forces the window (narrow cards, deterministic tests).
- `never` keeps the classic full row.
- Windowing only engages for horizontal rows with **more than 3 steps** (a 3-step row is its own window); vertical timelines are untouched.
- Window computation is exported as a pure `computeTimelineWindow()` for unit tests.

Backward compatible: existing consumers render identically on wide hosts.

## Verification (local, node-1)

- `vitest run` in packages/vue: **44 files / 370 tests pass** (12 new HkTimeline tests: window DOM structure, fade flags, boundary emptiness, connectors, ordinals, clickable neighbours, never/vertical/3-step exclusions).
- `vue-tsc --noEmit` clean.
- DemoApp gains a 280px-wide auto-window showcase plus a first-step `collapse="always"` sample.
- 0.5.1 → 0.5.2.