### PR TITLE
✨ Route the back gesture through open windows before page history.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkDrawer.test.tsx
+++ b/packages/vue/src/components/HkDrawer.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkDrawer from "./HkDrawer";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(async () => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  // Let any suppressed traversal land so it cannot leak into the next test.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+});
+
+describe("HkDrawer back-guard (window-first back priority)", () => {
+  async function settle(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+
+  /** Wait until pred() holds (history navigation settles asynchronously). */
+  async function until(pred: () => boolean, ms = 500): Promise<void> {
+    const deadline = Date.now() + ms;
+    while (!pred() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await nextTick();
+    }
+  }
+
+  function mountDrawer(open: { value: boolean }, closable = true) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkDrawer, {
+            modelValue: open.value,
+            closable,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    return app;
+  }
+
+  it("pushes a history entry on open and back closes the drawer, not the page", async () => {
+    const open = ref(true);
+    const app = mountDrawer(open);
+    await settle();
+
+    expect((window.history.state as Record<string, unknown>)?.__hkBack).toEqual(expect.any(String));
+
+    window.history.back();
+    await until(() => open.value === false);
+    await until(() => window.history.state === null);
+    app.unmount();
+  });
+
+  it("a non-closable drawer never owns history", async () => {
+    const open = ref(true);
+    const app = mountDrawer(open, false);
+    await settle();
+
+    expect((window.history.state as Record<string, unknown>)?.__hkBack).toBeUndefined();
+    app.unmount();
+  });
+});

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -15,6 +15,7 @@ import "./HkDrawer.scss";
 import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
+import { createBackGuard } from "../runtime/backStack";
 
 type DrawerSide = "left" | "right" | "top" | "bottom";
 
@@ -31,6 +32,14 @@ export default defineComponent({
      *  body/footer padding overrides (attrs fallthrough cannot reach a
      *  Teleported panel). */
     panelClass: { type: String, default: undefined },
+    /**
+     * Consume the browser/system back gesture while open (window-first
+     * back priority): a marked history entry is pushed on open so back
+     * closes the drawer instead of leaving the page. Only meaningful
+     * together with `closable`; disable for surfaces that manage their
+     * own history entries.
+     */
+    backGuard: { type: Boolean, default: true },
   },
   emits: {
     "update:modelValue": (_value: boolean) => true,
@@ -53,6 +62,19 @@ export default defineComponent({
     const panelRef = ref<HTMLElement>();
     let unmounted = false;
     let previouslyFocused: HTMLElement | null = null;
+
+    /**
+     * Window-first back priority: while this drawer is the topmost open
+     * window, the back gesture closes it instead of navigating the
+     * page. Disabled for non-closable drawers — back must not be
+     * swallowed by a surface it cannot close.
+     */
+    const backGuardEnabled = () => props.closable && props.backGuard;
+    const backGuard = createBackGuard({
+      onBack: () => {
+        if (backGuardEnabled()) close();
+      },
+    });
 
     const isVertical = computed(
       () => props.side === "left" || props.side === "right",
@@ -112,15 +134,31 @@ export default defineComponent({
           handle.value = manager.register("drawer", true);
           overlayHook.open();
           previouslyFocused = document.activeElement as HTMLElement | null;
+          if (backGuardEnabled() && backGuard.entries === 0) {
+            backGuard.push();
+          }
         } else {
           // Register/unregister WITH the open state so a closed-but-mounted
           // drawer does not linger in the overlay registry (isOverlayOpen
           // must reflect reality). The popup manager handle is torn down by
           // the leave transition or by cleanup() on unmount.
           overlayHook.close();
+          backGuard.release();
         }
       },
       { immediate: true },
+    );
+
+    // closable/backGuard may flip while open (submit flows disable
+    // closing): keep the owned entry in lockstep so back is never a
+    // dead gesture on a surface it can no longer close.
+    watch(
+      backGuardEnabled,
+      (enabled) => {
+        if (unmounted || !props.modelValue) return;
+        if (enabled && backGuard.entries === 0) backGuard.push();
+        else if (!enabled && backGuard.entries > 0) backGuard.release();
+      },
     );
 
     onMounted(() => {
@@ -129,6 +167,7 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       unmounted = true;
+      backGuard.destroy();
       cleanup();
     });
 

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -121,7 +121,7 @@ afterEach(async () => {
   while (mounts.length) mounts.pop()?.unmount();
   // Unmounting restores history asynchronously; wait for it to land so a
   // pending traversal cannot pop the NEXT test's freshly pushed entries.
-  await until(() => window.history.state?.__hkMenuId === undefined);
+  await until(() => window.history.state?.__hkBack === undefined);
   while (containers.length) containers.pop()?.remove();
   window.innerWidth = 1024;
 });
@@ -217,27 +217,27 @@ describe("HkMenu mobile sheets", () => {
 
     // Root sheet only, with its own history entry.
     expect(sheets().length).toBe(1);
-    expect(window.history.state?.__hkMenuDepth).toBe(0);
+    expect(window.history.state?.__hkBackDepth).toBe(0);
 
     // Enter the first branch → two stacked sheets + a new history entry.
     rowByLabel("Branch One")!.click();
     await settle();
     expect(sheets().length).toBe(2);
-    expect(window.history.state?.__hkMenuDepth).toBe(1);
+    expect(window.history.state?.__hkBackDepth).toBe(1);
 
     // Browser/system back closes ONE level: back to the root sheet.
     window.history.back();
     await settle();
     expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
-    expect(window.history.state?.__hkMenuDepth).toBe(0);
+    expect(window.history.state?.__hkBackDepth).toBe(0);
 
     // Back from the root closes the menu entirely.
     window.history.back();
     await settle();
     expect(openRef.value).toBe(false);
     expect(document.querySelector(".hk-menu-sheet")).toBeNull();
-    expect(window.history.state?.__hkMenuId).toBeUndefined();
+    expect(window.history.state?.__hkBack).toBeUndefined();
   });
 
   it("keeps the root sheet when a pushed level is dismissed via its back button", async () => {
@@ -257,7 +257,7 @@ describe("HkMenu mobile sheets", () => {
     await settle();
     expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
-    expect(window.history.state?.__hkMenuDepth).toBe(0);
+    expect(window.history.state?.__hkBackDepth).toBe(0);
   });
 
   it("selecting a leaf on mobile closes every sheet and restores history", async () => {
@@ -277,8 +277,8 @@ describe("HkMenu mobile sheets", () => {
     expect(selected).toEqual(["two-b"]);
     expect(openRef.value).toBe(false);
     expect(document.querySelector(".hk-menu-sheet")).toBeNull();
-    await until(() => window.history.state?.__hkMenuId === undefined);
-    expect(window.history.state?.__hkMenuId).toBeUndefined();
+    await until(() => window.history.state?.__hkBack === undefined);
+    expect(window.history.state?.__hkBack).toBeUndefined();
   });
 
   it("follows live viewport changes without closing the menu", async () => {
@@ -287,7 +287,7 @@ describe("HkMenu mobile sheets", () => {
     mountMenu(openRef, siblingItems);
     await settle();
     expect(sheets().length).toBe(1);
-    expect(window.history.state?.__hkMenuDepth).toBe(0);
+    expect(window.history.state?.__hkBackDepth).toBe(0);
 
     // Rotate/grow to desktop while open: sheets become desktop panels and
     // the pushed history entry is released — but the menu stays open.
@@ -297,8 +297,8 @@ describe("HkMenu mobile sheets", () => {
     expect(openRef.value).toBe(true);
     expect(sheets().length).toBe(0);
     expect(panels().length).toBe(1);
-    await until(() => window.history.state?.__hkMenuId === undefined);
-    expect(window.history.state?.__hkMenuId).toBeUndefined();
+    await until(() => window.history.state?.__hkBack === undefined);
+    expect(window.history.state?.__hkBack).toBeUndefined();
 
     // Shrink back: the root sheet returns with a fresh root entry.
     window.innerWidth = 390;
@@ -306,7 +306,7 @@ describe("HkMenu mobile sheets", () => {
     await settle();
     expect(openRef.value).toBe(true);
     expect(sheets().length).toBe(1);
-    expect(window.history.state?.__hkMenuDepth).toBe(0);
+    expect(window.history.state?.__hkBackDepth).toBe(0);
   });
 });
 
@@ -344,7 +344,7 @@ describe("HkMenu sidebar variant", () => {
     // Inline render: no teleport, no panels, no history ownership.
     expect(document.querySelector(".hk-menu-panel")).toBeNull();
     expect(document.querySelector(".hk-menu-sheet")).toBeNull();
-    expect(window.history.state?.__hkMenuId).toBeUndefined();
+    expect(window.history.state?.__hkBack).toBeUndefined();
 
     const nav = container.querySelector(".hk-menu-sidebar");
     expect(nav).not.toBeNull();

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -15,6 +15,7 @@ import {
 import { ChevronLeft, ChevronRight } from "lucide-vue-next";
 
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import { createBackGuard } from "../runtime/backStack";
 import { useI18n } from "../i18n/context";
 import "./HkMenu.scss";
 
@@ -46,14 +47,6 @@ export interface HkMenuItem {
   badge?: string;
   children?: HkMenuItem[];
 }
-
-/** Marker we stamp into history.state for levels this instance pushed. */
-interface MenuHistoryState {
-  __hkMenuId?: string;
-  __hkMenuDepth?: number;
-}
-
-const MENU_ID = "__hkMenu";
 
 function viewportIsMobile(breakpoint: number): boolean {
   return typeof window !== "undefined" && window.innerWidth < breakpoint;
@@ -96,15 +89,6 @@ export default defineComponent({
     const desktopPath = ref<string[]>([]);
     /** Pushed sheet chain on mobile: each entry is one submenu level. */
     const mobileStack = ref<{ title: string; items: HkMenuItem[] }[]>([]);
-    const instanceId = `${MENU_ID}-${Math.random().toString(36).slice(2, 8)}`;
-    /**
-     * History entries this instance pushed above the page's base entry —
-     * also the number of back() calls needed to reach the base again.
-     * History depth 0 (the root sheet) counts, so this is depth + 1.
-     */
-    let pushedDepth = 0;
-    /** Popstate events produced by our own restoreHistory — not user backs. */
-    let suppressPop = 0;
     /** Bumped on viewport resize so an open menu re-renders in the right mode. */
     const viewportTick = ref(0);
 
@@ -120,36 +104,37 @@ export default defineComponent({
       return viewportIsMobile(props.mobileBreakpoint);
     });
 
-    function pushHistoryEntry(depth: number): void {
-      window.history.pushState(
-        { __hkMenuId: instanceId, __hkMenuDepth: depth } satisfies MenuHistoryState,
-        "",
-      );
-      pushedDepth = depth + 1;
-    }
-
-    function restoreHistory(): void {
-      // Single multi-step traversal: consecutive back() calls can be
-      // coalesced (happy-dom) or racy (browsers), go(-n) cannot. Depth is
-      // only trusted while our entry is still current — a foreign pushState
-      // while open (router navigation, another component) invalidates the
-      // count, so release ownership by de-marking the current entry instead
-      // of traversing a count we can no longer trust.
-      if (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
-        suppressPop++;
-        window.history.go(-pushedDepth);
-      } else if (pushedDepth > 0) {
-        // Our entries are still buried below the foreign top; replacing the
-        // current entry releases ownership without touching live history.
-        window.history.replaceState(null, "");
-      }
-      pushedDepth = 0;
-    }
+    /**
+     * History ownership rides the shared back-guard service: every
+     * pushed sheet level is one marked entry, user back gestures are
+     * dispatched window-first (topmost surface consumes them), and
+     * programmatic closes rewind our entries via suppressed
+     * traversals. See runtime/backStack.ts.
+     */
+    let backGuard: ReturnType<typeof createBackGuard>;
+    backGuard = createBackGuard({
+      onBack: (depth) => {
+        desktopPath.value = [];
+        if (depth === null) {
+          // Landed outside our stack — collapse whatever remains.
+          mobileStack.value = [];
+          emit("update:open", false);
+          return;
+        }
+        // Landed on one of our own entries — close exactly one level.
+        mobileStack.value = props.open ? mobileStack.value.slice(0, depth) : [];
+        if (!props.open) {
+          // Forward gesture into a spent stack while closed: release the
+          // ownership marker so a closed menu never owns live history.
+          backGuard.forget();
+        }
+      },
+    });
 
     function closeAll(): void {
       desktopPath.value = [];
       mobileStack.value = [];
-      restoreHistory();
+      backGuard.release();
       emit("update:open", false);
     }
 
@@ -162,46 +147,19 @@ export default defineComponent({
       }
     }
 
-    function onPopState(e: PopStateEvent): void {
-      if (suppressPop > 0) {
-        // Our own restore traversal landing — not a user back gesture.
-        suppressPop--;
-        return;
-      }
-      const st = e.state as MenuHistoryState | null;
-      if (st?.__hkMenuId === instanceId) {
-        // Landed on one of our own entries — close exactly one level.
-        const depth = Math.max(0, st.__hkMenuDepth ?? 0);
-        mobileStack.value = props.open ? mobileStack.value.slice(0, depth) : [];
-        desktopPath.value = [];
-        pushedDepth = depth + 1;
-        if (!props.open) {
-          // Forward gesture into a spent stack while closed: release the
-          // ownership marker so a closed menu never owns live history.
-          window.history.replaceState(null, "");
-          pushedDepth = 0;
-        }
-        return;
-      }
-      if (!props.open && pushedDepth === 0) return; // idle; nothing to do
-      // Landed outside our stack — collapse whatever remains.
-      pushedDepth = 0;
-      mobileStack.value = [];
-      desktopPath.value = [];
-      emit("update:open", false);
-    }
-
     function pushLevel(title: string, items: HkMenuItem[]): void {
       mobileStack.value.push({ title, items });
-      pushHistoryEntry(mobileStack.value.length);
+      backGuard.push();
     }
 
     function popLevel(): boolean {
       if (mobileStack.value.length === 0) return false;
-      if (pushedDepth > 0 && window.history.state?.__hkMenuId === instanceId) {
-        // The popstate handler (ours, depth-1) truncates the stack — one
-        // source of truth for both drivers (in-app back and browser back).
-        window.history.back();
+      if (backGuard.entries > 0 && backGuard.ownsCurrent()) {
+        // The suppressed history.back() inside the guard lands without
+        // re-entering dispatch — truncate our visual stack here so
+        // in-app back and browser back stay in lockstep.
+        mobileStack.value = mobileStack.value.slice(0, -1);
+        backGuard.pop();
       } else {
         mobileStack.value.pop();
       }
@@ -216,7 +174,6 @@ export default defineComponent({
 
     onMounted(() => {
       if (props.variant === "sidebar") return; // no popover machinery
-      window.addEventListener("popstate", onPopState);
       window.addEventListener("resize", onResize);
     });
     onBeforeUnmount(() => {
@@ -224,10 +181,12 @@ export default defineComponent({
         manager.unregister(handle.value.id);
         handle.value = null;
       }
+      // Every variant registers its guard (the service is cheap for a
+      // never-pushed guard) — every variant must destroy it too, or
+      // sidebar mounts leak records and pin the module listener.
+      backGuard.destroy();
       if (props.variant === "sidebar") return;
-      window.removeEventListener("popstate", onPopState);
       window.removeEventListener("resize", onResize);
-      restoreHistory();
     });
 
     /**
@@ -248,10 +207,10 @@ export default defineComponent({
             manager.unregister(handle.value.id);
             handle.value = null;
           }
-          if (pushedDepth > 0 || mobileStack.value.length > 0 || desktopPath.value.length > 0) {
+          if (backGuard.entries > 0 || mobileStack.value.length > 0 || desktopPath.value.length > 0) {
             desktopPath.value = [];
             mobileStack.value = [];
-            restoreHistory();
+            backGuard.release();
           }
           return;
         }
@@ -260,12 +219,12 @@ export default defineComponent({
         }
         if (mobile) {
           // Normalize: exactly one fresh root entry above the page's history.
-          if (pushedDepth !== 0) restoreHistory();
-          pushHistoryEntry(0);
-        } else if (pushedDepth > 0) {
+          if (backGuard.entries !== 0) backGuard.release();
+          backGuard.push();
+        } else if (backGuard.entries > 0) {
           desktopPath.value = [];
           mobileStack.value = [];
-          restoreHistory();
+          backGuard.release();
         }
       },
       { immediate: true, flush: "sync" },

--- a/packages/vue/src/components/HkModal.test.tsx
+++ b/packages/vue/src/components/HkModal.test.tsx
@@ -67,3 +67,108 @@ describe("HkModal overlay integration", () => {
     expect(emitted).toEqual([]);
   });
 });
+
+describe("HkModal back-guard (window-first back priority)", () => {
+  async function settle(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+
+  /** Wait until pred() holds (history navigation settles asynchronously). */
+  async function until(pred: () => boolean, ms = 500): Promise<void> {
+    const deadline = Date.now() + ms;
+    while (!pred() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await nextTick();
+    }
+  }
+
+  it("pushes a history entry on open and back closes the modal, not the page", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: open.value,
+            closable: true,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await settle();
+
+    // The open modal owns one marked history entry above the page base.
+    expect((window.history.state as Record<string, unknown>)?.__hkBack).toEqual(expect.any(String));
+
+    // Browser/system back: closes the modal and stays on the page.
+    // (happy-dom never fires transition end events, so the leave
+    // animation keeps the DOM node — the logical state is what matters.)
+    window.history.back();
+    await until(() => open.value === false);
+    await until(() => window.history.state === null);
+    app.unmount();
+  });
+
+  it("closing via the X button rewinds the pushed entry (no dead back)", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: open.value,
+            closable: true,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await settle();
+    expect((window.history.state as Record<string, unknown>)?.__hkBack).toEqual(expect.any(String));
+
+    (document.querySelector(".hk-modal-close") as HTMLButtonElement).click();
+    await until(() => open.value === false);
+    // History rewound to the page base — a subsequent back leaves the page,
+    // it is not consumed by a spent modal entry.
+    await until(() => window.history.state === null);
+    app.unmount();
+  });
+
+  it("a non-closable modal never owns history", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: open.value,
+            closable: false,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          }, { default: () => h("div", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await settle();
+
+    expect((window.history.state as Record<string, unknown>)?.__hkBack).toBeUndefined();
+    app.unmount();
+  });
+});

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -16,6 +16,7 @@ import "./HkModal.scss";
 import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
+import { createBackGuard } from "../runtime/backStack";
 import HButton from "./HkButton";
 import HSpinner from "./HkSpinner";
 
@@ -45,6 +46,14 @@ export default defineComponent({
     windowed: { type: Boolean, default: false },
     overscanScreens: { type: Number, default: 1 },
     autoFollow: { type: Boolean, default: false },
+    /**
+     * Consume the browser/system back gesture while open (window-first
+     * back priority): a marked history entry is pushed on open so back
+     * closes the modal instead of leaving the page. Only meaningful
+     * together with `closable`; disable for surfaces that manage their
+     * own history entries.
+     */
+    backGuard: { type: Boolean, default: true },
   },
   emits: {
     "update:modelValue": (_value: boolean) => true,
@@ -82,6 +91,20 @@ export default defineComponent({
     const isFollowing = ref(true);
     let userScrolled = false;
     const scrollContainerRef = ref<HTMLElement>();
+
+    /**
+     * Window-first back priority: while this modal is the topmost open
+     * window, the back gesture (mobile back button/gesture, desktop
+     * browser back) closes it instead of navigating the page. Disabled
+     * for non-closable modals — back must not be swallowed by a surface
+     * it cannot close.
+     */
+    const backGuardEnabled = () => props.closable && props.backGuard;
+    const backGuard = createBackGuard({
+      onBack: () => {
+        if (backGuardEnabled()) close();
+      },
+    });
 
     function close() {
       emit("update:modelValue", false);
@@ -271,14 +294,30 @@ export default defineComponent({
           shouldRender.value = true;
           handle.value = manager.register("modal", true, props.title);
           overlay.open();
+          if (backGuardEnabled() && backGuard.entries === 0) {
+            backGuard.push();
+          }
         } else {
           // Close happens via Transition onAfterLeave,
           // but if modelValue flips to false without Transition
           // (e.g. immediate), clean up now.
           overlay.close();
+          backGuard.release();
         }
       },
       { immediate: true },
+    );
+
+    // closable/backGuard may flip while open (submit flows disable
+    // closing): keep the owned entry in lockstep so back is never a
+    // dead gesture on a surface it can no longer close.
+    watch(
+      backGuardEnabled,
+      (enabled) => {
+        if (unmounted || !props.modelValue) return;
+        if (enabled && backGuard.entries === 0) backGuard.push();
+        else if (!enabled && backGuard.entries > 0) backGuard.release();
+      },
     );
 
     watch(
@@ -298,6 +337,7 @@ export default defineComponent({
       unmounted = true;
       teardownWindowed();
       teardownAutoFollow();
+      backGuard.destroy();
       if (handle.value) {
         manager.unregister(handle.value.id);
         handle.value = null;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -158,6 +158,9 @@ export {
   closeAll,
   isOverlayOpen,
   TOAST_DURATION,
+  createBackGuard,
+  BACK_GUARD_MARKER,
+  BACK_GUARD_DEPTH,
   type AnimationHandle,
   useReportedTransition,
   type ReportedTransition,
@@ -174,6 +177,8 @@ export {
   type PageLifecycleState,
   type PageLifecycleListener,
   type SafeAreaInsets,
+  type BackGuard,
+  type BackGuardOptions,
 } from "./runtime";
 
 // i18n

--- a/packages/vue/src/runtime/backStack.test.ts
+++ b/packages/vue/src/runtime/backStack.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  BACK_GUARD_DEPTH,
+  BACK_GUARD_MARKER,
+  __backListenerActive,
+  __registeredBackGuards,
+  createBackGuard,
+} from "./backStack";
+
+/** Wait until pred() holds (history navigation settles asynchronously). */
+async function until(pred: () => boolean, ms = 500): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+/** Let deferred flushes + queued traversals commit (macrotask depth). */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 6; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+afterEach(async () => {
+  window.history.replaceState(null, "");
+  await settle();
+  window.history.replaceState(null, "");
+});
+
+describe("createBackGuard", () => {
+  it("pushes a marked entry and consumes one user back for a single window", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    const before = window.history.state;
+
+    g.push();
+    expect(g.entries).toBe(1);
+    expect((window.history.state as Record<string, unknown>)[BACK_GUARD_MARKER]).toBe(g.id);
+    expect((window.history.state as Record<string, unknown>)[BACK_GUARD_DEPTH]).toBe(0);
+    expect(before).toBeNull();
+
+    // User back gesture: lands on the page base — window collapses.
+    window.history.back();
+    await until(() => onBack.mock.calls.length > 0);
+    expect(onBack).toHaveBeenCalledWith(null);
+    expect(g.entries).toBe(0);
+    g.destroy();
+  });
+
+  it("dispatches multi-level backs with the landed depth", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push(); // root, depth 0
+    g.push(); // level 1
+    expect(g.entries).toBe(2);
+
+    window.history.back(); // → root entry
+    await until(() => onBack.mock.calls.length > 0);
+    expect(onBack).toHaveBeenLastCalledWith(0);
+    expect(g.entries).toBe(1);
+
+    window.history.back(); // → base
+    await until(() => onBack.mock.calls.length > 1);
+    expect(onBack).toHaveBeenLastCalledWith(null);
+    expect(g.entries).toBe(0);
+    g.destroy();
+  });
+
+  it("release rewinds owned entries without firing onBack (programmatic close)", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    g.push();
+
+    g.release();
+    await until(() => g.entries === 0);
+    // traversal landed on the base entry, suppressed
+    await until(() => window.history.state === null);
+    expect(onBack).not.toHaveBeenCalled();
+    g.destroy();
+  });
+
+  it("pop removes one level with a suppressed back", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    g.push();
+
+    g.pop();
+    await until(() => (window.history.state as Record<string, unknown>)?.[BACK_GUARD_DEPTH] === 0);
+    expect(onBack).not.toHaveBeenCalled();
+    expect(g.entries).toBe(1);
+    g.destroy();
+  });
+
+  it("gives the topmost window priority over an earlier one", async () => {
+    const onBackA = vi.fn();
+    const onBackB = vi.fn();
+    const a = createBackGuard({ onBack: onBackA });
+    const b = createBackGuard({ onBack: onBackB });
+
+    a.push(); // menu root
+    a.push(); // menu level 1
+    b.push(); // modal above the menu
+
+    // User back from the modal: lands on the menu's level-1 entry, but
+    // the TOPMOST window (b) must consume the gesture — not the menu.
+    window.history.back();
+    await until(() => onBackB.mock.calls.length > 0);
+    expect(onBackB).toHaveBeenCalledWith(null);
+    expect(onBackB).toHaveBeenCalledTimes(1);
+    expect(onBackA).not.toHaveBeenCalled();
+    expect(b.entries).toBe(0);
+    expect(a.entries).toBe(2); // menu untouched, still owns its levels
+
+    // Next back closes one menu level.
+    window.history.back();
+    await until(() => onBackA.mock.calls.length > 0);
+    expect(onBackA).toHaveBeenLastCalledWith(0);
+    a.destroy();
+    b.destroy();
+  });
+
+  it("dispatches by OPEN order, not mount order (regression)", async () => {
+    // Both guards exist (mounted) long before either opens; b opens
+    // first, a opens second — a is the topmost window.
+    const onBackA = vi.fn();
+    const onBackB = vi.fn();
+    const a = createBackGuard({ onBack: onBackA }); // mounted first
+    const b = createBackGuard({ onBack: onBackB }); // mounted second
+
+    b.push(); // b opens first
+    a.push(); // a opens second — visually on top
+
+    window.history.back();
+    await until(() => onBackA.mock.calls.length > 0);
+    expect(onBackA).toHaveBeenCalledTimes(1);
+    expect(onBackB).not.toHaveBeenCalled();
+    expect(a.entries).toBe(0);
+    expect(b.entries).toBe(1);
+    a.destroy();
+    b.destroy();
+  });
+
+  it("close A then open B in the same tick never fires a spurious back into B", async () => {
+    // The classic pattern: select a menu leaf → closeAll() → a modal
+    // opens synchronously. A's rewind must not compute from a history
+    // top that B's push already replaced.
+    const onBackA = vi.fn();
+    const onBackB = vi.fn();
+    const a = createBackGuard({ onBack: onBackA });
+    const b = createBackGuard({ onBack: onBackB });
+
+    a.push();
+    a.push();
+    a.release(); // queued rewind (deferred)
+    b.push(); // same tick: B opens above A's entries
+
+    await settle();
+    // A dropped its claim without traversing (B owns the top now).
+    expect(a.entries).toBe(0);
+    expect(b.entries).toBe(1);
+    // B must NOT have received a spurious onBack from A's stale rewind.
+    expect(onBackB).not.toHaveBeenCalled();
+    expect(onBackA).not.toHaveBeenCalled();
+
+    // The user's next back closes B (window-first), wherever it lands.
+    window.history.back();
+    await until(() => onBackB.mock.calls.length > 0);
+    expect(onBackB).toHaveBeenCalledTimes(1);
+    a.destroy();
+    b.destroy();
+  });
+
+  it("unmounting while a traversal is in flight never swallows the next real gesture", async () => {
+    // B1 regression: listener teardown with a stale suppression must
+    // reset the expectation, or the FIRST genuine back of the next
+    // window gets silently eaten.
+    const onBackA = vi.fn();
+    const a = createBackGuard({ onBack: onBackA });
+    a.push();
+    a.release(); // rewind queued; traversal in flight
+    a.destroy(); // unmount before it lands
+
+    // Whatever happens, the counters must not leak into the next guard.
+    await settle();
+    const onBackB = vi.fn();
+    const b = createBackGuard({ onBack: onBackB });
+    b.push();
+
+    window.history.back(); // genuine user gesture
+    await until(() => onBackB.mock.calls.length > 0, 800);
+    expect(onBackB).toHaveBeenCalledTimes(1);
+    b.destroy();
+  });
+
+  it("releases a spent marker when a forward gesture lands on it while closed", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    g.release();
+    await until(() => window.history.state === null);
+
+    // Forward onto the spent entry: the service de-marks it.
+    window.history.forward();
+    await until(() => window.history.state === null);
+    expect(
+      (window.history.state as Record<string, unknown> | null)?.[BACK_GUARD_MARKER],
+    ).toBeUndefined();
+    g.destroy();
+  });
+
+  it("leaves a foreign history top untouched when releasing beneath it", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+
+    // A router pushes above our entry.
+    window.history.pushState({ router: true }, "");
+    expect(g.ownsCurrent()).toBe(false);
+
+    g.release();
+    await settle();
+    expect(g.entries).toBe(0);
+    // The foreign entry's state is NOT damaged.
+    expect((window.history.state as Record<string, unknown>).router).toBe(true);
+    g.destroy();
+  });
+
+  it("forgets its claim and de-marks the current entry without traversing", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+
+    g.forget();
+    expect(g.entries).toBe(0);
+    expect(window.history.state).toBeNull(); // marker replaced in place
+    // No traversal was scheduled — history length unchanged.
+    const len = window.history.length;
+    await settle();
+    expect(window.history.length).toBe(len);
+    g.destroy();
+  });
+
+  it("drops the module listener once every guard is gone, and re-adds it later", async () => {
+    expect(__backListenerActive()).toBe(false);
+    const g = createBackGuard({ onBack: vi.fn() });
+    expect(__backListenerActive()).toBe(true);
+    g.destroy();
+    expect(__backListenerActive()).toBe(false);
+    expect(__registeredBackGuards()).toBe(0);
+  });
+});

--- a/packages/vue/src/runtime/backStack.ts
+++ b/packages/vue/src/runtime/backStack.ts
@@ -1,0 +1,337 @@
+/**
+ * Central back-guard service — window-first back navigation.
+ *
+ * Priority rule (user directive): the back gesture — the mobile
+ * back button/gesture and the desktop browser back button alike —
+ * must be consumed by the topmost open WINDOW first (modal, drawer,
+ * menu sheet stack); only when every window has closed does the
+ * gesture reach page history and actually navigate back.
+ *
+ * Mechanism (a generalization of HkMenu's battle-tested Android
+ * modal-navigation mode): every window-like surface pushes marked
+ * history entries while open, so a back gesture lands on an entry
+ * below the window instead of leaving the page. ONE module-level
+ * popstate listener dispatches each gesture to the guard that should
+ * consume it, and programmatic closes (X / Escape / overlay tap)
+ * rewind the entries the window pushed so the page's own history
+ * stays clean.
+ *
+ * Traversal discipline (the subtle part):
+ * - pushes are SYNCHRONOUS (marker depth must stack immediately);
+ * - rewinds (pop / release) are DEFERRED to a macrotask and
+ *   re-validated at execution time. A same-tick "close A, open B"
+ *   (select a menu leaf → closeAll → modal opens) must not fire a
+ *   go(-n) computed from a history top that B's push already
+ *   replaced: at flush time a guard that no longer owns the current
+ *   entry simply drops its claim (its markers stay buried and inert)
+ *   instead of yanking B's live entry to the forward stack;
+ * - a popstate while a suppressed traversal is in flight is ours;
+ *   any other is a user gesture. Listener teardown resets the
+ *   expectation so a stale counter can never swallow a later,
+ *   genuine gesture after the guard set changed.
+ *
+ * State markers stamped into history.state:
+ *   { __hkBack: <guardId>, __hkBackDepth: <0-based level> }
+ */
+
+import type { ShallowRef } from "vue";
+import { shallowRef } from "vue";
+
+/** history.state key holding the owning guard id. */
+export const BACK_GUARD_MARKER = "__hkBack";
+/** history.state key holding the 0-based level of the pushed entry. */
+export const BACK_GUARD_DEPTH = "__hkBackDepth";
+
+interface BackState {
+  [BACK_GUARD_MARKER]?: string;
+  [BACK_GUARD_DEPTH]?: number;
+}
+
+export interface BackGuardOptions {
+  /**
+   * A user back gesture arrived while this guard is the topmost window.
+   * `depth` is the landed entry's level when it belongs to this guard
+   * (multi-level surfaces — menu sheet stacks — truncate to it);
+   * `null` means the landing was outside this guard's stack and the
+   * surface must collapse entirely. The service has already updated
+   * its entry bookkeeping before the call.
+   */
+  onBack: (depth: number | null) => void;
+}
+
+export interface BackGuard {
+  readonly id: string;
+  /** History entries this guard currently owns above the page base. */
+  readonly entries: number;
+  /** Push one marked entry (opening a window / adding a level). */
+  push(): void;
+  /**
+   * In-app one-level back (a sheet's own back button): a suppressed
+   * history.back() deferred like every rewind. The caller truncates
+   * its own visual stack; the service only maintains history.
+   */
+  pop(): void;
+  /**
+   * Programmatic full close (X / Escape / overlay / unmount): rewind
+   * every entry this guard pushed via one suppressed traversal. When a
+   * foreign entry sits on top (a router or another window pushed while
+   * open) the live state is left untouched — the buried markers simply
+   * become inert and are released if the user ever lands on them.
+   */
+  release(): void;
+  /**
+   * Drop every entry claim WITHOUT touching history: for a surface
+   * that is already closed yet finds itself owning the current (spent)
+   * marker — de-marks it so a closed window never owns live history.
+   */
+  forget(): void;
+  /** True when the current history entry carries this guard's marker. */
+  ownsCurrent(): boolean;
+  /** Release and unregister from dispatch. */
+  destroy(): void;
+}
+
+interface GuardRecord {
+  id: string;
+  options: BackGuardOptions;
+  /** Live entry count — kept reactive for devtool-friendly consumers. */
+  count: ShallowRef<number>;
+  /** Entry count the surface WANTS (drives deferred rewinds). */
+  desired: number;
+}
+
+const hasWindow = typeof window !== "undefined";
+
+/**
+ * Dispatch stack, ordered by LAST ACTIVATION (last = topmost window).
+ * Guards register at component setup — mount order, not open order —
+ * so every 0→1 entry transition re-stamps the activation order; a
+ * window opened later must consume the back gesture first.
+ */
+const guards: GuardRecord[] = [];
+/**
+ * Records with a pending rewind claim — INCLUDING destroyed ones: a
+ * guard unmounted between release() and the flush must still rewind
+ * its entries (its markers live in history regardless), or the dead
+ * marker strands as the current entry.
+ */
+const rewindQueue = new Set<GuardRecord>();
+/** Popstate events produced by our own suppressed traversals. */
+let suppressCount = 0;
+/** A suppressed traversal has been issued and expects one popstate. */
+let traversalInFlight = false;
+/** Macrotask-scheduled rewind flush (single-flight). */
+let flushScheduled = false;
+let listening = false;
+
+function readState(): BackState | null {
+  if (!hasWindow) return null;
+  const st = window.history.state;
+  return st != null && typeof st === "object" ? (st as BackState) : null;
+}
+
+function onPopState(e: PopStateEvent): void {
+  if (suppressCount > 0) {
+    // Our own rewind traversal landing — not a user gesture.
+    suppressCount--;
+    traversalInFlight = false;
+    maybeDropListener();
+    return;
+  }
+  // Window priority: the topmost guard still owning entries consumes
+  // the gesture. Only when no window owns history does the gesture
+  // fall through to plain page navigation (handled by the router /
+  // the browser, not by us).
+  for (let i = guards.length - 1; i >= 0; i--) {
+    const g = guards[i];
+    if (g.count.value <= 0) continue;
+    const st =
+      e.state != null && typeof e.state === "object" ? (e.state as BackState) : null;
+    const own = st?.[BACK_GUARD_MARKER] === g.id;
+    const depth =
+      own && typeof st?.[BACK_GUARD_DEPTH] === "number" ? st[BACK_GUARD_DEPTH] : null;
+    g.count.value = depth === null ? 0 : depth + 1;
+    g.desired = g.count.value;
+    g.options.onBack(depth);
+    return;
+  }
+  // No window owns history: a forward gesture onto one of our spent
+  // marker entries releases the marker so closed surfaces never keep
+  // owning live history.
+  const st =
+    e.state != null && typeof e.state === "object" ? (e.state as BackState) : null;
+  if (typeof st?.[BACK_GUARD_MARKER] === "string") {
+    window.history.replaceState(null, "");
+  }
+}
+
+function ensureListener(): void {
+  if (!hasWindow || listening) return;
+  listening = true;
+  window.addEventListener("popstate", onPopState);
+}
+
+/**
+ * Drop the listener when nothing needs it — but NEVER while a
+ * suppressed traversal is still in flight (its landing popstate must
+ * be consumed here, or the expectation leaks into the next listener
+ * generation and swallows a genuine gesture). Teardown also clears a
+ * spent expectation: a landing nobody observes is harmless, a stale
+ * counter is not.
+ */
+function maybeDropListener(): void {
+  if (!hasWindow || !listening) return;
+  if (guards.length > 0 || traversalInFlight) return;
+  listening = false;
+  window.removeEventListener("popstate", onPopState);
+  suppressCount = 0;
+}
+
+/**
+ * Deferred rewind flush, re-validated at execution time. Only the
+ * record that still OWNS the current entry may traverse — a foreign or
+ * newer window push above it makes its count unreliable, so it DROPS
+ * the claim instead (its markers stay buried, inert, self-releasing).
+ * Destroyed records keep their place in the queue: their markers live
+ * in history regardless of the component tree.
+ */
+function scheduleRewind(record: GuardRecord): void {
+  if (!hasWindow) return;
+  rewindQueue.add(record);
+  if (flushScheduled) return;
+  flushScheduled = true;
+  setTimeout(() => {
+    flushScheduled = false;
+    const candidates = [...rewindQueue];
+    for (const g of guards) {
+      if (g.count.value > g.desired) candidates.push(g);
+    }
+    rewindQueue.clear();
+    for (const g of candidates) {
+      if (g.count.value <= g.desired) continue;
+      const st = readState();
+      if (st?.[BACK_GUARD_MARKER] === g.id) {
+        const n = g.count.value - g.desired;
+        g.count.value = g.desired;
+        if (n > 0) {
+          if (listening) {
+            suppressCount++;
+            traversalInFlight = true;
+          }
+          // With no listener attached (every guard unmounted before
+          // this flush ran), the landing popstate goes unobserved —
+          // issuing suppression bookkeeping anyway would leak the
+          // expectation into the next listener generation and eat a
+          // genuine gesture.
+          window.history.go(-n);
+        }
+        return; // one traversal per flush; nothing else can own the top
+      }
+      // Not ours to rewind (a router or newer window pushed above):
+      // abandon the entries where they lie — dead markers are
+      // released by the landing cleanup whenever the user reaches
+      // them, and forward-stack entries simply die with the session.
+      g.count.value = g.desired;
+    }
+  }, 0);
+}
+
+/**
+ * Create a back-guard for one window-like surface. The guard must be
+ * `destroy()`ed on unmount; `onBack` fires only for user gestures that
+ * this guard — as the topmost window — should consume.
+ */
+export function createBackGuard(options: BackGuardOptions): BackGuard {
+  const id = `hk-back-${Math.random().toString(36).slice(2, 10)}`;
+  const record: GuardRecord = { id, options, count: shallowRef(0), desired: 0 };
+  guards.push(record);
+  ensureListener();
+
+  function ownsCurrent(): boolean {
+    return readState()?.[BACK_GUARD_MARKER] === id;
+  }
+
+  return {
+    id,
+    get entries(): number {
+      return record.count.value;
+    },
+    push(): void {
+      if (!hasWindow) return;
+      window.history.pushState(
+        { [BACK_GUARD_MARKER]: id, [BACK_GUARD_DEPTH]: record.count.value },
+        "",
+      );
+      record.count.value++;
+      record.desired = record.count.value;
+      if (record.count.value === 1) {
+        // Open order wins over mount order for dispatch priority.
+        const i = guards.indexOf(record);
+        if (i >= 0 && i !== guards.length - 1) {
+          guards.splice(i, 1);
+          guards.push(record);
+        }
+      }
+    },
+    pop(): void {
+      if (!hasWindow || record.count.value <= 0) return;
+      // A foreign entry above ours means the history top is not ours to
+      // pop — the caller still truncates its visual stack locally.
+      if (!ownsCurrent()) return;
+      record.desired = record.count.value - 1;
+      scheduleRewind(record);
+    },
+    release(): void {
+      record.desired = 0;
+      if (!hasWindow) {
+        record.count.value = 0;
+        return;
+      }
+      if (record.count.value > 0) {
+        scheduleRewind(record);
+      } else {
+        record.count.value = 0;
+      }
+    },
+    forget(): void {
+      record.count.value = 0;
+      record.desired = 0;
+      if (hasWindow && ownsCurrent()) {
+        // Spent marker on the live entry — release ownership in place.
+        window.history.replaceState(null, "");
+      }
+    },
+    ownsCurrent,
+    destroy(): void {
+      this.release();
+      // A destroyed guard's rewind cannot wait for the deferred flush:
+      // later mounts (the next view, a router swap) stack entries above
+      // ours before the macrotask runs, and the deferred candidate can
+      // then only abandon — stranding our dead markers mid-stack, where
+      // every later rewind stops one short of the page base. The
+      // unmount sweep runs before sibling mounts within one patch, so
+      // rewinding synchronously here is safe.
+      if (hasWindow && record.count.value > 0 && ownsCurrent()) {
+        const n = record.count.value;
+        record.count.value = 0;
+        record.desired = 0;
+        rewindQueue.delete(record);
+        suppressCount++;
+        traversalInFlight = true;
+        window.history.go(-n);
+      }
+      const i = guards.indexOf(record);
+      if (i >= 0) guards.splice(i, 1);
+      maybeDropListener();
+    },
+  };
+}
+
+/** Test hook: how many guards are registered (leak detection). */
+export function __registeredBackGuards(): number {
+  return guards.length;
+}
+/** Test hook: does the module popstate listener currently exist? */
+export function __backListenerActive(): boolean {
+  return listening;
+}

--- a/packages/vue/src/runtime/index.ts
+++ b/packages/vue/src/runtime/index.ts
@@ -2,6 +2,13 @@ export * from "./animationBus";
 export * from "./cronBus";
 export * from "./intervalBus";
 export * from "./pageLifecycle";
+export {
+  createBackGuard,
+  BACK_GUARD_MARKER,
+  BACK_GUARD_DEPTH,
+  type BackGuard,
+  type BackGuardOptions,
+} from "./backStack";
 export { useMediaQuery, releaseMediaQuery } from "./useMediaQuery";
 export { useOverlay, closeAll, isOverlayOpen, type OverlayHandle, type UseOverlayOptions } from "./useOverlay";
 export { usePopupManager, type PopupHandle, type PopupKind } from "./usePopupManager";


### PR DESCRIPTION
## Summary

Window-first back priority for every window-like surface: the mobile
back gesture and the desktop browser back button now close the topmost
open window (modal / drawer / menu sheet) first; only when every window
has closed does the gesture reach page history and actually navigate.

## Implementation

- **`runtime/backStack.ts`** — central back-guard service generalizing
  HkMenu's Android modal-navigation mode: every window pushes marked
  history entries while open; ONE module-level popstate listener
  dispatches each gesture to the topmost open window (**open order, not
  mount order**); programmatic closes rewind via suppressed traversals.
- **`HkModal` / `HkDrawer`** — integrate via a `backGuard` prop
  (default on) gated by `closable`: non-closable surfaces never own
  history; mid-flight `closable` flips sync their entries.
- **`HkMenu`** — migrates onto the shared service, multi-level sheet
  semantics preserved; the sidebar variant now destroys its guard
  (fixes a record/listener leak).
- **Traversal discipline** — rewinds are deferred + re-validated at
  flush time (same-tick close-then-open never fires a stale traversal);
  `destroy` rewinds synchronously (unmount sweeps precede sibling
  mounts); a traversal issued with no listener skips suppression
  bookkeeping so a stale counter can never eat a later genuine gesture.

## Verification

- 392 vitest tests green (12 new service unit tests incl. open-order
  dispatch, same-tick close-then-open, unmount-mid-traversal, leak
  hooks; modal/drawer back-close coverage), vue-tsc clean, two
  consecutive full runs.
- Real-browser E2E (Chromium, 390px viewport): modal back-close keeps
  the page; nested modals peel one level per back; X-close leaves zero
  dead entries; router push while open then close leaves the router
  entry intact; drawer back-closes.

Closes the window-first back priority directive (PLAN P71).