### PR TITLE
🐛 Recheck modal overflow when the autoscroll settle drain kicks.

### DIFF
--- a/packages/vue/src/components/HkModal.autofollow.test.ts
+++ b/packages/vue/src/components/HkModal.autofollow.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression coverage for the HkModal auto-follow affordances.
+ *
+ * The 2026-08-27 model-log incident: the "Auto" chip and jump FAB existed
+ * but never appeared because hasOverflow is only recomputed in settle
+ * frames and scroll events — windowed bodies that grow *late* (async
+ * chunks, virtualized mounts) tripped neither. kickSettle() must poll it.
+ *
+ * These tests exercise the exported hooks rather than a full DOM mount:
+ * the component's internal state machine (isFollowing/hasOverflow) is
+ * private, so we pin the two observable contracts:
+ *   1. kickSettle re-evaluates overflow on its synchronous path — a body
+ *      that overflows after mount gets its affordance without any user
+ *      scroll.
+ *   2. The render gate stays `hasOverflow && isFollowing` for the chip and
+ *      `!isFollowing` for the FAB (follow ↔ cancel swap).
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkModal.tsx"), "utf-8");
+
+describe("HkModal auto-follow affordances", () => {
+  it("recomputes overflow when the settle drain is kicked", () => {
+    const fn = src.match(/function kickSettle\(\) \{([\s\S]*?)\n    \}/);
+    expect(fn, "kickSettle() not found").toBeTruthy();
+    // updateOverflow() must run before scheduling: late-growing windowed
+    // bodies depend on this synchronous recheck.
+    expect(fn![1]).toMatch(/updateOverflow\(\)/);
+  });
+
+  it("gates the Auto chip on real overflow and active follow", () => {
+    const chip = src.match(/hasOverflow\.value && isFollowing\.value/);
+    expect(chip, "Auto chip gate missing").toBeTruthy();
+  });
+
+  it("shows the jump FAB exactly when follow was cancelled", () => {
+    const fab = src.match(/!isFollowing\.value && \(\s*\n?\s*<HFab/s);
+    expect(fab, "jump FAB gate missing").toBeTruthy();
+  });
+});

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -278,6 +278,12 @@ export default defineComponent({
     }
 
     function kickSettle() {
+      // hasOverflow gates the "Auto" tag and the jump FAB. It is only
+      // recomputed inside settle frames and scroll events; with windowed
+      // lists the body can grow late (async chunks, virtualized mounts)
+      // without either firing — poll it alongside the settle drain so the
+      // affordances appear on the frame the overflow actually exists.
+      updateOverflow();
       settleRemaining = SETTLE_FRAMES;
       if (settleHandle) return;
       settleHandle = scheduleFrame(runSettleFrame);


### PR DESCRIPTION
## Problem

Chest's conversation-history modal (TodoLogModal → HkModal windowed + autoFollow) never showed the Auto chip or the jump-to-latest FAB on a long log. Root cause: both affordances gate on `hasOverflow`, which was only recomputed in settle frames (4 frames after each kick, driven by MutationObserver) and scroll events. A windowed body that grows **late** — async chunk loads, virtualized item mounts landing after the last settle frame — left `hasOverflow=false` with no follow-up event, so a fully-followable scrolling modal permanently showed neither indicator.

Also documented for the record: chest #504's earlier "fixed" claim only wired these props into an unrelated panel; #295 landed the actual affordances hours later and the day's bundles were built from a pre-#295 hikari snapshot — so the user-visible behavior never changed until now.

## Fix

`kickSettle()` re-evaluates overflow synchronously before scheduling the drain, so late growth flips `hasOverflow` on the next mutation-driven kick regardless of gesture state.

Plus a source-contract regression test pinning: (1) updateOverflow runs in kickSettle, (2) chip gate = overflow ∧ following, (3) FAB gate = ¬following.

## Verification

- New test 3/3; full suite 54 files / 438 tests green.
- vue-tsc: 0 errors.