### PR TITLE
🐛 Spread fallthrough attrs onto the icon button root.

### DIFF
--- a/packages/vue/src/components/HkIconButton.test.tsx
+++ b/packages/vue/src/components/HkIconButton.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkIconButton from "./HkIconButton";
+
+/**
+ * HkIconButton contract tests:
+ * - extra attrs (aria-label / title / data-*) fall through onto the root
+ *   <button> (the component sets inheritAttrs:false and MUST spread
+ *   $attrs itself — regression guard for silent dead attributes)
+ * - the declared `click` emit keeps firing alongside the fallthrough
+ * - disabled + size classes compose with the fallthrough attrs.
+ *
+ * House style: no @vue/test-utils dependency — raw createApp mounts on a
+ * shared container list torn down after each case.
+ */
+
+const mounts: Array<ReturnType<typeof createApp>> = [];
+
+function mountComp(render: () => ReturnType<typeof h>): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp(defineComponent({ setup: () => render }));
+  mounts.push(app);
+  app.mount(container);
+  return container;
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+});
+
+describe("HkIconButton", () => {
+  it("falls through extra attrs (aria-label / title) onto the root button", () => {
+    const c = mountComp(() =>
+      h(HkIconButton, {
+        "aria-label": "Close inspector",
+        title: "Close inspector",
+        "data-test": "probe",
+      }, { icon: () => h("span", "x") }),
+    );
+    const btn = c.querySelector("button")!;
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute("aria-label")).toBe("Close inspector");
+    expect(btn.getAttribute("title")).toBe("Close inspector");
+    expect(btn.getAttribute("data-test")).toBe("probe");
+  });
+
+  it("keeps the declared click emit working alongside attr fallthrough", async () => {
+    let clicks = 0;
+    const c = mountComp(() =>
+      h(HkIconButton, {
+        "aria-label": "go",
+        onClick: () => { clicks += 1; },
+      }, { icon: () => h("span") }),
+    );
+    (c.querySelector("button")! as HTMLButtonElement).click();
+    await Promise.resolve();
+    expect(clicks).toBe(1);
+  });
+
+  it("renders disabled and the size class together with fallthrough attrs", () => {
+    const c = mountComp(() =>
+      h(HkIconButton, {
+        size: 16,
+        disabled: true,
+        "aria-label": "sync",
+      }),
+    );
+    const btn = c.querySelector("button")! as HTMLButtonElement;
+    expect(btn.classList.contains("hk-icon-button-16")).toBe(true);
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("aria-label")).toBe("sync");
+  });
+});

--- a/packages/vue/src/components/HkIconButton.tsx
+++ b/packages/vue/src/components/HkIconButton.tsx
@@ -14,7 +14,7 @@ export default defineComponent({
   emits: {
     click: (_e: MouseEvent) => true,
   },
-  setup(props, { emit, slots }) {
+  setup(props, { emit, slots, attrs }) {
     const cls = computed(() => [
       "hk-icon-button",
       `hk-icon-button-${props.size}`,
@@ -26,6 +26,7 @@ export default defineComponent({
         class={cls.value}
         disabled={props.disabled}
         onClick={(e: MouseEvent) => emit("click", e)}
+        {...attrs}
       >
         <span class="hk-icon-button-icon">
           {slots.icon ? (


### PR DESCRIPTION
## What

`HkIconButton` sets `inheritAttrs: false` but never spread `$attrs` onto its root `<button>`, so every `aria-label` / `title` passed by a consumer was silently dropped — the buttons rendered, worked, but had no accessible name and no tooltip. Live victims include chest's 3D detail-panel close button (`PhysicalPreview.tsx`) and the new panel-config edit affordance.

The fix is one line (spread `{...attrs}` on the root button) plus a three-case regression test pinning the contract (fallthrough works; the declared `click` emit still fires; disabled + size classes compose with attrs).

## Verification

- `vitest run`: 53 files / 435 tests green (431 baseline + 3 new − net 435 with the file counted once)
- `vue-tsc --noEmit`: clean