### PR TITLE
🐛 Pin the leaving toast box so closing toasts slide out instead of flashing.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -105,8 +105,11 @@
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
   transition-duration: var(--hi-duration-normal, 0.3s);
   transition-timing-function: cubic-bezier(0.36, 0, 0.66, 1);
+  /* Only the positioning switch lives here; the leaving slot's box is
+     frozen by the before-leave hook (pinLeaveGeometry), same contract
+     as HkToast — the shrink-to-fit fixed column cannot size leaving
+     cards (a percentage width resolves against the collapsed wrapper). */
   position: absolute;
-  width: 100%;
 }
 
 .hk-blocking-toast-enter-from,

--- a/packages/vue/src/components/HkBlockingToast.test.tsx
+++ b/packages/vue/src/components/HkBlockingToast.test.tsx
@@ -185,4 +185,37 @@ describe("HkBlockingToast", () => {
     await expect(gate).resolves.toBe(true);
     await setLocale("en");
   });
+
+  it("pins the leaving card slot to its in-flow box before it goes absolute", async () => {
+    mountHost();
+    const gate = showBlockingToast("Confirm me");
+    await settle();
+
+    // happy-dom has no layout engine; feed the leave hook the geometry
+    // a real browser would read from the laid-out stack column.
+    const slot = document.querySelector<HTMLElement>(".hk-blocking-toast-slot");
+    expect(slot).not.toBeNull();
+    const wrapper = slot!.parentElement as HTMLElement;
+    Object.defineProperty(wrapper, "clientWidth", { value: 384, configurable: true });
+    Object.defineProperty(slot!, "offsetParent", { value: wrapper, configurable: true });
+    Object.defineProperty(slot!, "offsetTop", { value: 0, configurable: true });
+    Object.defineProperty(slot!, "offsetLeft", { value: 0, configurable: true });
+    Object.defineProperty(slot!, "offsetWidth", { value: 384, configurable: true });
+    Object.defineProperty(slot!, "offsetHeight", { value: 120, configurable: true });
+
+    actionButtons(cards()[0])[0].click();
+    await nextTick();
+
+    const leaving = document.querySelector<HTMLElement>(".hk-blocking-toast-leave-active");
+    expect(leaving).not.toBeNull();
+    expect(leaving!.style.right).toBe("0px");
+    expect(leaving!.style.top).toBe("0px");
+    expect(leaving!.style.width).toBe("384px");
+    expect(leaving!.style.height).toBe("120px");
+    expect(leaving!.style.boxSizing).toBe("border-box");
+
+    await expect(gate).resolves.toBe(false);
+    await settle();
+    expect(cards().length).toBe(0);
+  });
 });

--- a/packages/vue/src/components/HkBlockingToast.tsx
+++ b/packages/vue/src/components/HkBlockingToast.tsx
@@ -31,6 +31,7 @@ import {
 
 import { useI18n } from "../i18n/context";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
+import { clearLeaveGeometry, pinLeaveGeometry } from "../utils/dom";
 import {
   resolveBlockingToast,
   useBlockingToast,
@@ -138,7 +139,12 @@ export default defineComponent({
     return () => (
       <Teleport to="body">
         <div class="hk-blocking-toast-container">
-          <TransitionGroup tag="div" name="hk-blocking-toast">
+          <TransitionGroup
+            tag="div"
+            name="hk-blocking-toast"
+            onBeforeLeave={pinLeaveGeometry}
+            onLeaveCancelled={clearLeaveGeometry}
+          >
             {queue.map((item) => (
               <div
                 key={item.id}

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -170,9 +170,14 @@
   transform: translateX(1rem);
 }
 
+/* The leaving toast only switches positioning here; its box is frozen
+   by HkToast's before-leave hook (pinLeaveGeometry writes right/top/
+   width/height inline). The fixed stack column is shrink-to-fit, so a
+   percentage width would resolve against the collapsed wrapper once
+   the toast leaves the flow — never size a leaving toast from its
+   parent. */
 .hk-toast-leave-active {
   position: absolute;
-  width: 100%;
 }
 
 .hk-toast-move {

--- a/packages/vue/src/components/HkToast.test.tsx
+++ b/packages/vue/src/components/HkToast.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import HkToast from "./HkToast";
+import { useToast } from "../runtime/useToast";
+
+/**
+ * HkToast leave-transition contract:
+ * - the leaving toast is pinned to its in-flow box (right/top/width/
+ *   height + border-box) by the before-leave hook, because the fixed
+ *   stack column is shrink-to-fit and collapses once the toast leaves
+ *   the flow — a percentage width there resolves against a dead
+ *   containing block and the toast "flashes" into a sliver
+ * - the toast is gone after the leave settles
+ *
+ * (Repo test convention: raw createApp + document queries, no
+ * @vue/test-utils dependency.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountHost() {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkToast) });
+  mounts.push({ app, container });
+  app.mount(container);
+  return container;
+}
+
+async function settle() {
+  await nextTick();
+  await new Promise((r) => setTimeout(r, 30));
+  await nextTick();
+}
+
+function items(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>(".hk-toast-item"));
+}
+
+function stubLayout(el: HTMLElement, over: Partial<{
+  offsetTop: number;
+  offsetLeft: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}>): void {
+  // happy-dom has no layout engine; feed the leave hook the geometry a
+  // real browser would read from the laid-out stack.
+  const wrapper = el.parentElement as HTMLElement;
+  Object.defineProperty(wrapper, "clientWidth", { value: 384, configurable: true });
+  Object.defineProperty(el, "offsetParent", { value: wrapper, configurable: true });
+  Object.defineProperty(el, "offsetTop", { value: over.offsetTop ?? 0, configurable: true });
+  Object.defineProperty(el, "offsetLeft", { value: over.offsetLeft ?? 0, configurable: true });
+  Object.defineProperty(el, "offsetWidth", { value: over.offsetWidth ?? 384, configurable: true });
+  Object.defineProperty(el, "offsetHeight", { value: over.offsetHeight ?? 83, configurable: true });
+}
+
+afterEach(async () => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  const { toasts, remove } = useToast();
+  for (const t of [...toasts]) remove(t.id);
+  document.querySelectorAll(".hk-toast-container").forEach((el) => el.remove());
+});
+
+describe("HkToast", () => {
+  it("renders a toast slot per severity", async () => {
+    mountHost();
+    const toast = useToast();
+    toast.error("backend unreachable");
+    await settle();
+
+    const [item] = items();
+    expect(item).toBeTruthy();
+    expect(item.className).toContain("hk-toast-error");
+    expect(item.textContent).toContain("backend unreachable");
+
+    toast.remove(toast.toasts[0]!.id);
+    await settle();
+    expect(items().length).toBe(0);
+  });
+
+  it("pins the leaving toast to its in-flow box so the stack collapse cannot deform it", async () => {
+    mountHost();
+    const toast = useToast();
+    toast.error("long enough error body that wrapped to a tall box");
+    await settle();
+
+    const item = items()[0];
+    stubLayout(item, { offsetTop: 0, offsetLeft: 0, offsetWidth: 384, offsetHeight: 83 });
+
+    item.querySelector<HTMLButtonElement>(".hk-toast-close")!.click();
+    await nextTick();
+
+    const leaving = document.querySelector<HTMLElement>(".hk-toast-leave-active");
+    expect(leaving).not.toBeNull();
+    // The pin mirrors the measured in-flow box exactly.
+    expect(leaving!.style.right).toBe("0px");
+    expect(leaving!.style.top).toBe("0px");
+    expect(leaving!.style.width).toBe("384px");
+    expect(leaving!.style.height).toBe("83px");
+    expect(leaving!.style.boxSizing).toBe("border-box");
+
+    await settle();
+    expect(items().length).toBe(0);
+  });
+});

--- a/packages/vue/src/components/HkToast.tsx
+++ b/packages/vue/src/components/HkToast.tsx
@@ -7,6 +7,7 @@ import { useToast, type ToastItem, type ToastMessage, type ToastType } from "../
 import { useClipboard } from "../runtime/useClipboard";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useI18n } from "../i18n/context";
+import { clearLeaveGeometry, pinLeaveGeometry } from "../utils/dom";
 import "./HkToast.scss";
 
 const LONG_THRESHOLD = 50;
@@ -187,6 +188,8 @@ export default defineComponent({
           <TransitionGroup
             tag="div"
             name="hk-toast"
+            onBeforeLeave={pinLeaveGeometry}
+            onLeaveCancelled={clearLeaveGeometry}
           >
             {toasts.map((item) => (
               <HkToastItem

--- a/packages/vue/src/utils/dom.test.ts
+++ b/packages/vue/src/utils/dom.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { clearLeaveGeometry, pinLeaveGeometry } from "./dom";
+
+/**
+ * pinLeaveGeometry contract:
+ * - freezes the in-flow box (right/top/width/height + border-box) of a
+ *   leaving list item against its offsetParent, anchored to the
+ *   containing block's right padding-box edge
+ *   (right = clientWidth - (offsetLeft + offsetWidth))
+ * - reads every metric before writing any style, so no intermediate
+ *   write can skew a later read (content-box rewrap hazard)
+ * - is a no-op when layout info is unavailable (offsetParent null)
+ */
+
+interface StubElement {
+  offsetParent: unknown;
+  offsetTop: number;
+  offsetLeft: number;
+  offsetWidth: number;
+  offsetHeight: number;
+  style: Record<string, string>;
+}
+
+function stubEl(parent: unknown, over: Partial<StubElement> = {}): StubElement {
+  return {
+    offsetParent: parent,
+    offsetTop: 0,
+    offsetLeft: 0,
+    offsetWidth: 0,
+    offsetHeight: 0,
+    style: {},
+    ...over,
+  };
+}
+
+describe("pinLeaveGeometry", () => {
+  it("pins the in-flow box anchored to the parent's right padding edge", () => {
+    const parent = { clientWidth: 384 };
+    const el = stubEl(parent, { offsetTop: 0, offsetLeft: 0, offsetWidth: 384, offsetHeight: 83 });
+
+    pinLeaveGeometry(el as unknown as Element);
+
+    expect(el.style).toEqual({
+      right: "0px",
+      top: "0px",
+      width: "384px",
+      height: "83px",
+      boxSizing: "border-box",
+    });
+  });
+
+  it("measures the right offset from the parent's inner width, not the viewport", () => {
+    const parent = { clientWidth: 400 };
+    const el = stubEl(parent, { offsetTop: 60, offsetLeft: 100, offsetWidth: 200, offsetHeight: 48 });
+
+    pinLeaveGeometry(el as unknown as Element);
+
+    // 400 - (100 + 200) = 100px from the containing block's right edge.
+    expect(el.style.right).toBe("100px");
+    expect(el.style.top).toBe("60px");
+    expect(el.style.width).toBe("200px");
+    expect(el.style.height).toBe("48px");
+  });
+
+  it("is a no-op without layout information (offsetParent null)", () => {
+    const el = stubEl(null, { offsetWidth: 384, offsetHeight: 83 });
+
+    pinLeaveGeometry(el as unknown as Element);
+
+    expect(el.style).toEqual({});
+  });
+
+  it("clearLeaveGeometry strips exactly the pins pinLeaveGeometry wrote", () => {
+    const parent = { clientWidth: 384 };
+    const el = stubEl(parent, { offsetWidth: 384, offsetHeight: 83 });
+    el.style.marginLeft = "4px"; // foreign style must survive the clear.
+
+    pinLeaveGeometry(el as unknown as Element);
+    clearLeaveGeometry(el as unknown as Element);
+
+    // On a real CSSStyleDeclaration an empty string removes the
+    // property; the stub keeps the keys, so assert emptiness.
+    expect(el.style.right).toBe("");
+    expect(el.style.top).toBe("");
+    expect(el.style.width).toBe("");
+    expect(el.style.height).toBe("");
+    expect(el.style.boxSizing).toBe("");
+    expect(el.style.marginLeft).toBe("4px");
+  });
+});

--- a/packages/vue/src/utils/dom.ts
+++ b/packages/vue/src/utils/dom.ts
@@ -37,3 +37,70 @@ export function scrollToElement(selector: string, opts?: ScrollIntoViewOptions):
   const el = document.querySelector(selector) as HTMLElement | null;
   el?.scrollIntoView(opts ?? { block: "nearest" });
 }
+
+/**
+ * Pin a leaving list item's geometry before its `*-leave-active` rule
+ * switches it to `position: absolute`.
+ *
+ * TransitionGroup hosts that live in a shrink-to-fit container (the
+ * fixed toast columns are sized by their content, anchored by `right`
+ * plus a `max-width` only) collapse to zero width the moment their
+ * last in-flow child starts leaving. A `width: 100%` on the leaving
+ * item then resolves against that dead containing block: the item
+ * snaps into a padding-only sliver, its static position jumps to the
+ * collapsed edge, and the group's FLIP move transition flings the
+ * sliver across the screen while it fades — the closing-toast "flash".
+ *
+ * Recording the in-flow box makes the leave transition play as a true
+ * mirror of the entrance instead. The pin is anchored to the RIGHT
+ * inner edge of the containing block (the relative transition-group
+ * wrapper, which is also the element's offsetParent): right-anchored
+ * hosts keep that edge put while the left edge collapses, so a
+ * `right + width` pin survives the collapse that defeats a `left`
+ * pin. All metrics come from the offset* family — layout boxes that
+ * ignore transforms, so a concurrent FLIP move cannot skew the pin —
+ * and the width/height pins are paired with an inline
+ * `box-sizing: border-box` so they reproduce the measured border-box
+ * exactly for content-box items.
+ *
+ * No-op when layout information is unavailable (no offsetParent:
+ * hidden subtrees, detached nodes, non-layout environments).
+ */
+export function pinLeaveGeometry(el: Element): void {
+  const node = el as HTMLElement;
+  const parent = node.offsetParent as HTMLElement | null;
+  if (parent == null) return;
+  // Read every metric BEFORE writing any style: writes take effect
+  // immediately (layout is flushed on the next read), and on a
+  // content-box element an intermediate `width` write silently changes
+  // the wrap width — a height read after it would freeze a transient
+  // rewrap instead of the box the user is looking at.
+  const top = node.offsetTop;
+  const left = node.offsetLeft;
+  const width = node.offsetWidth;
+  const height = node.offsetHeight;
+  // CSS `right` for an absolutely positioned box is measured from the
+  // containing block's right padding-box edge; offsetLeft/offsetWidth
+  // place the item's right border edge within that same padding box.
+  const right = parent.clientWidth - (left + width);
+  node.style.right = `${right}px`;
+  node.style.top = `${top}px`;
+  node.style.width = `${width}px`;
+  node.style.height = `${height}px`;
+  node.style.boxSizing = "border-box";
+}
+
+/**
+ * Drop the pins written by {@link pinLeaveGeometry}. Wire this to the
+ * transition's leave-cancelled hook: when a leave is aborted and the
+ * element re-enters the flow, stale right/width/height pins would
+ * freeze its geometry even as its content changes.
+ */
+export function clearLeaveGeometry(el: Element): void {
+  const node = el as HTMLElement;
+  node.style.right = "";
+  node.style.top = "";
+  node.style.width = "";
+  node.style.height = "";
+  node.style.boxSizing = "";
+}


### PR DESCRIPTION
## Problem

Closing a toast sometimes "flashed": the toast's height snapped tall, its width snapped to a sliver, and it vanished (or got flung sideways) instead of playing the entrance animation in reverse.

## Root cause (measured live in a browser against the real component)

The toast stack column is `position: fixed` + shrink-to-fit (`right` anchor + `max-width` only). When the **last** (or widest) toast starts leaving:

1. `*-leave-active { position: absolute; width: 100% }` takes the toast out of flow → the column instantly collapses to **zero width** → `width: 100%` resolves to a **32px padding-only sliver** (measured: 384px → 32px on frame 1).
2. The sliver's static position jumps to the collapsed edge, and the TransitionGroup FLIP `move` transition animates it back — flinging the deformed sliver ~400px across the screen while it fades (measured x: 1040 → 1439 over ~270ms).
3. When the message body keeps a nonzero width (stacked messages, count pill, a narrower sibling), the squeezed text rewraps — the tall/narrow flash users reported.

## Fix

- `pinLeaveGeometry` (new in `utils/dom.ts`): a before-leave hook freezes the leaving item's in-flow box — `right` (anchored to the containing block's **right** padding edge, the one coordinate that survives the collapse), `top`, `width`, `height` + inline `box-sizing: border-box`. All metrics come from the transform-free `offset*` family, read **before any style write** (interleaved reads once froze a transient content-box rewrap during development).
- `clearLeaveGeometry` wired to `leave-cancelled` so an aborted leave never leaves stale pins.
- Wired into both `HkToast` and `HkBlockingToast`; the `width: 100%` footgun is deleted from both leave-active rules.

## Verification

- **Live browser trace** (real component, per-rAF geometry sampling): leaving toast holds **384×83 constant**, slides **exactly 1rem right**, opacity 1→0 over the 0.3s curve, removed at ~320ms — for both the last-toast and widest-of-two cases. Before/after traces attached to the task log.
- `vitest`: 15/15 across `dom.test.ts` (new), `HkToast.test.tsx` (new), `HkBlockingToast.test.tsx` (pin regression added); full package suite green.
- `vue-tsc --noEmit` clean.
- Independent subagent review: PASS on all 7 checklist items (incl. Vue 3.5.40 source check that `onBeforeLeave` runs before the leave classes are applied).

## Known latent pattern (out of scope, report-only)

`.hk-list-grow-leave-active` (`HkListTransition.scss`) still combines `position: absolute; width: 100%`; its hosts have definite widths today so it cannot collapse, but any future shrink-to-fit host would hit the same flash.

Version: `@celestia-island/hikari` 0.13.0 → 0.13.1.