### PR TITLE
🐛 Reset keyword-search results and log tab bodies on content switches.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkKeywordSearchModal.tsx
+++ b/packages/vue/src/components/HkKeywordSearchModal.tsx
@@ -159,8 +159,13 @@ export default defineComponent({
       }
     }
 
+    const resultsRef = ref<HTMLDivElement | null>(null);
+
     watch(debouncedQuery, (q) => {
       if (semanticActive.value) void runSemantic(q);
+      // New results replace the list (fuzzy + semantic paths both
+      // recompute from debouncedQuery): return the viewport to the top.
+      resultsRef.value?.scrollTo({ top: 0 });
     });
 
     const results = computed(() => {
@@ -246,7 +251,7 @@ export default defineComponent({
             )}
           </div>
 
-          <div class="hk-kw-search-results">
+          <div class="hk-kw-search-results" ref={resultsRef}>
             {semanticActive.value ? (
               semanticLoading.value && semanticResults.value.length === 0 ? (
                 <div class="hk-kw-search-empty">

--- a/packages/vue/src/components/HkLogWindow.tsx
+++ b/packages/vue/src/components/HkLogWindow.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, watch, type PropType } from "vue";
+import { computed, defineComponent, nextTick, ref, watch, type PropType } from "vue";
 import { Copy, Eraser, Pause, Play, ScrollText } from "lucide-vue-next";
 import { HModal, HScrollContainer, useClipboard } from "@celestia-island/hikari";
 
@@ -10,6 +10,12 @@ export interface HLogTab {
   key: string;
   title: string;
   lines: string[];
+}
+
+/** Public surface HScrollContainer exposes via setup expose() —
+ *  InstanceType does not carry expose() members, so type it structurally. */
+interface ScrollContainerPublic {
+  getScrollElement: () => HTMLElement | undefined;
 }
 
 function levelOf(line: string): "error" | "warn" | "debug" | "info" {
@@ -72,6 +78,19 @@ export const HkLogWindow = defineComponent({
       },
       { immediate: true },
     );
+
+    const scrollRef = ref<ScrollContainerPublic | null>(null);
+
+    // Log viewers follow the newest-line convention: switching tabs
+    // tail-jumps to the bottom of the new tab's lines (nextTick so
+    // the swapped body has rendered before measuring scrollHeight;
+    // landing at the bottom also re-arms autoFollow's pinned zone).
+    watch(activeTab, () => {
+      void nextTick(() => {
+        const el = scrollRef.value?.getScrollElement();
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+    });
 
     const currentTab = computed(() => props.tabs.find((tab) => tab.key === activeTab.value) ?? null);
     const currentLines = computed(() => currentTab.value?.lines ?? []);
@@ -154,7 +173,11 @@ export const HkLogWindow = defineComponent({
               </button>
             </div>
           </div>
-          <HScrollContainer class="s-log-viewer-scroll" autoFollow={autoscroll.value && !paused.value}>
+          <HScrollContainer
+            class="s-log-viewer-scroll"
+            autoFollow={autoscroll.value && !paused.value}
+            ref={scrollRef}
+          >
             {currentLines.value.length === 0 ? (
               <div class="s-log-empty">{t("hikari::log.empty", "No log lines yet.")}</div>
             ) : (


### PR DESCRIPTION
## What

Follow-up to the protocol-modal round: every content-switching control should land its scrollable content in a predictable position.

- **HkKeywordSearchModal** — the results pane now scrolls back to the top whenever the debounced query changes (covers the fuzzy path, the semantic path and the clear button). Chest consumers: ReportsView search and MindMapView node search.
- **HkLogWindow** — switching log tabs now tail-jumps to the newest lines of the new tab and re-arms the autoFollow pinned zone, instead of inheriting the previous tab's offset.
- Version bump 0.6.1 → 0.6.2 (bundled per workspace policy).

## Verification

- `vue-tsc --noEmit` exit 0
- `vitest run src/components` 32 files / 239 tests passed
- `vite build` exit 0
- Cross-verified by an independent agent (all 6 checks passed)

Companion chest PR consumes these fixes and applies the same rule to ~18 in-repo sites.