### PR TITLE
✨ Add a floating jump control and rework autoscroll follow.

### DIFF
--- a/packages/vue/src/components/HkFab.scss
+++ b/packages/vue/src/components/HkFab.scss
@@ -1,0 +1,159 @@
+// HkFab.scss — floating action button + optional speed dial.
+// Attribute-driven positioning: data-positioning (absolute|fixed) +
+// data-corner select the anchored insets; --hk-fab-offset-* extends the
+// safe-area-aware base per instance (set from offsetX / offsetY).
+.hk-fab {
+  position: absolute;
+  z-index: var(--hk-fab-z, 40);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+
+  &[data-positioning="fixed"] { position: fixed; }
+
+  // Layout axis follows the expansion direction (DOM order [actions, main]).
+  &[data-expand="up"] { flex-direction: column; }
+  &[data-expand="down"] { flex-direction: column-reverse; }
+  &[data-expand="left"] { flex-direction: row; }
+  &[data-expand="right"] { flex-direction: row-reverse; }
+
+  // Base insets: safe-area aware, extended by --hk-fab-offset-*.
+  --_hk-fab-x: max(0.875rem, env(safe-area-inset-left, 0px));
+  --_hk-fab-y: max(0.875rem, env(safe-area-inset-bottom, 0px));
+
+  &[data-corner$="-right"] {
+    --_hk-fab-x: max(0.875rem, env(safe-area-inset-right, 0px));
+    right: calc(var(--_hk-fab-x) + var(--hk-fab-offset-x, 0px));
+  }
+
+  &[data-corner$="-left"] {
+    left: calc(var(--_hk-fab-x) + var(--hk-fab-offset-x, 0px));
+  }
+
+  &[data-corner^="top"] {
+    --_hk-fab-y: max(0.875rem, env(safe-area-inset-top, 0px));
+    top: calc(var(--_hk-fab-y) + var(--hk-fab-offset-y, 0px));
+  }
+
+  &[data-corner^="bottom"] {
+    bottom: calc(var(--_hk-fab-y) + var(--hk-fab-offset-y, 0px));
+  }
+}
+
+.hk-fab-button {
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 0;
+  border: none;
+  border-radius: var(--hi-radius-full, 9999px);
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform var(--hi-duration-fast, 0.15s) ease, box-shadow var(--hi-duration-fast, 0.15s) ease;
+
+  &:active:not(:disabled) { transform: scale(0.94); }
+  &:focus-visible { outline: 2px solid var(--hi-color-primary, #7aa2f7); outline-offset: 2px; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .hk-fab-icon {
+    display: inline-flex;
+    line-height: 0;
+
+    svg { display: block; fill: none; }
+  }
+}
+
+// Size map — px values are part of the component contract.
+$sizes: (sm: 34px, md: 42px, lg: 50px);
+
+@each $name, $dim in $sizes {
+  .hk-fab[data-size="#{$name}"] .hk-fab-button {
+    width: $dim;
+    height: $dim;
+
+    .hk-fab-icon svg {
+      width: calc($dim * 0.48);
+      height: calc($dim * 0.48);
+    }
+  }
+}
+
+.hk-fab[data-variant="glass"] .hk-fab-button {
+  color: var(--hi-color-text-secondary, #555);
+  background: color-mix(in srgb, var(--hi-color-surface, #fff) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
+  backdrop-filter: blur(4px); // chip language shared with autotag pills
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+
+  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #fff) 92%, transparent); }
+}
+
+.hk-fab[data-variant="primary"] .hk-fab-button {
+  color: var(--hi-color-on-primary, #fff);
+  background: var(--hi-color-primary, #7aa2f7);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.22);
+
+  &:hover:not(:disabled) { filter: brightness(1.06); }
+}
+
+// ------
+// Speed-dial stack
+// ------
+
+.hk-fab-actions {
+  display: inherit;
+  flex-direction: inherit;
+  align-items: center;
+  gap: inherit;
+}
+
+.hk-fab-mini {
+  pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  appearance: none;
+  -webkit-appearance: none;
+  padding: 0 0.5rem;
+  min-width: 2rem;
+  height: 2rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  color: var(--hi-color-text-secondary, #555);
+  background: color-mix(in srgb, var(--hi-color-surface, #fff) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
+  border-radius: var(--hi-radius-full, 9999px);
+  cursor: pointer;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
+  opacity: 0;
+  transform: scale(0.4);
+  transition: opacity var(--hi-duration-fast, 0.15s) ease, transform var(--hi-duration-fast, 0.15s) ease;
+
+  .hk-fab-mini-icon {
+    display: inline-flex;
+    line-height: 0;
+    svg { width: 14px; height: 14px; display: block; }
+  }
+
+  &:focus-visible { outline: 2px solid var(--hi-color-primary, #7aa2f7); outline-offset: 1px; }
+  &:disabled { opacity: 0.35; cursor: not-allowed; }
+}
+
+// Staggered reveal while expanded (CSS only, via nth-child delay).
+.hk-fab[data-expanded="true"] .hk-fab-mini {
+  pointer-events: auto;
+  opacity: 1;
+  transform: scale(1);
+
+  @for $i from 1 through 6 {
+    &:nth-child(#{$i}) { transition-delay: #{($i - 1) * 30}ms; }
+  }
+}

--- a/packages/vue/src/components/HkFab.test.tsx
+++ b/packages/vue/src/components/HkFab.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, describe, expect, it, vitest } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkFab from "./HkFab";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+interface Harness {
+  root: HTMLElement;
+  button: HTMLButtonElement;
+  clicks: MouseEvent[];
+  toggles: boolean[];
+}
+
+/** Mount an HkFab through a wrapper app and collect emitted click /
+ *  toggle events (mirrors the HkModal.test.tsx mount pattern). */
+function mountFab(props: Record<string, unknown> = {}): Harness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const harness: Harness = {
+    root: null as unknown as HTMLElement,
+    button: null as unknown as HTMLButtonElement,
+    clicks: [],
+    toggles: [],
+  };
+
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkFab, {
+          "onClick": (e: MouseEvent) => harness.clicks.push(e),
+          "onToggle": (open: boolean) => harness.toggles.push(open),
+          ...props,
+        });
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+
+  const root = container.querySelector<HTMLElement>(".hk-fab");
+  const button = container.querySelector<HTMLButtonElement>(".hk-fab-button");
+  if (!root || !button) throw new Error("HkFab did not render its shell");
+  harness.root = root;
+  harness.button = button;
+  return harness;
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("HkFab shell", () => {
+  it("renders a round button with the aria label and the default chevron svg", () => {
+    const m = mountFab({ ariaLabel: "Jump to latest" });
+    expect(m.button.getAttribute("aria-label")).toBe("Jump to latest");
+    // No icon prop -> inline chevron-down fallback svg.
+    expect(m.button.querySelector("svg polyline")).not.toBeNull();
+  });
+
+  it("mirrors positioning/corner/size/variant props onto data attributes", () => {
+    const m = mountFab({
+      positioning: "fixed",
+      corner: "top-left",
+      size: "lg",
+      variant: "primary",
+    });
+    expect(m.root.getAttribute("data-positioning")).toBe("fixed");
+    expect(m.root.getAttribute("data-corner")).toBe("top-left");
+    expect(m.root.getAttribute("data-size")).toBe("lg");
+    expect(m.root.getAttribute("data-variant")).toBe("primary");
+
+    const plain = mountFab();
+    expect(plain.root.getAttribute("data-positioning")).toBe("absolute");
+    expect(plain.root.getAttribute("data-corner")).toBe("bottom-right");
+    expect(plain.root.getAttribute("data-size")).toBe("md");
+    expect(plain.root.getAttribute("data-variant")).toBe("glass");
+  });
+
+  it("resolves registry icons before falling back to the inline svg", () => {
+    const m = mountFab({ icon: "ArrowDown" });
+    // Lucide renders its own svg without this component's polyline.
+    expect(m.button.querySelector(".hk-fab-icon svg")).not.toBeNull();
+    expect(m.button.querySelector("svg polyline[points='6 9 12 15 18 9']")).toBeNull();
+  });
+});
+
+describe("HkFab plain mode", () => {
+  it("emits click for each main-button press and never toggles", () => {
+    const m = mountFab({ ariaLabel: "act" });
+    m.button.click();
+    m.button.click();
+    expect(m.clicks.length).toBe(2);
+    expect(m.toggles).toEqual([]);
+  });
+
+  it("blocks emission while disabled", () => {
+    const m = mountFab({ ariaLabel: "act", disabled: true });
+    expect(m.button.disabled).toBe(true);
+    m.button.click();
+    expect(m.clicks).toEqual([]);
+    expect(m.toggles).toEqual([]);
+  });
+});
+
+describe("HkFab speed dial", () => {
+  function mountDial() {
+    const firstAction = vitest.fn();
+    return {
+      firstAction,
+      ...mountFab({
+        ariaLabel: "dial",
+        actions: [
+          { key: "a", label: "Alpha", icon: "Zap", onClick: firstAction },
+          { key: "b", label: "Beta" },
+        ],
+      }),
+    };
+  }
+
+  it("expands on first press, runs the action, then collapses", async () => {
+    const d = mountDial();
+
+    let minis = d.root.querySelectorAll<HTMLButtonElement>(".hk-fab-mini");
+    expect(minis.length).toBe(2);
+    expect(minis[0].getAttribute("aria-hidden")).toBe("true");
+
+    d.button.click();
+    await nextTick();
+    expect(d.toggles).toEqual([true]);
+    expect(d.root.getAttribute("data-expanded")).toBe("true");
+
+    minis = d.root.querySelectorAll<HTMLButtonElement>(".hk-fab-mini");
+    expect(minis[0].getAttribute("aria-hidden")).toBe("false");
+
+    minis[0].click();
+    expect(d.firstAction).toHaveBeenCalledTimes(1);
+    await nextTick();
+    expect(d.root.getAttribute("data-expanded")).toBeNull();
+    expect(d.toggles).toEqual([true, false]);
+  });
+
+  it("collapses on an outside pointerdown", async () => {
+    const d = mountDial();
+    d.button.click();
+    await nextTick();
+    expect(d.root.getAttribute("data-expanded")).toBe("true");
+
+    document.body.dispatchEvent(
+      new MouseEvent("pointerdown", { bubbles: true }),
+    );
+    await nextTick();
+    expect(d.root.getAttribute("data-expanded")).toBeNull();
+    expect(d.toggles).toEqual([true, false]);
+  });
+
+  it("collapses on Escape and swallows the key from ancestors", async () => {
+    const d = mountDial();
+    d.button.click();
+    await nextTick();
+    expect(d.root.getAttribute("data-expanded")).toBe("true");
+
+    const bubbled: string[] = [];
+    const ancestor = (e: Event) => bubbled.push((e as KeyboardEvent).key);
+    document.addEventListener("keydown", ancestor);
+    try {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+      await nextTick();
+      // Swallowed during capture: neither the probe nor HkModal saw it.
+      expect(bubbled).toEqual([]);
+      expect(d.root.getAttribute("data-expanded")).toBeNull();
+      expect(d.toggles).toEqual([true, false]);
+    } finally {
+      document.removeEventListener("keydown", ancestor);
+    }
+  });
+
+  it("exposes open/close/toggle control methods", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const instance = ref<{ open(): void; close(): void; toggle(): void } | null>(null);
+    const toggles: boolean[] = [];
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkFab, {
+            ref: instance as never,
+            ariaLabel: "ctrl",
+            "onToggle": (open: boolean) => toggles.push(open),
+            actions: [{ key: "a" }],
+          });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await nextTick();
+
+    const ctrl = instance.value;
+    ctrl!.open();
+    expect(toggles).toEqual([true]);
+    ctrl!.open(); // idempotent
+    expect(toggles).toEqual([true]);
+    ctrl!.close();
+    expect(toggles).toEqual([true, false]);
+    ctrl!.toggle();
+    expect(toggles).toEqual([true, false, true]);
+    ctrl!.toggle();
+    expect(toggles).toEqual([true, false, true, false]);
+  });
+});

--- a/packages/vue/src/components/HkFab.tsx
+++ b/packages/vue/src/components/HkFab.tsx
@@ -1,0 +1,214 @@
+import {
+  defineComponent,
+  onBeforeUnmount,
+  ref,
+  type PropType,
+} from "vue";
+
+import { iconByName } from "../composables/iconRegistry";
+import "./HkFab.scss";
+
+/** One entry of the HkFab speed dial. */
+export interface HFabAction {
+  key: string;
+  label?: string;
+  icon?: string;
+  onClick?: () => void;
+}
+
+type FabPositioning = "absolute" | "fixed";
+type FabCorner = "bottom-right" | "bottom-left" | "top-right" | "top-left";
+type FabSize = "sm" | "md" | "lg";
+type FabVariant = "primary" | "glass";
+type FabExpandDirection = "up" | "down" | "left" | "right";
+
+/**
+ * Material-design-style floating action button with an optional
+ * speed dial. Anchored via `positioning` + `corner` (CSS only), sized
+ * through a fixed map, and styled in the library's glass/primary
+ * variants. Without `actions` it is a plain round icon button; with
+ * `actions` the main button toggles a staggered mini-button stack.
+ */
+export default defineComponent({
+  name: "HkFab",
+  props: {
+    /** Registry name of the icon; falls back to an inline chevron-down
+     *  when empty. The "icon" slot overrides everything. */
+    icon: { type: String, default: "" },
+    /** Always pass from consumers — warn-free default only. */
+    ariaLabel: { type: String, default: "" },
+    positioning: { type: String as PropType<FabPositioning>, default: "absolute" },
+    corner: { type: String as PropType<FabCorner>, default: "bottom-right" },
+    offsetX: { type: String, default: undefined },
+    offsetY: { type: String, default: undefined },
+    size: { type: String as PropType<FabSize>, default: "md" },
+    variant: { type: String as PropType<FabVariant>, default: "glass" },
+    disabled: { type: Boolean, default: false },
+    actions: { type: Array as PropType<HFabAction[]>, default: undefined },
+    expandDirection: { type: String as PropType<FabExpandDirection>, default: "up" },
+  },
+  emits: {
+    click: (_e: MouseEvent) => true,
+    toggle: (_open: boolean) => true,
+  },
+  setup(props, { emit, slots, expose }) {
+    const isOpen = ref(false);
+    const rootRef = ref<HTMLElement>();
+
+    let unmounted = false;
+
+    function setOpen(next: boolean) {
+      if (isOpen.value === next || unmounted) return;
+      isOpen.value = next;
+      if (next) {
+        document.addEventListener("keydown", onDocKeydown, true);
+        document.addEventListener("pointerdown", onDocPointerdown, true);
+      } else {
+        unbindDismiss();
+      }
+      emit("toggle", next);
+    }
+
+    function unbindDismiss() {
+      document.removeEventListener("keydown", onDocKeydown, true);
+      document.removeEventListener("pointerdown", onDocPointerdown, true);
+    }
+
+    // Capture phase so the speed dial collapses BEFORE ancestor keydown
+    // handlers see Escape (e.g. HkModal would otherwise close entirely).
+    function onDocKeydown(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(false);
+    }
+
+    function onDocPointerdown(e: PointerEvent) {
+      const root = rootRef.value;
+      if (!root) return;
+      const target = e.target instanceof Node ? e.target : null;
+      if (target && root.contains(target)) return;
+      setOpen(false);
+    }
+
+    onBeforeUnmount(() => {
+      unmounted = true;
+      unbindDismiss();
+    });
+
+    expose({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+      toggle: () => setOpen(!isOpen.value),
+    });
+
+    function onMainClick(e: MouseEvent) {
+      if (props.disabled) return;
+      emit("click", e);
+      if (props.actions && props.actions.length > 0) {
+        setOpen(!isOpen.value);
+      }
+    }
+
+    function onActionClick(action: HFabAction) {
+      action.onClick?.();
+      setOpen(false);
+    }
+
+    return () => {
+      // Icon precedence: slot > registry > inline chevron-down fallback.
+      // `as any` matches HkIcon — the registry returns a loose Component.
+      const RegistryIcon = props.icon ? (iconByName(props.icon) as any) : null;
+
+      const mainIcon = (
+        <span class="hk-fab-icon">
+          {slots.icon
+            ? slots.icon()
+            : RegistryIcon
+              ? <RegistryIcon />
+              : (
+                // Inline chevron-down fallback (kept local to avoid
+                // pulling the lucide symbol through a non-registry path).
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="6 9 12 15 18 9" />
+                </svg>
+              )}
+        </span>
+      );
+
+      return (
+        <div
+          ref={rootRef}
+          class="hk-fab"
+          data-positioning={props.positioning}
+          data-corner={props.corner}
+          data-size={props.size}
+          data-variant={props.variant}
+          data-expand={props.expandDirection}
+          data-expanded={isOpen.value ? "true" : undefined}
+          style={{
+            "--hk-fab-offset-x": props.offsetX,
+            "--hk-fab-offset-y": props.offsetY,
+          }}
+        >
+          {(props.actions?.length ?? 0) > 0 && (
+            <div
+              class="hk-fab-actions"
+              aria-hidden={isOpen.value ? "false" : "true"}
+            >
+              {props.actions!.map((action) => (
+                <button
+                  key={action.key}
+                  type="button"
+                  class="hk-fab-mini"
+                  tabindex={isOpen.value ? 0 : -1}
+                  aria-hidden={isOpen.value ? "false" : "true"}
+                  disabled={props.disabled}
+                  title={action.label}
+                  aria-label={action.label ?? action.key}
+                  onClick={() => onActionClick(action)}
+                >
+                  {action.icon ? <RegistryGlyph name={action.icon} /> : null}
+                  {action.label ? <span class="hk-fab-mini-label">{action.label}</span> : null}
+                </button>
+              ))}
+            </div>
+          )}
+          <button
+            type="button"
+            class="hk-fab-button"
+            aria-label={props.ariaLabel}
+            aria-expanded={(props.actions?.length ?? 0) > 0
+              ? (isOpen.value ? "true" : "false")
+              : undefined}
+            disabled={props.disabled}
+            onClick={onMainClick}
+          >
+            {mainIcon}
+          </button>
+        </div>
+      );
+    };
+  },
+});
+
+/** Tiny internal helper resolving a speed-dial action icon through the
+ *  shared registry (same tree-shaking rationale as HkIcon). */
+const RegistryGlyph = defineComponent({
+  name: "HkFabGlyph",
+  props: { name: { type: String, required: true } },
+  setup(props) {
+    return () => {
+      const Comp = iconByName(props.name) as any;
+      return <span class="hk-fab-mini-icon"><Comp /></span>;
+    };
+  },
+});

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -244,38 +244,38 @@
 }
 
 // ------
-// Auto-follow indicator bar
+// Auto-follow indicator chip + jump-to-latest affordance
 // ------
 
-.hk-modal-autofollow-bar {
+// Muted "Auto" pill — visible only while follow is actively pinned at
+// the bottom AND the body actually scrolls. Same visual language as
+// .hk-scroll-container-autotag.
+.hk-modal-autofollow-tag {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.25rem;
-  padding: 0.375rem 0.75rem;
-  background: var(
-    --hk-modal-autofollow-bg,
-    var(--hi-color-surface, rgba(255, 255, 255, 0.9))
-  );
-  backdrop-filter: blur(8px);
-  border-top: 1px solid
-    var(--hk-modal-divider-color, var(--hi-color-border, rgba(0, 0, 0, 0.06)));
-  font-size: 0.75rem;
-  color: var(--hi-color-text-secondary, #666);
-  cursor: pointer;
+  right: 0.75rem;
+  bottom: 0.625rem;
+  z-index: 6;
+  pointer-events: none;
   user-select: none;
-  transition: background 0.15s ease;
+  -webkit-user-select: none;
+  padding: 2px 8px;
+  font-size: 0.625rem;
+  letter-spacing: 0.04em;
+  color: var(--hi-color-muted);
+  background: color-mix(in srgb, var(--hi-color-surface) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border) 12%, transparent);
+  border-radius: var(--hi-radius-full, 9999px);
+  backdrop-filter: blur(4px);
+  opacity: 0.85;
+  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+}
 
-  &:hover {
-    background: var(
-      --hi-secondary-bg,
-      rgba(0, 0, 0, 0.04)
-    );
-  }
+// Jump-back FAB (HkFab root) — floats above scroll content while follow
+// is cancelled. The .hk-fab anchor is .hk-modal-body (position:relative);
+// the child selector lifts specificity above the generic .hk-fab
+// z-index default so ordering stays deterministic.
+.hk-modal-body > .hk-modal-jump {
+  z-index: 12;
 }
 
 // ------

--- a/packages/vue/src/components/HkModal.test.tsx
+++ b/packages/vue/src/components/HkModal.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineComponent, h, nextTick, ref } from "vue";
 
 import HkModal from "./HkModal";
@@ -170,5 +170,165 @@ describe("HkModal back-guard (window-first back priority)", () => {
 
     expect((window.history.state as Record<string, unknown>)?.__hkBack).toBeUndefined();
     app.unmount();
+  });
+});
+
+describe("HkModal autoFollow", () => {
+  const SCROLL_H = 1000;
+  const CLIENT_H = 300;
+  /** scrollTop that leaves exactly 200px hidden below the fold. */
+  const CANCEL_TOP = SCROLL_H - CLIENT_H - 200;
+  /** Bottom-anchored scrollTop (distance to bottom = 0). */
+  const BOTTOM_TOP = SCROLL_H - CLIENT_H;
+
+  async function until(pred: () => boolean, ms = 1500): Promise<void> {
+    await vi.waitFor(() => {
+      if (!pred()) throw new Error("condition not met yet");
+    }, { timeout: ms, interval: 10 });
+  }
+
+  interface Setup {
+    scroller: HTMLElement;
+    tag: () => Element | null;
+    jump: () => HTMLButtonElement | null;
+  }
+
+  function stubGeometry(el: HTMLElement) {
+    for (const [key, value] of [
+      ["scrollHeight", SCROLL_H],
+      ["clientHeight", CLIENT_H],
+    ] as const) {
+      Object.defineProperty(el, key, { configurable: true, value });
+    }
+  }
+
+  /** Mount an open autoFollow modal and return its scroll container.
+   *  Geometry stubs land BEFORE the enter transition finishes so the
+   *  follow setup sees them; a first scroll pass makes the tag appear. */
+  async function mountAutoFollow(): Promise<Setup> {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkModal, {
+            modelValue: true,
+            autoFollow: true,
+          }, { default: () => h("p", { class: "follow-line" }, "log line") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    await nextTick();
+
+    const scroller = document.body.querySelector<HTMLElement>(".hk-modal-body-scroll");
+    if (!scroller) throw new Error("scroller not rendered");
+    stubGeometry(scroller);
+
+    // onAfterEnter wires setupAutoFollow; poll instead of assuming when
+    // the Transition hook fires under happy-dom. One synthetic scroll
+    // makes the initial overflow sense deterministic whenever it runs.
+    await until(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+      return document.body.querySelector(".hk-modal-autofollow-tag") !== null;
+    });
+
+    return {
+      scroller,
+      tag: () => document.body.querySelector(".hk-modal-autofollow-tag"),
+      jump: () => document.body.querySelector<HTMLButtonElement>(".hk-modal-jump .hk-fab-button"),
+    };
+  }
+
+  async function flush(): Promise<void> {
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+
+  it("streaming-style pinning never cancels follow", async () => {
+    const s = await mountAutoFollow();
+    expect(s.tag()).not.toBeNull();
+    expect(s.jump()).toBeNull();
+
+    // MutationObserver path: append content while pinned at bottom.
+    s.scroller.scrollTop = BOTTOM_TOP;
+    const inner = document.body.querySelector(".hk-modal-body-inner");
+    if (!inner) throw new Error("body inner missing");
+    inner.appendChild(document.createElement("p"));
+    // Settle frames keep pinning to the (stubbed constant) bottom.
+    await until(() => s.scroller.scrollTop === SCROLL_H);
+    await flush();
+    await flush();
+
+    expect(s.tag()).not.toBeNull();
+    expect(s.jump()).toBeNull();
+  });
+
+  it("a gesture followed by an over-threshold scroll cancels follow", async () => {
+    const s = await mountAutoFollow();
+    expect(s.tag()).not.toBeNull();
+
+    s.scroller.dispatchEvent(new WheelEvent("wheel"));
+    s.scroller.scrollTop = CANCEL_TOP; // distance 200 > FOLLOW_THRESHOLD
+    s.scroller.dispatchEvent(new Event("scroll"));
+    await flush();
+
+    expect(s.tag()).toBeNull();
+    expect(s.jump()).not.toBeNull();
+  });
+
+  it("a slow drag keeps the flag alive across sub-threshold scrolls and cancels", async () => {
+    const s = await mountAutoFollow();
+    expect(s.tag()).not.toBeNull();
+
+    s.scroller.dispatchEvent(new WheelEvent("wheel"));
+    // First sub-threshold step (<32px): still following — must NOT eat
+    // the gesture flag (regression guard for BLOCKER 1).
+    s.scroller.scrollTop = BOTTOM_TOP - 10; // distance 10
+    s.scroller.dispatchEvent(new Event("scroll"));
+    await flush();
+    expect(s.tag()).not.toBeNull();
+    expect(s.jump()).toBeNull();
+
+    // Drag crosses the threshold later: cancellation must still happen.
+    s.scroller.scrollTop = CANCEL_TOP; // distance 200
+    s.scroller.dispatchEvent(new Event("scroll"));
+    await flush();
+    expect(s.tag()).toBeNull();
+    expect(s.jump()).not.toBeNull();
+  });
+
+  it("jump-to-latest pins to bottom, re-arms follow, drops the FAB", async () => {
+    const s = await mountAutoFollow();
+
+    s.scroller.dispatchEvent(new WheelEvent("wheel"));
+    s.scroller.scrollTop = CANCEL_TOP;
+    s.scroller.dispatchEvent(new Event("scroll"));
+    await flush();
+    const fab = s.jump();
+    if (!fab) throw new Error("jump FAB did not appear after cancel");
+
+    fab.click(); // resumeJumpLatest: direct pin + settle frames re-kick
+    await until(() => s.scroller.scrollTop === SCROLL_H);
+    await until(() => s.tag() !== null);
+    expect(s.scroller.scrollTop).toBe(SCROLL_H);
+    expect(s.jump()).toBeNull();
+    // Follow is armed again: the next streaming chunk must neither
+    // cancel nor demand a fresh gesture. (happy-dom keeps scrollTop
+    // unclamped above scrollHeight - clientHeight, so geometry reads
+    // as "past the bottom" here — the render state is what matters.)
+    const innerAfterJump = document.body.querySelector(".hk-modal-body-inner");
+    if (!innerAfterJump) throw new Error("body inner missing");
+    innerAfterJump.appendChild(document.createElement("p"));
+    for (let i = 0; i < 8; i++) {
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      await flush();
+    }
+    expect(s.tag()).not.toBeNull();
+    expect(s.jump()).toBeNull();
   });
 });

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -1,10 +1,10 @@
 import {
   computed,
   defineComponent,
-  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
+  shallowRef,
   Teleport,
   Transition,
   watch,
@@ -17,7 +17,9 @@ import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
+import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
 import HButton from "./HkButton";
+import HFab from "./HkFab";
 import HSpinner from "./HkSpinner";
 
 export interface ModalAction {
@@ -89,7 +91,16 @@ export default defineComponent({
     // Auto-follow state
     let autoFollowMutationObserver: MutationObserver | null = null;
     const isFollowing = ref(true);
-    let userScrolled = false;
+    /** Body actually scrolls (drives the "Auto" tag visibility). */
+    const hasOverflow = shallowRef(false);
+    /**
+     * Sticky user-intent flag. Set by wheel / touch / drag-press /
+     * scroll-key gestures and consumed by the scroll handler; cleared
+     * by every programmatic movement (which is never user intent).
+     * Fling momentum keeps firing scroll events without new touches,
+     * which is why the flag stays set until consumed or cleared.
+     */
+    let gestureDirty = false;
     const scrollContainerRef = ref<HTMLElement>();
 
     /**
@@ -217,30 +228,105 @@ export default defineComponent({
     }
 
     // --- Auto-follow ---
+    //
+    // Follow policy: ONLY real user motion can cancel following.
+    // Streaming content is pinned with direct scrollTop assignments
+    // drained across a few animation frames (never smooth-scroll
+    // chains), and every programmatic movement clears the sticky
+    // gesture flag — so mid-flight scroll events cannot flip isFollowing
+    // back and forth (the old flicker).
 
-    function scrollToBottom(smooth = false) {
+    const FOLLOW_THRESHOLD = 32;
+    const SETTLE_FRAMES = 4;
+
+    let settleRemaining = 0;
+    let settleHandle: AnimationHandle | null = null;
+
+    function runSettleFrame() {
+      settleHandle = null;
+      // A cancelled follow must not be fought by pending pins: drained
+      // frames bail out immediately (resumeJumpLatest re-kicks). The
+      // reset above must stay first so kickSettle() never sees a stale,
+      // already-consumed handle — that would deadlock all future pins.
+      if (!isFollowing.value) {
+        settleRemaining = 0;
+        return;
+      }
+      pinToBottom();
+      // Programmatic movement never counts as user intent.
+      gestureDirty = false;
+      updateOverflow();
+      if (settleRemaining > 0) {
+        settleRemaining--;
+        settleHandle = scheduleFrame(runSettleFrame);
+      }
+    }
+
+    function kickSettle() {
+      settleRemaining = SETTLE_FRAMES;
+      if (settleHandle) return;
+      settleHandle = scheduleFrame(runSettleFrame);
+    }
+
+    function cancelSettle() {
+      settleHandle?.disconnect();
+      settleHandle = null;
+      settleRemaining = 0;
+    }
+
+    /** Direct assignment — no smooth scrolling, no intermediate events. */
+    function pinToBottom() {
       const el = scrollContainerRef.value;
       if (!el) return;
-      el.scrollTo({
-        top: el.scrollHeight,
-        behavior: smooth ? "smooth" : "instant" as ScrollBehavior,
-      });
+      el.scrollTop = el.scrollHeight;
+    }
+
+    function updateOverflow() {
+      const el = scrollContainerRef.value;
+      if (!el) return;
+      hasOverflow.value = el.scrollHeight > el.clientHeight + 4;
     }
 
     function onBodyScroll() {
       if (!props.autoFollow) return;
       const el = scrollContainerRef.value;
       if (!el) return;
-      const threshold = 32;
+      updateOverflow();
       const distanceFromBottom =
         el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (distanceFromBottom > threshold) {
-        userScrolled = true;
-        isFollowing.value = false;
-      } else {
-        userScrolled = false;
+      if (distanceFromBottom > FOLLOW_THRESHOLD) {
+        // Without a sticky gesture flag nothing cancels here — streaming
+        // pins no longer flash anything.
+        if (gestureDirty) {
+          gestureDirty = false;
+          isFollowing.value = false;
+        }
+      } else if (!isFollowing.value) {
+        // User returned near the bottom (or a pin landed): re-arm naturally.
+        gestureDirty = false;
         isFollowing.value = true;
       }
+      // Sub-threshold events while still following must NOT touch the
+      // flag: a slow upward drag emits many <32px scrolls, and eating
+      // the flag on any of them would make cancellation impossible.
+    }
+
+    const GESTURE_KEYS = new Set([
+      "ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End", " ",
+    ]);
+
+    function markGesture() {
+      gestureDirty = true;
+    }
+
+    function onGestureKeydown(e: KeyboardEvent) {
+      if (GESTURE_KEYS.has(e.key)) gestureDirty = true;
+    }
+
+    /** Press-and-drag covers mouse/touch before the drag starts; the
+     *  flag stays sticky so post-fling momentum still cancels follow. */
+    function onGesturePointerdown(e: PointerEvent) {
+      if (e.button === 0) gestureDirty = true;
     }
 
     function setupAutoFollow() {
@@ -248,16 +334,22 @@ export default defineComponent({
       teardownAutoFollow();
 
       isFollowing.value = true;
-      userScrolled = false;
-      scrollToBottom(false);
+      gestureDirty = false;
+      pinToBottom();
+      updateOverflow();
+      kickSettle();
+
+      const el = scrollContainerRef.value!;
+      el.addEventListener("wheel", markGesture, { passive: true });
+      el.addEventListener("touchstart", markGesture, { passive: true });
+      el.addEventListener("keydown", onGestureKeydown);
+      el.addEventListener("pointerdown", onGesturePointerdown);
 
       autoFollowMutationObserver = new MutationObserver(() => {
-        if (isFollowing.value && !unmounted) {
-          nextTick(() => scrollToBottom(true));
-        }
+        if (isFollowing.value && !unmounted) kickSettle();
       });
 
-      autoFollowMutationObserver.observe(scrollContainerRef.value, {
+      autoFollowMutationObserver.observe(el, {
         childList: true,
         subtree: true,
         characterData: true,
@@ -269,15 +361,24 @@ export default defineComponent({
         autoFollowMutationObserver.disconnect();
         autoFollowMutationObserver = null;
       }
+      const el = scrollContainerRef.value;
+      if (el) {
+        el.removeEventListener("wheel", markGesture);
+        el.removeEventListener("touchstart", markGesture);
+        el.removeEventListener("keydown", onGestureKeydown);
+        el.removeEventListener("pointerdown", onGesturePointerdown);
+      }
+      cancelSettle();
       isFollowing.value = true;
-      userScrolled = false;
+      hasOverflow.value = false;
+      gestureDirty = false;
     }
 
-    function resumeAutoFollow() {
+    function resumeJumpLatest() {
       if (!props.autoFollow) return;
       isFollowing.value = true;
-      userScrolled = false;
-      scrollToBottom(true);
+      pinToBottom();
+      kickSettle();
     }
 
     // --- Lifecycle ---
@@ -456,24 +557,30 @@ export default defineComponent({
                           : slots.default?.()}
                       </div>
                     </div>
-                    {props.autoFollow && !isFollowing.value && (
-                      <div
-                        class="hk-modal-autofollow-bar"
-                        onClick={resumeAutoFollow}
-                      >
-                        <svg
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          width="14"
-                          height="14"
-                        >
-                          <polyline points="6 9 12 15 18 9" />
-                        </svg>
-                        <span>{t("hikari::modal.auto", "Auto")}</span>
-                      </div>
+                    {props.autoFollow && (
+                      <>
+                        {/* "Auto" marks ACTIVE follow: pinned at bottom
+                            with a body that overflows. Cancelled follow
+                            swaps it for the jump-back FAB instead. */}
+                        {hasOverflow.value && isFollowing.value && (
+                          <span
+                            class="hk-modal-autofollow-tag"
+                            aria-hidden="true"
+                          >
+                            {t("hikari::modal.auto", "Auto")}
+                          </span>
+                        )}
+                        {!isFollowing.value && (
+                          <HFab
+                            class="hk-modal-jump"
+                            positioning="absolute"
+                            corner="bottom-right"
+                            icon="ArrowDown"
+                            ariaLabel={t("hikari::modal.jumpToLatest", "Back to latest")}
+                            onClick={resumeJumpLatest}
+                          />
+                        )}
+                      </>
                     )}
                   </div>
                   {renderFooter()}

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -351,6 +351,21 @@ export default defineComponent({
       }
     }
 
+    /** A press-drag longer than the quiet window would otherwise have
+     *  its flag purged mid-gesture (a mutation frame pins under the
+     *  finger and the rest of the drag can no longer cancel). Moving
+     *  while buttons are held re-stamps freshness; free hovering —
+     *  e.buttons === 0 — must NOT keep a stale flag alive forever. */
+    function onGesturePointermove(e: PointerEvent) {
+      if (e.buttons !== 0) markGesture();
+    }
+
+    /** Touch drags emit touchmove without pointermove on some engines
+     *  (and happy-dom tests synthesize either); belt and suspenders. */
+    function onGestureTouchmove() {
+      markGesture();
+    }
+
     function setupAutoFollow() {
       if (!props.autoFollow || !scrollContainerRef.value) return;
       teardownAutoFollow();
@@ -364,8 +379,10 @@ export default defineComponent({
       const el = scrollContainerRef.value!;
       el.addEventListener("wheel", markGesture, { passive: true });
       el.addEventListener("touchstart", markGesture, { passive: true });
+      el.addEventListener("touchmove", onGestureTouchmove, { passive: true });
       el.addEventListener("keydown", onGestureKeydown);
       el.addEventListener("pointerdown", onGesturePointerdown);
+      el.addEventListener("pointermove", onGesturePointermove, { passive: true });
 
       autoFollowMutationObserver = new MutationObserver(() => {
         if (isFollowing.value && !unmounted) kickSettle();
@@ -387,8 +404,10 @@ export default defineComponent({
       if (el) {
         el.removeEventListener("wheel", markGesture);
         el.removeEventListener("touchstart", markGesture);
+        el.removeEventListener("touchmove", onGestureTouchmove);
         el.removeEventListener("keydown", onGestureKeydown);
         el.removeEventListener("pointerdown", onGesturePointerdown);
+        el.removeEventListener("pointermove", onGesturePointermove);
       }
       cancelSettle();
       isFollowing.value = true;

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -101,6 +101,9 @@ export default defineComponent({
      * which is why the flag stays set until consumed or cleared.
      */
     let gestureDirty = false;
+    /** performance.now() of the last gesture that raised the flag —
+     *  drives the settle-frame quiet window below. */
+    let gestureAt = 0;
     const scrollContainerRef = ref<HTMLElement>();
 
     /**
@@ -238,6 +241,8 @@ export default defineComponent({
 
     const FOLLOW_THRESHOLD = 32;
     const SETTLE_FRAMES = 4;
+    /** Pending pin frames yield to gestures younger than this. */
+    const GESTURE_QUIET_MS = 250;
 
     let settleRemaining = 0;
     let settleHandle: AnimationHandle | null = null;
@@ -252,9 +257,19 @@ export default defineComponent({
         settleRemaining = 0;
         return;
       }
-      pinToBottom();
-      // Programmatic movement never counts as user intent.
+      if (gestureDirty && performance.now() - gestureAt < GESTURE_QUIET_MS) {
+        // A live gesture is in flight: yield this frame to it and let
+        // the scroll handler judge the resulting position. Stale flags
+        // older than the quiet window fall through and are consumed
+        // below — no stale-flag stall, no fight against the finger.
+        if (settleRemaining > 0) {
+          settleRemaining--;
+          settleHandle = scheduleFrame(runSettleFrame);
+        }
+        return;
+      }
       gestureDirty = false;
+      pinToBottom();
       updateOverflow();
       if (settleRemaining > 0) {
         settleRemaining--;
@@ -317,16 +332,23 @@ export default defineComponent({
 
     function markGesture() {
       gestureDirty = true;
+      gestureAt = performance.now();
     }
 
     function onGestureKeydown(e: KeyboardEvent) {
-      if (GESTURE_KEYS.has(e.key)) gestureDirty = true;
+      if (GESTURE_KEYS.has(e.key)) {
+        gestureDirty = true;
+        gestureAt = performance.now();
+      }
     }
 
     /** Press-and-drag covers mouse/touch before the drag starts; the
      *  flag stays sticky so post-fling momentum still cancels follow. */
     function onGesturePointerdown(e: PointerEvent) {
-      if (e.button === 0) gestureDirty = true;
+      if (e.button === 0) {
+        gestureDirty = true;
+        gestureAt = performance.now();
+      }
     }
 
     function setupAutoFollow() {

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -100,6 +100,11 @@
   transition: opacity var(--hi-duration-fast, 0.15s) ease;
 }
 
+// Jump-back FAB — above the scrollbar tracks (z-index 10).
+.hk-scroll-container > .hk-scroll-container-jump {
+  z-index: 11;
+}
+
 .hk-scrollbar-track {
   position: absolute;
   z-index: 10;

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -14,6 +14,7 @@ import "./HkScrollContainer.scss";
 import { provideScrollWindow } from "../composables/useScrollWindow";
 import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
 import { notifyScrollStart, onceFrame, scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
+import HFab from "./HkFab";
 
 type ScrollAxis = "vertical" | "horizontal" | "both";
 type ScrollMode = "traditional" | "windowed";
@@ -74,6 +75,10 @@ export default defineComponent({
     /** Fade the viewport's inline edges (CSS mask) on the sides where
      *  the sensed overflow (`data-h-overflow`) reports hidden content. */
     fade: { type: Boolean, default: false },
+    /** Additive opt-in: while autoFollow is enabled and the user has
+     *  scrolled away from the bottom, float a small jump-back FAB that
+     *  snaps to the latest content and re-arms follow. */
+    followAffordance: { type: Boolean, default: false },
   },
   setup(props, { slots, expose }) {
     const { t } = useI18n();
@@ -146,6 +151,15 @@ export default defineComponent({
       const vp = viewportRef.value;
       if (!vp) return;
       pinned.value = vp.scrollHeight - vp.scrollTop - vp.clientHeight < FOLLOW_THRESHOLD;
+    }
+
+    /** Jump-back affordance: resume semantics, not pinned-recompute —
+     *  pin first, then sense so follow state agrees with the new offset. */
+    function jumpToLatest() {
+      const vp = viewportRef.value;
+      if (!vp) return;
+      vp.scrollTop = vp.scrollHeight;
+      recomputePinned();
     }
 
     function pinToBottomIfPinned() {
@@ -479,6 +493,17 @@ export default defineComponent({
           </div>
           {showAutoTag.value && (
             <span class="hk-scroll-container-autotag" aria-hidden="true">{t("hikari::scrollContainer.auto", "Auto")}</span>
+          )}
+          {props.autoFollow && props.followAffordance && !pinned.value && (
+            <HFab
+              class="hk-scroll-container-jump"
+              positioning="absolute"
+              corner="bottom-right"
+              icon="ArrowDown"
+              size="sm"
+              ariaLabel={t("hikari::modal.jumpToLatest", "Back to latest")}
+              onClick={jumpToLatest}
+            />
           )}
         </Tag>
       );

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "نسخ",
     "hikari::toast.close": "إغلاق",
     "hikari::modal.auto": "تلقائي",
+    "hikari::modal.jumpToLatest": "الانتقال إلى الأحدث",
     "hikari::scrollContainer.auto": "تلقائي",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "أدخل كلمة المرور",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Kopieren",
     "hikari::toast.close": "Schließen",
     "hikari::modal.auto": "Automatisch",
+    "hikari::modal.jumpToLatest": "Zum Neuesten",
     "hikari::scrollContainer.auto": "Automatisch",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Passwort eingeben",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Copy",
     "hikari::toast.close": "Close",
     "hikari::modal.auto": "Auto",
+    "hikari::modal.jumpToLatest": "Back to latest",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Enter your password",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Copiar",
     "hikari::toast.close": "Cerrar",
     "hikari::modal.auto": "Automático",
+    "hikari::modal.jumpToLatest": "Ir al final",
     "hikari::scrollContainer.auto": "Automático",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Introduzca la contraseña",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Copier",
     "hikari::toast.close": "Fermer",
     "hikari::modal.auto": "Auto",
+    "hikari::modal.jumpToLatest": "Aller au plus récent",
     "hikari::scrollContainer.auto": "Auto",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Saisissez le mot de passe",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "コピー",
     "hikari::toast.close": "閉じる",
     "hikari::modal.auto": "自動",
+    "hikari::modal.jumpToLatest": "最新へ戻る",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "？",
     "hikari::passwordInput.placeholderPassword": "パスワードを入力",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "복사",
     "hikari::toast.close": "닫기",
     "hikari::modal.auto": "자동",
+    "hikari::modal.jumpToLatest": "최신으로 이동",
     "hikari::scrollContainer.auto": "자동",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "비밀번호 입력",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Copiar",
     "hikari::toast.close": "Fechar",
     "hikari::modal.auto": "Automático",
+    "hikari::modal.jumpToLatest": "Ir para o mais recente",
     "hikari::scrollContainer.auto": "Automático",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Digite a senha",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "Копировать",
     "hikari::toast.close": "Закрыть",
     "hikari::modal.auto": "Авто",
+    "hikari::modal.jumpToLatest": "К последнему",
     "hikari::scrollContainer.auto": "Авто",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "Введите пароль",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "复制",
     "hikari::toast.close": "关闭",
     "hikari::modal.auto": "自动",
+    "hikari::modal.jumpToLatest": "回到最新",
     "hikari::scrollContainer.auto": "自动",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "输入密码",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -44,6 +44,7 @@
     "hikari::toast.copy": "複製",
     "hikari::toast.close": "關閉",
     "hikari::modal.auto": "自動",
+    "hikari::modal.jumpToLatest": "回到最新",
     "hikari::scrollContainer.auto": "自動",
     "hikari::avatar.fallback": "?",
     "hikari::passwordInput.placeholderPassword": "輸入密碼",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -19,6 +19,7 @@ export { default as HDivider } from "./components/HkDivider";
 export { default as HDrawer } from "./components/HkDrawer";
 export { default as HEmptyState } from "./components/HkEmptyState";
 export { default as HExpansionPanel } from "./components/HkExpansionPanel";
+export { default as HFab, type HFabAction } from "./components/HkFab";
 export { default as HIcon } from "./components/HkIcon";
 export { default as HIconButton } from "./components/HkIconButton";
 export { default as HInput } from "./components/HkInput";


### PR DESCRIPTION
## Summary
- New `HkFab`: Material-style floating action button with optional speed dial, container-relative (`absolute`) or global (`fixed`) positioning, safe-area-aware insets + offset props, size/variant props, registry-based icon resolution (no lucide tree-shaking regression), capture-phase Escape / outside-pointer dismissal.
- `HkModal` autoFollow rewritten: settle-frame pinning via direct `scrollTop` assignment (shared animation bus) replaces smooth-scroll chains — streaming appends can no longer flash the follow state mid-flight; a sticky gesture flag (`wheel`/`touchstart`/`touchmove`/scroll-keys/`pointerdown`, restamped by pressed `pointermove`) ensures only real user motion cancels the tail; pending pins yield to live gestures under a 250 ms quiet window and drain once cancelled instead of fighting the finger.
- Semantics inverted per report: the "Auto" chip now renders only while actively following at the bottom; scrolling away swaps it for an `HkFab` jump-to-latest button that resumes follow on tap. The old inverted bar is removed.
- `HkScrollContainer` gains opt-in `followAffordance` exposing the same jump control for pinned log panes; existing consumers unaffected (default off).
- i18n: `hikari::modal.jumpToLatest` added to all 11 locales; version 0.6.5 → 0.7.0.

## Motivation
Mobile bug report on shittim-chest chat-log windows: the auto marker flickered during scroll, appeared when follow was cancelled (inverted), and no affordance existed to return to the tail. Desktop shares the code path.

## Verification
- vue-tsc 0 errors; vitest 424/424 across multiple consecutive full-suite runs (incl. 9 HkFab unit tests + 4 behavioral HkModal autoFollow regression tests; the slow-drag case demonstrably fails against the pre-fix algorithm).
- Adversarial review rounds traced fling/cancel ordering, teardown symmetry, hover-vs-press stamping, windowed-mode pinning; residual known limits documented (still-held drags may admit one pin before the next move re-stamps — self-healing).

Depends-on consumer wave: celestia-island/shittim-chest PR wiring `followAffordance` lands after this merges.