### PR TITLE
✨ Add a sliding thumb to segmented groups and measured morphing tab indicators.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkMorphingTabs.scss
+++ b/packages/vue/src/components/HkMorphingTabs.scss
@@ -23,19 +23,42 @@
   background: color-mix(in srgb, var(--hi-color-surface) 60%, transparent);
 }
 
+/*
+ * Indicator geometry is measured (useMeasuredHighlight) and applied as
+ * inline transform/width, so unequal trigger widths (overflowing labels
+ * under `flex: 1 1 0`) no longer drift the highlight off the active tab.
+ * `left: 0` + translateX(x) lands on the trigger's own offsetLeft, which is
+ * padding-edge relative — the same reference frame as the old `left: 2px`.
+ * Width 0 + opacity 0 (before the first measurement) keep the indicator
+ * invisible with no mount grow/slide; `data-ready` fades it in once real
+ * layout exists.
+ */
 .hk-morphing-tabs-indicator {
   position: absolute;
   top: 2px;
-  left: 2px;
+  left: 0;
   height: calc(100% - 4px);
-  width: calc((100% - 4px) / var(--tab-count, 1));
+  width: 0;
   border-radius: var(--hi-radius-sm, 4px);
   background: color-mix(in srgb, var(--hi-color-primary) 12%, transparent);
   box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
   pointer-events: none;
   z-index: 0;
-  transform: translateX(calc(var(--tab-index, 0) * 100%));
-  transition: transform var(--hi-duration-normal, 0.3s) ease;
+  opacity: 0;
+  transition:
+    transform var(--hi-duration-normal, 0.3s) ease,
+    width var(--hi-duration-normal, 0.3s) ease,
+    opacity var(--hi-duration-normal, 0.3s) ease;
+}
+
+.hk-morphing-tabs-triggers[data-ready="true"] .hk-morphing-tabs-indicator {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-morphing-tabs-indicator {
+    transition: none;
+  }
 }
 
 .hk-morphing-tabs-trigger {

--- a/packages/vue/src/components/HkMorphingTabs.test.tsx
+++ b/packages/vue/src/components/HkMorphingTabs.test.tsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkMorphingTabs, { type TabItem } from "./HkMorphingTabs";
+
+/** Let Vue's out-in panel transition and the post-measure indicator render
+ *  finish in happy-dom (frame/timeout based). */
+async function settle(): Promise<void> {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 20));
+  await nextTick();
+}
+
+const tabs: TabItem[] = [
+  { key: "color", label: "Color" },
+  { key: "wallpaper", label: "Wallpaper" },
+  { key: "style", label: "Style" },
+  { key: "dpi", label: "DPI Controls" },
+];
+
+const PANEL_TEXT: Record<string, string> = {
+  color: "Color panel",
+  wallpaper: "Wallpaper panel",
+  style: "Style panel",
+  dpi: "DPI panel",
+};
+
+/** Mount HkMorphingTabs with a live v-model and one slot panel per tab
+ *  (the repo's test convention — no @vue/test-utils; assert the DOM). */
+function mountTabs(initial = "color"): {
+  root: HTMLElement;
+  modelValue: ReturnType<typeof ref<string>>;
+  unmount: () => void;
+} {
+  const modelValue = ref(initial);
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          HkMorphingTabs as never,
+          {
+            tabs,
+            modelValue: modelValue.value,
+            "onUpdate:modelValue": (v: string) => { modelValue.value = v; },
+          },
+          Object.fromEntries(
+            Object.entries(PANEL_TEXT).map(([key, text]) => [
+              key,
+              () => h("p", { class: `panel-${key}` }, text),
+            ]),
+          ),
+        );
+    },
+  });
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const app = createApp(Host);
+  app.mount(el);
+  return { root: el, modelValue, unmount: () => { app.unmount(); el.remove(); } };
+}
+
+function triggers(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll(".hk-morphing-tabs-trigger"));
+}
+
+describe("HkMorphingTabs", () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  /** Stub trigger layout (happy-dom has none); returns an undo handle. */
+  function stubTriggerGeometry(root: HTMLElement, offsets: number[], width: number): () => void {
+    const restore: Array<() => void> = [];
+    triggers(root).forEach((trg, i) => {
+      Object.defineProperty(trg, "offsetLeft", { value: offsets[i] ?? 0, configurable: true });
+      Object.defineProperty(trg, "offsetWidth", { value: width, configurable: true });
+      restore.push(() => {
+        delete (trg as unknown as Record<string, unknown>).offsetLeft;
+        delete (trg as unknown as Record<string, unknown>).offsetWidth;
+      });
+    });
+    return () => restore.forEach((fn) => fn());
+  }
+
+  it("renders one trigger per tab plus the indicator", () => {
+    const { root, unmount } = mountTabs();
+    expect(triggers(root)).toHaveLength(4);
+    const indicator = root.querySelector(".hk-morphing-tabs-indicator");
+    expect(indicator).not.toBeNull();
+    expect(indicator!.getAttribute("aria-hidden")).toBe("true");
+    expect(root.querySelector(".hk-morphing-tabs-triggers")!.getAttribute("role")).toBe("tablist");
+    unmount();
+  });
+
+  it("clicking a trigger emits update:modelValue and moves selection", async () => {
+    const { root, modelValue, unmount } = mountTabs("color");
+    triggers(root)[1].click();
+    await nextTick();
+    expect(modelValue.value).toBe("wallpaper");
+    expect(triggers(root)[1].getAttribute("aria-selected")).toBe("true");
+    expect(triggers(root)[0].getAttribute("aria-selected")).toBe("false");
+    unmount();
+  });
+
+  it("positions the indicator with measured trigger geometry", async () => {
+    const { root, unmount } = mountTabs("style");
+    // Unequal offsets: what equal-width percentage math gets wrong.
+    cleanups.push(stubTriggerGeometry(root, [2, 82, 162, 262], 78));
+    await nextTick();
+    await nextTick();
+    const triggersEl = root.querySelector(".hk-morphing-tabs-triggers")!;
+    expect(triggersEl.getAttribute("data-ready")).toBe("true");
+    const indicator = root.querySelector(".hk-morphing-tabs-indicator") as HTMLElement;
+    expect(indicator.style.transform).toBe("translateX(162px)");
+    expect(indicator.style.width).toBe("78px");
+    unmount();
+  });
+
+  it("switches the panel slot content with modelValue", async () => {
+    const { root, modelValue, unmount } = mountTabs("color");
+    expect(root.querySelector(".hk-morphing-tabs-panel")!.textContent).toContain("Color panel");
+    modelValue.value = "dpi";
+    await settle();
+    expect(root.querySelector(".hk-morphing-tabs-panel")!.textContent).toContain("DPI panel");
+    unmount();
+  });
+});

--- a/packages/vue/src/components/HkMorphingTabs.tsx
+++ b/packages/vue/src/components/HkMorphingTabs.tsx
@@ -1,5 +1,6 @@
 import { computed, defineComponent, onMounted, ref, Teleport, Transition, type PropType } from "vue";
 
+import { useMeasuredHighlight } from "../composables/useMeasuredHighlight";
 import "./HkMorphingTabs.scss";
 
 export interface TabItem {
@@ -22,31 +23,43 @@ export default defineComponent({
   },
   setup(props, { emit, slots }) {
     const activeKey = computed(() => props.modelValue);
-    const ready = ref(false);
+    // Gates the Teleport (a teleported target only exists after mount).
+    const mounted = ref(false);
 
-    const tabCount = computed(() => props.tabs.length);
-    const tabIndex = computed(() => {
+    const triggersRef = ref<HTMLElement | null>(null);
+    const activeIndex = computed(() => {
       const idx = props.tabs.findIndex((t) => t.key === activeKey.value);
       return idx >= 0 ? idx : 0;
+    });
+
+    // Indicator geometry from real trigger measurements. The old CSS-var
+    // percentage math assumed equal-width triggers, but `flex: 1 1 0` +
+    // `min-width: auto` lets overflowing labels widen some triggers, which
+    // drifted the indicator off the active tab (visible with 4+ tabs).
+    const { x, width, ready } = useMeasuredHighlight({
+      container: triggersRef,
+      activeIndex,
+      itemSelector: ".hk-morphing-tabs-trigger",
+      extraSources: [() => props.tabs],
     });
 
     const indicatorStyle = computed(
       () =>
         ({
-          "--tab-count": tabCount.value,
-          "--tab-index": tabIndex.value,
-        }) as Record<string, string | number>,
+          transform: `translateX(${x.value}px)`,
+          width: `${width.value}px`,
+        }) as Record<string, string>,
     );
 
     onMounted(() => {
-      ready.value = true;
+      mounted.value = true;
     });
 
     function renderTriggers() {
       if (props.hideTriggers) return null;
       return (
-        <div class="hk-morphing-tabs-triggers" role="tablist">
-          <div class="hk-morphing-tabs-indicator" style={indicatorStyle.value} />
+        <div class="hk-morphing-tabs-triggers" ref={triggersRef} role="tablist" data-ready={ready.value ? "true" : undefined}>
+          <div class="hk-morphing-tabs-indicator" aria-hidden="true" style={indicatorStyle.value} />
           {props.tabs.map((tab) => {
             const isActive = activeKey.value === tab.key;
             return (
@@ -78,7 +91,7 @@ export default defineComponent({
       return (
         <Tag class="hk-morphing-tabs">
           {props.teleportTo ? (
-            ready.value && <Teleport to={props.teleportTo}>{triggerContent}</Teleport>
+            mounted.value && <Teleport to={props.teleportTo}>{triggerContent}</Teleport>
           ) : (
             <div class="hk-morphing-tabs-header">{triggerContent}</div>
           )}

--- a/packages/vue/src/components/HkSegmented.scss
+++ b/packages/vue/src/components/HkSegmented.scss
@@ -5,6 +5,9 @@
   padding: 2px;
   border-radius: 10px;
   background: rgb(var(--hk-surface-muted, 240 240 244) / 60%);
+  /* Anchor the sliding thumb; also makes segment offsetLeft
+   * container-relative for the measurement composable. */
+  position: relative;
   /* Match the surrounding form controls' focus ring token where defined. */
   --hk-segmented-h: 34px;
 }
@@ -17,6 +20,42 @@
 .hk-segmented[data-block="true"] {
   display: flex;
   width: 100%;
+}
+
+/* ── Sliding thumb ──────────────────────────────────────────────────────
+ * Rendered by HkSegmented as the first root child and positioned with real
+ * measurements (useMeasuredHighlight). Invisible (width 0) until a non-zero
+ * width is measured, so the per-segment checked styling below remains the
+ * fallback and there is never a flash of no indicator. */
+.hk-segmented__thumb {
+  position: absolute;
+  top: 2px;
+  left: 0;
+  height: calc(100% - 4px);
+  border-radius: 8px;
+  /* Same pill treatment the checked segment used to carry. Invisible
+   * (opacity 0, width 0) until measured — no mount grow/slide, no
+   * zero-width box-shadow sliver. */
+  background: rgb(var(--hk-surface, 255 255 255));
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: transform 0.2s ease, width 0.2s ease, opacity 0.2s ease;
+  will-change: transform;
+}
+
+.hk-segmented[data-ready="true"] .hk-segmented__thumb {
+  opacity: 1;
+}
+
+/* A disabled group dims its labels and its thumb alike. */
+.hk-segmented[data-disabled="true"] .hk-segmented__thumb {
+  opacity: 0.45;
+}
+
+.hk-segmented[data-size="sm"] .hk-segmented__thumb {
+  border-radius: 6px;
 }
 
 .hk-segmented__segment {
@@ -38,6 +77,9 @@
   transition: background 0.15s ease, color 0.15s ease;
   white-space: nowrap;
   flex: 1 1 auto;
+  /* Keep segments (and their text) painted above the thumb. */
+  position: relative;
+  z-index: 1;
 }
 
 .hk-segmented[data-size="sm"] .hk-segmented__segment {
@@ -55,6 +97,13 @@
   color: rgb(var(--hk-text, 20 20 26));
   /* Soft elevation keeps the active pill legible on the muted track. */
   box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+}
+
+/* Once the thumb is measured it carries the checked pill — suppress the
+ * per-segment background/shadow (the checked text color stays). */
+.hk-segmented[data-ready="true"] .hk-segmented__segment[data-checked="true"] {
+  background: transparent;
+  box-shadow: none;
 }
 
 .hk-segmented__segment:disabled,
@@ -94,5 +143,14 @@
     font-size: 14px;
     border-radius: 8px;
     padding: 0 6px;
+  }
+
+  /* The thumb keeps working here: top 2px + height calc(100% - 4px)
+   * stretches it over the 40px segments; width/offset stay measured. */
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-segmented__thumb {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkSegmented.test.tsx
+++ b/packages/vue/src/components/HkSegmented.test.tsx
@@ -1,7 +1,15 @@
-import { describe, expect, it } from "vitest";
-import { createApp, defineComponent, h } from "vue";
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
 
 import HkSegmented from "./HkSegmented";
+
+/** Let the thumb's post-measure render flush land in happy-dom (the
+ *  measurement composable re-renders one tick after a modelValue change). */
+async function settle(): Promise<void> {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 20));
+  await nextTick();
+}
 
 const options = [
   { value: "a", label: "Alpha" },
@@ -29,6 +37,21 @@ function mountSegmented(
 
 function segments(root: HTMLElement): HTMLElement[] {
   return Array.from(root.querySelectorAll(".hk-segmented__segment"));
+}
+
+/** Stub layout geometry on the segments (happy-dom has none) and return an
+ *  undo handle — the defineProperty descriptors must not leak across tests. */
+function stubSegmentGeometry(root: HTMLElement, offsets: number[], width: number): () => void {
+  const restore: Array<() => void> = [];
+  segments(root).forEach((seg, i) => {
+    Object.defineProperty(seg, "offsetLeft", { value: offsets[i] ?? 0, configurable: true });
+    Object.defineProperty(seg, "offsetWidth", { value: width, configurable: true });
+    restore.push(() => {
+      delete (seg as unknown as Record<string, unknown>).offsetLeft;
+      delete (seg as unknown as Record<string, unknown>).offsetWidth;
+    });
+  });
+  return () => restore.forEach((fn) => fn());
 }
 
 describe("HkSegmented", () => {
@@ -71,5 +94,94 @@ describe("HkSegmented", () => {
       .toBe("true");
     expect((segments(r2)[1] as HTMLButtonElement).disabled).toBe(true);
     u2();
+  });
+});
+
+describe("HkSegmented sliding thumb", () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  /** Host with a live v-model so modelValue changes re-render. */
+  function mountReactiveSegmented(): {
+    root: HTMLElement;
+    modelValue: ReturnType<typeof ref<string>>;
+    unmount: () => void;
+  } {
+    const modelValue = ref("a");
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(HkSegmented as never, {
+            options,
+            modelValue: modelValue.value,
+            "onUpdate:modelValue": (v: string) => { modelValue.value = v; },
+          });
+      },
+    });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const app = createApp(Host);
+    app.mount(el);
+    return { root: el, modelValue, unmount: () => { app.unmount(); el.remove(); } };
+  }
+
+  it("renders an aria-hidden thumb span as the first root child", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    const seg = root.querySelector(".hk-segmented")!;
+    const thumb = seg.querySelector(".hk-segmented__thumb");
+    expect(thumb).not.toBeNull();
+    expect(thumb!.getAttribute("aria-hidden")).toBe("true");
+    expect(seg.firstElementChild).toBe(thumb);
+    // Pre-measurement (happy-dom layout is all zeros): not ready yet, and
+    // the thumb carries no geometry.
+    expect(seg.getAttribute("data-ready")).toBeNull();
+    unmount();
+  });
+
+  it("measures the active segment and marks the root data-ready", async () => {
+    const { root, unmount } = mountSegmented({ modelValue: "b" });
+    // Segment "b" sits one gap (2px) past segment "a" at 14px.
+    cleanups.push(stubSegmentGeometry(root, [14, 64, 114], 48));
+    await nextTick();
+    await nextTick();
+    const seg = root.querySelector(".hk-segmented")!;
+    expect(seg.getAttribute("data-ready")).toBe("true");
+    const thumb = seg.querySelector(".hk-segmented__thumb") as HTMLElement;
+    expect(thumb.style.transform).toBe("translateX(64px)");
+    expect(thumb.style.width).toBe("48px");
+    unmount();
+  });
+
+  it("moves the thumb when modelValue changes", async () => {
+    const { root, modelValue, unmount } = mountReactiveSegmented();
+    cleanups.push(stubSegmentGeometry(root, [14, 64, 114], 48));
+    await nextTick();
+    await nextTick();
+    modelValue.value = "c";
+    await settle();
+    const thumb = root.querySelector(".hk-segmented__thumb") as HTMLElement;
+    expect(thumb.style.transform).toBe("translateX(114px)");
+    expect(thumb.style.width).toBe("48px");
+    unmount();
+  });
+
+  it("stays without data-ready when no geometry is measurable", async () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    await nextTick();
+    await nextTick();
+    expect(root.querySelector(".hk-segmented")!.getAttribute("data-ready")).toBeNull();
+    unmount();
+  });
+
+  it("keeps data-ready unset when modelValue matches no option", async () => {
+    const { root, unmount } = mountSegmented({ modelValue: "nope" });
+    cleanups.push(stubSegmentGeometry(root, [14, 64, 114], 48));
+    await settle();
+    expect(root.querySelector(".hk-segmented")!.getAttribute("data-ready")).toBeNull();
+    const thumb = root.querySelector(".hk-segmented__thumb") as HTMLElement;
+    expect(thumb.style.width).toBe("0px");
+    unmount();
   });
 });

--- a/packages/vue/src/components/HkSegmented.tsx
+++ b/packages/vue/src/components/HkSegmented.tsx
@@ -1,5 +1,6 @@
-import { defineComponent, type PropType } from "vue";
+import { computed, defineComponent, ref, type PropType } from "vue";
 
+import { useMeasuredHighlight } from "../composables/useMeasuredHighlight";
 import "./HkSegmented.scss";
 
 /** One segment of an [HkSegmented] group. */
@@ -48,6 +49,27 @@ export default defineComponent({
     "update:modelValue": (_value: string) => true,
   },
   setup(props, { emit }) {
+    const rootRef = ref<HTMLElement | null>(null);
+    // -1 (no match, e.g. the default "") clears the thumb instead of
+    // pointing it at the first segment — mirrors aria-checked all-false.
+    const activeIndex = computed(() =>
+      props.options.findIndex((o) => o.value === props.modelValue),
+    );
+    // Sliding thumb geometry from real measurements — options of unequal
+    // label width would drift percentage math. Until a non-zero width is
+    // measured (jsdom/SSR never get there) the per-segment checked styling
+    // below remains as the fallback.
+    const { x, width, ready } = useMeasuredHighlight({
+      container: rootRef,
+      activeIndex,
+      itemSelector: ".hk-segmented__segment",
+      extraSources: [() => props.options],
+    });
+    const thumbStyle = computed(() => ({
+      transform: `translateX(${x.value}px)`,
+      width: `${width.value}px`,
+    }));
+
     function select(v: string) {
       if (props.disabled) return;
       const opt = props.options.find((o) => o.value === v);
@@ -59,11 +81,14 @@ export default defineComponent({
     return () => (
       <div
         class="hk-segmented"
+        ref={rootRef}
         data-size={props.size}
         data-block={props.block || undefined}
         data-disabled={props.disabled || undefined}
+        data-ready={ready.value ? "true" : undefined}
         role="radiogroup"
       >
+        <span class="hk-segmented__thumb" aria-hidden="true" style={thumbStyle.value} />
         {props.options.map((opt) => (
           <button
             key={opt.value}

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -75,9 +75,14 @@
  * calc((100% - 4px) / 3 + 2px). NOTE: HkSegmented's mobileBreakpoint prop
  * is currently unwired (its touch form is pure CSS at the same 767px), so
  * these hardcoded calcs stay in lockstep; revisit both if that changes.
+ *
+ * z-index 2 keeps the strip above the segments, which HkSegmented promotes
+ * to position: relative / z-index: 1 so its sliding thumb can slot under
+ * them.
  */
 .s-theme-mode-autoalt {
   position: absolute;
+  z-index: 2;
   top: 2px;
   bottom: 2px;
   right: 2px;

--- a/packages/vue/src/composables/useMeasuredHighlight.ts
+++ b/packages/vue/src/composables/useMeasuredHighlight.ts
@@ -1,0 +1,144 @@
+import { nextTick, onScopeDispose, ref, watch, type Ref, type WatchSource } from "vue";
+
+/** Options for [useMeasuredHighlight]. */
+export interface UseMeasuredHighlightOptions {
+  /** The element that visually owns the highlight — make it
+   *  `position: relative` so item `offsetLeft` is already relative to it. */
+  container: Ref<HTMLElement | null>;
+  /** Index of the active item within the matched items. Negative means
+   *  "no active item" (the highlight clears); a too-large index clamps to
+   *  the last item. */
+  activeIndex: Ref<number>;
+  /** Selector matching the measurable items inside `container`. */
+  itemSelector: string;
+  /** Extra reactive sources whose changes re-measure — pass the options /
+   *  tabs array here so swapped item sets re-measure even when the active
+   *  index number is unchanged. */
+  extraSources?: WatchSource<unknown>[];
+}
+
+export interface MeasuredHighlight {
+  /** Left offset (px) of the active item relative to `container`. */
+  x: Ref<number>;
+  /** Measured width (px) of the active item; 0 before a successful measure. */
+  width: Ref<number>;
+  /** True once a non-zero width has been measured — i.e. real layout was
+   *  available (stays false under jsdom/happy-dom/SSR, where reads are 0). */
+  ready: Ref<boolean>;
+}
+
+/**
+ * Offset of `item` relative to `container`, robust to intermediate
+ * positioned ancestors. `offsetLeft` is relative to the nearest positioned
+ * ancestor (the offsetParent); when that is the container itself the value
+ * is already container-relative. Otherwise accumulate offsetLeft up the
+ * offsetParent chain until the container is reached — and if the chain
+ * escapes without passing through the container (no positioned ancestor:
+ * hidden subtrees, layout-less test environments, fixed items), fall back
+ * to the direct offsetLeft read rather than reporting a wrong frame.
+ */
+function offsetWithin(item: HTMLElement, container: HTMLElement): number {
+  if (item.offsetParent === container) return item.offsetLeft;
+  let x = 0;
+  let cur: HTMLElement | null = item;
+  while (cur && cur !== container) {
+    x += cur.offsetLeft;
+    const parent = cur.offsetParent as HTMLElement | null;
+    // Chain ended above the container (hidden subtree, or a layout-less
+    // test environment): trust the direct offsetLeft read — 0 in real
+    // hidden subtrees, the stubbed value under tests.
+    if (!parent) return item.offsetLeft;
+    if (parent === cur) return 0;
+    cur = parent;
+  }
+  return cur === container ? x : item.offsetLeft;
+}
+
+/**
+ * Measure the active item of a flat group (segmented options, tab triggers)
+ * so a sliding highlight can follow real geometry instead of assumed equal
+ * widths — `flex: 1 1 0` + `min-width: auto` lets overflowing labels widen
+ * some items, which silently drifts percentage-math indicators.
+ *
+ * Measures after mount (nextTick), after `activeIndex` / `extraSources`
+ * changes, on container resizes (ResizeObserver, when the environment
+ * provides one), and once after `document.fonts.ready` so late font swaps
+ * re-align the highlight. The observer is disconnected on scope dispose.
+ *
+ * jsdom/happy-dom/SSR-safe: layout reads return 0 there, so `ready` stays
+ * false and callers keep their pre-measurement CSS fallback — nothing
+ * throws and no NaN leaks (every number is finite-coerced to 0).
+ */
+export function useMeasuredHighlight(opts: UseMeasuredHighlightOptions): MeasuredHighlight {
+  const x = ref(0);
+  const width = ref(0);
+  const ready = ref(false);
+
+  let observer: ResizeObserver | null = null;
+
+  function measure(): void {
+    const containerEl = opts.container.value;
+    if (!containerEl) return;
+    const items = containerEl.querySelectorAll<HTMLElement>(opts.itemSelector);
+    if (items.length === 0) {
+      width.value = 0;
+      ready.value = false;
+      return;
+    }
+    const raw = opts.activeIndex.value;
+    if (raw < 0) {
+      // Explicit "no active item" (e.g. modelValue matches no option):
+      // clear the highlight instead of pointing at the first item.
+      x.value = 0;
+      width.value = 0;
+      ready.value = false;
+      return;
+    }
+    const idx = Math.min(raw, items.length - 1);
+    const item = items[idx];
+    if (!item) {
+      width.value = 0;
+      ready.value = false;
+      return;
+    }
+    const nx = offsetWithin(item, containerEl);
+    const nw = item.offsetWidth;
+    x.value = Number.isFinite(nx) ? nx : 0;
+    width.value = Number.isFinite(nw) ? nw : 0;
+    ready.value = width.value > 0;
+  }
+
+  /** Re-measure after the current render flush commits layout. */
+  function schedule(): void {
+    void nextTick(measure);
+  }
+
+  watch(
+    opts.container,
+    (el) => {
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+      if (el && typeof ResizeObserver !== "undefined") {
+        observer = new ResizeObserver(schedule);
+        observer.observe(el);
+      }
+      schedule();
+    },
+    { immediate: true },
+  );
+
+  watch(() => opts.activeIndex.value, schedule);
+  for (const source of opts.extraSources ?? []) watch(source, schedule);
+
+  // Late font load changes label metrics — re-align once fonts settle.
+  if (typeof document !== "undefined") document.fonts?.ready.then(schedule).catch(() => {});
+
+  onScopeDispose(() => {
+    observer?.disconnect();
+    observer = null;
+  });
+
+  return { x, width, ready };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -208,6 +208,8 @@ export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";
 export { extOf, isImageFile, isAudioFile, codeLanguage, isCodeFile, isArchiveFile, isTextFile, fileIcon, mediaKindOf } from "./utils/fileType";
 
 export { useReducedMotion } from "./composables/useReducedMotion";
+export { useMeasuredHighlight } from "./composables/useMeasuredHighlight";
+export type { UseMeasuredHighlightOptions, MeasuredHighlight } from "./composables/useMeasuredHighlight";
 export {
   registerCssAnimation,
   listCssAnimations,


### PR DESCRIPTION
Fixes the two reported regressions in one wave:

- **Segmented control lost its sliding-thumb animation** (#294 rebuilt the theme-toggle mode group onto `HkSegmented`, which had no thumb). `HkSegmented` itself now renders an animated sliding thumb: a measured highlight positioned with real geometry (`useMeasuredHighlight` composable), transitioning `transform`/`width` at 0.2s. Per-segment checked styling stays as the fallback until a non-zero width is measured (jsdom/SSR never get there), so there is never a flash of no-indicator.
- **Morphing-tabs indicator drifted with 4+ tabs**: the old `--tab-count`/`--tab-index` percentage math assumed equal-width triggers, but `flex: 1 1 0` + `min-width: auto` + `white-space: nowrap` lets overflowing labels widen some triggers (e.g. 颜色/壁纸/样式/DPI 控制 in a narrow bottom sheet). The indicator now uses measured trigger offsets/widths from the same composable.

## Details

- New public composable `useMeasuredHighlight({ container, activeIndex, itemSelector, extraSources? }) → { x, width, ready }`: measures on mount (nextTick), on active-index/extra-source changes, via `ResizeObserver` on the container (guarded), and once after `document.fonts.ready`. `offsetLeft` accumulation walks the offsetParent chain when the container is not the direct offsetParent. jsdom/happy-dom/SSR-safe: layout reads are 0 there, `ready` stays false, nothing throws, no NaN (finite-coerced). Disconnects on scope dispose. Exported from the package root.
- `HkSegmented`: thumb is the first root child (`aria-hidden="true"`), root gets `data-ready="true"` only once measured; root is `position: relative`, segments promoted to `z-index: 1` so text stays above the thumb; `data-ready` suppresses the per-segment checked background/shadow (checked text color kept); a disabled group dims its thumb like its labels; negative `modelValue` match clears the highlight instead of pointing at segment 0 (mirrors all-false `aria-checked`); `prefers-reduced-motion` disables the transition; touch form (≤767px) unchanged and thumb-correct.
- `HkMorphingTabs`: indicator carries inline `transform`/`width`, fades in on the triggers' `data-ready`, `aria-hidden="true"`, reduced-motion opt-out; teleport/a11y/footer behavior untouched.
- `HkThemeToggle.scss`: the auto-mode altitude cover strip gets `z-index: 2` so the promoted segments (z-index 1) don't paint above it.
- Version bump 0.11.0 → 0.12.0.

## Verification

- Scoped: `vitest run HkSegmented.test.tsx HkMorphingTabs.test.tsx HkThemeToggle.test.ts` → 18/18 (HkThemeToggle's 5 stay green).
- Full suite: `vitest run` → **59 files, 475 passed / 0 failed** (baseline before: 466 tests).
- `vite build` → success. (`vue-tsc` TS2688 'node' types is the known environmental failure, not run as a gate.)
- 3-round verify cycle with independent review subagents; fixed disabled-thumb dimming, no-match phantom highlight, mount grow/slide artifact + zero-width shadow sliver, and missing indicator `aria-hidden` along the way.
