### PR TITLE
🐛 Pin popup menu rows to flex-start so sheet items stay left aligned.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -369,6 +369,13 @@
   background: none;
   width: 100%;
   text-align: left;
+  /* Rows are flex containers (icon + label + optional trailing caret).
+     Without an explicit justification, Chrome's button UA default
+     (justify-content: center) applies — invisible on shrink-to-fit
+     popovers, glaring in full-width mobile sheets where icon+label
+     float to the middle. Pin to flex-start; trailing carets keep
+     parking at the far edge via their own margin-left: auto. */
+  justify-content: flex-start;
   outline: none;
   border-radius: var(--radius-sm);
 }


### PR DESCRIPTION
Root cause of the mixed row alignment seen in chest's mobile account sheet (#513 follow-up): .s-popup-menu-item is a flex button and the token sheet never set justify-content, so Chrome's button UA default (center) applied. Invisible on shrink-to-fit desktop popovers; in full-width mobile bottom sheets the icon+label cluster floats to the middle. Rows carrying a trailing caret absorb the free space via their own margin-left: auto — which is exactly why some rows read left-aligned while others read centered.

One-line token fix: justify-content: flex-start on .s-popup-menu-item. Trailing carets keep parking at the far edge. Version 0.10.0 → 0.11.0.