### PR TITLE
✨ Add a form slider component with a persistent themed thumb and steps.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSlider.scss
+++ b/packages/vue/src/components/HkSlider.scss
@@ -1,0 +1,99 @@
+.hk-slider {
+  position: relative;
+  // Comfortable pointer/touch hit area; the visual track is drawn inside
+  // via ::before so the control stays grabbable without a fat look.
+  height: 18px;
+  cursor: pointer;
+  touch-action: none;
+  user-select: none;
+  outline: none;
+}
+
+.hk-slider::before {
+  content: "";
+  position: absolute;
+  inset: 50% 0 auto 0;
+  height: 6px;
+  transform: translateY(-50%);
+  border-radius: var(--radius-full, 999px);
+  background: rgb(var(--color-muted) / 22%);
+}
+
+.hk-slider[data-size="sm"] {
+  height: 14px;
+}
+
+.hk-slider[data-size="sm"]::before {
+  height: 4px;
+}
+
+.hk-slider.is-disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.hk-slider:focus-visible {
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 2px rgb(var(--color-primary) / 40%);
+}
+
+.hk-slider-fill {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 6px;
+  transform: translateY(-50%);
+  border-radius: var(--radius-full, 999px);
+  background: rgb(var(--color-primary));
+  pointer-events: none;
+}
+
+.hk-slider[data-size="sm"] .hk-slider-fill {
+  height: 4px;
+}
+
+.hk-slider-tick {
+  position: absolute;
+  top: 50%;
+  width: 2px;
+  height: 2px;
+  margin-left: -1px;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  background: rgb(var(--color-muted) / 45%);
+  pointer-events: none;
+}
+
+.hk-slider-tick[data-active] {
+  background: rgb(var(--color-primary) / 70%);
+}
+
+.hk-slider-thumb {
+  // The whole point of this variant next to HkMediaSlider: the thumb is
+  // ALWAYS visible — no hover gating — so the control reads as draggable
+  // at first glance, on desktop and touch alike.
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  border-radius: 50%;
+  background: rgb(var(--color-primary));
+  box-shadow:
+    0 0 0 2px rgb(var(--color-surface, var(--color-background)) / 90%),
+    0 1px 3px rgb(0 0 0 / 35%);
+  transform: translateY(-50%);
+  transition: transform var(--hi-duration-short, 0.15s);
+  pointer-events: none;
+}
+
+.hk-slider:hover .hk-slider-thumb,
+.hk-slider:active .hk-slider-thumb {
+  transform: translateY(-50%) scale(1.15);
+}
+
+.hk-slider[data-size="sm"] .hk-slider-thumb {
+  width: 12px;
+  height: 12px;
+  margin-left: -6px;
+}

--- a/packages/vue/src/components/HkSlider.test.tsx
+++ b/packages/vue/src/components/HkSlider.test.tsx
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import HkSlider from "./HkSlider";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+/** Mount with a reactive render closure so controlled updates flow back. */
+function mount(renderNode: () => ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: renderNode });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+/** Pin a 200px-wide, left-0 rect on the track so drag math is exact. */
+function pinRect(slider: HTMLElement) {
+  Object.defineProperty(slider, "getBoundingClientRect", {
+    configurable: true,
+    value: () =>
+      ({ left: 0, width: 200, height: 18, top: 0, right: 200, bottom: 18, x: 0, y: 0 }) as DOMRect,
+  });
+}
+
+function pointer(type: string, clientX: number) {
+  return new PointerEvent(type, { bubbles: true, clientX, pointerId: 1, pointerType: "touch" });
+}
+
+describe("HkSlider", () => {
+  it("renders the slider role with stepped aria values", () => {
+    const c = mount(() => h(HkSlider, { modelValue: 150, min: 100, max: 300, step: 25, ariaLabel: "DPI" }));
+    const el = c.querySelector(".hk-slider") as HTMLElement;
+    expect(el.getAttribute("role")).toBe("slider");
+    expect(el.getAttribute("aria-label")).toBe("DPI");
+    expect(el.getAttribute("aria-valuemin")).toBe("100");
+    expect(el.getAttribute("aria-valuemax")).toBe("300");
+    expect(el.getAttribute("aria-valuenow")).toBe("150");
+  });
+
+  it("snaps an off-grid value onto the step grid", () => {
+    const c = mount(() => h(HkSlider, { modelValue: 137, min: 100, max: 300, step: 25 }));
+    expect((c.querySelector(".hk-slider") as HTMLElement).getAttribute("aria-valuenow")).toBe("125");
+  });
+
+  it("keeps the thumb visible without hover gating and themed by --color-primary", () => {
+    // Source contract (the HkMediaSlider defect this variant exists for):
+    // the thumb is always visible and always follows the theme color.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const scss = readFileSync(join(here, "HkSlider.scss"), "utf-8");
+    const thumb = scss.match(/\.hk-slider-thumb\s*{[^}]*}/)?.[0] ?? "";
+    expect(thumb).toContain("background: rgb(var(--color-primary))");
+    expect(thumb).not.toContain("opacity");
+  });
+
+  it("sizes the fill and thumb from the snapped value percentage", () => {
+    const c = mount(() => h(HkSlider, { modelValue: 200, min: 100, max: 300, step: 25 }));
+    expect((c.querySelector(".hk-slider-fill") as HTMLElement).style.width).toBe("50%");
+    expect((c.querySelector(".hk-slider-thumb") as HTMLElement).style.left).toBe("50%");
+  });
+
+  it("emits a snapped value when the track is pressed and dragged", () => {
+    const seen: number[] = [];
+    const value = ref(100);
+    const c = mount(() => h(HkSlider, {
+      modelValue: value.value,
+      min: 100,
+      max: 300,
+      step: 25,
+      "onUpdate:modelValue": (v: number) => { value.value = v; seen.push(v); },
+    }));
+    const slider = c.querySelector(".hk-slider") as HTMLElement;
+    pinRect(slider);
+    slider.dispatchEvent(pointer("pointerdown", 100)); // exact middle → 200
+    expect(seen).toEqual([200]);
+    window.dispatchEvent(pointer("pointermove", 200)); // right edge → 300
+    window.dispatchEvent(pointer("pointerup", 200));
+    expect(seen).toEqual([200, 300]);
+    window.dispatchEvent(pointer("pointermove", 0)); // released: no further emit
+    expect(seen).toEqual([200, 300]);
+  });
+
+  it("steps from the keyboard and clamps at the bounds", async () => {
+    const seen: number[] = [];
+    const value = ref(275);
+    const c = mount(() => h(HkSlider, {
+      modelValue: value.value,
+      min: 100,
+      max: 300,
+      step: 25,
+      "onUpdate:modelValue": (v: number) => { value.value = v; seen.push(v); },
+    }));
+    const slider = c.querySelector(".hk-slider") as HTMLElement;
+    slider.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    await nextTick(); // let the controlled parent feed the new value back
+    expect(seen).toEqual([300]);
+    slider.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    await nextTick();
+    // Clamped at max: ArrowRight again emits nothing.
+    expect(seen).toEqual([300]);
+    slider.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    await nextTick();
+    expect(seen).toEqual([300, 100]);
+  });
+
+  it("ignores pointers and keys while disabled", () => {
+    const seen: number[] = [];
+    const c = mount(() => h(HkSlider, {
+      modelValue: 100,
+      min: 100,
+      max: 300,
+      step: 25,
+      disabled: true,
+      "onUpdate:modelValue": (v: number) => seen.push(v),
+    }));
+    const slider = c.querySelector(".hk-slider") as HTMLElement;
+    pinRect(slider);
+    slider.dispatchEvent(pointer("pointerdown", 200));
+    slider.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(seen).toEqual([]);
+    expect(slider.getAttribute("aria-disabled")).toBe("true");
+    expect(slider.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("renders one tick per stop when showTicks is set", () => {
+    const c = mount(() => h(HkSlider, { modelValue: 200, min: 100, max: 300, step: 25, showTicks: true }));
+    expect(c.querySelectorAll(".hk-slider-tick").length).toBe(9);
+    // 100..200 inclusive sit at or left of the value.
+    expect(c.querySelectorAll(".hk-slider-tick[data-active]").length).toBe(5);
+    const bare = mount(() => h(HkSlider, { modelValue: 200, min: 100, max: 300, step: 25 }));
+    expect(bare.querySelectorAll(".hk-slider-tick").length).toBe(0);
+  });
+
+  it("formats the aria value text through formatValue", () => {
+    const c = mount(() => h(HkSlider, {
+      modelValue: 175,
+      min: 100,
+      max: 300,
+      step: 25,
+      formatValue: (v: number) => `${v}%`,
+    }));
+    expect((c.querySelector(".hk-slider") as HTMLElement).getAttribute("aria-valuetext")).toBe("175%");
+  });
+});

--- a/packages/vue/src/components/HkSlider.tsx
+++ b/packages/vue/src/components/HkSlider.tsx
@@ -1,0 +1,173 @@
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, type PropType } from "vue";
+
+import "./HkSlider.scss";
+
+/**
+ * HkSlider — the form/settings range slider. Unlike the hover-only
+ * HkMediaSlider seek primitive, the thumb here is persistent and always
+ * visible (a bare fill bar reads as a progress display, not a control),
+ * values snap to a `step` grid with optional tick marks per stop, and the
+ * whole control is keyboard reachable. Thumb and fill pick up
+ * `--color-primary` from the active theme, so they follow whatever color
+ * scheme the user picks without extra wiring.
+ *
+ * Interaction model matches the rest of the library: pointerdown on the
+ * track jumps and drags (emitting continuously so hosts can apply live),
+ * with window-level move/up listeners so the drag keeps tracking the
+ * pointer past the element bounds.
+ */
+export default defineComponent({
+  name: "HkSlider",
+  props: {
+    /** Controlled value; every emitted value lands on the step grid. */
+    modelValue: { type: Number, required: true },
+    min: { type: Number, default: 0 },
+    max: { type: Number, default: 100 },
+    /** Snap step — emitted values are `min + n * step`. */
+    step: { type: Number, default: 1 },
+    disabled: { type: Boolean, default: false },
+    /** Render one tick dot per stop (kept sane for modest stop counts). */
+    showTicks: { type: Boolean, default: false },
+    size: { type: String as () => "sm" | "md", default: "md" },
+    ariaLabel: { type: String, default: undefined },
+    /** Optional aria-valuetext formatter (e.g. `v => `${v}%``). */
+    formatValue: { type: Function as PropType<(value: number) => string>, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_value: number) => true,
+  },
+  setup(props, { emit }) {
+    const trackRef = ref<HTMLElement | null>(null);
+    let dragging = false;
+
+    const safeStep = computed(() => (props.step > 0 ? props.step : 1));
+
+    /** Snap to the step grid and clamp into [min, max]; kills float drift. */
+    function snap(value: number): number {
+      const steps = Math.round((value - props.min) / safeStep.value);
+      const snapped = props.min + steps * safeStep.value;
+      const fixed = Number(snapped.toFixed(6));
+      return Math.min(props.max, Math.max(props.min, fixed));
+    }
+
+    const value = computed(() =>
+      snap(Math.min(props.max, Math.max(props.min, props.modelValue))),
+    );
+
+    const pct = computed(() => {
+      const span = props.max - props.min;
+      return span > 0 ? ((value.value - props.min) / span) * 100 : 0;
+    });
+
+    const tickPositions = computed<number[]>(() => {
+      if (!props.showTicks) return [];
+      const count = Math.round((props.max - props.min) / safeStep.value);
+      // Degenerate ranges and unreadable tick density both render bare.
+      if (count < 2 || count > 32) return [];
+      return Array.from({ length: count + 1 }, (_, i) => (i / count) * 100);
+    });
+
+    const valueText = computed(() =>
+      props.formatValue ? props.formatValue(value.value) : String(value.value),
+    );
+
+    function valueFrom(clientX: number): number {
+      const el = trackRef.value;
+      if (!el) return value.value;
+      const rect = el.getBoundingClientRect();
+      if (rect.width <= 0) return value.value;
+      const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+      return snap(props.min + ratio * (props.max - props.min));
+    }
+
+    function commit(next: number) {
+      if (next !== value.value) emit("update:modelValue", next);
+    }
+
+    function onDown(e: PointerEvent) {
+      if (props.disabled) return;
+      dragging = true;
+      (e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId);
+      commit(valueFrom(e.clientX));
+    }
+    function onMove(e: PointerEvent) {
+      if (dragging && !props.disabled) commit(valueFrom(e.clientX));
+    }
+    function onUp() {
+      dragging = false;
+    }
+
+    function onKey(e: KeyboardEvent) {
+      if (props.disabled) return;
+      const big = safeStep.value * 4;
+      let next: number;
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          next = value.value + safeStep.value;
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          next = value.value - safeStep.value;
+          break;
+        case "PageUp":
+          next = value.value + big;
+          break;
+        case "PageDown":
+          next = value.value - big;
+          break;
+        case "Home":
+          next = props.min;
+          break;
+        case "End":
+          next = props.max;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      commit(snap(next));
+    }
+
+    onMounted(() => {
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    });
+    onBeforeUnmount(() => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    });
+
+    return () => (
+      <div
+        ref={trackRef}
+        class={["hk-slider", props.disabled && "is-disabled"].filter(Boolean).join(" ")}
+        data-size={props.size}
+        role="slider"
+        tabindex={props.disabled ? -1 : 0}
+        aria-label={props.ariaLabel}
+        aria-valuemin={props.min}
+        aria-valuemax={props.max}
+        aria-valuenow={value.value}
+        aria-valuetext={valueText.value}
+        aria-disabled={props.disabled || undefined}
+        onPointerdown={onDown}
+        onKeydown={onKey}
+      >
+        {tickPositions.value.map((left, i) => (
+          <span
+            key={i}
+            class="hk-slider-tick"
+            data-active={left <= pct.value + 0.001 || undefined}
+            style={{ left: `${left}%` }}
+            aria-hidden="true"
+          />
+        ))}
+        <div class="hk-slider-fill" style={{ width: `${pct.value}%` }} />
+        <div class="hk-slider-thumb" style={{ left: `${pct.value}%` }} />
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -59,6 +59,7 @@ export { default as HSelectPanel, type SelectPanelPlacement } from "./components
 export { default as HSidebar } from "./components/HkSidebar";
 export { default as HSkeleton } from "./components/HkSkeleton";
 export { default as HSkeletonList } from "./components/HkSkeletonList";
+export { default as HSlider } from "./components/HkSlider";
 export { default as HSpinner } from "./components/HkSpinner";
 export { default as HSwitch } from "./components/HkSwitch";
 export { default as HTable } from "./components/HkTable";


### PR DESCRIPTION
## Summary
- New `HSlider` form/settings slider in packages/vue, exported alongside the existing primitives:
  - Persistent, always-visible thumb (the media seek bar keeps its hover-only thumb by design; settings surfaces need a control that reads as draggable at first glance — reported as a bare progress bar with no knob in the theme dialog).
  - Thumb + fill follow the active theme via `--color-primary`.
  - `step` snapping (every emitted value lands on `min + n * step`), optional `showTicks` per stop with active-tick tinting.
  - Full keyboard support (arrows, PageUp/Down, Home/End) and slider aria semantics incl. `formatValue` → `aria-valuetext`.
  - `sm`/`md` sizes, disabled state, same window-level pointer-drag model as HkMediaSlider.
- Version 0.8.0 → 0.9.0.

## Verification
- `vitest run`: 58 files, 466/466 green (includes 9 new HkSlider tests; one pins the always-visible themed thumb as a source contract so the hover-gated regression cannot return).
- `vue-tsc --noEmit`: clean.
- Downstream: shittim-chest will consume this for the theme dialog DPI control + wallpaper brightness slider in a follow-up PR right after this merges.