### PR TITLE
🐛 Retrigger the reconnect when a phone taps the status light.

### DIFF
--- a/packages/vue/src/components/HkStatusBar.test.tsx
+++ b/packages/vue/src/components/HkStatusBar.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick } from "vue";
 
 import { HkStatusBar } from "./HkStatusBar";
@@ -93,5 +93,85 @@ describe("HkStatusBar", () => {
     // the [data-compact] CSS (styles/admin-tokens.scss) and the versions
     // ride the aria-label for assistive tech instead.
     expect(tag.getAttribute("aria-label")).toBe("Connected · 1.2.3 · 9.8.7");
+  });
+
+  it("a touch tap on a disconnected light fires onRetry exactly once and opens the popover", async () => {
+    const onRetry = vi.fn();
+    const container = mountBar({
+      version: "1.2.3",
+      connectionStatus: "disconnected",
+      connectionInfo: INFO,
+      compact: true,
+      onRetry,
+    });
+    await nextTick();
+    const tag = container.querySelector<HTMLElement>(".s-status-bar-tag")!;
+
+    // Simulated one-finger tap without any synthesized mouse events —
+    // the degenerate case this fix exists for (browsers dropping the
+    // click half of the synthesis around mid-gesture DOM mutations).
+    const touch = { clientX: 12, clientY: 700 } as Touch;
+    const tap = () => {
+      tag.dispatchEvent(Object.assign(new Event("touchstart", { bubbles: true, cancelable: true }), {
+        touches: [touch],
+      }));
+      return Object.assign(new Event("touchend", { bubbles: true, cancelable: true }), {
+        touches: [],
+        changedTouches: [touch],
+      });
+    };
+    const endEvent = tap();
+    const preventDefault = vi.spyOn(endEvent, "preventDefault");
+    tag.dispatchEvent(endEvent);
+    await nextTick();
+
+    expect(onRetry, "tap retriggers the reconnect").toHaveBeenCalledTimes(1);
+    expect(preventDefault, "synthesized mouse chain is suppressed").toHaveBeenCalled();
+    // The popover opens so the tap gets visible feedback instead of a
+    // seemingly dead dot; touch-opened popovers dismiss outside.
+    const panel = document.body.querySelector<HTMLElement>(".hk-popover-panel");
+    expect(panel, "popover opens for feedback").toBeTruthy();
+    expect(panel!.textContent).toContain("Protocol");
+
+    // A late synthetic click slipping through the suppression must not
+    // double-fire within the dedup window.
+    tag.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+
+    // A second tap toggles the popover closed WITHOUT another retry.
+    tag.dispatchEvent(tap());
+    await nextTick();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    // happy-dom never fires transitionend, so the panel may still be
+    // mid leave-animation here; assert closure semantics (leaving or
+    // gone), not DOM removal timing.
+    const tail = document.body.querySelector<HTMLElement>(".hk-popover-panel");
+    if (tail) {
+      expect(tail.className).toContain("hk-popover-leave");
+    }
+  });
+
+  it("a scroll-like touch ending over the tag does not retry", async () => {
+    const onRetry = vi.fn();
+    const container = mountBar({
+      version: "1.2.3",
+      connectionStatus: "disconnected",
+      connectionInfo: INFO,
+      compact: true,
+      onRetry,
+    });
+    await nextTick();
+    const tag = container.querySelector<HTMLElement>(".s-status-bar-tag")!;
+    const start = { clientX: 12, clientY: 400 } as Touch;
+    tag.dispatchEvent(Object.assign(new Event("touchstart", { bubbles: true, cancelable: true }), {
+      touches: [start],
+    }));
+    tag.dispatchEvent(Object.assign(new Event("touchend", { bubbles: true, cancelable: true }), {
+      touches: [],
+      changedTouches: [{ clientX: 14, clientY: 610 } as Touch],
+    }));
+    await nextTick();
+    expect(onRetry, "flick is not a tap").not.toHaveBeenCalled();
+    expect(document.body.querySelector(".hk-popover-panel")).toBeNull();
   });
 });

--- a/packages/vue/src/components/HkStatusBar.tsx
+++ b/packages/vue/src/components/HkStatusBar.tsx
@@ -100,6 +100,15 @@ export const HkStatusBar = defineComponent({
     const popupOpen = ref(false);
     const anchorRef = ref<HTMLElement | null>(null);
     let closeTimer: ReturnType<typeof setTimeout> | null = null;
+    // Tap-vs-gesture discrimination for the touch activation path below.
+    let touchStartedAt = 0;
+    let touchStartX = 0;
+    let touchStartY = 0;
+    // Whether the CURRENTLY open popover was opened by a touch tap
+    // (instead of a mouse hover). Touch has no hover model, so such a
+    // popover must close on an outside tap rather than on mouseleave —
+    // otherwise it would hang open forever on phones.
+    const touchOpenedPopover = ref(false);
 
     const dotColorMap: Record<string, string> = {
       connected: "rgb(var(--color-success))",
@@ -112,19 +121,88 @@ export const HkStatusBar = defineComponent({
       if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
       popupOpen.value = true;
     }
+    function closePopover() {
+      popupOpen.value = false;
+      // Clear the touch-origin marker on EVERY close path so hybrid
+      // devices never carry it into a later hover-open popover.
+      touchOpenedPopover.value = false;
+    }
     function onTagLeave() {
-      closeTimer = setTimeout(() => { popupOpen.value = false; }, 250);
+      closeTimer = setTimeout(() => { closePopover(); }, 250);
     }
     function onPopupEnter() {
       if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
     }
     function onPopupLeave() {
-      popupOpen.value = false;
+      closePopover();
     }
+    // Belt-and-braces echo guard: preventDefault stops the synthesized
+    // mouse chain on every mainstream engine, but should one slip
+    // through anyway, a synthetic click must never double-fire the
+    // retry behind a touch tap. Real user clicks always arrive later
+    // than this short window.
+    let touchEchoGuardUntil = 0;
     function onTagClick() {
+      if (Date.now() < touchEchoGuardUntil) return;
       if (props.connectionStatus !== "connected") {
         props.onRetry?.();
       }
+    }
+
+    // ── Touch activation ────────────────────────────────────────────
+    // Mobile tap-to-retry used to ride the SYNTHESIZED mouse chain
+    // (touchend → mouseenter → click → mouseleave), which browsers may
+    // reorder or drop around mid-gesture DOM mutations — the popover
+    // flashing open could swallow the very click that should have
+    // re-triggered the reconnect. The pointer path now OWNS taps:
+    // preventDefault stops the synthesis entirely, so one touchend
+    // performs the action deterministically. Mouse hover and keyboard
+    // behavior are untouched.
+    function onTouchStart(e: TouchEvent) {
+      const t0 = e.touches[0];
+      if (!t0) return;
+      touchStartedAt = Date.now();
+      touchStartX = t0.clientX;
+      touchStartY = t0.clientY;
+    }
+
+    // A canceled gesture (palm, system gesture edge, incoming call)
+    // invalidates the pending tap bookkeeping.
+    function onTouchCancel() {
+      touchStartedAt = 0;
+    }
+
+    function onTouchEnd(e: TouchEvent) {
+      // Only single-finger taps count; continuation touches of
+      // multi-finger gestures fall through untouched.
+      if (e.touches.length > 0) return;
+      const t0 = e.changedTouches[0];
+      if (!t0 || touchStartedAt === 0) return;
+      // A scroll/flick that happens to end over the element is not a
+      // tap: require near-zero travel and a short press.
+      const moved = Math.hypot(t0.clientX - touchStartX, t0.clientY - touchStartY);
+      const heldMs = Date.now() - touchStartedAt;
+      touchStartedAt = 0;
+      if (moved > 12 || heldMs > 900) return;
+      if (e.cancelable) e.preventDefault();
+
+      if (popupOpen.value && touchOpenedPopover.value) {
+        // Tapping again toggles the details popover closed. The echo
+        // guard re-arms here too: a late synthetic click after this
+        // close must not fire an unguarded retry.
+        closePopover();
+        touchEchoGuardUntil = Date.now() + 400;
+        return;
+      }
+      touchOpenedPopover.value = true;
+      popupOpen.value = true;
+      // The whole point: a red light answers a tap with an immediate
+      // reconnect attempt plus visible feedback — the popover shows the
+      // probing/retrying rows instead of leaving a seemingly dead dot.
+      // The echo guard arms only AFTER the real activation so it blocks
+      // late synthetic clicks, never the tap itself.
+      onTagClick();
+      touchEchoGuardUntil = Date.now() + 400;
     }
 
     return () => {
@@ -168,6 +246,9 @@ export const HkStatusBar = defineComponent({
             onMouseenter={onTagEnter}
             onMouseleave={onTagLeave}
             onClick={onTagClick}
+            onTouchstart={onTouchStart}
+            onTouchend={onTouchEnd}
+            onTouchcancel={onTouchCancel}
             onKeydown={(e: KeyboardEvent) => {
               if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onTagClick(); }
             }}
@@ -195,7 +276,11 @@ export const HkStatusBar = defineComponent({
             onUpdate:modelValue={(v: boolean) => { popupOpen.value = v; }}
             placement="top-start"
             backdrop={false}
-            closeOnBackdrop={false}
+            // Touch has no hover model: a tap-opened popover would only
+            // close via the mouseleave timer that never fires, so it
+            // dismisses on an outside tap instead. Hover-opened
+            // (desktop) popovers keep the leave-timer semantics.
+            closeOnBackdrop={touchOpenedPopover.value}
             anchorRef={anchorRef.value}
           >
             <div

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -224,6 +224,20 @@
   .s-status-bar-tag-value {
     display: none;
   }
+
+  /* Invisible touch slop around the pill: the visible light is
+     intentionally tiny, but its tap target must satisfy the same
+     thumb-reach standard as the mobile sheet/confirm controls (the
+     landed effective target is ~35x56px). The tag itself carries
+     position:relative inline, so this pseudo rides along with zero
+     layout shift; vertical slop dominates because corner taps land
+     off-axis, horizontal stays small so the sliver stolen from the
+     footer gap never covers the first tab. */
+  &::after {
+    content: "";
+    position: absolute;
+    inset: -14px -6px;
+  }
 }
 
 .s-status-bar-version,


### PR DESCRIPTION
## Problem (user report)

On phones, tapping the bottom-left connection indicator while disconnected did not re-trigger the reconnect. The deployed bundle already wires the click handler to `onRetry → forceReconnect()`, so the failure is in the interaction layer, not a missing wire.

## Root causes

1. **Synthesized mouse chain** — mobile taps ran through touchend → mouseenter → click → mouseleave. Engines may reorder/suppress links of that chain around mid-gesture DOM mutations; the popover flashing open could swallow the very click that should have reconnected.
2. **Touch-opened popover could never close** — its only close path was the mouseleave timer, which touch devices never fire.
3. **Sub-standard hit target** — the compact pill measured ~23×28px against this project's own thumb-reach standard.

## Fix

- `HkStatusBar.tsx`: the pointer path now owns taps — one-finger low-travel short-touch gestures call `preventDefault()` (suppressing synthesis) and deterministically toggle the popover + fire `onRetry` for non-connected states. A 400ms echo guard blocks late synthetic clicks from double-firing; `touchcancel` clears pending bookkeeping; the touch-origin flag resets on every close path so hybrid hover/touch devices never leak it into later popovers.
- `admin-tokens.scss`: invisible `:after` touch slop (`inset: -14px -6px`) on `[data-compact]` — effective target ~35×56px, zero layout shift, sized so the stolen footer gap never covers the first tab.
- Keyboard paths (role=button/Enter/Space) and desktop hover semantics are byte-identical.

## Verification

- Full hikari suite 411/411 green (two new tests: tap→retry-once+popover+late-click dedup; flick does not retry).
- vue-tsc clean, admin-tokens.scss compiles (emitted `[data-compact]::after` rule verified).
- Independent reviewer subagent re-ran tests and audited state machine / HkPopover shield interplay / stacking: PASS.

Consumer note: chest consumes hikari via workspace link and needs no code change; companion fix for the dead `forceReconnect` paths on anonymous clients and frozen background recovery loops is in celestia-island/plana.