### PR TITLE
🔧 Show only the status dot in compact connection footers.

### DIFF
--- a/packages/vue/src/components/HkStatusBar.test.tsx
+++ b/packages/vue/src/components/HkStatusBar.test.tsx
@@ -67,7 +67,7 @@ describe("HkStatusBar", () => {
     expect(panel!.textContent).toContain("HTTP poll");
   });
 
-  it("compact mode collapses the tag to the dot + translated status text", async () => {
+  it("compact mode shows the bare status dot with no text", async () => {
     const container = mountBar({
       version: "1.2.3",
       engineVersion: "9.8.7",
@@ -79,12 +79,15 @@ describe("HkStatusBar", () => {
 
     const tag = container.querySelector<HTMLElement>(".s-status-bar-tag")!;
     expect(tag.getAttribute("data-compact")).toBe("true");
-    // Translated connection state surfaces next to the dot.
-    const label = tag.querySelector<HTMLElement>(".s-status-bar-tag-label");
-    expect(label?.textContent).toBe("Connected");
-    // The version rows leave the visible pill: they are hidden inline by
-    // the [data-compact] CSS (styles/admin-tokens.scss) and the versions
-    // ride the aria-label for assistive tech instead.
+    // No translated status text next to the dot — the light alone, and
+    // tapping it opens the popover with the details.
+    const dot = tag.querySelector<HTMLElement>(".s-status-bar-dot");
+    expect(dot, "the status dot must render").toBeTruthy();
+    expect(dot!.style.background).toContain("rgb");
+    // No translated status text next to the dot (the version rows stay in
+    // the DOM but are visually hidden by the [data-compact] CSS).
+    expect(tag.textContent).not.toContain("Connected");
+    // Details ride the aria-label for assistive tech.
     expect(tag.getAttribute("aria-label")).toBe("Connected · 1.2.3 · 9.8.7");
   });
 });

--- a/packages/vue/src/components/HkStatusBar.tsx
+++ b/packages/vue/src/components/HkStatusBar.tsx
@@ -14,9 +14,11 @@ import { HkCountdownDigit } from "./HkCountdownDigit";
  * A traffic-light dot plus a two-column-grid version block (panel row,
  * engine row). Hovering/tapping the pill opens an HPopover with the
  * quality icon, latency, retry countdown and protocol/network rows.
- * With `compact` the pill collapses to the bare dot + translated status
- * text (mobile logged-in footers): the version rows move into the
- * popover and ride the aria-label for assistive tech.
+ * With `compact` the pill collapses to the bare status dot (mobile
+ * logged-in footers): no text at all — the light speaks for itself, and
+ * tapping it opens the popover with the full connection details. The
+ * version rows move into the popover and ride the aria-label for
+ * assistive tech.
  *
  * Styling rides the shared `s-status-bar*` classes from
  * `styles/admin-tokens.scss` (the `[data-compact]` rules hide the inline
@@ -173,12 +175,6 @@ export const HkStatusBar = defineComponent({
             <span class="s-status-bar-dot" style={{
               background: dotColorMap[mode] ?? dotColorMap.disconnected,
             }} />
-            {props.compact && (
-              /* Compact (mobile): surface the translated connection state
-               * next to the dot — the version block alone read as a version
-               * chip with no connection feedback. */
-              <span class="s-status-bar-tag-label" style={{ marginLeft: "2px" }}>{statusText}</span>
-            )}
             <span class="s-status-bar-tag-value">
               <span class="s-status-bar-tag-label">{t("hikari::statusBar.panel", "Panel")}</span>
               <span class="s-status-bar-version">{pv}</span>


### PR DESCRIPTION
HkStatusBar compact mode drops the translated status text — mobile footers show the bare traffic-light dot; tapping it still opens the popover with full connection details (latency/tier/versions), and the aria-label keeps the state for assistive tech. Test updated.