### PR TITLE
🐛 Stack the auth card footer rows onto separate lines.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAuthCard.tsx
+++ b/packages/vue/src/components/HkAuthCard.tsx
@@ -1,5 +1,17 @@
 import { defineComponent, type PropType } from "vue";
 
+/**
+ * HkAuthCard — the shared shell of every Celestia auth screen (login,
+ * register, setup): centered header (logo/title/subtitle) over a column
+ * form body.
+ *
+ * Slot layout contract:
+ * - `footer` renders into `.s-auth-footer`, a CENTERED FLEX COLUMN — each
+ *   slot child is its own row (remember-me, protocol consent, a sign-in
+ *   link…). Children must not assume a shared inline line; content that
+ *   must sit on one row belongs inside one child element.
+ * - `logo` swaps the header's logo slot; `default` is the form body.
+ */
 export const HkAuthCard = defineComponent({
   name: "HkAuthCard",
   props: {

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -597,6 +597,18 @@
 
 .s-auth-footer {
   margin-top: var(--space-16, 1rem);
+  /* Stack footer rows (remember-me, protocol consent, sign-in link…) the
+     same way the header stacks its children. A plain block left the rows
+     as inline-level siblings sharing one text line-box: HkCheckbox (and
+     any short inline row) next to another short row jammed side by side
+     whenever their combined width fit the card — the login card showed
+     "Remember login" and the agreement row fused into one line after the
+     8-23 de-customization dropped the per-row wrapper divs. Flex column
+     guarantees one row per child at every card width and locale. */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
   text-align: center;
   padding: 0 var(--space-32, 2rem) var(--space-24, 1.5rem);
   font-size: var(--text-xs, 0.75rem);


### PR DESCRIPTION
## 问题（用户报告，chest 登录卡片）

8-23 的去定制化波次（chest #440 + hikari #265）把 auth footer 的每行包装 div（`s-auth-options` / `s-auth-protocol-row`）拆掉后，「记住登录」与「我已阅读并同意 用户协议」两个 `label.hk-checkbox`（`display:inline-flex`）成为 `.s-auth-footer`（普通 block）的直接子元素，共享同一文本 line-box。中文下两行合计宽度小于卡片内容宽，必定并排挤成一行（真浏览器复现：1280px 视口 zh-Hans sameRow=true）。字体统一（HkLabel 14px）反而让两行更窄，更容易并排——这正是「调完字体后仍不换行」的原因。

## 修复

`.s-auth-footer` 改为居中 flex column（镜像同文件 `.s-auth-header` 既有模式）：每个 footer 子元素独占一行，行距 `--space-8`（8px），其余（text-align/padding/字号）不变。同时在 `HkAuthCard` 组件文档写明 footer 槽位的布局契约。

- 版本 0.5.2 → 0.5.3（随本 PR）。
- 影响面：全工作区唯一的多子元素 footer 就是 chest LoginView（已审计 chest/erp/arona/plana/kirino 全部 HAuthCard/HSignInCard/s-auth-footer 使用点；erp SignInCard 无 footer 槽）。

## 验证

- 真浏览器（Chromium，注入式预验证 + 构建产物复验）：zh-Hans@1280 修复前 sameRow=true → 修复后两行分开、均与卡片中心线对齐（640=640=640）、gap 8px；zh/en@360 窄屏两行分开且无横向溢出。
- `vue-tsc --noEmit` 0 错误；vitest 31 文件 234 用例全绿（其中 1 例计时敏感用例偶发，连续两次全量重跑全绿，干净 master 单跑亦绿）；admin-tokens.scss standalone sass 编译通过。
- 3 轮独立子代理验证（消费方回归审计 / 交叉复推 / 长词语言 de-ru-fr-es + RTL + reduced-motion + 浏览器基线终审）全部 APPROVE。