### PR TITLE
🐛 Inset the mobile select sheet options from the screen edges.

### DIFF
--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -98,7 +98,9 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
-  padding: var(--space-4);
+  /* 8px panel inset (was 4px): option hover blocks used to run almost
+     edge-to-edge, reading as a glued full-width strip on touch widths. */
+  padding: var(--space-8);
   border-radius: var(--radius-md);
   overflow-y: auto;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
@@ -222,6 +224,10 @@
 .hk-select-sheet-list {
   overflow-y: auto;
   overscroll-behavior: contain;
+  /* Side insets so the option blocks (full-row hover pills) read as
+     cards inside the sheet instead of an edge-to-edge strip glued to
+     both screen sides — matching the popover family's breathing room. */
+  padding-inline: var(--space-16);
   padding-bottom: var(--space-16);
 
   .hk-select-option {

--- a/packages/vue/src/components/HkSelect.test.tsx
+++ b/packages/vue/src/components/HkSelect.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HSelect } from "../index";
+
+/**
+ * Mobile select contract: below the touch breakpoint the select renders
+ * as a bottom sheet (scrim + panel + grabber) instead of an anchored
+ * popout. The sheet's option list must carry side insets — full-row
+ * option pills used to glue to both screen edges and read as a broken
+ * edge-to-edge strip (the language picker popover keeps margins, which
+ * made the mismatch visible).
+ */
+
+const originalWidth = window.innerWidth;
+
+function setViewportWidth(px: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: px,
+  });
+}
+
+async function mountSelect() {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const app = createApp({
+    render: () =>
+      h(HSelect, {
+        modelValue: "",
+        "onUpdate:modelValue": () => {},
+        options: [
+          { value: "a", label: "Option A" },
+          { value: "b", label: "Option B" },
+        ],
+      }),
+  });
+  app.mount(el);
+  await nextTick();
+  return { el, app };
+}
+
+describe("HSelect mobile sheet", () => {
+  afterEach(() => {
+    setViewportWidth(originalWidth);
+    document.body.innerHTML = "";
+  });
+
+  it("renders a bottom sheet with side-inset options on touch widths", async () => {
+    setViewportWidth(375);
+    const { app } = await mountSelect();
+    const trigger = document.querySelector<HTMLButtonElement>(".hk-select-trigger")!;
+    trigger.click();
+    await nextTick();
+
+    const panel = document.querySelector<HTMLElement>(".hk-select-sheet-panel");
+    expect(panel).not.toBeNull();
+    const scrim = document.querySelector(".hk-select-sheet-scrim");
+    expect(scrim).not.toBeNull();
+    // No anchored popout in sheet mode.
+    expect(document.querySelector(".hk-select-popout")).toBeNull();
+
+    // The list node must exist (side insets are enforced in SCSS —
+    // padding-inline on .hk-select-sheet-list — which happy-dom does not
+    // compute; the visual assertion lives in the stylesheet).
+    const list = document.querySelector<HTMLElement>(".hk-select-sheet-list");
+    expect(list).not.toBeNull();
+    const options = panel!.querySelectorAll(".hk-select-option");
+    expect(options.length).toBe(2);
+
+    app.unmount();
+  });
+
+  it("renders an anchored popout on desktop widths", async () => {
+    setViewportWidth(1280);
+    const { app } = await mountSelect();
+    const trigger = document.querySelector<HTMLButtonElement>(".hk-select-trigger")!;
+    trigger.click();
+    await nextTick();
+
+    expect(document.querySelector(".hk-select-sheet-panel")).toBeNull();
+    const popout = document.querySelector<HTMLElement>(".hk-select-popout");
+    expect(popout).not.toBeNull();
+
+    app.unmount();
+  });
+});


### PR DESCRIPTION
## 用户报告

手机端下拉框（HSelect 的 bottom sheet 形态）里选项直接填满整宽、贴左右屏边，无内边距；而语言选择器等弹层系（HPopover 家族）有正常留白——两种形态不一致。

## 定性

**组件级系统性问题**（非个别消费端错乱）：HSelect 手机端渲染为 bottom sheet（scrim + 抓手 + 列表），但 `.hk-select-sheet-list` 只有 padding-bottom、没有左右内边距——全行选项块贴满 sheet 两缘。所有使用 HSelect 的表单在手机端都受影响（erp 全部管理弹窗 + chest）。

## 修复

- `.hk-select-sheet-list` 增加 `padding-inline: var(--space-16)`——选项块成为 sheet 内的圆角卡片，与 popover 家族的留白一致；
- 新增 HkSelect 移动端形态回归测试（sheet 出现 + 无锚定 popout / 桌面反之），钉住两种形态不回退。

377 测试 + vue-tsc 全绿。