### PR TITLE
🐛 Keep the back-guard rewind claim through same-tick normalize pushes.

### DIFF
--- a/packages/vue/src/runtime/backStack.test.ts
+++ b/packages/vue/src/runtime/backStack.test.ts
@@ -174,6 +174,30 @@ describe("createBackGuard", () => {
     b.destroy();
   });
 
+  it("normalizes a same-tick release-then-push to exactly one entry (N1)", async () => {
+    // HkMenu's normalizer: a desktop→mobile flip releases the desktop
+    // residue (deferred rewind) and pushes a fresh root in the SAME
+    // tick. The rewind claim must survive the push, or the stale entry
+    // strands and one back turns into two.
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+
+    g.push(); // mobile root
+    g.release(); // desktop flip: rewind deferred
+    g.push(); // back to mobile, same tick
+
+    await settle();
+    expect(g.entries).toBe(1);
+    expect((window.history.state as Record<string, unknown>)[BACK_GUARD_DEPTH]).toBe(0);
+
+    // One back closes the menu entirely — not two.
+    window.history.back();
+    await until(() => onBack.mock.calls.length > 0);
+    expect(onBack).toHaveBeenCalledWith(null);
+    expect(g.entries).toBe(0);
+    g.destroy();
+  });
+
   it("unmounting while a traversal is in flight never swallows the next real gesture", async () => {
     // B1 regression: listener teardown with a stale suppression must
     // reset the expectation, or the FIRST genuine back of the next

--- a/packages/vue/src/runtime/backStack.ts
+++ b/packages/vue/src/runtime/backStack.ts
@@ -30,6 +30,16 @@
  *   expectation so a stale counter can never swallow a later,
  *   genuine gesture after the guard set changed.
  *
+ * Dead markers (documented trade-off): when a window closes while a
+ * foreign entry sits above it (a router pushed during the window's
+ * lifetime), its markers are buried mid-stack and cannot be removed —
+ * the history API has no delete-entry primitive. They are inert and
+ * self-releasing: the next back that lands on one is treated as plain
+ * navigation (the router re-syncs from the URL) and the marker is
+ * de-marked in place. A back through such a marker can therefore cost
+ * one extra press before the URL actually changes — the unavoidable
+ * price of keeping the router's live state intact.
+ *
  * State markers stamped into history.state:
  *   { __hkBack: <guardId>, __hkBackDepth: <0-based level> }
  */
@@ -202,9 +212,12 @@ function scheduleRewind(record: GuardRecord): void {
   flushScheduled = true;
   setTimeout(() => {
     flushScheduled = false;
-    const candidates = [...rewindQueue];
+    // A record can sit in the rewind queue AND still be registered (the
+    // normalizer's release-then-push), so collect into a Set to visit
+    // each exactly once.
+    const candidates = new Set<GuardRecord>(rewindQueue);
     for (const g of guards) {
-      if (g.count.value > g.desired) candidates.push(g);
+      if (g.count.value > g.desired) candidates.add(g);
     }
     rewindQueue.clear();
     for (const g of candidates) {
@@ -263,7 +276,13 @@ export function createBackGuard(options: BackGuardOptions): BackGuard {
         "",
       );
       record.count.value++;
-      record.desired = record.count.value;
+      // desired advances by ONE level, never snaps to count: a pending
+      // release() (desired = 0, rewind deferred) followed by a same-tick
+      // push — the HkMenu normalizer's "desktop → mobile" flip — must
+      // keep the rewind claim, or the flush sees count == desired and
+      // strands the stale entry (N1). Absolute writes (pop / release /
+      // dispatch landing) remain absolute: they assert a state, not a delta.
+      record.desired++;
       if (record.count.value === 1) {
         // Open order wins over mount order for dispatch priority.
         const i = guards.indexOf(record);


### PR DESCRIPTION
## Summary

Follow-up to #283: fix the N1 normalization drift and document the
remaining dead-marker trade-off.

## What

- **`push()` advances `desired` by one level instead of snapping it to
  `count`.** The HkMenu normalizer's desktop→mobile flip runs
  `release()` (desired=0, rewind deferred) + `push()` in the SAME tick;
  snapping desired back to count made the deferred flush see
  `count == desired` and skip the rewind, stranding the stale entry —
  one back turned into two. A relative `desired++` keeps the rewind
  claim alive so the flush correctly rewinds to exactly one entry.
- **flush candidates use a `Set`** so a record present in both the
  rewind queue and the registry (normalize release-then-push) is
  visited once (behaviour-identical, removes the duplicate visit).
- **Head comment documents the dead-marker trade-off** (N2): a marker
  buried mid-stack when a router pushed above the window cannot be
  deleted by the history API; it is inert and self-releasing, at the
  cost of one extra back until the router re-syncs from the URL.

## Verification

- 393 vitest green (new N1 regression test asserts exactly one entry
  after a same-tick release-then-push and a single back closing the
  surface), vue-tsc clean.
- HkDateTimePicker flake under full-suite NFS load is unrelated and
  passes 22/22 in isolation (also reproducible on clean master).
- N2/N3/N4 intentionally left unchanged: N2 is a history-API
  limitation (removing it needs hooking global pushState for direction
  detection, or breaks forward history), N3 is baseline-shared, N4 is
  B1's defensive code.

Closes P71 续 (PLAN P71-d).