### PR TITLE
✨ Make the select panel one back-gesture layer that closes before the page navigates.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -14,7 +14,7 @@ afterEach(() => {
   // finish and teleported panels linger on <body> — strip them or the
   // next test's querySelector sees this test's panel.
   document.body
-    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-sheet-panel, .hk-select-sheet-scrim")
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-popout, .hk-select-sheet-panel, .hk-select-sheet-scrim")
     .forEach((el) => el.remove());
   setViewport(1200);
 });
@@ -275,5 +275,105 @@ describe("HkSelectPanel custom invocation", () => {
     await nextTick();
     const flipped = Number.parseInt(popout.style.top, 10);
     expect(flipped).toBeGreaterThan(8);
+  });
+});
+
+describe("HkSelectPanel back-guard (window-first back priority)", () => {
+  /** nextTick + one macrotask: lets deferred rewinds (setTimeout 0) flush. */
+  async function settle(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+
+  /** Wait until pred() holds (history navigation settles asynchronously). */
+  async function until(pred: () => boolean, ms = 500): Promise<void> {
+    const deadline = Date.now() + ms;
+    while (!pred() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await nextTick();
+    }
+  }
+
+  it("back closes the open panel instead of navigating the page", async () => {
+    const { open, container } = mountPanel();
+    await nextTick();
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await settle();
+
+    // The open panel owns one marked history entry above the page base.
+    expect(
+      (window.history.state as Record<string, unknown>)?.__hkBack,
+    ).toEqual(expect.any(String));
+
+    // Browser/system back: closes the panel, stays on the page.
+    window.history.back();
+    await until(() => open.value === false);
+    await until(() => window.history.state === null);
+    expect(open.value).toBe(false);
+  });
+
+  it("closing via outside click rewinds the pushed entry (no dead back)", async () => {
+    const { open, container } = mountPanel();
+    await nextTick();
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await settle();
+    expect(
+      (window.history.state as Record<string, unknown>)?.__hkBack,
+    ).toEqual(expect.any(String));
+
+    // An ordinary close (outside click) rewinds the entry so no dead
+    // back remains — assert BOTH the logical close and the history base,
+    // so a broken rewind fails loudly instead of timing out silently.
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    outside.click();
+    outside.remove();
+    await until(() => open.value === false);
+    expect(open.value).toBe(false);
+    await until(() => window.history.state === null);
+    expect(window.history.state).toBeNull();
+  });
+
+  it("unmounting an open panel rewinds its entry (no stranded marker)", async () => {
+    const { container } = mountPanel();
+    await nextTick();
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await settle();
+    expect(
+      (window.history.state as Record<string, unknown>)?.__hkBack,
+    ).toEqual(expect.any(String));
+
+    // Unmount (e.g. route change) must not strand a dead marker entry.
+    const app = mounts.pop()!;
+    app.unmount();
+    await settle();
+    await until(() => window.history.state === null);
+    expect(window.history.state).toBeNull();
+  });
+
+  it("a same-tick close→reopen keeps the reopened panel guarded", async () => {
+    const { open, container } = mountPanel();
+    await nextTick();
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await settle();
+
+    // Close, let the watcher's close branch run (release claims the
+    // rewind), then reopen before the deferred flush fires — the flush
+    // must not consume the freshly pushed entry: after it settles the
+    // reopened panel still owns exactly one marked entry.
+    open.value = false;
+    await nextTick();
+    open.value = true;
+    await settle();
+    const st = window.history.state as Record<string, unknown> | null;
+    expect(st?.__hkBack).toEqual(expect.any(String));
+
+    // And the back gesture still closes it (not the page).
+    window.history.back();
+    await until(() => open.value === false);
+    expect(open.value).toBe(false);
+    await until(() => window.history.state === null);
+    expect(window.history.state).toBeNull();
   });
 });

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useOverlay } from "../runtime/useOverlay";
 import { useBreakpoint } from "../runtime/useBreakpoint";
+import { createBackGuard } from "../runtime/backStack";
 import "./HkSelect.scss";
 
 /**
@@ -27,6 +28,12 @@ import "./HkSelect.scss";
  * BEING a dropdown. This component is that surface: give it an anchor
  * element and arbitrary row content, and it behaves exactly like the panel
  * a select would open.
+ *
+ * The panel is one WINDOW layer for the back gesture (the shared
+ * window-first back priority — HkModal/HkMenu convention): opening pushes
+ * one marked history entry, so the first browser/system back closes the
+ * panel instead of navigating the page; any ordinary close (row click,
+ * Escape, outside click, scrim) rewinds the entry so no dead back remains.
  *
  * HkSelect itself delegates here (bottom-start + matched trigger width), so
  * the two can never drift apart. Content is a plain default slot; keyboard
@@ -84,6 +91,15 @@ export default defineComponent({
     const { isMobile } = useBreakpoint();
     const sheetMode = computed(() => props.sheetOnMobile && isMobile.value);
 
+    // Window-first back priority (HkModal convention): while this panel is
+    // the topmost window, the back gesture closes it instead of navigating
+    // the page. The service owns all history bookkeeping — push on open,
+    // rewind on close — so the panel is exactly one back layer wherever it
+    // is opened (real dropdown or custom invocation, popout or sheet).
+    const backGuard = createBackGuard({
+      onBack: () => { close(); },
+    });
+
     // Crossing the mobile/desktop breakpoint mid-flight would leave a sheet
     // hung between two form factors — close and let the user reopen in the
     // shape the viewport now calls for (HkSelect's historic behavior).
@@ -133,6 +149,13 @@ export default defineComponent({
         if (open) {
           handle.value = manager.register("dropdown", false);
           overlay.open();
+          // Release-then-push (the HkMenu normalizer form): a same-tick
+          // close→reopen must not leave the reopened panel unguarded —
+          // release() keeps its rewind claim (desired snaps to 0) and the
+          // following push() re-advances desired by one, so the pending
+          // flush rewinds exactly to the fresh entry instead of past it.
+          if (backGuard.entries > 0) backGuard.release();
+          backGuard.push();
           if (!sheetMode.value) {
             document.addEventListener("click", onDocumentClick, true);
           }
@@ -140,6 +163,7 @@ export default defineComponent({
         } else {
           document.removeEventListener("click", onDocumentClick, true);
           window.removeEventListener("resize", onResize);
+          backGuard.release();
           if (handle.value) {
             manager.unregister(handle.value.id);
             handle.value = null;
@@ -157,6 +181,7 @@ export default defineComponent({
       document.removeEventListener("click", onDocumentClick, true);
       window.removeEventListener("resize", onResize);
       overlay.close();
+      backGuard.destroy();
       if (handle.value) {
         manager.unregister(handle.value.id);
         handle.value = null;


### PR DESCRIPTION
## What

User-reported defect: the dropdown panel opened via `HkSelectPanel` (the shared surface behind BOTH the real `HkSelect` dropdown and custom invocations like the chest cruise clock popover) did not count as a back-gesture layer — pressing browser/system back while it was open navigated the page/window instead of first closing the panel.

Fix: integrate the shared back-guard service (`runtime/backStack.ts`) — the same window-first back priority `HkModal`/`HkMenu` already use:

- `createBackGuard({ onBack: close })` at setup
- open pushes ONE marked history entry (release-then-push form, the HkMenu normalizer pattern — a same-tick close→reopen keeps the reopened panel guarded; the service's N1 semantics at backStack.ts:279-285)
- any ordinary close (row click, Escape, outside click, scrim, breakpoint cross) rewinds the entry — no dead back left behind
- unmount rewinds synchronously — no stranded marker

Single implementation, every consumer inherits: real dropdown, custom invocation, desktop popout, mobile sheet. No new prop (always on, like HkMenu mobile sheets).

## Tests (12 in HkSelectPanel.test.tsx, +4 back-guard)

- back closes the open panel, not the page (marker asserted, then history.back() → closed + clean base)
- outside-click close rewinds the entry (hard asserts after each wait)
- unmount-while-open rewinds (no stranded marker)
- same-tick close→reopen keeps the reopened panel guarded (with the flush actually crossing the close branch — mutation-verified: removing close-branch `release()` fails both rewind tests)

## Verification

3-round cycle (count restarted once when a round caught a vacuous test — twice, both fixed with real close paths + hard asserts + mutation checks). Local: vue-tsc 0 errors, vitest 49 files / 407 tests green (neighbors: backStack 13, HkModal 5, HkMenu 11, HkSelect 2). Version 0.6.4 → 0.6.5.