### PR TITLE
✨ Stack compact timeline steps vertically and add the shared step flow container.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -290,6 +290,12 @@
   justify-content: flex-end;
   gap: 0.5rem;
   flex-shrink: 0;
+
+  // Conditional footer slots (phases without actions, close transitions)
+  // render nothing — never leave a bare bordered strip behind.
+  &:empty {
+    display: none;
+  }
 }
 
 // ------

--- a/packages/vue/src/components/HkStepFlow.scss
+++ b/packages/vue/src/components/HkStepFlow.scss
@@ -10,6 +10,21 @@
   --hk-stepflow-duration: 0.2s;
 }
 
+// Sticky header mode: keeps the step indicator visible while the body
+// scrolls inside long modal hosts. Surface tint + blur approximate the
+// floating-chrome look; hosts retune through the custom properties.
+.hk-step-flow[data-sticky-header] > .hk-timeline {
+  position: sticky;
+  top: var(--hk-stepflow-sticky-top, 0px);
+  z-index: var(--hk-stepflow-sticky-z, 10);
+  background: var(
+    --hk-stepflow-sticky-bg,
+    color-mix(in srgb, var(--hi-color-surface, #fff) 95%, transparent)
+  );
+  backdrop-filter: blur(6px);
+  padding-bottom: var(--hi-space-8, 8px);
+}
+
 .hk-stepflow-body {
   width: 100%;
 }

--- a/packages/vue/src/components/HkStepFlow.scss
+++ b/packages/vue/src/components/HkStepFlow.scss
@@ -1,0 +1,49 @@
+// Direction-aware step body transitions for HkStepFlow.
+//
+// Forward slides the body leftward (the flow advances to a later step),
+// back mirrors it toward the right. Timings follow the phase-transition
+// family — an expressive ease-out on enter, a sharp ease-in on leave.
+// Duration resolves from one local custom property so consumers can tune
+// every phase at once.
+
+.hk-step-flow {
+  --hk-stepflow-duration: 0.2s;
+}
+
+.hk-stepflow-body {
+  width: 100%;
+}
+
+.hk-stepflow-fwd-enter-active,
+.hk-stepflow-back-enter-active {
+  transition:
+    opacity var(--hk-stepflow-duration, 0.2s) cubic-bezier(0.16, 1, 0.3, 1),
+    transform var(--hk-stepflow-duration, 0.2s) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.hk-stepflow-fwd-leave-active,
+.hk-stepflow-back-leave-active {
+  transition:
+    opacity var(--hk-stepflow-duration, 0.2s) cubic-bezier(0.5, 0, 0.75, 0),
+    transform var(--hk-stepflow-duration, 0.2s) cubic-bezier(0.5, 0, 0.75, 0);
+}
+
+.hk-stepflow-fwd-enter-from {
+  opacity: 0;
+  transform: translateX(24px);
+}
+
+.hk-stepflow-fwd-leave-to {
+  opacity: 0;
+  transform: translateX(-24px);
+}
+
+.hk-stepflow-back-enter-from {
+  opacity: 0;
+  transform: translateX(-24px);
+}
+
+.hk-stepflow-back-leave-to {
+  opacity: 0;
+  transform: translateX(24px);
+}

--- a/packages/vue/src/components/HkStepFlow.test.tsx
+++ b/packages/vue/src/components/HkStepFlow.test.tsx
@@ -211,7 +211,7 @@ describe("HkStepFlow", () => {
     document.body.appendChild(container);
     containers.push(container);
 
-    const current = ref("c");
+    const current = ref("a");
     const steps = ref(STEPS.map((s) => ({ ...s })));
     const app = createApp(defineComponent({
       setup() {
@@ -233,12 +233,14 @@ describe("HkStepFlow", () => {
     steps.value = [...steps.value].reverse().map((s) => ({ ...s }));
     await nextTick();
 
-    // With "c" now at index 1, moving to "a" (index 3) is FORWARD again;
-    // without the resync the stale index (2) would mislabel this as back.
-    current.value = "a";
+    // Discriminating case: WITHOUT the resync watch the remembered index
+    // stays 0 ("a"'s pre-swap slot); landing on "c" (now index 1) would then
+    // compare 1 < 0 and mislabel the move FORWARD. With the resync the
+    // remembered index follows the array to 3, so 1 < 3 correctly reads BACK.
+    current.value = "c";
     await nextTick();
     await settle();
-    expect(seen.at(-1)).toEqual({ key: "a", index: 3, direction: "forward" });
+    expect(seen.at(-1)).toEqual({ key: "c", index: 1, direction: "back" });
     await settle();
   });
 });

--- a/packages/vue/src/components/HkStepFlow.test.tsx
+++ b/packages/vue/src/components/HkStepFlow.test.tsx
@@ -196,4 +196,49 @@ describe("HkStepFlow", () => {
       warnSpy.mockRestore();
     }
   });
+
+  it("pins the collapse option onto the header timeline", () => {
+    const t = mountStepFlow({ collapse: "always" });
+    // Four steps with collapse=always must render the window (compact) form.
+    expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("window");
+    const bare = mountStepFlow({ collapse: "never" });
+    expect(bare.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
+  });
+
+  it("resyncs the direction memory when the steps array is swapped in place", async () => {
+    const seen: StepFlowSlotProps[] = [];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const current = ref("c");
+    const steps = ref(STEPS.map((s) => ({ ...s })));
+    const app = createApp(defineComponent({
+      setup() {
+        return () =>
+          h(HkStepFlow, {
+            steps: steps.value,
+            modelValue: current.value,
+            "onUpdate:modelValue": (key: string) => { current.value = key; },
+          }, Object.fromEntries(steps.value.map((s) => [
+            s.key,
+            (arg: StepFlowSlotProps) => { seen.push(arg); return h("p", `${s.key}-body`); },
+          ])));
+      },
+    }));
+    mounts.push(app);
+    app.mount(container);
+
+    // Swap the array (same current key) — e.g. a locale switch rebuilding it.
+    steps.value = [...steps.value].reverse().map((s) => ({ ...s }));
+    await nextTick();
+
+    // With "c" now at index 1, moving to "a" (index 3) is FORWARD again;
+    // without the resync the stale index (2) would mislabel this as back.
+    current.value = "a";
+    await nextTick();
+    await settle();
+    expect(seen.at(-1)).toEqual({ key: "a", index: 3, direction: "forward" });
+    await settle();
+  });
 });

--- a/packages/vue/src/components/HkStepFlow.test.tsx
+++ b/packages/vue/src/components/HkStepFlow.test.tsx
@@ -1,0 +1,199 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkStepFlow from "./HkStepFlow";
+import type { StepFlowSlotProps } from "./HkStepFlow";
+
+/**
+ * HkStepFlow contract tests. House style: no @vue/test-utils dependency —
+ * raw createApp mounts on shared containers torn down after each case.
+ *
+ * Note on transition-class assertions: happy-dom does not run stylesheet
+ * transitions, so Vue's `out-in` leave phase leaves the leave-from/leave-
+ * active classes in place until its rAF/settling timers fire — checking
+ * class names right after `nextTick` is deterministic here.
+ */
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+const STEPS = [
+  { key: "a", label: "Alpha" },
+  { key: "b", label: "Beta" },
+  { key: "c", label: "Gamma" },
+  { key: "d", label: "Delta" },
+];
+
+interface StepFlowHarness {
+  container: HTMLElement;
+  setCurrent: (key: string) => void;
+}
+
+function mountStepFlow(options: {
+  initial?: string;
+  hideTimeline?: boolean;
+  timelineClickable?: boolean;
+  collapse?: string;
+  seen?: StepFlowSlotProps[];
+} = {}): StepFlowHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const current = ref(options.initial ?? "a");
+  const Wrapper = defineComponent({
+    setup() {
+      const slotBodies: Record<string, (arg: StepFlowSlotProps) => unknown> = {};
+      for (const s of STEPS) {
+        slotBodies[s.key] = (arg: StepFlowSlotProps) => {
+          options.seen?.push(arg);
+          return h("p", { class: "step-body" }, `${s.key}-body`);
+        };
+      }
+      return () =>
+        h(HkStepFlow, {
+          steps: STEPS,
+          modelValue: current.value,
+          hideTimeline: options.hideTimeline ?? false,
+          timelineClickable: options.timelineClickable ?? false,
+          collapse: (options.collapse ?? "auto") as never,
+          "onUpdate:modelValue": (key: string) => { current.value = key; },
+        }, slotBodies);
+    },
+  });
+
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { container, setCurrent: (key) => { current.value = key; } };
+}
+
+/** Let Vue finish the out-in cycle's settling timers before teardown. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 80));
+}
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("HkStepFlow", () => {
+  it("renders the timeline header bound to modelValue plus the slotted body", () => {
+    const t = mountStepFlow({ initial: "b" });
+    const header = t.container.querySelector(".hk-timeline");
+    expect(header).not.toBeNull();
+    expect(header?.querySelector('[data-el="label"]')?.textContent).toBe("Alpha");
+    expect(
+      t.container.querySelector(".hk-timeline-step[aria-current='step'] [data-el='label']")
+        ?.textContent,
+    ).toBe("Beta");
+    expect(t.container.querySelector(".hk-stepflow-body")?.textContent).toBe("b-body");
+  });
+
+  it("hides the timeline header with hideTimeline while keeping the body", () => {
+    const t = mountStepFlow({ hideTimeline: true });
+    expect(t.container.querySelector(".hk-timeline")).toBeNull();
+    expect(t.container.querySelector(".hk-step-flow")).not.toBeNull();
+    expect(t.container.querySelector(".hk-stepflow-body")?.textContent).toBe("a-body");
+  });
+
+  it("swaps the named-slot content per step key", async () => {
+    const t = mountStepFlow({ initial: "a" });
+    expect(t.container.querySelector(".hk-stepflow-body")?.textContent).toBe("a-body");
+    t.setCurrent("d");
+    await nextTick();
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(t.container.querySelector(".hk-stepflow-body")?.textContent).toBe("d-body");
+    await settle();
+  });
+
+  it("slides forward when moving to a later step and back when returning", async () => {
+    const t = mountStepFlow({ initial: "b" });
+    const bodyClass = (): string =>
+      t.container.querySelector(".hk-stepflow-body")?.className ?? "";
+
+    t.setCurrent("c");
+    await nextTick();
+    // out-in: the old body is mid-leave on this tick.
+    expect(bodyClass()).toContain("hk-stepflow-fwd-leave-active");
+
+    await settle();
+    t.setCurrent("b");
+    await nextTick();
+    expect(bodyClass()).toContain("hk-stepflow-back-leave-active");
+    await settle();
+  });
+
+  it("passes key/index/direction to scoped slots across navigation", async () => {
+    const seen: StepFlowSlotProps[] = [];
+    const t = mountStepFlow({ initial: "a", seen });
+    expect(seen.map((s) => `${s.key}:${s.index}:${s.direction}`)).toEqual(["a:0:forward"]);
+
+    t.setCurrent("c");
+    await settle();
+    expect(seen.at(-1)).toEqual({ key: "c", index: 2, direction: "forward" });
+
+    t.setCurrent("b");
+    await settle();
+    expect(seen.at(-1)).toEqual({ key: "b", index: 1, direction: "back" });
+
+    // Returning forward again flips the direction back.
+    t.setCurrent("d");
+    await settle();
+    expect(seen.at(-1)?.direction).toBe("forward");
+    await settle();
+  });
+
+  it("emits update:modelValue when a clickable completed step is selected", async () => {
+    const selected: string[] = [];
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const current = ref("c");
+    const app = createApp(defineComponent({
+      setup() {
+        return () =>
+          h(HkStepFlow, {
+            steps: STEPS,
+            modelValue: current.value,
+            timelineClickable: true,
+            "onUpdate:modelValue": (key: string) => { selected.push(key); current.value = key; },
+          }, {
+            c: () => h("p", "C-body"),
+            b: () => h("p", "B-body"),
+          });
+      },
+    }));
+    mounts.push(app);
+    app.mount(container);
+
+    // Full-row mode with plenty of room: click the first completed step.
+    const first = container.querySelector(".hk-timeline-step[data-clickable]") as HTMLElement;
+    expect(first?.getAttribute("data-status")).toBe("completed");
+    first.dispatchEvent(new MouseEvent("click"));
+    await nextTick();
+    await settle();
+    expect(selected).toEqual(["a"]);
+    expect(container.querySelector(".hk-stepflow-body")?.textContent).toBe("");
+    await settle();
+  });
+
+  it("renders an empty body without warnings for an unknown key", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const t = mountStepFlow({ initial: "a" });
+      t.setCurrent("does-not-exist");
+      await nextTick();
+      await settle();
+      const body = t.container.querySelector(".hk-stepflow-body");
+      expect(body).not.toBeNull();
+      expect(body?.textContent).toBe("");
+      expect(warnSpy.mock.calls.some((args) => String(args[0]).includes("Slot"))).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/vue/src/components/HkStepFlow.tsx
+++ b/packages/vue/src/components/HkStepFlow.tsx
@@ -31,6 +31,12 @@ export default defineComponent({
     hideTimeline: { type: Boolean, default: false },
     /** Passthrough to the header timeline's clickable behaviour. */
     timelineClickable: { type: Boolean, default: false },
+    /**
+     * Pin the header to the top of the nearest scroll container (modal
+     * body hosts) so the step indicator stays visible over long bodies.
+     * Styling knobs: --hk-stepflow-sticky-top/-z/-bg.
+     */
+    stickyHeader: { type: Boolean, default: false },
     collapse: {
       type: String as PropType<TimelineCollapse>,
       default: "auto",
@@ -80,7 +86,10 @@ export default defineComponent({
       const dir = direction.value;
 
       return (
-        <div class="hk-step-flow">
+        <div
+          class="hk-step-flow"
+          data-sticky-header={props.stickyHeader || undefined}
+        >
           {!props.hideTimeline && (
             <HkTimeline
               steps={props.steps}

--- a/packages/vue/src/components/HkStepFlow.tsx
+++ b/packages/vue/src/components/HkStepFlow.tsx
@@ -46,12 +46,14 @@ export default defineComponent({
      * its new index. Unknown keys (-1) degrade gracefully to "forward".
      */
     const direction = ref<"forward" | "back">("forward");
-    let previousIndex = props.steps.findIndex((s) => s.key === props.modelValue);
+    const indexOf = (key: string): number =>
+      props.steps.findIndex((s) => s.key === key);
+    let previousIndex = indexOf(props.modelValue);
 
     watch(
       () => props.modelValue,
       () => {
-        const nextIndex = props.steps.findIndex((s) => s.key === props.modelValue);
+        const nextIndex = indexOf(props.modelValue);
         direction.value =
           previousIndex >= 0 && nextIndex >= 0 && nextIndex < previousIndex
             ? "back"
@@ -60,8 +62,18 @@ export default defineComponent({
       },
     );
 
+    // A steps-array swap while modelValue stays put (locale switch, flow
+    // reconfigured) invalidates the remembered position — resync silently
+    // so the NEXT navigation still compares against reality.
+    watch(
+      () => props.steps.map((s) => s.key).join("\u0000"),
+      () => {
+        previousIndex = indexOf(props.modelValue);
+      },
+    );
+
     return () => {
-      const index = props.steps.findIndex((s) => s.key === props.modelValue);
+      const index = indexOf(props.modelValue);
       // An unknown key finds no slot: the body simply renders empty, no
       // warnings — consumers may briefly park between two known steps.
       const slotFn = index >= 0 ? slots[props.modelValue] : undefined;

--- a/packages/vue/src/components/HkStepFlow.tsx
+++ b/packages/vue/src/components/HkStepFlow.tsx
@@ -1,0 +1,94 @@
+import { defineComponent, Transition, watch, ref, type PropType } from "vue";
+
+import HkTimeline from "./HkTimeline";
+import type { TimelineCollapse, TimelineStep } from "./HkTimeline";
+
+import "./HkStepFlow.scss";
+
+/** Scoped argument every step-keyed slot receives. */
+export interface StepFlowSlotProps {
+  /** Step key this slot renders for (equals the current modelValue). */
+  key: string;
+  /** Zero-based position of the step inside `steps`. */
+  index: number;
+  /** Which way navigation moved compared to the previous value. */
+  direction: "forward" | "back";
+}
+
+/**
+ * Generic step-flow container: an optional HkTimeline header bound to
+ * `modelValue` plus a direction-aware sliding body fed purely by named
+ * slots keyed by step key. Navigation state lives in the consumer — the
+ * component only translates `modelValue` changes into `out-in` body
+ * transitions and echoes timeline selections upward.
+ */
+export default defineComponent({
+  name: "HkStepFlow",
+  props: {
+    steps: { type: Array as PropType<TimelineStep[]>, required: true },
+    modelValue: { type: String, required: true },
+    /** Render the body only (header hidden) — for body-only usage. */
+    hideTimeline: { type: Boolean, default: false },
+    /** Passthrough to the header timeline's clickable behaviour. */
+    timelineClickable: { type: Boolean, default: false },
+    collapse: {
+      type: String as PropType<TimelineCollapse>,
+      default: "auto",
+    },
+  },
+  emits: {
+    "update:modelValue": (_key: string) => true,
+  },
+  setup(props, { slots, emit }) {
+    /**
+     * Which way the body slides: remember the index of the PREVIOUS
+     * `modelValue` within `steps`; when the value changes, compare against
+     * its new index. Unknown keys (-1) degrade gracefully to "forward".
+     */
+    const direction = ref<"forward" | "back">("forward");
+    let previousIndex = props.steps.findIndex((s) => s.key === props.modelValue);
+
+    watch(
+      () => props.modelValue,
+      () => {
+        const nextIndex = props.steps.findIndex((s) => s.key === props.modelValue);
+        direction.value =
+          previousIndex >= 0 && nextIndex >= 0 && nextIndex < previousIndex
+            ? "back"
+            : "forward";
+        previousIndex = nextIndex;
+      },
+    );
+
+    return () => {
+      const index = props.steps.findIndex((s) => s.key === props.modelValue);
+      // An unknown key finds no slot: the body simply renders empty, no
+      // warnings — consumers may briefly park between two known steps.
+      const slotFn = index >= 0 ? slots[props.modelValue] : undefined;
+      const dir = direction.value;
+
+      return (
+        <div class="hk-step-flow">
+          {!props.hideTimeline && (
+            <HkTimeline
+              steps={props.steps}
+              currentKey={props.modelValue}
+              clickable={props.timelineClickable}
+              collapse={props.collapse}
+              onSelect={(key: string) => emit("update:modelValue", key)}
+            />
+          )}
+          <Transition
+            name={dir === "back" ? "hk-stepflow-back" : "hk-stepflow-fwd"}
+            mode="out-in"
+            appear
+          >
+            <div key={props.modelValue} class="hk-stepflow-body">
+              {slotFn?.({ key: props.modelValue, index, direction: dir })}
+            </div>
+          </Transition>
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -81,28 +81,30 @@
   top: var(--hk-timeline-link-top);
   height: var(--hk-timeline-link-thickness);
 
-  // Fixed thirds put node centers at 16.6667% / 50% / 83.3333%; each bond
-  // spans between adjacent centers minus a clearance on both ends so it
-  // never touches the circles themselves.
+  // Fixed thirds put node centers at one-sixth / half / five-sixths ALONG
+  // THE INLINE AXIS; bonds span between adjacent centers minus a clearance
+  // on both ends so they never touch the circles themselves. Logical
+  // properties keep the overlay aligned when the host document flows RTL
+  // (the grid cells mirror with direction, so must the links).
   &[data-segment="before-current"] {
-    left: calc(16.6667% + var(--hk-timeline-link-clearance));
+    inset-inline-start: calc(16.6667% + var(--hk-timeline-link-clearance));
     width: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
   }
 
   &[data-segment="current-after"] {
-    left: calc(50% + var(--hk-timeline-link-clearance));
+    inset-inline-start: calc(50% + var(--hk-timeline-link-clearance));
     width: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
   }
 
   // Continuation hints run from a container edge toward that column's node,
   // fading out INTO the edge ("more steps exist beyond this side").
   &[data-segment="edge-before"] {
-    left: 0;
+    inset-inline-start: 0;
     width: calc(16.6667% - var(--hk-timeline-link-clearance));
   }
 
   &[data-segment="edge-after"] {
-    right: 0;
+    inset-inline-end: 0;
     width: calc(16.6667% - var(--hk-timeline-link-clearance));
   }
 
@@ -119,7 +121,8 @@
   background-color: var(--_link-color);
 
   // ONE fade mechanism (gradient fill — no mask layering): solid near the
-  // node, transparent at the container edge.
+  // node, transparent at the container edge. Gradients are physical, so the
+  // fade directions swap under RTL to keep dissolving into the outer edge.
   &[data-fade-dir="left"] {
     background-color: transparent;
     background-image: linear-gradient(to left, var(--_link-color), transparent);
@@ -129,6 +132,13 @@
     background-color: transparent;
     background-image: linear-gradient(to right, var(--_link-color), transparent);
   }
+}
+
+/* RTL mirrors every bond: logical insets above already place each segment
+   correctly along the flipped axis; only the fade DIRECTION remains
+   physical and therefore swaps here. Non-fading bonds inherit nothing. */
+[dir="rtl"] .hk-timeline[data-mode="window"] .hk-timeline-link[data-fade-dir] {
+  filter: fliph;
 }
 
 

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -12,48 +12,123 @@
 
 // ── Compact window mode ────────────────────────────────────────────────
 // Engaged automatically (collapse="auto") when the full row cannot fit the
-// host: a three-cell grid keeps the current step dead-center, reveals at
-// most one neighbour per side, and fades the side outward where further
-// hidden steps continue — the connector gains the space the crowded full
-// row was denying it.
+// host: three FIXED equal thirds keep the geometry stable even when an edge
+// cell is empty, each visible step stacks vertically (indicator circle on
+// top, single-line label below), and horizontal link segments join the
+// neighbouring node centers on an overlay — continuing past a side's edge
+// with a fading gradient where further hidden steps go on.
 .hk-timeline[data-mode="window"] {
+  position: relative;
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: start;
+
+  // Geometry contract with the stacked steps above: the node is the 24px
+  // indicator circle at the top of every stack, so its center sits half a
+  // node below the cell top in ALL columns — that is where link segments go.
+  --hk-timeline-node-size: 24px;
+  --hk-timeline-link-clearance: 20px;
+  --hk-timeline-link-thickness: 2px;
+  --hk-timeline-link-top: calc(
+    (var(--hk-timeline-node-size) - var(--hk-timeline-link-thickness)) / 2
+  );
 }
 
-.hk-timeline-window {
+.hk-timeline[data-mode="window"] .hk-timeline-window {
   display: flex;
+  flex-direction: column;
   align-items: center;
   min-width: 0;
 }
 
-// Each side cell holds a single step that stretches across its whole 1fr
-// column so the connector fills the distance to the centre. The step must
-// NOT carry [data-last] (its flex:0 0 auto override would squash the
-// stretch and kill the fade) — the component only sets it in full mode.
-.hk-timeline-window .hk-timeline-step {
-  flex: 1 1 auto;
-  min-width: 0;
+// The stacked step itself: node centered horizontally ON TOP, label BELOW as
+// normal horizontal text — one line, ellipsised when too long.
+.hk-timeline[data-mode="window"] .hk-timeline-step {
+  flex-direction: column;
+  align-items: center;
+  gap: var(--hi-space-4, 4px);
+
+  [data-el="label"] {
+    display: block;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    text-align: center;
+  }
 }
 
-// The after side mirrors the step so its connector leads from the centre
-// node out to the neighbour: [—— connector ——][label][node], node at the
-// outer edge — exactly where the fade mask sits.
-.hk-timeline-window[data-side="after"] .hk-timeline-step {
-  flex-direction: row-reverse;
+// Neighbour dimming expresses "previous / upcoming step"; a clickable
+// neighbour brightens back up while pointed at (affordance to jump back).
+.hk-timeline[data-mode="window"] .hk-timeline-window[data-dimmed] {
+  opacity: var(--hk-timeline-neighbor-opacity, 0.55);
+  transition: opacity var(--hi-duration-normal, 0.3s) ease;
+
+  &:has(.hk-timeline-step[data-clickable]):hover {
+    opacity: 1;
+  }
 }
 
-// A side fades toward its outer edge only when hidden steps continue past
-// the window — the "about to disappear" hint that more steps lie beyond.
-.hk-timeline-window[data-side="before"][data-fade] {
-  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 55%);
-  mask-image: linear-gradient(to right, transparent 0, #000 55%);
+// Link segments overlay: invisible to pointers and assistive tech.
+.hk-timeline-links {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
-.hk-timeline-window[data-side="after"][data-fade] {
-  -webkit-mask-image: linear-gradient(to left, transparent 0, #000 55%);
-  mask-image: linear-gradient(to left, transparent 0, #000 55%);
+.hk-timeline-link {
+  position: absolute;
+  top: var(--hk-timeline-link-top);
+  height: var(--hk-timeline-link-thickness);
+
+  // Fixed thirds put node centers at 16.6667% / 50% / 83.3333%; each bond
+  // spans between adjacent centers minus a clearance on both ends so it
+  // never touches the circles themselves.
+  &[data-segment="before-current"] {
+    left: calc(16.6667% + var(--hk-timeline-link-clearance));
+    width: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
+  }
+
+  &[data-segment="current-after"] {
+    left: calc(50% + var(--hk-timeline-link-clearance));
+    width: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
+  }
+
+  // Continuation hints run from a container edge toward that column's node,
+  // fading out INTO the edge ("more steps exist beyond this side").
+  &[data-segment="edge-before"] {
+    left: 0;
+    width: calc(16.6667% - var(--hk-timeline-link-clearance));
+  }
+
+  &[data-segment="edge-after"] {
+    right: 0;
+    width: calc(16.6667% - var(--hk-timeline-link-clearance));
+  }
+
+  // Bond colors follow the adjacent neighbour's status semantics.
+  &[data-status="completed"] {
+    --_link-color: var(--hi-color-primary);
+  }
+
+  &[data-status="active"],
+  &[data-status="pending"] {
+    --_link-color: color-mix(in srgb, var(--hi-color-border) 30%, transparent);
+  }
+
+  background-color: var(--_link-color);
+
+  // ONE fade mechanism (gradient fill — no mask layering): solid near the
+  // node, transparent at the container edge.
+  &[data-fade-dir="left"] {
+    background-color: transparent;
+    background-image: linear-gradient(to left, var(--_link-color), transparent);
+  }
+
+  &[data-fade-dir="right"] {
+    background-color: transparent;
+    background-image: linear-gradient(to right, var(--_link-color), transparent);
+  }
 }
 
 

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -136,9 +136,10 @@
 
 /* RTL mirrors every bond: logical insets above already place each segment
    correctly along the flipped axis; only the fade DIRECTION remains
-   physical and therefore swaps here. Non-fading bonds inherit nothing. */
+   physical and therefore swaps here. Non-fading bonds inherit nothing.
+   scaleX mirrors paint only — the box is symmetric around its own center. */
 [dir="rtl"] .hk-timeline[data-mode="window"] .hk-timeline-link[data-fade-dir] {
-  filter: fliph;
+  transform: scaleX(-1);
 }
 
 

--- a/packages/vue/src/components/HkTimeline.test.tsx
+++ b/packages/vue/src/components/HkTimeline.test.tsx
@@ -168,9 +168,12 @@ describe("HkTimeline window mode", () => {
     expect(t.container.textContent).not.toContain("Alpha");
     expect(t.container.textContent).not.toContain("Epsilon");
 
-    // Both sides continue past the window, so both fade.
-    expect(before?.hasAttribute("data-fade")).toBe(true);
-    expect(after?.hasAttribute("data-fade")).toBe(true);
+    // Both sides continue past the window, so continuation hints fill both
+    // edges on the overlay.
+    const fadeLinks = t.container.querySelectorAll(
+      '.hk-timeline-links [data-segment^="edge-"]',
+    );
+    expect(fadeLinks.length).toBe(2);
 
     // Real ordinal numbers survive the collapse.
     expect(current?.querySelector('[data-el="num"]')?.textContent).toBe("3");
@@ -250,7 +253,6 @@ describe("HkTimeline window mode", () => {
     const t = mountTimeline({ currentKey: "a", collapse: "always" });
     const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
     expect(before?.querySelector(".hk-timeline-step")).toBeNull();
-    expect(before?.hasAttribute("data-fade")).toBe(false);
     // The empty edge draws neither a dimmed placeholder nor stray lines.
     expect(before?.hasAttribute("data-dimmed")).toBe(false);
     expect(
@@ -268,7 +270,6 @@ describe("HkTimeline window mode", () => {
     await nextTick();
     const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
     expect(after?.querySelector(".hk-timeline-step")).toBeNull();
-    expect(after?.hasAttribute("data-fade")).toBe(false);
     expect(after?.hasAttribute("data-dimmed")).toBe(false);
     expect(
       t.container.querySelector('.hk-timeline-links [data-segment="current-after"]'),

--- a/packages/vue/src/components/HkTimeline.test.tsx
+++ b/packages/vue/src/components/HkTimeline.test.tsx
@@ -130,6 +130,14 @@ describe("HkTimeline full mode", () => {
     expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
   });
 
+  it("marks exactly the active step with aria-current=step", () => {
+    const t = mountTimeline({ currentKey: "c" });
+    const els = t.container.querySelectorAll(".hk-timeline-step");
+    expect(els[2].getAttribute("aria-current")).toBe("step");
+    expect(els[1].getAttribute("aria-current")).toBeNull();
+    expect(els[3].getAttribute("aria-current")).toBeNull();
+  });
+
   it("keeps vertical orientation in full mode", () => {
     const t = mountTimeline({ currentKey: "b", orientation: "vertical", collapse: "always" });
     expect(t.container.querySelector(".hk-timeline")?.getAttribute("data-mode")).toBe("full");
@@ -146,9 +154,15 @@ describe("HkTimeline window mode", () => {
     const current = t.container.querySelector('.hk-timeline-window[data-side="current"]');
     const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
 
+    // Stacked layout: the label lives UNDER the node in every cell, so each
+    // cell still exposes exactly one step with indicator + label.
     expect(before?.querySelector('[data-el="label"]')?.textContent).toBe("Beta");
     expect(current?.querySelector('[data-el="label"]')?.textContent).toBe("Gamma");
     expect(after?.querySelector('[data-el="label"]')?.textContent).toBe("Delta");
+    for (const cell of [before, current, after]) {
+      expect(cell?.querySelectorAll(".hk-timeline-step").length).toBe(1);
+      expect(cell?.querySelector('[data-el="indicator"]')).not.toBeNull();
+    }
 
     // Steps 1 and 5 are hidden entirely.
     expect(t.container.textContent).not.toContain("Alpha");
@@ -162,21 +176,74 @@ describe("HkTimeline window mode", () => {
     expect(current?.querySelector('[data-el="num"]')?.textContent).toBe("3");
   });
 
-  it("draws the window connectors on the neighbour cells, never the center", () => {
+  it("draws link segments joining neighbour nodes on an overlay, never inline", () => {
     const t = mountTimeline({ currentKey: "c", collapse: "always" });
-    const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
-    const current = t.container.querySelector('.hk-timeline-window[data-side="current"]');
-    const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
-    // The previous step trails its connector toward the centre; the next
-    // step (row-reversed) leads its connector back from the centre; the
-    // current step owns no connector at all — both bonds are drawn by the
-    // neighbours, and no [data-last] flex override may apply (the fade and
-    // the connector stretch live on these cells).
-    expect(before?.querySelector('[data-el="connector"]')).not.toBeNull();
-    expect(after?.querySelector('[data-el="connector"]')).not.toBeNull();
-    expect(current?.querySelector('[data-el="connector"]')).toBeNull();
-    expect(current?.querySelector(".hk-timeline-step")?.hasAttribute("data-last")).toBe(false);
-    expect(after?.querySelector(".hk-timeline-step")?.hasAttribute("data-last")).toBe(false);
+    const links = t.container.querySelector(".hk-timeline-links");
+    expect(links?.getAttribute("aria-hidden")).toBe("true");
+
+    // prev→current bond takes the previous (completed) status colors; the
+    // current→next bond keeps the pending look.
+    expect(links?.querySelector('[data-segment="before-current"]')?.getAttribute("data-status")).toBe("completed");
+    expect(links?.querySelector('[data-segment="current-after"]')?.getAttribute("data-status")).toBe("pending");
+
+    // Continuation hints fill both fading edges with matching status.
+    expect(links?.querySelector('[data-segment="edge-before"]')?.getAttribute("data-fade-dir")).toBe("left");
+    expect(links?.querySelector('[data-segment="edge-after"]')?.getAttribute("data-fade-dir")).toBe("right");
+
+    // No connector is rendered inline inside any stacked window step.
+    expect(
+      t.container.querySelectorAll('.hk-timeline-window [data-el="connector"]').length,
+    ).toBe(0);
+  });
+
+  it("dims neighbour cells but never the current one", () => {
+    const t = mountTimeline({ currentKey: "c", collapse: "always" });
+    expect(
+      t.container.querySelector('.hk-timeline-window[data-side="before"]')
+        ?.hasAttribute("data-dimmed"),
+    ).toBe(true);
+    expect(
+      t.container.querySelector('.hk-timeline-window[data-side="after"]')
+        ?.hasAttribute("data-dimmed"),
+    ).toBe(true);
+    expect(
+      t.container.querySelector('.hk-timeline-window[data-side="current"]')
+        ?.hasAttribute("data-dimmed"),
+    ).toBe(false);
+  });
+
+  it("omits continuation hints where no hidden steps continue past a side", async () => {
+    // Parked on the second step: left edge is the real start (no hint), the
+    // right side hides steps 4..5 (hint present).
+    const t = mountTimeline({ currentKey: "b", collapse: "always" });
+    const links = t.container.querySelector(".hk-timeline-links");
+    expect(links?.querySelector('[data-segment="edge-before"]')).toBeNull();
+    expect(links?.querySelector('[data-segment="edge-after"]')).not.toBeNull();
+    // The before bond itself still exists — only its outer hint is absent.
+    expect(links?.querySelector('[data-segment="before-current"]')).not.toBeNull();
+
+    // On the first step the left edge draws neither a bond nor a hint.
+    t.setCurrent("a");
+    await nextTick();
+    const linksAfter = t.container.querySelector(".hk-timeline-links");
+    expect(linksAfter?.querySelector('[data-segment="before-current"]')).toBeNull();
+    expect(linksAfter?.querySelector('[data-segment="edge-before"]')).toBeNull();
+    // ...while the right side keeps its live segments toward Beta.
+    expect(linksAfter?.querySelector('[data-segment="current-after"]')).not.toBeNull();
+    expect(linksAfter?.querySelector('[data-segment="edge-after"]')).not.toBeNull();
+  });
+
+  it("marks the active window step with aria-current=step", () => {
+    const t = mountTimeline({ currentKey: "c", collapse: "always" });
+    const current = t.container.querySelector(
+      '.hk-timeline-window[data-side="current"] .hk-timeline-step',
+    );
+    expect(current?.getAttribute("aria-current")).toBe("step");
+    const neighbours = t.container.querySelectorAll(
+      '.hk-timeline-window[data-dimmed] .hk-timeline-step',
+    );
+    expect(neighbours.length).toBe(2);
+    for (const n of neighbours) expect(n.getAttribute("aria-current")).toBeNull();
   });
 
   it("empties the left cell on the first step and the right cell on the last", async () => {
@@ -184,6 +251,14 @@ describe("HkTimeline window mode", () => {
     const before = t.container.querySelector('.hk-timeline-window[data-side="before"]');
     expect(before?.querySelector(".hk-timeline-step")).toBeNull();
     expect(before?.hasAttribute("data-fade")).toBe(false);
+    // The empty edge draws neither a dimmed placeholder nor stray lines.
+    expect(before?.hasAttribute("data-dimmed")).toBe(false);
+    expect(
+      t.container.querySelector('.hk-timeline-links [data-segment="before-current"]'),
+    ).toBeNull();
+    expect(
+      t.container.querySelector('.hk-timeline-links [data-segment="edge-before"]'),
+    ).toBeNull();
     expect(
       t.container.querySelector('.hk-timeline-window[data-side="after"] [data-el="label"]')
         ?.textContent,
@@ -194,6 +269,13 @@ describe("HkTimeline window mode", () => {
     const after = t.container.querySelector('.hk-timeline-window[data-side="after"]');
     expect(after?.querySelector(".hk-timeline-step")).toBeNull();
     expect(after?.hasAttribute("data-fade")).toBe(false);
+    expect(after?.hasAttribute("data-dimmed")).toBe(false);
+    expect(
+      t.container.querySelector('.hk-timeline-links [data-segment="current-after"]'),
+    ).toBeNull();
+    expect(
+      t.container.querySelector('.hk-timeline-links [data-segment="edge-after"]'),
+    ).toBeNull();
     expect(
       t.container.querySelector('.hk-timeline-window[data-side="before"] [data-el="label"]')
         ?.textContent,

--- a/packages/vue/src/components/HkTimeline.tsx
+++ b/packages/vue/src/components/HkTimeline.tsx
@@ -141,6 +141,15 @@ export default defineComponent({
       computeTimelineWindow(props.steps, props.currentKey),
     );
 
+    function statusOf(idx: number): TimelineStepStatus {
+      return idx < currentIndex.value
+        ? "completed"
+        : idx === currentIndex.value
+          ? "active"
+          : "pending";
+    }
+
+
     function measure(): void {
       const el = host.value;
       if (!el || !windowable.value || props.collapse !== "auto") {
@@ -195,12 +204,7 @@ export default defineComponent({
 
     function renderStep(idx: number, opts: { connector: boolean; last: boolean }) {
       const step = props.steps[idx];
-      const status: TimelineStepStatus =
-        idx < currentIndex.value
-          ? "completed"
-          : idx === currentIndex.value
-            ? "active"
-            : "pending";
+      const status = statusOf(idx);
 
       return (
         <div
@@ -208,6 +212,7 @@ export default defineComponent({
           class="hk-timeline-step"
           data-status={status}
           data-last={opts.last || undefined}
+          aria-current={status === "active" ? "step" : undefined}
           data-clickable={(props.clickable && status === "completed") || undefined}
           role={props.clickable ? "button" : undefined}
           tabindex={props.clickable && status === "completed" ? 0 : undefined}
@@ -247,13 +252,14 @@ export default defineComponent({
 
     return () => {
       if (windowed.value) {
-        // Window-mode connector layout: the PREVIOUS step trails its
-        // connector rightward into the current node, and the NEXT step is
-        // row-reversed (see SCSS) so its connector leads leftward from the
-        // current node out to the neighbour — both fill their 1fr grid
-        // columns. The current step itself carries no connector (both sides
-        // are drawn by the neighbours), so no `data-last` flex override ever
-        // applies inside the window and every window step stretches.
+        // Window-mode layout: three fixed equal thirds — previous / current /
+        // next stack VERTICALLY (indicator circle centered on top, single-line
+        // ellipsised label below, see SCSS). Horizontal link segments drawn on
+        // an overlay join the neighbouring node centers (16.6667% → 50% →
+        // 83.3333%) and continue past a side's edge with a fading gradient
+        // where hidden steps go on; edge cells stay empty when no neighbour
+        // exists.
+        const w = win.value;
         return (
           <div
             ref={host}
@@ -261,13 +267,48 @@ export default defineComponent({
             data-orientation={props.orientation}
             data-mode="window"
           >
+            {(w.beforeIndex >= 0 || w.afterIndex >= 0) && (
+              <div class="hk-timeline-links" aria-hidden="true">
+                {w.beforeIndex >= 0 && (
+                  <div
+                    class="hk-timeline-link"
+                    data-segment="before-current"
+                    data-status={statusOf(w.beforeIndex)}
+                  />
+                )}
+                {w.afterIndex >= 0 && (
+                  <div
+                    class="hk-timeline-link"
+                    data-segment="current-after"
+                    data-status={statusOf(w.afterIndex)}
+                  />
+                )}
+                {w.beforeIndex >= 0 && w.fadeBefore && (
+                  <div
+                    class="hk-timeline-link"
+                    data-segment="edge-before"
+                    data-status={statusOf(w.beforeIndex)}
+                    data-fade-dir="left"
+                  />
+                )}
+                {w.afterIndex >= 0 && w.fadeAfter && (
+                  <div
+                    class="hk-timeline-link"
+                    data-segment="edge-after"
+                    data-status={statusOf(w.afterIndex)}
+                    data-fade-dir="right"
+                  />
+                )}
+              </div>
+            )}
             <div
               class="hk-timeline-window"
               data-side="before"
-              data-fade={win.value.fadeBefore || undefined}
+              data-fade={w.fadeBefore || undefined}
+              data-dimmed={(w.beforeIndex >= 0) || undefined}
             >
-              {win.value.beforeIndex >= 0
-                ? renderStep(win.value.beforeIndex, { connector: true, last: false })
+              {w.beforeIndex >= 0
+                ? renderStep(w.beforeIndex, { connector: false, last: false })
                 : null}
             </div>
             <div class="hk-timeline-window" data-side="current">
@@ -276,10 +317,11 @@ export default defineComponent({
             <div
               class="hk-timeline-window"
               data-side="after"
-              data-fade={win.value.fadeAfter || undefined}
+              data-fade={w.fadeAfter || undefined}
+              data-dimmed={(w.afterIndex >= 0) || undefined}
             >
-              {win.value.afterIndex >= 0
-                ? renderStep(win.value.afterIndex, { connector: true, last: false })
+              {w.afterIndex >= 0
+                ? renderStep(w.afterIndex, { connector: false, last: false })
                 : null}
             </div>
           </div>

--- a/packages/vue/src/components/HkTimeline.tsx
+++ b/packages/vue/src/components/HkTimeline.tsx
@@ -304,7 +304,6 @@ export default defineComponent({
             <div
               class="hk-timeline-window"
               data-side="before"
-              data-fade={w.fadeBefore || undefined}
               data-dimmed={(w.beforeIndex >= 0) || undefined}
             >
               {w.beforeIndex >= 0
@@ -317,7 +316,6 @@ export default defineComponent({
             <div
               class="hk-timeline-window"
               data-side="after"
-              data-fade={w.fadeAfter || undefined}
               data-dimmed={(w.afterIndex >= 0) || undefined}
             >
               {w.afterIndex >= 0

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -72,6 +72,7 @@ export { default as HWindowedItem } from "./components/HkWindowedItem";
 export { default as HDateTimePicker } from "./components/HkDateTimePicker";
 export { default as HDatePicker } from "./components/HkDatePicker";
 export { default as HTimeline } from "./components/HkTimeline";
+export { default as HStepFlow } from "./components/HkStepFlow";
 
 // Media player kit
 export { default as HMediaPlayer, MEDIA_RATES } from "./components/HkMediaPlayer";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -73,6 +73,7 @@ export { default as HDateTimePicker } from "./components/HkDateTimePicker";
 export { default as HDatePicker } from "./components/HkDatePicker";
 export { default as HTimeline } from "./components/HkTimeline";
 export { default as HStepFlow } from "./components/HkStepFlow";
+export type { StepFlowSlotProps } from "./components/HkStepFlow";
 
 // Media player kit
 export { default as HMediaPlayer, MEDIA_RATES } from "./components/HkMediaPlayer";


### PR DESCRIPTION
## What

Two coordinated changes to unify step/wizard UX across consumers (shittim-chest migrates onto this in a follow-up PR):

### 1. HkTimeline compact "window" mode redesign
The old compact mode laid labels BESIDE numbers and row-reversed the right cell so its label sat LEFT of its number — confusing on phones. New behavior:
- three fixed equal slots always present; each rendered step stacks the 24px indicator circle on top with its label BELOW as normal horizontal text (centered, ellipsised)
- previous/next cells dimmed (`--hk-timeline-neighbor-opacity`, default 0.55) to read as "previous / upcoming"; clickable completed neighbours brighten on hover
- an overlay of link segments joins neighbouring node centers, colored by adjacent status; where hidden steps continue past an edge a gradient-fading hint dissolves toward that container edge (single fade mechanism — masks deleted)
- empty edge cells stay truly empty; RTL supported via logical insets + mirrored fade paint; `aria-current="step"` added in both modes
- full-row desktop rendering untouched

### 2. New `HStepFlow` component
Generic step container: optional HkTimeline header bound via v-model + a direction-aware sliding body (`out-in`, forward/back translateX ±24px) fed purely by named slots keyed by step key. Additive API: `steps`, `modelValue`, `hideTimeline`, `timelineClickable`, `stickyHeader`, `collapse`; scoped slot arg `{ key, index, direction }`. Unknown keys render an empty body silently. Also:
- `.hk-modal-footer:empty { display:none }` so conditional footer phases never flash a bare bordered strip
- version 0.7.1 → 0.8.0

## Verification
- 3-round independent adversarial verification (R1/R2/R3), final verdict MERGE-APPROVED (findings round-tripped and fixed: discriminating direction-resync regression test, valid scaleX(-1) RTL mirror instead of invalid filter)
- vitest: 57 files / 454 tests green; vue-tsc --noEmit clean
- consumer impact: additive only; HkTimeline props/emits/public pure function unchanged