### PR TITLE
🐛 Rename the menu panel container class to hk-menu-list to dodge the HkMenu popup collision.

### DIFF
--- a/packages/vue/src/components/HkMenuPanel.scss
+++ b/packages/vue/src/components/HkMenuPanel.scss
@@ -9,7 +9,7 @@
  * The same container works in popovers, dropdowns or anywhere else —
  * nothing here depends on a drawer. */
 
-.hk-menu-panel {
+.hk-menu-list {
   display: flex;
   flex-direction: column;
   gap: var(--space-4, 4px);

--- a/packages/vue/src/components/HkMenuPanel.test.tsx
+++ b/packages/vue/src/components/HkMenuPanel.test.tsx
@@ -27,12 +27,12 @@ describe("HkMenuPanel facility", () => {
     app.mount(el);
     await nextTick();
 
-    const panel = el.querySelector(".hk-menu-panel") as HTMLElement;
+    const panel = el.querySelector(".hk-menu-list") as HTMLElement;
     expect(panel).not.toBeNull();
     expect(panel.getAttribute("role")).toBe("menu");
     expect(panel.getAttribute("aria-label")).toBe("Account");
     expect(panel.querySelectorAll(".hk-menu-action-item").length).toBe(2);
-    expect(panel.classList.contains("hk-menu-panel")).toBe(true);
+    expect(panel.classList.contains("hk-menu-list")).toBe(true);
 
     app.unmount();
   });

--- a/packages/vue/src/components/HkMenuPanel.tsx
+++ b/packages/vue/src/components/HkMenuPanel.tsx
@@ -24,7 +24,7 @@ export default defineComponent({
   },
   setup(props, { slots }) {
     return () => (
-      <div class="hk-menu-panel" role="menu" aria-label={props.label}>
+      <div class="hk-menu-list" role="menu" aria-label={props.label}>
         {slots.default?.()}
       </div>
     );


### PR DESCRIPTION
HkMenu 的弹层面板已占用 `.hk-menu-panel`（border/背景/max-height/backdrop-blur），HkMenuPanel 容器在消费端继承了这套弹层样式（实测抽屉底部出现 1px 边框与弹层背景）。容器类改为 `.hk-menu-list`（组件名不变），vue-tsc + 5 测试全绿。