### PR TITLE
🐛 Position the color picker slider thumb absolutely so it follows the value.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -144,6 +144,18 @@
 }
 
 .hk-color-picker-slider-thumb {
+  // Absolute INSIDE the slider container (the track is the only in-flow
+  // flex child and spans the full width, so `left: N%` of the container
+  // is N% of the track). Without this the thumb was a static flex item:
+  // the inline `left` from HkColorPicker.tsx is ignored on static
+  // elements and the thumb sat parked after the flex:1 track at the
+  // right edge on every layout, never following the value.
+  position: absolute;
+  top: 50%;
+  left: 0;
+  // Center the thumb ON the value point; hover scale must extend (not
+  // replace) this transform or the thumb would jump back half its size.
+  transform: translate(-50%, -50%);
   display: block;
   width: 14px;
   height: 14px;
@@ -157,7 +169,7 @@
   touch-action: none;
   -webkit-touch-callout: none;
 
-  &:hover { transform: scale(1.15); }
+  &:hover { transform: translate(-50%, -50%) scale(1.15); }
   &:active { cursor: grabbing; }
 }
 

--- a/packages/vue/src/components/HkColorPickerTouch.test.tsx
+++ b/packages/vue/src/components/HkColorPickerTouch.test.tsx
@@ -79,6 +79,15 @@ describe("HkColorPicker slider touch drag", () => {
     await nextTick();
     expect(rgb.value.r).toBeGreaterThanOrEqual(188);
     expect(rgb.value.r).toBeLessThanOrEqual(194);
+
+    // The thumb's inline left% must track the channel value: the CSS
+    // (position:absolute) turns this binding into the thumb's on-track
+    // position. Losing either half parks the thumb at the row's edge.
+    const thumb = rSlider.querySelector<HTMLElement>(".hk-color-picker-slider-thumb")!;
+    const pct = parseFloat(thumb.style.left);
+    expect(Number.isFinite(pct)).toBe(true);
+    expect(pct).toBeGreaterThan(73);
+    expect(pct).toBeLessThan(79);
   });
 
   it("stops tracking after pointercancel reclaims the gesture", async () => {


### PR DESCRIPTION
## Problem

The color picker's channel-slider thumb never moved from the right edge — on desktop and mobile alike, dragging changed the value (and the swatch/gradient) but the knob stayed parked on the right side, so it never indicated the actual value.

## Root cause

`.hk-color-picker-slider-thumb` had **no positioning**: as a static element the inline `left: N%` set by `HkColorPicker.tsx` is simply ignored, and as a static flex item the thumb always sat after the `flex: 1` track at the row's end. PR #263 fixed the drag *value* routing (window-level pointer listeners) but not the thumb geometry, which is why the knob still looked stuck.

## Fix

- `position: absolute` + `translate(-50%, -50%)` inside the existing `position: relative` slider container. The track is the only in-flow child and spans the container's full width, so `left: N%` of the container lands exactly at `N%` of the track — matching the in-repo precedent (`hk-media-slider-thumb`, `hk-color-picker-hue-band-thumb`).
- Hover scale merged into the same transform chain (`translate(-50%,-50%) scale(1.15)`) so hovering doesn't drop the centering.
- The touch-drag test now also pins the thumb's inline `left%` binding (the TSX half of the contract; the CSS half cannot be observed in happy-dom).
- Mobile sheet overrides only resize the thumb (14→22px), so the sheet layout inherits the fix — verified visually in both 1440px popover and 390px bottom-sheet: thumb center matches value% (e.g. 32→12.5%, 128→50.2%, 200→78.4%), and a synthetic drag updates both value and position (G 128→194 ⇒ thumb 76.1%).

## Verification

- 3-round verify cycle (3 independent subagent verifications, all PASS).
- Full suite: **393/393 tests**, `vue-tsc --noEmit` clean.
- No other rule in the repo touches these classes; downstream (chest) has no overrides — checked.
- Edge cases reasoned + visually checked: no clipping at 0%/100% (overhang stays within panel padding in both layouts), no transform conflicts, hue-band untouched, no RTL flipping (all physical properties).
- Version 0.6.3 → 0.6.4.