### PR TITLE
✨ Add a floating field label to the number input.

### DIFF
--- a/packages/vue/src/components/HkNumberInput.scss
+++ b/packages/vue/src/components/HkNumberInput.scss
@@ -1,3 +1,15 @@
+/* Field caption, mirroring .hk-input-label in HkInput.scss (the number
+   input carries its own copy so it does not depend on HInput's stylesheet
+   being loaded too). */
+.hk-input-label {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
+}
+
 .hk-number-input {
   display: block;
   width: 100%;

--- a/packages/vue/src/components/HkNumberInput.tsx
+++ b/packages/vue/src/components/HkNumberInput.tsx
@@ -11,6 +11,7 @@ export default defineComponent({
     step: { type: Number, default: 1 },
     disabled: { type: Boolean, default: false },
     placeholder: { type: String, default: undefined },
+    label: { type: String, default: undefined },
     size: {
       type: String as PropType<"sm" | "md" | "lg">,
       default: "md",
@@ -84,6 +85,7 @@ export default defineComponent({
 
     return () => (
       <div class={wrapperClass.value}>
+        {props.label && <label class="hk-input-label">{props.label}</label>}
         <div class="hk-number-input-inner">
           {slots.prefix ? (
             <span class="hk-number-input-prefix">{slots.prefix()}</span>


### PR DESCRIPTION
erp 表单完善前置：HkNumberInput 缺少 label prop（HInput/HSelect 均有），激活码数量等数字字段无法显示左上角悬浮标题。补齐：label prop + 渲染 .hk-input-label（样式自包含于自身 stylesheet，不依赖 HInput 的 CSS 被同时加载）。vue-tsc 通过。