### PR TITLE
🐛 Type the menu action icon prop loosely so cross-vue-copy consumers compile.

### DIFF
--- a/packages/vue/src/components/HkMenuActionItem.tsx
+++ b/packages/vue/src/components/HkMenuActionItem.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, type PropType, type VNode } from "vue";
+import { defineComponent } from "vue";
 import "./HkMenuActionItem.scss";
 
 /**
@@ -11,8 +11,10 @@ import "./HkMenuActionItem.scss";
 export default defineComponent({
   name: "HkMenuActionItem",
   props: {
-    /** Leading icon node (e.g. `<Camera size={14} />`). */
-    icon: { type: Object as PropType<VNode>, default: undefined },
+    /** Leading icon node (e.g. `<Camera size={14} />`). Typed loosely
+     *  (plain Object) so consumers building on a different vue copy than
+     *  hikari's own node_modules never hit VNode type identity errors. */
+    icon: { type: Object, default: undefined },
     label: { type: String, required: true },
     /** Destructive styling (logout, delete…). */
     danger: { type: Boolean, default: false },


### PR DESCRIPTION
erp/chest 消费 HkMenuActionItem 时，hikari 快照的 vue（3.5.40）与 app 的 vue（3.5.41）VNode 类型身份不匹配导致 TS2322。icon prop 改为普通 Object 类型（运行时不变），跨 vue 副本安全。hikari vue-tsc + HkMenuPanel 测试全绿。