### PR TITLE
✨ Dock the header popovers as mobile bottom sheets and flatten the account menu.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAdminHeader.tsx
+++ b/packages/vue/src/components/HkAdminHeader.tsx
@@ -1,6 +1,6 @@
 import { defineComponent, ref, type PropType, type VNode } from "vue";
 import { Camera, Languages, LogOut, Menu } from "lucide-vue-next";
-import { HBadge, HButton, HDivider, HPopover, HSpinner } from "@celestia-island/hikari";
+import { HBadge, HButton, HPopover, HSpinner } from "@celestia-island/hikari";
 import { useI18n } from "../i18n/context";
 
 export interface LocaleOption {
@@ -144,6 +144,7 @@ export const HkAdminHeader = defineComponent({
           placement="bottom-start"
           anchorRef={userTriggerRef.value ?? null}
           class="w-56"
+          sheetOnMobile
         >
           {/* Empty identity (fetchUser race on a hard refresh): render a
               single subtle placeholder row instead of the action items —
@@ -156,7 +157,6 @@ export const HkAdminHeader = defineComponent({
                 <HSpinner size="sm" />
                 <div class="s-user-header-email">{props.signingInLabel ?? t("hikari::adminHeader.signingIn", "Signing in…")}</div>
               </div>
-              <HDivider spacing="sm" />
               <button
                 class="s-popup-menu-item"
                 onClick={() => props.onForceSignOut?.()}
@@ -188,7 +188,6 @@ export const HkAdminHeader = defineComponent({
                   </div>
                 )}
               </div>
-              <HDivider spacing="sm" />
               <button
                 class="s-popup-menu-item"
                 onClick={() => {
@@ -222,7 +221,6 @@ export const HkAdminHeader = defineComponent({
                 triggerRef: localeTriggerRef,
               })}
               {slots["user-menu-extra"]?.()}
-              <HDivider spacing="sm" />
               <button
                 class="s-popup-menu-item"
                 onClick={() => {

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -195,6 +195,7 @@ export const HkThemeToggle = defineComponent({
           onUpdate:modelValue={(v: boolean) => { menuOpen.value = v; }}
           placement={props.popoverPlacement}
           anchorRef={triggerRef.value ?? null}
+          sheetOnMobile
         >
           <div class="s-theme-menu">
             <div class="s-theme-menu-label">{t("hikari::theme.mode")}</div>

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -398,9 +398,10 @@
   min-width: 0;
   /* In menus this aligns with .s-popup-menu-item's own space-14 (menu
      padding applies equally to both); bare surfaces (the popover
-     wrapper) rely on it entirely. Vertical breathing keeps the block
-     off the menu's top edge and the divider below. */
+     wrapper) rely on it entirely. The bottom margin restores the
+     separation the removed section divider used to provide. */
   padding: var(--space-10) var(--space-14) var(--space-12);
+  margin-bottom: var(--space-4);
 }
 
 /* Pending variant (identity not yet hydrated): spinner beside the


### PR DESCRIPTION
## What
- `sheetOnMobile` on the **theme-toggle popover** and the **admin avatar account-menu popover**, so on mobile viewports (<768px) both open as bottom sheets rising from the bottom edge instead of anchored floating popovers (reuses the existing HkPopover sheet capability — no new mechanism).
- Removed every `HDivider` from the admin account menu (both pending and main branches) so it reads as one flat left-aligned list; `.s-user-header` gains a bottom margin to restore the separation the dividers used to provide.
- Version bump 0.7.1 → 0.8.0.

## Why
Product directive for the chest webui family: top-left and top-right header menus must be bottom sheets on phones, and dropdowns drop the divider lines. Admin pages across products (chest backend, arona) render through `HkAdminHeader`/`HkThemeToggle`, so the change lives here.

## Verification
- Local vitest (HkAdminHeader + HkThemeToggle + HkPopoverSheet suites) 17/17 green; vue-tsc clean.
- Consumer shittim-chest branch (independent PR) uses only `sheetOnMobile`, which already exists on master — no API dependency on this PR.