### PR TITLE
✨ Rebuild the theme menu mode group on HkSegmented and unify list row highlights.

### DIFF
--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -47,35 +47,100 @@
   padding: var(--space-4, 0.25rem) var(--space-6, 0.375rem);
 }
 
+/* ── Color-mode group (shared HkSegmented + auto overlay) ─────────────── */
+
 .s-theme-mode-row {
-  display: flex;
-  gap: var(--space-4, 0.25rem);
   padding: 0 var(--space-6, 0.375rem) var(--space-4, 0.25rem);
 }
 
-.s-theme-mode-btn {
+.s-theme-mode-seg {
+  position: relative;
+}
+
+/* Equal thirds so the overlay lands exactly on the Light/Dark halves. */
+.s-theme-mode-seg .hk-segmented[data-block="true"] .hk-segmented__segment {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+/*
+ * Auto-mode cover strip: replaces the Light/Dark segments with a passive
+ * solar-altitude readout in the segmented typography. Deliberately styled
+ * static (no hover affordance) yet pressable — pressing it resolves auto
+ * to manual (day → light, night → dark).
+ *
+ * Geometry (desktop/tablet track): 2px padding each side + two 2px gaps,
+ * equal segment widths → second segment starts at
+ * calc((100% - 8px) / 3 + 4px). The ≤767px touch form drops the gaps →
+ * calc((100% - 4px) / 3 + 2px). NOTE: HkSegmented's mobileBreakpoint prop
+ * is currently unwired (its touch form is pure CSS at the same 767px), so
+ * these hardcoded calcs stay in lockstep; revisit both if that changes.
+ */
+.s-theme-mode-autoalt {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  right: 2px;
+  left: calc((100% - 8px) / 3 + 4px);
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-4, 0.25rem);
-  padding: var(--space-4, 0.25rem) var(--space-8, 0.5rem);
   border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
-  border-radius: var(--radius-sm, 6px);
-  background: transparent;
-  color: rgb(var(--color-muted));
-  font-size: var(--text-xs, 0.75rem);
-  cursor: pointer;
+  border-radius: 6px;
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-secondary, var(--color-muted)));
+  font: inherit;
+  font-size: 12px;
+  line-height: 1;
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  appearance: none;
+  padding: 0;
 }
 
-.s-theme-mode-btn:hover:not([data-active]) {
-  background: rgb(var(--color-primary) / 12%);
-  color: rgb(var(--color-text));
+.s-theme-mode-autoalt:hover {
+  background: rgb(var(--color-surface));
+  color: rgb(var(--color-text-secondary, var(--color-muted)));
 }
 
-.s-theme-mode-btn[data-active] {
-  background: rgb(var(--color-primary));
-  border-color: rgb(var(--color-primary));
-  color: rgb(var(--color-on-primary));
+.s-theme-mode-autoalt:active {
+  background: rgb(var(--color-primary) / 8%);
 }
+
+.s-theme-mode-autoalt:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: 1px;
+}
+
+.s-theme-mode-autoalt-value {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+@media (max-width: 767px) {
+  /* Segments stay equal thirds; recompute the boundary without gaps.
+   * Vertical geometry still stretches between the 2px track paddings,
+   * so no explicit height is needed for the taller touch segments. */
+  .s-theme-mode-row {
+    padding: 0 0 var(--space-4, 0.25rem);
+  }
+
+  .s-theme-mode-autoalt {
+    left: calc((100% - 4px) / 3 + 2px);
+    /* Match the touch segments' corner radius. */
+    border-radius: 8px;
+    font-size: 14px;
+  }
+}
+
+/* ── Theme list rows ────────────────────────────────────────────────────
+ * Every row shares identical geometry: [pill button][fixed trailing slot].
+ * Non-custom themes get an invisible slot mirroring the delete button's
+ * footprint, so every active highlight is exactly the same width.
+ */
 
 .s-theme-item-row {
   display: flex;
@@ -83,11 +148,17 @@
   gap: var(--space-4, 0.25rem);
 }
 
+.s-theme-item-slot {
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+}
+
 .s-theme-item-btn {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: var(--space-8, 0.5rem);
+  gap: var(--space-6, 0.375rem);
+  min-width: 0;
   flex: 1;
   padding: var(--space-6, 0.375rem) var(--space-8, 0.5rem);
   border: none;
@@ -97,6 +168,19 @@
   font-size: var(--text-sm, 0.8125rem);
   text-align: left;
   cursor: pointer;
+}
+
+.s-theme-item-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.s-theme-item-check {
+  flex-shrink: 0;
+  color: rgb(var(--color-primary));
 }
 
 .s-theme-item-btn:hover:not([data-active]) {

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -1,13 +1,36 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createApp, h, nextTick } from "vue";
 
 import { HkThemeToggle } from "./HkThemeToggle";
+import { themePresets, useTheme, type CustomThemePreset } from "../theme";
 
 const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
 
 interface Mounted {
   container: HTMLElement;
   openCustomize: () => number;
+}
+
+const MODE_KEY = "hikari-theme-mode";
+
+function anyPresetTokens(): CustomThemePreset {
+  const [base] = Object.values(themePresets);
+  if (!base) throw new Error("no builtin theme presets available");
+  return {
+    id: "test-custom",
+    name: "A Rather Long Custom Scheme Name For Width Checks",
+    light: base.light,
+    dark: base.dark,
+  };
+}
+
+function resetThemeState(): void {
+  const { setMode, removeCustomTheme } = useTheme();
+  setMode("system");
+  removeCustomTheme("test-custom");
+  for (const key of ["hikari-theme", MODE_KEY, "hikari-custom-themes"]) {
+    localStorage.removeItem(key);
+  }
 }
 
 function mountToggle(externalCustomize: boolean): Mounted {
@@ -48,11 +71,27 @@ function paletteButton(): HTMLButtonElement {
   return btn!;
 }
 
+function modeSegments(): HTMLButtonElement[] {
+  return [...document.body.querySelectorAll<HTMLButtonElement>(".s-theme-mode-seg .hk-segmented__segment")];
+}
+
+function altitudeOverlay(): HTMLButtonElement | null {
+  return document.body.querySelector<HTMLButtonElement>(".s-theme-mode-autoalt");
+}
+
+beforeEach(() => {
+  // Hermetic geo: the component probes a geo API on mount; answer "not ok"
+  // so it silently falls back to the timezone heuristic with no network.
+  vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: false })));
+  resetThemeState();
+});
+
 afterEach(() => {
   for (const { app, container } of mounts.splice(0)) {
     app.unmount();
     container.remove();
   }
+  vi.unstubAllGlobals();
 });
 
 describe("HkThemeToggle external customization", () => {
@@ -83,5 +122,91 @@ describe("HkThemeToggle external customization", () => {
 
     expect(openCustomize()).toBe(0);
     expect(document.body.querySelector(".s-scheme-dialog")).toBeTruthy();
+  });
+});
+
+describe("HkThemeToggle color-mode group", () => {
+  it("renders three segments with the altitude overlay only in auto mode", async () => {
+    useTheme().setMode("dark");
+    const { container } = mountToggle(true);
+    await settle();
+
+    openMenu(container);
+    await settle();
+
+    // Manual mode: plain three-way group, no cover strip.
+    expect(modeSegments()).toHaveLength(3);
+    expect(altitudeOverlay()).toBeNull();
+    const dark = modeSegments().find((b) => b.textContent?.includes("Dark"));
+    const lightSeg = modeSegments().find((b) => b.textContent?.includes("Light"));
+    expect(dark?.getAttribute("aria-checked")).toBe("true");
+    expect(lightSeg?.disabled).toBe(false);
+
+    // Back to auto: the cover strip replaces the Light/Dark halves.
+    modeSegments()
+      .find((b) => b.textContent?.includes("Auto"))!
+      .click();
+    await settle();
+
+    const overlay = altitudeOverlay();
+    expect(overlay).toBeTruthy();
+    expect(overlay!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
+    // Covered segments sit out of the tab order; the overlay is the single
+    // pointer surface while auto is active.
+    expect(lightSeg?.disabled).toBe(true);
+    expect(dark?.disabled).toBe(true);
+  });
+
+  it("resolves auto to a manual side when the altitude strip is pressed", async () => {
+    useTheme().setMode("system");
+    const { container } = mountToggle(true);
+    await settle();
+
+    openMenu(container);
+    await settle();
+    expect(altitudeOverlay()).toBeTruthy();
+
+    altitudeOverlay()!.click();
+    await settle();
+
+    expect(altitudeOverlay()).toBeNull();
+    const stored = localStorage.getItem(MODE_KEY);
+    expect(["light", "dark"]).toContain(stored);
+    const active = modeSegments().find((b) => b.getAttribute("aria-checked") === "true");
+    expect(active?.textContent).toContain(stored === "light" ? "Light" : "Dark");
+  });
+
+  it("keeps every theme row footprint uniform for list highlights", async () => {
+    useTheme().addCustomTheme(anyPresetTokens());
+    const { container } = mountToggle(true);
+    await settle();
+
+    openMenu(container);
+    await settle();
+
+    const rows = [...document.body.querySelectorAll<HTMLElement>(".s-theme-menu .s-theme-item-row")];
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+
+    let customRows = 0;
+    for (const row of rows) {
+      // Every row is exactly [pill button][trailing slot] — delete button
+      // for custom themes, an equally sized invisible slot otherwise — so
+      // all highlight boxes share one width and left/right padding.
+      expect(row.children).toHaveLength(2);
+      expect(row.children[0].classList.contains("s-theme-item-btn")).toBe(true);
+      const trailing = row.children[1];
+      const isDelete = trailing.classList.contains("s-theme-item-delete");
+      const isSlot = trailing.classList.contains("s-theme-item-slot");
+      expect(isDelete || isSlot).toBe(true);
+      if (isDelete) customRows += 1;
+    }
+    expect(customRows).toBe(1);
+
+    // Built-ins keep an explicit reserved slot element.
+    expect(rows[0].querySelector(".s-theme-item-slot")).toBeTruthy();
+
+    // Active check glyph sits inside the pill, leading the name.
+    const activeBtn = document.body.querySelector<HTMLButtonElement>(".s-theme-item-btn[data-active]");
+    expect(activeBtn?.querySelector(".s-theme-item-check")).toBeTruthy();
   });
 });

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -1,20 +1,42 @@
-import { computed, defineComponent, onMounted, ref, type PropType } from "vue";
+import { computed, defineComponent, onMounted, onUnmounted, ref, watch, type PropType } from "vue";
 import { Check, ChevronDown, Monitor, Moon, Palette, Sun, Trash as Trash2 } from "lucide-vue-next";
-import { HDivider, HPopover, useI18n, useTheme, type PopupPlacement, type ThemeId } from "@celestia-island/hikari";
+import {
+  DEFAULT_GEO_LOCATION,
+  HDivider,
+  HPopover,
+  getGeolocation,
+  solarAltitude,
+  useI18n,
+  useTheme,
+  type PopupPlacement,
+  type ThemeId,
+} from "@celestia-island/hikari";
 
 import { HColorSchemeDialog, type HCustomTheme } from "./HkColorSchemeDialog";
+import HkSegmented, { type HkSegmentedOption } from "./HkSegmented";
 import "./HkThemeToggle.scss";
 
+/** One shared geo resolution per page load (component may mount often). */
+let geoPromise: Promise<{ lat: number; lng: number }> | null = null;
+function geoOnce(): Promise<{ lat: number; lng: number }> {
+  geoPromise ??= getGeolocation();
+  return geoPromise;
+}
 
 /**
  * HkThemeToggle — light/dark/auto theme control over hikari's theme engine.
  *
  * Composes hikari's `useTheme()` (theme presets + custom themes + mode
  * persistence); it does NOT reimplement the theme engine. A main button
- * cycles light/dark (auto keeps a Monitor glyph); the popover offers
- * explicit Light/Dark/Auto modes, preset/custom theme selection (custom
- * themes are removable), and opens HColorSchemeDialog to create a new
- * custom scheme.
+ * cycles light/dark (auto keeps a Monitor glyph); the popover offers the
+ * color-mode group and preset/custom theme selection (custom themes are
+ * removable), and opens HColorSchemeDialog to create a new custom scheme.
+ *
+ * Color-mode group: a shared HkSegmented button group (Auto | Light |
+ * Dark). In AUTO mode the Light/Dark halves are covered by a passive
+ * solar-altitude readout strip rendered in the segmented typography: it
+ * looks non-interactive but pressing it resolves to manual, selecting
+ * whichever side auto currently resolves to (day → light, night → dark).
  */
 export const HkThemeToggle = defineComponent({
   name: "HkThemeToggle",
@@ -41,6 +63,53 @@ export const HkThemeToggle = defineComponent({
     const triggerRef = ref<HTMLElement | null>(null);
     const schemeDialogOpen = ref(false);
 
+    // ── Solar-altitude readout (auto-mode overlay) ──────────────────────
+    const geo = ref<{ lat: number; lng: number }>({ ...DEFAULT_GEO_LOCATION });
+    const altTick = ref(0);
+
+    let altTimer: ReturnType<typeof setInterval> | null = null;
+    watch(menuOpen, (open) => {
+      if (open) {
+        if (!altTimer) altTimer = setInterval(() => { altTick.value += 1; }, 60000);
+      } else if (altTimer) {
+        clearInterval(altTimer);
+        altTimer = null;
+      }
+    });
+    onUnmounted(() => {
+      if (altTimer) clearInterval(altTimer);
+    });
+
+    onMounted(() => {
+      // Fire-and-forget: failures keep the timezone fallback and are silent
+      // (the aborting test/happy-dom teardown must not surface rejections).
+      // Memoized per module so remounts (menu reopen, route hops) reuse the
+      // resolved location instead of refetching the geo API.
+      geoOnce()
+        .then((g) => { geo.value = g; })
+        .catch(() => {});
+    });
+
+    /** Current sun altitude formatted like "+32.5°". */
+    const altitudeText = computed(() => {
+      void menuOpen.value;
+      void altTick.value;
+      void geo.value;
+      const alt = solarAltitude(geo.value.lat, geo.value.lng, new Date());
+      return `${alt >= 0 ? "+" : ""}${alt.toFixed(1)}°`;
+    });
+
+    /** Glyph hints which side a press will land on: sun while auto
+     *  resolves light, moon once dusk/night flip it to dark. */
+    const altitudeNight = computed(() => {
+      void menuOpen.value;
+      void altTick.value;
+      void geo.value;
+      return effectiveMode.value === "dark";
+    });
+
+    const isAutoMode = computed(() => currentMode.value === "system");
+
     const modeLabel = computed(() => {
       const map: Record<string, string> = {
         system: t("hikari::theme.modeAuto"),
@@ -50,11 +119,37 @@ export const HkThemeToggle = defineComponent({
       return map[currentMode.value] ?? currentMode.value;
     });
 
-    const modeOptions = computed(() => [
-      { key: "light", label: t("hikari::theme.modeLight"), icon: () => <Sun size={12} /> },
-      { key: "dark", label: t("hikari::theme.modeDark"), icon: () => <Moon size={12} /> },
-      { key: "system", label: t("hikari::theme.modeAuto"), icon: () => <Monitor size={12} /> },
-    ]);
+    /**
+     * Fresh option objects (and fresh icon vnodes) on every call — never
+     * cache icon vnodes across renders, or closing/reopening the popover
+     * would re-mount the same vnode instances.
+     */
+    function modeOptions(): HkSegmentedOption[] {
+      const auto = isAutoMode.value;
+      return [
+        { value: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={12} /> },
+        { value: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={12} />, disabled: auto },
+        { value: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={12} />, disabled: auto },
+      ];
+    }
+
+    function onSelectMode(value: string) {
+      setMode(value as "light" | "dark" | "system");
+    }
+
+    /**
+     * Pressing the altitude strip in auto mode drops back to manual and
+     * selects whichever side auto currently resolves to (day → light,
+     * night → dark). Debounced: input synthesis may deliver both a pointer
+     * sequence and a click for one physical press.
+     */
+    let lastManualSwitchAt = 0;
+    function resolveAutoToManual() {
+      const now = Date.now();
+      if (now - lastManualSwitchAt < 700) return;
+      lastManualSwitchAt = now;
+      setMode(effectiveMode.value);
+    }
 
     function onSelectTheme(id: ThemeId) {
       setTheme(id);
@@ -104,18 +199,27 @@ export const HkThemeToggle = defineComponent({
           <div class="s-theme-menu">
             <div class="s-theme-menu-label">{t("hikari::theme.mode")}</div>
             <div class="s-theme-mode-row">
-              {modeOptions.value.map((opt) => (
-                <button
-                  key={opt.key}
-                  type="button"
-                  class="s-theme-mode-btn"
-                  data-active={currentMode.value === opt.key || undefined}
-                  onClick={() => setMode(opt.key as "light" | "dark" | "system")}
-                >
-                  {opt.icon()}
-                  {opt.label}
-                </button>
-              ))}
+              <div class="s-theme-mode-seg" data-auto={isAutoMode.value || undefined}>
+                <HkSegmented
+                  block
+                  size="sm"
+                  options={modeOptions()}
+                  modelValue={currentMode.value}
+                  onUpdate:modelValue={onSelectMode}
+                />
+                {isAutoMode.value && (
+                  <button
+                    type="button"
+                    class="s-theme-mode-autoalt"
+                    title={t("hikari::theme.autoAltitudeTip")}
+                    aria-label={t("hikari::theme.autoAltitudeTip")}
+                    onClick={resolveAutoToManual}
+                  >
+                    {altitudeNight.value ? <Moon size={12} /> : <Sun size={12} />}
+                    <span class="s-theme-mode-autoalt-value">{altitudeText.value}</span>
+                  </button>
+                )}
+              </div>
             </div>
 
             <HDivider spacing="md" />
@@ -129,10 +233,10 @@ export const HkThemeToggle = defineComponent({
                   data-active={currentTheme.value === th.id || undefined}
                   onClick={() => onSelectTheme(th.id)}
                 >
-                  <span>{th.name}</span>
-                  {currentTheme.value === th.id && <Check size={14} />}
+                  {currentTheme.value === th.id && <Check size={14} class="s-theme-item-check" />}
+                  <span class="s-theme-item-name">{th.name}</span>
                 </button>
-                {th.isCustom && (
+                {th.isCustom ? (
                   <button
                     type="button"
                     class="s-theme-item-delete"
@@ -141,6 +245,8 @@ export const HkThemeToggle = defineComponent({
                   >
                     <Trash2 size={12} />
                   </button>
+                ) : (
+                  <span class="s-theme-item-slot" aria-hidden="true" />
                 )}
               </div>
             ))}
@@ -158,7 +264,7 @@ export const HkThemeToggle = defineComponent({
               }}
             >
               <Palette size={14} />
-              <span>{t("hikari::theme.customize")}</span>
+              <span class="s-theme-item-name">{t("hikari::theme.customize")}</span>
             </button>
           </div>
           {slots["menu-extra"]?.()}

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "داكن",
     "hikari::theme.modeAuto": "تلقائي",
     "hikari::theme.themes": "سمات الألوان",
+    "hikari::theme.autoAltitudeTip": "يتبع الوضع التلقائي ارتفاع الشمس. اضغط للتبديل إلى الوضع اليدوي",
     "hikari::theme.editScheme": "تعديل نظام الألوان…",
     "hikari::theme.customize": "تخصيص",
     "hikari::theme.themeName": "اسم السمة",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Dunkel",
     "hikari::theme.modeAuto": "Automatisch",
     "hikari::theme.themes": "Farbschemata",
+    "hikari::theme.autoAltitudeTip": "Automatik folgt der Sonnenhöhe – zum Wechseln auf manuell drücken",
     "hikari::theme.editScheme": "Farbschema bearbeiten…",
     "hikari::theme.customize": "Anpassen",
     "hikari::theme.themeName": "Designname",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Dark",
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Color themes",
+    "hikari::theme.autoAltitudeTip": "Auto is following the sun altitude. Press to switch to manual.",
     "hikari::theme.editScheme": "Edit color scheme…",
     "hikari::theme.customize": "Customize",
     "hikari::theme.themeName": "Theme name",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Oscuro",
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de color",
+    "hikari::theme.autoAltitudeTip": "El modo automático sigue la altura solar. Pulsa para cambiar a manual",
     "hikari::theme.editScheme": "Editar esquema de color…",
     "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nombre del tema",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Sombre",
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Thèmes de couleurs",
+    "hikari::theme.autoAltitudeTip": "Le mode auto suit la hauteur du soleil. Appuyez pour passer en manuel",
     "hikari::theme.editScheme": "Modifier le schéma de couleurs…",
     "hikari::theme.customize": "Personnaliser",
     "hikari::theme.themeName": "Nom du thème",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "ダーク",
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色テーマ",
+    "hikari::theme.autoAltitudeTip": "自動モードは太陽高度に追従しています。押すと手動に切り替わります",
     "hikari::theme.editScheme": "配色を編集…",
     "hikari::theme.customize": "カスタマイズ",
     "hikari::theme.themeName": "テーマ名",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "다크",
     "hikari::theme.modeAuto": "자동",
     "hikari::theme.themes": "색상 테마",
+    "hikari::theme.autoAltitudeTip": "자동 모드가 태양 고도를 따르고 있습니다. 누르면 수동으로 전환됩니다",
     "hikari::theme.editScheme": "색 구성표 편집…",
     "hikari::theme.customize": "사용자 지정",
     "hikari::theme.themeName": "테마 이름",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Escuro",
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de cores",
+    "hikari::theme.autoAltitudeTip": "O modo automático segue a altitude do sol. Toque para mudar para manual",
     "hikari::theme.editScheme": "Editar esquema de cores…",
     "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nome do tema",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "Тёмная",
     "hikari::theme.modeAuto": "Авто",
     "hikari::theme.themes": "Цветовые темы",
+    "hikari::theme.autoAltitudeTip": "Авто следует высоте солнца. Нажмите, чтобы перейти в ручной режим",
     "hikari::theme.editScheme": "Изменить цветовую схему…",
     "hikari::theme.customize": "Настроить",
     "hikari::theme.themeName": "Название темы",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "深色",
     "hikari::theme.modeAuto": "自动",
     "hikari::theme.themes": "配色主题",
+    "hikari::theme.autoAltitudeTip": "自动模式正跟随太阳高度角，点按切换为手动",
     "hikari::theme.editScheme": "编辑配色方案…",
     "hikari::theme.customize": "自定义",
     "hikari::theme.themeName": "主题名称",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -21,6 +21,7 @@
     "hikari::theme.modeDark": "深色",
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色主題",
+    "hikari::theme.autoAltitudeTip": "自動模式正跟隨太陽高度角，點按切換為手動",
     "hikari::theme.editScheme": "編輯配色方案…",
     "hikari::theme.customize": "自訂",
     "hikari::theme.themeName": "主題名稱",


### PR DESCRIPTION
## Summary
Polishes the shared theme menu (HkThemeToggle) used by chest (desktop + mobile), erp.celestia.world and e.celestia.world:

1. **Uniform row highlights** — every theme row now has identical geometry: an invisible trailing slot mirrors the custom-theme delete button's footprint, so the active highlight is the same width with symmetric padding on all rows. The check glyph moved inside each pill.
2. **Mode group on a generic component** — the color-mode area is rebuilt on the shared HkSegmented button group (Auto | Light | Dark).
3. **Auto-mode altitude cover** — while Auto is active, the Light/Dark halves are covered by a passive solar-altitude readout strip in the segmented typography (sun/moon glyph + live altitude like "+32.5°"). It is not directly switchable, but pressing it falls back to manual mode selecting whichever side auto currently resolves to (day → light, dusk/night → dark). Manual mode shows the three normal segments; covered segments are disabled under the overlay.

New i18n string `hikari::theme.autoAltitudeTip` in all 11 locales. Consumer apps need no changes — props/emits/slots are untouched.

## Verification
- 3-round verify cycle with independent subagents: R1 PASS (0 major), R2 APPROVE (0 major), R3 **SHIP** verdict.
- Targeted vitest 5/5 (3 new cases: overlay visibility/press resolution, segment disablement in auto, row uniformity incl. custom delete rows); full package suite 414/414 (+3 over green master baseline 411); vue-tsc --noEmit exit 0.
- Locale JSON validated programmatically across all 11 languages (exactly one added key each).

## Notes
- Per §7.2 no manual build was run; local verification is green per §7 gate, deployment handled by malkuth watchers downstream.
- Follow-up candidate (upstream engine, out of scope here): useTheme's currentPeriod is computed once at module load and never re-ticked against resolved geolocation.