### PR TITLE
✨ Extract the select panel so custom triggers can open the dropdown surface.

### DIFF
--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -113,6 +113,30 @@
     </section>
 
     <section>
+      <h2>HSelectPanel</h2>
+      <div class="row">
+        <span style="align-self:center;color:var(--color-muted, gray)">custom trigger + checkbox rows:</span>
+        <span ref="panelAnchor" style="display:inline-flex">
+          <HButton @click="panel.open = !panel.open">Filter ▲</HButton>
+        </span>
+        <HSelectPanel
+          :open="panel.open"
+          @update:open="(v: boolean) => panel.open = v"
+          :anchor-ref="panelAnchor ?? null"
+          title="Filters"
+          placement="top-start"
+        >
+          <HCheckbox
+            v-for="opt in panel.opts"
+            :key="opt.key"
+            :model-value="panel.checked.includes(opt.key)"
+            @update:model-value="(v: boolean) => togglePanelOpt(opt.key, v)"
+          >{{ opt.label }}</HCheckbox>
+        </HSelectPanel>
+      </div>
+    </section>
+
+    <section>
       <h2>HSkeleton / HSkeletonList</h2>
       <div class="row">
         <HSkeleton width="100px" height="24px" />
@@ -273,7 +297,7 @@ import {
   HButton, HIconButton, HTooltip, HBadge, HTag, HIcon, HSpinner,
   HProgressBar, HProgressRing, HGaugeRing,
   HInput, HSearchInput, HNumberInput, HPasswordInput, HTextarea,
-  HCheckbox, HSwitch, HRadio, HSelect,
+  HCheckbox, HSwitch, HRadio, HSelect, HSelectPanel,
   HSkeleton, HSkeletonList, HAvatar, HKbd, HDivider,
   HAlert, HEmptyState, HExpansionPanel,
   HTabs, HMorphingTabs, HCard, HTable, HTimeline,
@@ -292,6 +316,21 @@ const flags = ref({ a: true, b: false, on: false, radio: 'x' })
 const radioOpts = [{ value: 'x', label: 'X' }, { value: 'y', label: 'Y' }]
 const gaugeRings = [{ pct: 45, color: 'rgb(var(--color-primary, 122 162 247))', trackColor: 'rgba(122, 162, 247, 0.15)' }]
 const select = ref({ val: '', opts: [{ value: 'a', label: 'Alpha' }, { value: 'b', label: 'Beta' }, { value: 'c', label: 'Gamma' }] })
+const panelAnchor = ref<HTMLElement | null>(null)
+const panel = ref({
+  open: false,
+  checked: ['a'] as string[],
+  opts: [
+    { key: 'a', label: 'Recent' },
+    { key: 'b', label: 'Starred' },
+    { key: 'c', label: 'Archived' },
+  ],
+})
+function togglePanelOpt(key: string, v: boolean) {
+  panel.value.checked = v
+    ? [...panel.value.checked, key]
+    : panel.value.checked.filter((k) => k !== key)
+}
 const tabs = ref({ active: 'tab1', items: [{ key: 'tab1', label: 'Overview' }, { key: 'tab2', label: 'Details' }, { key: 'tab3', label: 'Settings' }] })
 const morphTabs = ref({ active: 'm1', items: [{ key: 'm1', label: 'Read' }, { key: 'm2', label: 'Write' }, { key: 'm3', label: 'Preview' }] })
 

--- a/packages/vue/src/components/HkSelect.tsx
+++ b/packages/vue/src/components/HkSelect.tsx
@@ -2,19 +2,15 @@ import {
   computed,
   defineComponent,
   nextTick,
-  onBeforeUnmount,
   ref,
   watch,
   type PropType,
-  Teleport,
-  Transition,
 } from "vue";
 
 
-import { ChevronDown, Search } from "lucide-vue-next";
-import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
-import { useOverlay } from "../runtime/useOverlay";
+import { ChevronDown } from "lucide-vue-next";
 import { useBreakpoint } from "../runtime/useBreakpoint";
+import HkSelectPanel from "./HkSelectPanel";
 import "./HkSelect.scss";
 
 export interface HkSelectOption {
@@ -23,6 +19,12 @@ export interface HkSelectOption {
   disabled?: boolean;
 }
 
+/**
+ * Dropdown select. The opened panel — desktop popout and mobile sheet —
+ * lives in HkSelectPanel, the dropdown surface custom triggers may also
+ * invoke directly; this component owns the field chrome (label, trigger
+ * button, error) and the option model with keyboard navigation.
+ */
 export default defineComponent({
   name: "HkSelect",
   props: {
@@ -43,69 +45,14 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const isOpen = ref(false);
     const triggerRef = ref<HTMLElement>();
-    const panelRef = ref<HTMLElement>();
+    /** The panel surface (HkSelectPanel) — row queries stay scoped to it. */
+    const panelExpose = ref<{ panelEl: () => HTMLElement | null }>();
     const highlightedIndex = ref(-1);
 
-    // The popout registers with the popup manager so it stacks inside the
-    // shared overlay context (1000+2n) instead of a hardcoded z that later
-    // modals could overtake (select-in-modal used to get covered).
-    const manager = usePopupManager();
-    const handle = ref<PopupHandle | null>(null);
-    const popoutZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
-
-    // Registered with the overlay registry too so closeAll()/isOverlayOpen()
-    // see the open popout (unique per-instance ids — multiple selects can
-    // share the "hk-select" name without corrupting the registry). The
-    // onCloseRequested hook makes a global closeAll() flip this component's
-    // own open ref, which is what actually tears the popout down (the popup
-    // manager unregister happens in the isOpen watcher below).
-    const overlay = useOverlay({
-      name: "hk-select",
-      onCloseRequested: () => { isOpen.value = false; },
-    });
-
-    // Form factor: anchored popout on desktop, bottom sheet on phones.
-    // Crossing the breakpoint mid-flight closes the sheet rather than
-    // leaving it hung between shapes.
+    // Pointer-hover highlighting only applies to the desktop popout —
+    // master's sheet rows never had it (spurious tap-highlight on touch).
     const { isMobile } = useBreakpoint();
     const sheetMode = computed(() => isMobile.value);
-    watch(isMobile, () => {
-      if (isOpen.value) isOpen.value = false;
-    });
-
-    function onDocumentClick(e: MouseEvent) {
-      if (!isOpen.value || sheetMode.value) return;
-      const target = e.target as Node;
-      if (triggerRef.value?.contains(target)) return;
-      if (panelRef.value?.contains(target)) return;
-      isOpen.value = false;
-    }
-
-    watch(isOpen, (open) => {
-      if (open) {
-        handle.value = manager.register("dropdown", false);
-        overlay.open();
-        if (!sheetMode.value) {
-          document.addEventListener("click", onDocumentClick, true);
-        }
-      } else {
-        document.removeEventListener("click", onDocumentClick, true);
-        if (handle.value) {
-          manager.unregister(handle.value.id);
-          handle.value = null;
-        }
-        overlay.close();
-      }
-    });
-
-    onBeforeUnmount(() => {
-      document.removeEventListener("click", onDocumentClick, true);
-      overlay.close();
-      if (handle.value) {
-        manager.unregister(handle.value.id);
-        handle.value = null;
-      }
-    });
 
     const normalizedOptions = computed<HkSelectOption[]>(
       () => props.options ?? [],
@@ -179,6 +126,17 @@ export default defineComponent({
       }
     }
 
+    function scrollToHighlighted() {
+      // Scoped to OUR panel surface — a document-scoped query could hit
+      // another concurrently open panel's rows (HkPopupSelect rows carry
+      // the same data attribute).
+      const root = panelExpose.value?.panelEl();
+      const el = root?.querySelector(
+        `[data-select-index="${highlightedIndex.value}"]`,
+      );
+      el?.scrollIntoView({ block: "nearest" });
+    }
+
     watch(isOpen, (open) => {
       if (open) {
         const idx = normalizedOptions.value.findIndex(
@@ -193,28 +151,8 @@ export default defineComponent({
       }
     });
 
-    function scrollToHighlighted() {
-      const el = panelRef.value?.querySelector(
-        `[data-select-index="${highlightedIndex.value}"]`,
-      );
-      if (el) {
-        el.scrollIntoView({ block: "nearest" });
-      }
-    }
-
     watch(highlightedIndex, () => {
       scrollToHighlighted();
-    });
-
-    const triggerCoords = computed(() => {
-      if (!triggerRef.value) return {};
-      const rect = triggerRef.value.getBoundingClientRect();
-      return {
-        position: "fixed" as const,
-        top: `${rect.bottom + 4}px`,
-        left: `${rect.left}px`,
-        minWidth: `${rect.width}px`,
-      };
     });
 
     return () => (
@@ -239,85 +177,37 @@ export default defineComponent({
           <span class="hk-select-value">{displayLabel.value || props.placeholder}</span>
           <ChevronDown size={16} class="hk-select-arrow" />
         </button>
-        <Teleport to="body">
-          {sheetMode.value && isOpen.value && (
-            <div
-              class="hk-select-sheet-scrim"
-              style={{ zIndex: popoutZ.value - 1 }}
-              onClick={() => { isOpen.value = false; }}
-            />
-          )}
-          <Transition name="hk-select-sheet" appear>
-            {sheetMode.value && isOpen.value ? (
-              <div
-                ref={panelRef}
-                class="hk-select-sheet-panel"
-                style={{ zIndex: popoutZ.value }}
-                role="dialog"
-                aria-modal="true"
-                tabindex="-1"
-                onKeydown={onPopoutKeydown}
-              >
+        <HkSelectPanel
+          ref={panelExpose}
+          open={isOpen.value}
+          onUpdate:open={(v: boolean) => { isOpen.value = v; }}
+          anchorRef={triggerRef.value ?? null}
+          title={props.label ?? ""}
+          placement="bottom-start"
+          offset={4}
+          onKeydown={onPopoutKeydown}
+        >
+          {slots.default
+            ? slots.default()
+            : normalizedOptions.value.map((opt, i) => (
                 <div
-                  class="hk-select-sheet-grabber"
-                  aria-hidden="true"
-                  onClick={() => { isOpen.value = false; }}
-                />
-                {props.label ? (
-                  <div class="hk-select-sheet-title">{props.label}</div>
-                ) : null}
-                <div class="hk-select-sheet-list">
-                  {slots.default
-                    ? slots.default()
-                    : normalizedOptions.value.map((opt, i) => (
-                        <div
-                          key={opt.value}
-                          class="hk-select-option"
-                          data-highlighted={highlightedIndex.value === i || undefined}
-                          data-select-index={i}
-                          data-checked={opt.value === props.modelValue || undefined}
-                          data-disabled={opt.disabled || undefined}
-                          onClick={() => {
-                            if (!opt.disabled) select(opt.value);
-                          }}
-                        >
-                          <span>{opt.label}</span>
-                        </div>
-                      ))}
+                  key={opt.value}
+                  class="hk-select-option"
+                  data-highlighted={highlightedIndex.value === i || undefined}
+                  data-select-index={i}
+                  data-checked={opt.value === props.modelValue || undefined}
+                  data-disabled={opt.disabled || undefined}
+                  onClick={() => {
+                    if (!opt.disabled) select(opt.value);
+                  }}
+                  {...(isOpen.value && !sheetMode.value
+                    ? { onPointerenter: () => { highlightedIndex.value = i; } }
+                    : {})}
+                >
+                  <span>{opt.label}</span>
                 </div>
-              </div>
-            ) : null}
-          </Transition>
-          {!sheetMode.value && isOpen.value ? (
-            <div
-              ref={panelRef}
-              class="hk-select-popout"
-              style={{ ...triggerCoords.value, zIndex: popoutZ.value }}
-              onKeydown={onPopoutKeydown}
-            >
-              {slots.default
-                ? slots.default()
-                : normalizedOptions.value.map((opt, i) => (
-                    <div
-                      key={opt.value}
-                      class="hk-select-option"
-                      data-highlighted={highlightedIndex.value === i || undefined}
-                      data-select-index={i}
-                      data-checked={opt.value === props.modelValue || undefined}
-                      data-disabled={opt.disabled || undefined}
-                      onClick={() => {
-                        if (!opt.disabled) select(opt.value);
-                      }}
-                      onPointerenter={() => {
-                        highlightedIndex.value = i;
-                      }}
-                    >
-                      <span>{opt.label}</span>
-                    </div>
-                  ))}
-            </div>
-          ) : null}
-        </Teleport>
+              ))}
+        </HkSelectPanel>
         {props.error ? <p class="hk-select-error">{props.error}</p> : null}
       </div>
     );

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -1,0 +1,279 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+import type { ComponentPublicInstance } from "vue";
+
+import HkSelectPanel from "./HkSelectPanel";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  // happy-dom never fires transitionend, so leave transitions never
+  // finish and teleported panels linger on <body> — strip them or the
+  // next test's querySelector sees this test's panel.
+  document.body
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-sheet-panel, .hk-select-sheet-scrim")
+    .forEach((el) => el.remove());
+  setViewport(1200);
+});
+
+function setViewport(width: number) {
+  window.innerWidth = width;
+  window.dispatchEvent(new Event("resize"));
+}
+
+/**
+ * The custom-invocation rig: a plain button (NOT a dropdown trigger) that
+ * anchors a panel filled with checkbox rows — the exact "not a dropdown,
+ * but opens the dropdown's panel" shape downstream apps need.
+ */
+function mountPanel(props: Record<string, unknown> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const open = ref(false);
+  const checked = ref(["a"]);
+  const anchorEl = ref<HTMLElement | null>(null);
+  const keydownSpy = vi.fn();
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h("div", [
+          h(
+            "button",
+            {
+              ref: (el: Element | ComponentPublicInstance | null) => {
+                anchorEl.value = el as HTMLElement | null;
+              },
+              type: "button",
+              onClick: () => { open.value = !open.value; },
+            },
+            "filter",
+          ),
+          h(
+            HkSelectPanel,
+            {
+              open: open.value,
+              "onUpdate:open": (v: boolean) => { open.value = v; },
+              anchorRef: anchorEl.value,
+              title: "Filters",
+              placement: "top-start",
+              onKeydown: keydownSpy,
+              ...props,
+            },
+            {
+              default: () =>
+                ["a", "b"].map((k) =>
+                  h("label", { class: "row", key: k }, [
+                    h("input", {
+                      type: "checkbox",
+                      checked: checked.value.includes(k),
+                      onChange: () => {
+                        checked.value = checked.value.includes(k)
+                          ? checked.value.filter((x) => x !== k)
+                          : [...checked.value, k];
+                      },
+                    }),
+                    k,
+                  ]),
+                ),
+            },
+          ),
+        ]);
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { open, checked, container, keydownSpy };
+}
+
+describe("HkSelectPanel custom invocation", () => {
+  it("renders custom slot rows in an anchored popout on desktop", async () => {
+    const { container } = mountPanel();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await nextTick();
+
+    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+    expect(popout).toBeTruthy();
+    expect(popout.querySelectorAll("label.row")).toHaveLength(2);
+    // No sheet form on desktop widths.
+    expect(document.body.querySelector(".hk-select-sheet-panel")).toBeNull();
+  });
+
+  it("keeps the panel open while rows toggle (no auto-close)", async () => {
+    const { container, open } = mountPanel();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await nextTick();
+
+    const box = document.body.querySelector<HTMLInputElement>(".hk-select-popout label.row input")!;
+    box.click();
+    await nextTick();
+    expect(open.value).toBe(true);
+  });
+
+  it("closes on outside click but not on row clicks", async () => {
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    document.body.querySelector<HTMLElement>(".hk-select-popout label.row")!.click();
+    await nextTick();
+    expect(open.value).toBe(true);
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    outside.click();
+    await nextTick();
+    expect(open.value).toBe(false);
+    outside.remove();
+  });
+
+  it("forwards surface keydown to the owner and closes on surface Escape only", async () => {
+    const { open, keydownSpy } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect(keydownSpy).not.toHaveBeenCalled(); // document-level ≠ panel surface
+
+    document.body
+      .querySelector<HTMLElement>(".hk-select-popout")!
+      .dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+      );
+    expect(keydownSpy).toHaveBeenCalled();
+
+    // Escape on an unrelated input must NOT close the panel (no
+    // document-capture listener — Escape is surface-attached).
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await nextTick();
+    expect(open.value).toBe(true);
+
+    document.body
+      .querySelector<HTMLElement>(".hk-select-popout")!
+      .dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    await nextTick();
+    expect(open.value).toBe(false);
+  });
+
+  it("docks as a titled bottom sheet on mobile widths", async () => {
+    setViewport(375);
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    const sheet = document.body.querySelector<HTMLElement>(".hk-select-sheet-panel")!;
+    expect(sheet).toBeTruthy();
+    expect(sheet.getAttribute("aria-modal")).toBe("true");
+    expect(sheet.querySelector(".hk-select-sheet-title")!.textContent).toBe("Filters");
+    expect(sheet.querySelectorAll("label.row")).toHaveLength(2);
+    expect(document.body.querySelector(".hk-select-popout")).toBeNull();
+
+    (document.body.querySelector<HTMLElement>(".hk-select-sheet-scrim"))!.click();
+    await nextTick();
+    expect(open.value).toBe(false);
+  });
+
+  it("keeps the sheet mounted through its close so the leave transition runs", async () => {
+    setViewport(375);
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    const panel = document.body.querySelector<HTMLElement>(".hk-select-sheet-panel")!;
+    expect(panel).toBeTruthy();
+
+    open.value = false;
+    await nextTick();
+    // happy-dom never finishes leave transitions, so the panel lingers —
+    // exactly what a running slide-down leave looks like. A synchronous
+    // unmount (the regression this guards against) removes it instantly.
+    expect(document.body.querySelector(".hk-select-sheet-panel")).toBeTruthy();
+  });
+
+  it("registers with the popup manager when mounted already open", async () => {
+    // immediate:true — a panel mounted with open=true must land in the
+    // z band (handle z ≥ 1000), not the unregistered fallback.
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(true);
+    const anchorEl = ref<HTMLElement | null>(null);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h("div", [
+            h("button", {
+              ref: (el: Element | ComponentPublicInstance | null) => {
+                anchorEl.value = el as HTMLElement | null;
+              },
+              type: "button",
+            }, "anchor"),
+            h(
+              HkSelectPanel,
+              {
+                open: open.value,
+                "onUpdate:open": (v: boolean) => { open.value = v; },
+                anchorRef: anchorEl.value,
+                title: "Filters",
+              },
+              { default: () => h("label", { class: "row" }, "row") },
+            ),
+          ]);
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await nextTick();
+
+    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+    expect(popout).toBeTruthy();
+    const z = Number.parseInt(popout.style.zIndex, 10);
+    expect(z).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("places a top-start popout above the anchor and flips when cramped", async () => {
+    const { container, open } = mountPanel();
+    await nextTick();
+
+    const anchor = container.querySelector<HTMLButtonElement>("button")!;
+    anchor.getBoundingClientRect = () =>
+      ({ top: 500, bottom: 520, left: 40, right: 140, width: 100, height: 20 }) as DOMRect;
+    open.value = true;
+    await nextTick();
+
+    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+    const top = Number.parseInt(popout.style.top, 10);
+    // Anchor bottom at 520 → a top-start panel sits above 520 (minus offset).
+    expect(top).toBeLessThan(520);
+    expect(popout.style.minWidth).toBe("100px");
+
+    // Starved top side flips the panel below the anchor instead.
+    anchor.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 8, left: 40, right: 140, width: 100, height: 8 }) as DOMRect;
+    window.dispatchEvent(new Event("resize"));
+    await nextTick();
+    const flipped = Number.parseInt(popout.style.top, 10);
+    expect(flipped).toBeGreaterThan(8);
+  });
+});

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -1,0 +1,286 @@
+import {
+  computed,
+  defineComponent,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  Teleport,
+  Transition,
+  watch,
+  type PropType,
+} from "vue";
+
+import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import { useOverlay } from "../runtime/useOverlay";
+import { useBreakpoint } from "../runtime/useBreakpoint";
+import "./HkSelect.scss";
+
+/**
+ * The dropdown panel of HkSelect, detached from the select's trigger so it
+ * can be invoked in custom form.
+ *
+ * A dropdown's opened surface — the desktop popout geometry, the mobile
+ * bottom sheet (scrim + grabber + title), popup-manager z-stacking, the
+ * overlay registry entry, outside-click and Escape closing — is useful far
+ * beyond `<HkSelect>`: filter popovers anchored to icon buttons, checkbox
+ * list popovers, anything that should LOOK like a dropdown panel without
+ * BEING a dropdown. This component is that surface: give it an anchor
+ * element and arbitrary row content, and it behaves exactly like the panel
+ * a select would open.
+ *
+ * HkSelect itself delegates here (bottom-start + matched trigger width), so
+ * the two can never drift apart. Content is a plain default slot; keyboard
+ * events on the panel surface are forwarded (`keydown`) so owners that own
+ * an option model (like HkSelect) can run their own arrow/enter navigation.
+ */
+
+export type SelectPanelPlacement =
+  | "bottom-start"
+  | "bottom-end"
+  | "top-start"
+  | "top-end";
+
+const VIEWPORT_PAD = 8;
+
+export default defineComponent({
+  name: "HkSelectPanel",
+  props: {
+    /** Panel visibility — v-model:open. */
+    open: { type: Boolean, required: true },
+    /** Anchor element for the desktop popout (usually the custom trigger). */
+    anchorRef: { type: Object as PropType<HTMLElement | null>, default: null },
+    /** Sheet header on mobile / a11y name for the panel. */
+    title: { type: String, default: "" },
+    /** Base placement of the popout relative to the anchor (auto-flips). */
+    placement: {
+      type: String as PropType<SelectPanelPlacement>,
+      default: "bottom-start",
+    },
+    /** Gap between anchor and popout, in px. */
+    offset: { type: Number, default: 4 },
+    /** Popout min-width follows the anchor width (select parity). */
+    matchAnchorWidth: { type: Boolean, default: true },
+    /** Dock as a bottom sheet on phone-width viewports. */
+    sheetOnMobile: { type: Boolean, default: true },
+  },
+  emits: {
+    "update:open": (_v: boolean) => true,
+    /** Raw keydown from the panel surface (arrows/enter for option owners). */
+    keydown: (_e: KeyboardEvent) => true,
+  },
+  setup(props, { emit, slots, expose }) {
+    const manager = usePopupManager();
+    const handle = ref<PopupHandle | null>(null);
+    const popoutZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
+
+    // Overlay registry entry so closeAll()/isOverlayOpen() see the open
+    // panel; the onCloseRequested hook makes a global close flip the open
+    // prop, which is what actually tears the panel down.
+    const overlay = useOverlay({
+      name: "hk-select-panel",
+      onCloseRequested: () => { emit("update:open", false); },
+    });
+
+    const { isMobile } = useBreakpoint();
+    const sheetMode = computed(() => props.sheetOnMobile && isMobile.value);
+
+    // Crossing the mobile/desktop breakpoint mid-flight would leave a sheet
+    // hung between two form factors — close and let the user reopen in the
+    // shape the viewport now calls for (HkSelect's historic behavior).
+    watch(isMobile, () => {
+      if (props.open) emit("update:open", false);
+    });
+
+    const panelRef = ref<HTMLElement>();
+    const coords = ref<{ top?: string; left?: string; minWidth?: string }>({});
+
+    function close(): void {
+      emit("update:open", false);
+    }
+
+    function onDocumentClick(e: MouseEvent): void {
+      if (!props.open || sheetMode.value) return;
+      const target = e.target as Node;
+      if (props.anchorRef?.contains(target)) return;
+      if (panelRef.value?.contains(target)) return;
+      close();
+    }
+
+    // Escape is handled surface-attached (the panel's own onKeydown and,
+    // via forwarding, the owner) — NOT via a document-capture listener,
+    // which would close the panel on Escape pressed in unrelated inputs
+    // and run ahead of every other Escape handler on the page. This
+    // matches the library convention (HkPopover / HkModal surfaces).
+    function onSurfaceEscape(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        close();
+      }
+    }
+
+    function forwardKeydown(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        onSurfaceEscape(e);
+        return;
+      }
+      emit("keydown", e);
+    }
+
+    watch(
+      () => props.open,
+      (open) => {
+        if (open) {
+          handle.value = manager.register("dropdown", false);
+          overlay.open();
+          if (!sheetMode.value) {
+            document.addEventListener("click", onDocumentClick, true);
+          }
+          window.addEventListener("resize", onResize);
+        } else {
+          document.removeEventListener("click", onDocumentClick, true);
+          window.removeEventListener("resize", onResize);
+          if (handle.value) {
+            manager.unregister(handle.value.id);
+            handle.value = null;
+          }
+          overlay.close();
+        }
+      },
+      // immediate: mounting with open=true must register with the popup
+      // manager (z band) and overlay registry right away — the HkPopover /
+      // HkModal convention.
+      { immediate: true },
+    );
+
+    onBeforeUnmount(() => {
+      document.removeEventListener("click", onDocumentClick, true);
+      window.removeEventListener("resize", onResize);
+      overlay.close();
+      if (handle.value) {
+        manager.unregister(handle.value.id);
+        handle.value = null;
+      }
+    });
+
+    // ── desktop popout geometry ────────────────────────────────────
+    // Computed twice per opening: immediately from the anchor rect (with a
+    // height fallback so top placements land sensibly before measure) and
+    // again after the DOM settles, when the panel's real box is known and
+    // flip/clamp decisions can use actual numbers.
+    function positionPanel(): void {
+      const anchor = props.anchorRef;
+      if (!anchor) return;
+      const r = anchor.getBoundingClientRect();
+      // 0 (unstyled/test environments) counts as unmeasured — fall back.
+      const pw = panelRef.value?.offsetWidth || Math.max(r.width, 180);
+      const ph = panelRef.value?.offsetHeight || 200;
+      let side: "top" | "bottom" = props.placement.startsWith("top-") ? "top" : "bottom";
+      let top =
+        side === "top"
+          ? r.top - props.offset - ph
+          : r.bottom + props.offset;
+      // Auto-flip when the chosen side cannot host the panel.
+      if (side === "bottom" && top + ph > window.innerHeight - VIEWPORT_PAD) {
+        side = "top";
+        top = r.top - props.offset - ph;
+      } else if (side === "top" && top < VIEWPORT_PAD) {
+        side = "bottom";
+        top = r.bottom + props.offset;
+      }
+      let left = props.placement.endsWith("-end") ? r.right - pw : r.left;
+      const maxLeft = Math.max(VIEWPORT_PAD, window.innerWidth - VIEWPORT_PAD - pw);
+      left = Math.min(Math.max(left, VIEWPORT_PAD), maxLeft);
+      coords.value = {
+        top: `${Math.round(top)}px`,
+        left: `${Math.round(left)}px`,
+        ...(props.matchAnchorWidth ? { minWidth: `${Math.round(r.width)}px` } : {}),
+      };
+    }
+
+    function onResize(): void {
+      if (props.open && !sheetMode.value) positionPanel();
+    }
+
+    watch(
+      () => [props.open, props.anchorRef, props.placement] as const,
+      () => {
+        if (!props.open) return;
+        positionPanel();
+        void nextTick(positionPanel);
+      },
+      { immediate: true },
+    );
+
+    /** The live panel root element — sheet or popout, or null while closed.
+     * Lets option-owning consumers (HkSelect) scope row queries to THEIR
+     * panel instead of the whole document, where another open panel's
+     * rows (or HkPopupSelect's) could match first. */
+    expose({
+      panelEl: () => panelRef.value ?? null,
+    });
+
+    return () => {
+      // Sheet mode keeps its Teleport mounted across the close so the
+      // leave transition (slide-down) actually runs — unmounting the
+      // subtree on close would snap the sheet shut instead (the same
+      // reason HkPopover keeps its Teleport alive through the leave).
+      if (sheetMode.value) {
+        return (
+          <Teleport to="body">
+            <Transition name="hk-select-sheet" appear>
+              {props.open ? (
+                <div
+                  class="hk-select-sheet-scrim"
+                  style={{ zIndex: popoutZ.value - 1 }}
+                  onClick={close}
+                />
+              ) : null}
+            </Transition>
+            <Transition name="hk-select-sheet" appear>
+              {props.open ? (
+                <div
+                  ref={panelRef}
+                  class="hk-select-sheet-panel"
+                  style={{ zIndex: popoutZ.value }}
+                  role="dialog"
+                  aria-modal="true"
+                  aria-label={props.title || undefined}
+                  tabindex="-1"
+                  onKeydown={forwardKeydown}
+                >
+                  <div
+                    class="hk-select-sheet-grabber"
+                    aria-hidden="true"
+                    onClick={close}
+                  />
+                  {props.title ? (
+                    <div class="hk-select-sheet-title">{props.title}</div>
+                  ) : null}
+                  <div class="hk-select-sheet-list">{slots.default?.()}</div>
+                </div>
+              ) : null}
+            </Transition>
+          </Teleport>
+        );
+      }
+
+      // Desktop popout: no enter/leave transition on master either —
+      // mount on open, unmount on close.
+      if (!props.open) return null;
+      return (
+        <Teleport to="body">
+          <div
+            ref={panelRef}
+            class="hk-select-popout"
+            style={{ ...coords.value, zIndex: popoutZ.value }}
+            aria-label={props.title || undefined}
+            onKeydown={forwardKeydown}
+          >
+            {slots.default?.()}
+          </div>
+        </Teleport>
+      );
+    };
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -53,6 +53,7 @@ export { default as HScrollContainer } from "./components/HkScrollContainer";
 export { default as HSearchInput } from "./components/HkSearchInput";
 export { default as HSplash } from "./components/HkSplash";
 export { default as HSelect } from "./components/HkSelect";
+export { default as HSelectPanel, type SelectPanelPlacement } from "./components/HkSelectPanel";
 export { default as HSidebar } from "./components/HkSidebar";
 export { default as HSkeleton } from "./components/HkSkeleton";
 export { default as HSkeletonList } from "./components/HkSkeletonList";


### PR DESCRIPTION
## What

Extracts the opened panel of `HkSelect` — desktop popout + mobile bottom sheet, popup-manager z-stacking, overlay registry, outside-click/Escape close, placement geometry with auto-flip — into a new **`HkSelectPanel`** component that can be invoked in custom form: anchor it to any element, fill it with any rows. `HkSelect` itself now delegates to it, so the two cannot drift.

Motivated by the downstream chest change (demo CruiseDock time-range popover): the clock button is not a dropdown box, but the dropdown's opened panel is exactly the surface it should open — checkbox rows in the select panel.

## API

- Props: `open` (v-model:open), `anchorRef`, `title`, `placement` (bottom-start|bottom-end|top-start|top-end), `offset`, `matchAnchorWidth`, `sheetOnMobile`
- Emits: `update:open`, `keydown` (raw, forwarded from the panel surface)
- Expose: `panelEl()` — live panel root for scoped row queries
- Exported as `HSelectPanel` + type `SelectPanelPlacement`; 0.6.3 → 0.6.4

## Behavior notes

- Escape is surface-attached (panel surface / owner via forwarded keydown) — no document-capture listener; matches HkPopover/HkModal convention.
- Sheet Teleport stays mounted through close so the leave transition runs (parity with master's animated close).
- Mount-with-open registers with the popup manager immediately (`immediate: true`, HkPopover convention); pinned by a z ≥ 1000 test.
- Desktop popout gains auto-flip + viewport clamping.

## Verification (3-round cycle, all rounds subagent-verified)

- R1 FAIL→fixed: sheet leave animation (MAJOR), document-capture Escape, unscoped row queries.
- R2 FAIL→fixed: open watcher missing `immediate: true` (MAJOR), sheet pointerenter parity.
- R3 PASS: fixes verified in place; final audit clean.
- `vue-tsc --noEmit` 0 errors; `vitest run` 48 files / 401 tests green (8 new HkSelectPanel tests incl. leave-transition and z-band regression guards; legacy HkSelectSheet suite green through the delegation).
- Downstream sweep: no in-repo or downstream references to removed internals; no `isOverlayOpen("hk-select")` callers (arona/chest/plana/evernight/e.celestia.world swept); erp uses a vendored snapshot.

Demo: `DemoApp.vue` gains an HSelectPanel section (custom button trigger + HCheckbox rows).

Downstream: shittim-chest feat/cruise-time-checkboxes consumes this; merge this PR first.