### PR TITLE
🔥 Drop the dead plain-text protocol modal prop.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkProtocolModal.tsx
+++ b/packages/vue/src/components/HkProtocolModal.tsx
@@ -20,10 +20,8 @@ export const HkProtocolModal = defineComponent({
     modelValue: { type: Boolean, default: false },
     /** Modal title (defaults to "Agreement"). */
     title: { type: String, default: undefined },
-    /** Markdown content to render (or plain text when `plain`). */
+    /** Markdown content to render — protocols always render as markdown. */
     content: { type: String, default: "" },
-    /** Render `content` as escaped plain text instead of markdown. */
-    plain: { type: Boolean, default: false },
     /** Accept button label override. */
     acceptLabel: { type: String, default: undefined },
     /** Decline button label override. */
@@ -78,7 +76,7 @@ export const HkProtocolModal = defineComponent({
           style={props.bodyHeight ? { maxHeight: props.bodyHeight, overflowY: "auto" } : undefined}
         >
           {copied.value && <p class="s-protocol-modal-copied">{t("hikari::protocol.copied", "Copied")}</p>}
-          <HMarkdownRenderer content={props.content} plain={props.plain} />
+          <HMarkdownRenderer content={props.content} />
         </div>
       </HModal>
     );


### PR DESCRIPTION
## 背景

协议文档（license/CLA/CoC/security/contributing）全部以 markdown 形式 vendor（celestia-devtools 管线），`HkProtocolModal` 的 `plain` 直通参数从未被任何消费方使用——chest 已完成 vendor 管线迁移、所有文档一律 markdown 渲染。附件预览（HkAttachmentModal）对 .txt/.log/.csv 的纯文本模式是设计功能，**保留**其 `HkMarkdownRenderer` 的 `plain` 能力不变。

## 修复

- `HkProtocolModal`：删除 `plain` prop 与相关 JSDoc，渲染不再传递该参数。
- 版本 0.6.0 → 0.6.1。

## 验证

- vue-tsc 0 错误；vitest 32 文件 239 用例全绿；`celestia-devtools verify-versions` exit 0。
- 全工作区 grep：`HProtocolModal` 导出零消费方；`HkMarkdownRenderer` 的 plain 仅剩 HkAttachmentModal 一个合法消费方。
- 3 轮子代理验证 APPROVE（R2 交叉复推确认 scope 判断正确：renderer 的 plain 能力是附件预览与错误回退的活代码，必须保留）。