### PR TITLE
🎨 Align the auth footer rows left and even out their vertical rhythm.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library \u2014 production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAuthCard.tsx
+++ b/packages/vue/src/components/HkAuthCard.tsx
@@ -6,10 +6,12 @@ import { defineComponent, type PropType } from "vue";
  * form body.
  *
  * Slot layout contract:
- * - `footer` renders into `.s-auth-footer`, a CENTERED FLEX COLUMN — each
- *   slot child is its own row (remember-me, protocol consent, a sign-in
- *   link…). Children must not assume a shared inline line; content that
- *   must sit on one row belongs inside one child element.
+ * - `footer` renders into `.s-auth-footer`, a flex column sized to its
+ *   widest row and centered in the card: every slot child is its own row
+ *   (remember-me, protocol consent, a sign-in link…) and the rows share
+ *   one left edge. Children must not assume a shared inline line or
+ *   per-row centering; content that must sit on one row belongs inside
+ *   one child element.
  * - `logo` swaps the header's logo slot; `default` is the form body.
  */
 export const HkAuthCard = defineComponent({

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -596,23 +596,38 @@
 }
 
 .s-auth-footer {
-  margin-top: var(--space-16, 1rem);
   /* Stack footer rows (remember-me, protocol consent, sign-in link…) the
-     same way the header stacks its children. A plain block left the rows
-     as inline-level siblings sharing one text line-box: HkCheckbox (and
-     any short inline row) next to another short row jammed side by side
-     whenever their combined width fit the card — the login card showed
-     "Remember login" and the agreement row fused into one line after the
-     8-23 de-customization dropped the per-row wrapper divs. Flex column
-     guarantees one row per child at every card width and locale. */
+     same way the header stacks its children: one row per child at every
+     card width and locale (a plain block left the rows as inline-level
+     siblings sharing one text line-box, so two short rows fused onto one
+     line after the 8-23 de-customization dropped the per-row wrappers).
+     The rows share one LEFT edge and the group is centered as a whole:
+     fit-content sizes the block to the widest row and auto side margins
+     center it, so individually centering each row no longer scatters
+     their left edges when the labels differ in width. */
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-8, 0.5rem);
-  text-align: center;
+  width: fit-content;
+  margin: var(--space-16, 1rem) auto 0;
+  text-align: start;
   padding: 0 var(--space-32, 2rem) var(--space-24, 1.5rem);
   font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-muted, #666);
+}
+
+/* When a footer follows the form, collapse the form's bottom padding so
+   the whitespace around the footer rows stays symmetric — last field →
+   first row (8px + the footer's 16px top margin = 24px) equals last row
+   → card edge (the footer's 24px bottom padding). Without this the form
+   padding stacks onto the footer margin and the rows sit visibly closer
+   to the card's bottom edge. Specificity (0,2,0) also beats the ≤480px
+   media-query re-declaration, keeping the rhythm symmetric at both
+   breakpoints. Browsers without :has keep the previous padding — a
+   graceful, spacing-only degradation. */
+.s-auth-form:has(+ .s-auth-footer) {
+  padding-bottom: var(--space-8, 0.5rem);
 }
 
 .s-auth-link {


### PR DESCRIPTION
## 背景（用户对 #272 的跟进反馈）

#272 把 footer 改为居中 flex column 后，用户提出两处打磨：
1. **上下间距不对称**：桌面端 submit→首行 = 表单底衬 32px + footer margin 16px = 48px，末行→卡片底 = 24px（≤480px 为 40 vs 24+边框）。
2. **两行左边缘不齐**：`align-items: center` 让每行各自独立居中，"记住登录"（短）与协议行（长）左边缘错开。

## 修复

- `.s-auth-footer`：`width: fit-content` + `margin: var(--space-16) auto 0` + `align-items: flex-start` + `text-align: start` —— 块收缩到最宽行、整组居中、行间共享同一左边缘（换行的长词行第二行也 start 对齐）。
- 新增 `.s-auth-form:has(+ .s-auth-footer) { padding-bottom: var(--space-8) }`：有 footer 跟随时表单底衬塌到 8px，使 上 8+16=24px == 下 24px，两个断点均对称（特异性 (0,2,0) 压过 ≤480px 媒体查询的 (0,1,0)）。不支持 :has 的浏览器仅退化为原间距，无其它依赖。
- `HkAuthCard` 槽位契约文档同步更新；0.5.3 → 0.5.4。

## 验证

- 真浏览器注入式预验证 + 几何断言：zh/en × 1280/360 —— 上下间隙 24/25px（差为卡片 1px 边框）、行间距 8px、两行及复选框盒子左边缘完全相等、块中心 == 卡片中心、无横向溢出；长词换行场景（de ≈59ch）按可用宽换行且第二行 start 对齐。
- `vue-tsc --noEmit` 0 错误；vitest 31 文件 234 用例全绿；admin-tokens.scss standalone sass 编译通过（含 `:has` 与 `fit-content`）。
- 3 轮独立子代理验证 APPROVE：全消费方审计（chest/erp 全部 footer 槽——单行 footer 视觉不变；空 footer 卡片底部留白 72→48px 属良性收紧）、特异性/级联复推、RTL（start/flex-start/auto 边距均流相对）、:has 优雅降级、lockfile 无版本钉扎。