### PR TITLE
✨ Center panel loading spinners on both axes by default.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.6",
+  "version": "0.7.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -5,9 +5,24 @@
   gap: var(--space-8);
 }
 
+/* center — the shared loading-state placement contract: the spinner is
+   centered on BOTH axes relative to whatever panel/page/modal container
+   it is dropped into. The wrapper stretches to fill flexible parents and
+   carries a min-height floor, so even auto-height block parents place
+   the circle mid-panel instead of pinning it against the top edge (or,
+   uncentered, top-left). Column layout stacks spinner above optional
+   text; `gap` then spaces them vertically. Per-site geometry can be
+   tuned with --hk-loading-min-height (or the minHeight prop). */
 .hk-spinner-centered {
+  flex-direction: column;
   justify-content: center;
-  padding: var(--space-32) 0;
+  align-items: center;
+  width: 100%;
+  box-sizing: border-box;
+  align-self: stretch;
+  flex: 1 0 auto;
+  min-height: var(--hk-loading-min-height, clamp(6rem, 32vh, 14rem));
+  padding: var(--space-24) var(--space-16);
 }
 
 .hk-spinner {

--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -12,8 +12,7 @@
    the circle mid-panel instead of pinning it against the top edge (or,
    uncentered, top-left). Column layout stacks spinner above optional
    text; `gap` then spaces them vertically. Per-site geometry can be
-   tuned with --hk-loading-min-height (or the minHeight prop). */
-.hk-spinner-centered {
+   tuned with --hk-loading-min-height (or the minHeight prop). */.hk-spinner-centered {
   flex-direction: column;
   justify-content: center;
   align-items: center;
@@ -25,8 +24,15 @@
   height: 100%;
   box-sizing: border-box;
   align-self: stretch;
-  flex: 1 0 auto;
-  min-height: var(--hk-loading-min-height, clamp(6rem, 32vh, 14rem));
+  /* grow without shrink: min-height already floors the box, so letting
+     it shrink cannot go below the floor but avoids a rigid-sibling
+     overflow trap in tight flex rows. */
+  flex: 1 1 auto;
+  /* Predictable mid-panel presence on every viewport: a fixed floor,
+     not fluid scaling (fluid values hit their cap on all realistic
+     heights and balloon compact drawer/modal loading strips). Sites
+     wanting more presence tune --hk-loading-min-height locally. */
+  min-height: var(--hk-loading-min-height, 8rem);
   padding: var(--space-24) var(--space-16);
 }
 

--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -12,7 +12,8 @@
    the circle mid-panel instead of pinning it against the top edge (or,
    uncentered, top-left). Column layout stacks spinner above optional
    text; `gap` then spaces them vertically. Per-site geometry can be
-   tuned with --hk-loading-min-height (or the minHeight prop). */.hk-spinner-centered {
+   tuned with --hk-loading-min-height (or the minHeight prop). */
+.hk-spinner-centered {
   flex-direction: column;
   justify-content: center;
   align-items: center;

--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -18,6 +18,11 @@
   justify-content: center;
   align-items: center;
   width: 100%;
+  /* Block-formatting parents have no flex distribution: height:100%
+     claims their definite height directly (flex parents instead satisfy
+     it via stretch/grow below), while auto-height parents treat it as
+     auto and fall back to the min-height floor. */
+  height: 100%;
   box-sizing: border-box;
   align-self: stretch;
   flex: 1 0 auto;

--- a/packages/vue/src/components/HkSpinner.test.tsx
+++ b/packages/vue/src/components/HkSpinner.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import HkSpinner from "./HkSpinner";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkSpinner", () => {
+  it("renders the bare wheel without the centered contract by default", () => {
+    const c = mount(h(HkSpinner));
+    const wrapper = c.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(wrapper.className).not.toContain("hk-spinner-centered");
+    expect(wrapper.querySelector(".hk-spinner")).not.toBeNull();
+  });
+
+  it("center opts into the two-axis loading-state placement class", () => {
+    const c = mount(h(HkSpinner, { center: true }));
+    const wrapper = c.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(wrapper.className).toContain("hk-spinner-centered");
+  });
+
+  it("minHeight only emits the tuning custom property in centered mode", () => {
+    const c = mount(h(HkSpinner, { center: true, minHeight: 96 }));
+    const wrapper = c.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(wrapper.style.getPropertyValue("--hk-loading-min-height")).toBe("96px");
+
+    const c2 = mount(h(HkSpinner, { minHeight: "5rem" }));
+    const inline = c2.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(inline.style.getPropertyValue("--hk-loading-min-height")).toBe("");
+  });
+
+  it("stacks optional text below the wheel", () => {
+    const c = mount(h(HkSpinner, { center: true, text: "Loading" }));
+    const text = c.querySelector(".hk-spinner-text") as HTMLElement;
+    expect(text.textContent).toBe("Loading");
+  });
+});

--- a/packages/vue/src/components/HkSpinner.test.tsx
+++ b/packages/vue/src/components/HkSpinner.test.tsx
@@ -45,6 +45,16 @@ describe("HkSpinner", () => {
     expect(inline.style.getPropertyValue("--hk-loading-min-height")).toBe("");
   });
 
+  it("centered mode without minHeight leaves the floor fallback in place", () => {
+    const c = mount(h(HkSpinner, { center: true }));
+    const wrapper = c.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(wrapper.style.getPropertyValue("--hk-loading-min-height")).toBe("");
+
+    const empty = mount(h(HkSpinner, { center: true, minHeight: "" }));
+    const emptyWrapper = empty.querySelector(".hk-spinner-wrapper") as HTMLElement;
+    expect(emptyWrapper.style.getPropertyValue("--hk-loading-min-height")).toBe("");
+  });
+
   it("stacks optional text below the wheel", () => {
     const c = mount(h(HkSpinner, { center: true, text: "Loading" }));
     const text = c.querySelector(".hk-spinner-text") as HTMLElement;

--- a/packages/vue/src/components/HkSpinner.tsx
+++ b/packages/vue/src/components/HkSpinner.tsx
@@ -30,7 +30,7 @@ export default defineComponent({
         : null,
     );
     const centerStyle = computed(() => {
-      if (!props.center || props.minHeight == null) return null;
+      if (!props.center || props.minHeight == null || props.minHeight === "") return null;
       const v =
         typeof props.minHeight === "number" ? `${props.minHeight}px` : props.minHeight;
       return { "--hk-loading-min-height": v };

--- a/packages/vue/src/components/HkSpinner.tsx
+++ b/packages/vue/src/components/HkSpinner.tsx
@@ -13,6 +13,12 @@ export default defineComponent({
     text: { type: String, default: undefined },
     center: { type: Boolean, default: false },
     tone: { type: String as PropType<"primary" | "current">, default: "primary" },
+    /* Only meaningful with center=true: overrides the default
+       min-height floor (--hk-loading-min-height) for tight containers. */
+    minHeight: {
+      type: [String, Number] as PropType<string | number>,
+      default: undefined,
+    },
   },
   setup(props) {
     const sizeClass = computed(() =>
@@ -23,9 +29,18 @@ export default defineComponent({
         ? { width: `${props.size}px`, height: `${props.size}px` }
         : null,
     );
+    const centerStyle = computed(() => {
+      if (!props.center || props.minHeight == null) return null;
+      const v =
+        typeof props.minHeight === "number" ? `${props.minHeight}px` : props.minHeight;
+      return { "--hk-loading-min-height": v };
+    });
 
     return () => (
-      <div class={["hk-spinner-wrapper", props.center && "hk-spinner-centered"]}>
+      <div
+        class={["hk-spinner-wrapper", props.center && "hk-spinner-centered"]}
+        style={centerStyle.value ?? undefined}
+      >
         <div
           class={[
             "hk-spinner",


### PR DESCRIPTION
## Summary
`HkSpinner` `center` mode becomes the shared loading-state placement contract for every panel/page/modal surface:

- Column flex, centered on **both axes** (`justify-content:center` + `align-items:center`)
- Fills flexible parents (`flex: 1 1 auto`, `align-self:stretch`, `width:100%`) and claims definite-height block parents via `height:100%`; a **fixed `8rem` min-height floor** (predictable on every viewport height) keeps auto-height parents placing the circle mid-panel instead of top-centered — previously `center` only horizontally centered with vertical padding
- Optional `minHeight` prop emits `--hk-loading-min-height` for sites wanting a different footprint; blank strings are ignored
- New component tests incl. default-floor negative paths; version bump 0.7.0 (minor: new prop + default behavior flip)

Downstream `<HSpinner center />` call sites (~40 across shittim-chest and erp.celestia.world) adopt this automatically; companion PRs there only clean hand-rolled wrappers.

Note: `center + text` now stacks text below the wheel instead of beside it (standard panel-loading arrangement).

## Verification
- `vitest run`: 416 passed (incl. HkSpinner suite)
- `vue-tsc --noEmit`: clean