### PR TITLE
✨ Add a shared alternative sign-in entry component to hikari.

### DIFF
--- a/packages/vue/src/components/HkAltSignIn.scss
+++ b/packages/vue/src/components/HkAltSignIn.scss
@@ -1,0 +1,55 @@
+/* HkAltSignIn — alternative sign-in trigger row + entry panel.
+   Token-driven only; mirrors the .s-auth-footer type/color grammar so the
+   row sits inside an auth card without breaking its rhythm. */
+
+.hk-alt-signin {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 100%;
+}
+
+.hk-alt-signin__trigger {
+  display: flex;
+  align-items: center;
+  gap: var(--space-8, 0.5rem);
+  width: 100%;
+  padding: var(--space-4, 0.25rem) 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font-size: var(--text-xs, 0.75rem);
+  color: var(--hi-color-muted, #666);
+  transition:
+    color var(--duration-normal, 0.3s) ease,
+    opacity var(--duration-normal, 0.3s) ease;
+}
+
+.hk-alt-signin__trigger:hover:not(:disabled) {
+  color: var(--hi-color-text-secondary, #999);
+}
+
+.hk-alt-signin__trigger:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Decorative rules flanking the label give the collapsed row the
+   "section divider" read while staying a single focusable button. */
+.hk-alt-signin__rule {
+  flex: 1 1 auto;
+  height: 1px;
+  background: var(--hi-color-border-subtle, rgba(0, 0, 0, 0.08));
+}
+
+.hk-alt-signin__label {
+  flex: 0 0 auto;
+}
+
+.hk-alt-signin__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2, 0.125rem);
+  min-width: 12rem;
+  padding: var(--space-4, 0.25rem) var(--space-4, 0.25rem);
+}

--- a/packages/vue/src/components/HkAltSignIn.test.tsx
+++ b/packages/vue/src/components/HkAltSignIn.test.tsx
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import HkAltSignIn from "./HkAltSignIn";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+const entries = [
+  { key: "passkey", label: "使用 passkey 登录" },
+  { key: "feishu", label: "飞书登录" },
+];
+
+function trigger(c: HTMLElement): HTMLButtonElement {
+  const el = c.querySelector<HTMLButtonElement>(".hk-alt-signin__trigger");
+  if (!el) throw new Error("trigger button not rendered");
+  return el;
+}
+
+describe("HkAltSignIn", () => {
+  it("renders the trigger label and decorative rules", () => {
+    const c = mount(
+      h(HkAltSignIn, {
+        label: "其他方式登录",
+        entries,
+        onSelect: () => undefined,
+      }),
+    );
+    expect(trigger(c).textContent).toContain("其他方式登录");
+    expect(c.querySelectorAll(".hk-alt-signin__rule").length).toBe(2);
+  });
+
+  it("opens the entry panel and emits select with the entry key", async () => {
+    const selected: string[] = [];
+    const c = mount(
+      h(HkAltSignIn, {
+        label: "更多",
+        entries,
+        onSelect: (k: string) => selected.push(k),
+      }),
+    );
+    trigger(c).click();
+    // The popover manager + flip coords resolve over a couple of frames.
+    for (let i = 0; i < 5 && !document.querySelector(".hk-alt-signin__panel"); i++) {
+      await nextTick();
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const panel = document.querySelector(".hk-alt-signin__panel");
+    expect(panel).not.toBeNull();
+    const items = [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-action-item")];
+    expect(items.map((b) => b.textContent?.trim())).toEqual([
+      "使用 passkey 登录",
+      "飞书登录",
+    ]);
+    items[1]!.click();
+    expect(selected).toEqual(["feishu"]);
+  });
+
+  it("does not open while disabled", async () => {
+    const c = mount(
+      h(HkAltSignIn, {
+        label: "更多",
+        entries,
+        disabled: true,
+        onSelect: () => undefined,
+      }),
+    );
+    trigger(c).click();
+    await nextTick();
+    expect(trigger(c).disabled).toBe(true);
+    expect(c.querySelector(".hk-alt-signin__panel")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkAltSignIn.tsx
+++ b/packages/vue/src/components/HkAltSignIn.tsx
@@ -1,0 +1,92 @@
+import { defineComponent, ref } from "vue";
+import HkPopover from "./HkPopover";
+import HkMenuActionItem from "./HkMenuActionItem";
+import "./HkAltSignIn.scss";
+
+/**
+ * Shared "alternative sign-in" entry for auth cards (P77).
+ *
+ * A small muted trigger row (styled in the `.s-auth-footer` grammar) that
+ * opens a popover listing third-party/alternative credential entries —
+ * platform passkey on shittim-chest, feishu OAuth on easy-hydro-erp — so
+ * both apps share one implementation and only differ in content.
+ *
+ * Entries render as [`HkMenuActionItem`] rows inside an [`HkPopover`]
+ * (glass panel, flip/escape/backdrop close, bottom-sheet on mobile), which
+ * gives keyboard and pointer handling for free.
+ */
+export default defineComponent({
+  name: "HkAltSignIn",
+  props: {
+    /** Trigger row text, e.g. "其他方式登录". Consumer-localized on
+     *  purpose: hikari ships no dictionary dependency onto hosts here. */
+    label: { type: String, required: true },
+    /** Alternative sign-in entries offered in the dropdown. */
+    entries: {
+      type: Array as unknown as () => Array<{
+        key: string;
+        label: string;
+        icon?: Record<string, unknown>;
+        danger?: boolean;
+      }>,
+      required: true,
+    },
+    disabled: { type: Boolean, default: false },
+    /** Popover placement around the trigger row. */
+    placement: {
+      type: String,
+      default: "top",
+    } as const,
+  },
+  emits: {
+    /** An entry was chosen; the popover closes automatically. */
+    select: (_key: string) => true,
+  },
+  setup(props, { emit }) {
+    const open = ref(false);
+    const anchor = ref<HTMLElement | null>(null);
+
+    function choose(key: string): void {
+      open.value = false;
+      emit("select", key);
+    }
+
+    return () => (
+      <div class="hk-alt-signin">
+        <button
+          ref={(el) => (anchor.value = el as HTMLElement | null)}
+          type="button"
+          class="hk-alt-signin__trigger"
+          aria-haspopup="menu"
+          aria-expanded={open.value}
+          disabled={props.disabled}
+          onClick={() => {
+            if (!props.disabled) open.value = !open.value;
+          }}
+        >
+          <span class="hk-alt-signin__rule" />
+          <span class="hk-alt-signin__label">{props.label}</span>
+          <span class="hk-alt-signin__rule" />
+        </button>
+        <HkPopover
+          modelValue={open.value}
+          onUpdate:modelValue={(v: boolean) => (open.value = v)}
+          placement={props.placement as never}
+          anchorRef={anchor.value}
+        >
+          <div class="hk-alt-signin__panel" role="menu">
+            {props.entries.map((entry) => (
+              <HkMenuActionItem
+                key={entry.key}
+                icon={entry.icon}
+                label={entry.label}
+                danger={entry.danger === true}
+                onClick={() => choose(entry.key)}
+              />
+            ))}
+          </div>
+        </HkPopover>
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,6 +1,7 @@
 export { default as HActionBar } from "./components/HkActionBar";
 export { default as HAdaptiveDialog } from "./components/HkAdaptiveDialog";
 export { default as HAlert } from "./components/HkAlert";
+export { default as HAltSignIn } from "./components/HkAltSignIn";
 export { default as HAvatar } from "./components/HkAvatar";
 export { default as HBadge } from "./components/HkBadge";
 export { default as HBlockingToast } from "./components/HkBlockingToast";


### PR DESCRIPTION
## Summary
Adds `HAltSignIn` (file `HkAltSignIn`), the shared 'other ways to sign in' entry for auth cards, so shittim-chest (passkey entry, P77) and easy-hydro-erp (feishu OAuth) can render identically-styled alternative sign-in rows from one implementation while owning their own content.

## Behavior
- Trigger = full-width divider-style row ('── 其他方式登录 ──') using only s-auth-footer token grammar.
- Open → `HkPopover` glass panel hosting one `HkMenuActionItem` per entry (`{key,label,icon?,danger?}[]`); emits `select(key)` and closes; escape/backdrop/outside-click close + mobile sheet come free from HkPopover.
- Label is consumer-localized on purpose (no hikari dictionary dependency for hosts).

## Verification
- vitest: 412 passed / 0 failed (incl. 3 new component tests: render+rules, open→select emission & ordering, disabled no-open).
- vue-tsc --noEmit: 0 errors mentioning the new files.