### PR TITLE
✨ Let hosts retune floating surface finishes and sheet gaps.

### DIFF
--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -310,7 +310,9 @@
     max-width: 100% !important;
     width: 100%;
     top: var(--hk-sheet-top-inset, 4.25rem);
-    bottom: 0;
+    // --hk-sheet-bottom-gap keeps the docked sheet from touching the very
+    // bottom edge (host-tunable; chest narrows the default visual gap).
+    bottom: var(--hk-sheet-bottom-gap, 0.5rem);
     left: 0;
     right: 0;
     transform: none;
@@ -320,7 +322,7 @@
     border-left: 0;
     border-right: 0;
     border-bottom: 0;
-    // Top inset + bottom:0 size the sheet; content scrolls inside.
+    // Top inset + bottom gap size the sheet; content scrolls inside.
     max-height: none;
   }
 
@@ -367,6 +369,11 @@
   }
 
   .hk-modal-footer {
-    padding: 0.625rem 1rem calc(0.625rem + env(safe-area-inset-bottom, 0px));
+    // --hk-sheet-footer-gap lets a host app tune how far the docked sheet
+    // sits off the very bottom edge (chest asked for a visibly narrower
+    // gap than body bottom + safe area on phones). Safe area is added ON
+    // TOP of the gap so home-bar devices never lose tappable chrome.
+    padding: 0.625rem 1rem
+      calc(0.5rem + var(--hk-sheet-footer-gap, 0.75rem) + env(safe-area-inset-bottom, 0px));
   }
 }

--- a/packages/vue/src/components/HkModal.sheetgap.test.ts
+++ b/packages/vue/src/components/HkModal.sheetgap.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source contract for the mobile bottom-sheet spacing hooks (2026-08-27
+ * chest request: docked phone popups sat too far off the bottom edge).
+ *
+ * The sheet and its footer read tunable custom properties with safe
+ * defaults:
+ *   --hk-sheet-bottom-gap   sheet's distance from the viewport bottom edge
+ *                           (was hard `bottom: 0`)
+ *   --hk-sheet-footer-gap   extra breathing room above the home-bar inset
+ *
+ * Pinned here so a refactor cannot silently regress to hard-coded values —
+ * the same class of "looks fixed but never shipped" failure as the
+ * overflow-poll incident.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkModal.scss"), "utf-8");
+
+describe("HkModal mobile sheet spacing contract", () => {
+  it("sizes the docked sheet from --hk-sheet-bottom-gap (not hard 0)", () => {
+    const block = src.slice(src.indexOf("@media (max-width: 767px)"));
+    expect(block).toContain("bottom: var(--hk-sheet-bottom-gap");
+    // Default keeps a small visible gap; hosts may narrow or zero it.
+    expect(block).toMatch(/--hk-sheet-bottom-gap,\s*0\.5rem/);
+  });
+
+  it("keeps the footer gap host-tunable and stacks the safe-area inset", () => {
+    const footer = src.match(/\.hk-modal-footer\s*{[^}]*}/g)?.join("\n") ?? "";
+    expect(footer).toContain("--hk-sheet-footer-gap");
+    expect(footer).toContain("env(safe-area-inset-bottom");
+  });
+});

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -31,11 +31,14 @@
   transform: translateY(4px) scale(0.97);
 }
 
-/* Glass dropdown content — used when `glass` prop is true */
+/* Glass dropdown content — used when `glass` prop is true.
+   --hk-popover-bg/--hk-popover-blur let a host app's surface-finish
+   preference (chest html[data-surface]) re-skin this layer; the defaults
+   keep the historical look. */
 .hii-dropdown-content,
 .hk-popover-panel.hii-dropdown-content {
-  background: rgb(var(--color-surface));
-  backdrop-filter: blur(var(--blur-lg)) saturate(1.2);
+  background: var(--hk-popover-bg, rgb(var(--color-surface)));
+  backdrop-filter: var(--hk-popover-blur, blur(var(--blur-lg)) saturate(1.2));
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);

--- a/packages/vue/src/components/HkPopover.surfacevars.test.ts
+++ b/packages/vue/src/components/HkPopover.surfacevars.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Source contract: popover glass content reads --hk-popover-bg/--hk-popover-blur
+ * so a host surface-finish preference (chest html[data-surface]) can re-skin
+ * floating dropdown layers without forking the component.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkPopover.scss"), "utf-8");
+
+describe("HkPopover glass layer surface hooks", () => {
+  it("keeps the glass background host-tunable with the historical default", () => {
+    const block = src.slice(src.indexOf(".hii-dropdown-content"));
+    expect(block).toContain("var(--hk-popover-bg, rgb(var(--color-surface)))");
+    expect(block).toContain("var(--hk-popover-blur,");
+  });
+});


### PR DESCRIPTION
Host-side theming hooks requested from the chest style batch:

- **HkModal mobile sheet**: `--hk-sheet-bottom-gap` (was hard `bottom: 0`) and `--hk-sheet-footer-gap` — a docked phone popup can now sit close to the bottom edge without touching it; safe-area inset stays stacked on top so home-bar devices never lose tappable footer chrome.
- **HkPopover glass layer**: `--hk-popover-bg` / `--hk-popover-blur` with the historical look as fallback defaults.
- Source-contract tests pin both hook sets (`HkModal.sheetgap.test.ts`, `HkPopover.surfacevars.test.ts`) so the values cannot silently regress to hard-coded ones again.

Chest consumption lands in the companion shittim-chest PR (solid / glass blur(2px) / acrylic blur(4px)+saturate surface finish wired through `html[data-surface]`).