### PR TITLE
🔥 Drop the compact-mode inline connection label from the status bar.

### DIFF
--- a/packages/vue/src/components/HkStatusBar.test.tsx
+++ b/packages/vue/src/components/HkStatusBar.test.tsx
@@ -67,7 +67,7 @@ describe("HkStatusBar", () => {
     expect(panel!.textContent).toContain("HTTP poll");
   });
 
-  it("compact mode collapses the tag to the dot + translated status text", async () => {
+  it("compact mode collapses the tag to the bare dot with no inline status text", async () => {
     const container = mountBar({
       version: "1.2.3",
       engineVersion: "9.8.7",
@@ -79,9 +79,16 @@ describe("HkStatusBar", () => {
 
     const tag = container.querySelector<HTMLElement>(".s-status-bar-tag")!;
     expect(tag.getAttribute("data-compact")).toBe("true");
-    // Translated connection state surfaces next to the dot.
-    const label = tag.querySelector<HTMLElement>(".s-status-bar-tag-label");
-    expect(label?.textContent).toBe("Connected");
+    // Standing user directive: mobile shows ONLY the traffic light — no
+    // translated connection state ("Connected"/"已连接"/…) renders next to
+    // the dot in compact mode. The state rides the aria-label, and the
+    // full status stays reachable through the tap popover.
+    const inlineLabel = tag.querySelector<HTMLElement>(".s-status-bar-tag-label");
+    // The only tag-label left in the tag is the CSS-hidden "Panel" row of
+    // the version block — its text must NOT be a connection state.
+    expect(inlineLabel?.textContent).not.toMatch(/connected|connecting|disconnected/i);
+    // The dot itself renders.
+    expect(tag.querySelector(".s-status-bar-dot"), "traffic-light dot renders").toBeTruthy();
     // The version rows leave the visible pill: they are hidden inline by
     // the [data-compact] CSS (styles/admin-tokens.scss) and the versions
     // ride the aria-label for assistive tech instead.

--- a/packages/vue/src/components/HkStatusBar.tsx
+++ b/packages/vue/src/components/HkStatusBar.tsx
@@ -14,9 +14,13 @@ import { HkCountdownDigit } from "./HkCountdownDigit";
  * A traffic-light dot plus a two-column-grid version block (panel row,
  * engine row). Hovering/tapping the pill opens an HPopover with the
  * quality icon, latency, retry countdown and protocol/network rows.
- * With `compact` the pill collapses to the bare dot + translated status
- * text (mobile logged-in footers): the version rows move into the
- * popover and ride the aria-label for assistive tech.
+ * With `compact` the pill collapses to the BARE DOT only (mobile
+ * logged-in footers) — no inline status text next to the light; that
+ * label is a standing user directive (asked to be removed repeatedly,
+ * re-introduced once by an upstreaming wave and reported again on
+ * 2026-08-25). The state stays reachable via the tap popover and the
+ * compact-mode aria-label; the version rows likewise move into the
+ * popover.
  *
  * Styling rides the shared `s-status-bar*` classes from
  * `styles/admin-tokens.scss` (the `[data-compact]` rules hide the inline
@@ -81,9 +85,10 @@ export const HkStatusBar = defineComponent({
     },
     standalone: { type: Boolean, default: true },
     /** Collapse the tag to the bare traffic-light dot (mobile logged-in
-     *  footers where the centered tab strip needs the width). The
-     *  version rows move into the hover/tap popover, and the versions
-     *  ride the aria-label for assistive tech. */
+     *  footers where the centered tab strip needs the width). NO inline
+     *  status text renders next to the dot (standing user directive);
+     *  the connection state rides the aria-label, and the version rows
+     *  move into the hover/tap popover. */
     compact: { type: Boolean, default: false },
     onRetry: { type: Function as PropType<() => void>, default: undefined },
     latencyMs: { type: Number, default: null },
@@ -173,12 +178,6 @@ export const HkStatusBar = defineComponent({
             <span class="s-status-bar-dot" style={{
               background: dotColorMap[mode] ?? dotColorMap.disconnected,
             }} />
-            {props.compact && (
-              /* Compact (mobile): surface the translated connection state
-               * next to the dot — the version block alone read as a version
-               * chip with no connection feedback. */
-              <span class="s-status-bar-tag-label" style={{ marginLeft: "2px" }}>{statusText}</span>
-            )}
             <span class="s-status-bar-tag-value">
               <span class="s-status-bar-tag-label">{t("hikari::statusBar.panel", "Panel")}</span>
               <span class="s-status-bar-version">{pv}</span>


### PR DESCRIPTION
## What

Mobile (compact) status-bar footers showed the translated connection state — 已连接 / Connecting… / 已断开 — next to the traffic-light dot. The standing user directive is **dot only** on mobile. PR #268's upstreaming wave re-introduced the label after it had previously been removed on request; the user reported it again on 2026-08-25.

## Change

- `HkStatusBar.tsx`: remove the `{props.compact && …statusText…}` inline label. Compact mode now renders only the dot (the version block was already `display:none` under `[data-compact]`).
- Accessibility preserved: the compact `aria-label` still carries `"<status> · <panel version> · <engine version>"`, and the tap/hover popover still shows the full status (state, latency, retry countdown, protocol/network rows, versions).
- `HkStatusBar.test.tsx`: rewritten to pin the dot-only contract — no inline connection text in compact mode.
- Doc comments on the component and the `compact` prop record the directive so future upstreaming waves don't resurrect the label.

## Verify

- `vue-tsc --noEmit` clean.
- Full vitest suite: 47 files / 393 tests green (incl. the rewritten compact test).
- Downstream: chest StatusBar passes `compact={isMobile}`; no other in-repo renderer of connection status text (backend-health tag is a separate segment and unaffected).

Reported-by: user (mobile web UI, shittim-chest footer)