### PR TITLE
🐛 Fix popup stacking with kind priority z bands to keep toasts topmost.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -10,7 +10,7 @@
   position: fixed;
   top: 4rem;
   right: 1rem;
-  z-index: var(--hk-z-toast, 9999);
+  z-index: var(--hk-z-toast, 4000);
   max-width: 24rem;
   pointer-events: none;
 }

--- a/packages/vue/src/components/HkBlockingToast.tsx
+++ b/packages/vue/src/components/HkBlockingToast.tsx
@@ -12,13 +12,15 @@
  * Mount once at the shell level, next to `<HToast />`. Self-contained
  * Teleport-to-body host: cards sit in the same fixed top-right column
  * HkToast uses (`--hk-z-toast`), so transient toasts and blocking cards
- * share one visual stack; mount it after `<HToast />` so the blocking
- * host paints above the transient stack and stays clickable when both
- * are visible. While a card is visible it registers with
- * usePopupManager (kind "toast", no scroll lock, with its title) so
- * z-index ordering and popup introspection stay coherent with
- * modals/drawers; the popup handle also fixes card-vs-card stacking
- * (newer cards paint above older ones).
+ * share one visual stack; mount it after `<HToast />` (the established
+ * shell convention) so the blocking host paints above the transient
+ * stack when both are visible — the two containers share the toast band
+ * base, so DOM order breaks the tie. While a card is visible it
+ * registers with usePopupManager (kind "toast", no scroll lock, with
+ * its title) so z-index ordering and popup introspection stay coherent
+ * with modals/drawers; the popup handle also fixes card-vs-card
+ * stacking (newer cards paint above older ones), and the explicit card
+ * z keeps cards clickable under the pointer-transparent toast column.
  */
 import { AlertTriangle, CircleX as XCircle, Info } from "lucide-vue-next";
 import {

--- a/packages/vue/src/components/HkDraggableGrid.scss
+++ b/packages/vue/src/components/HkDraggableGrid.scss
@@ -117,7 +117,10 @@
   background: var(--hi-color-bg-elevated, #161b22);
   backdrop-filter: blur(2px);
   pointer-events: none;
-  z-index: 9999;
+  /* Drag ghost: above page chrome (--z-sidebar 900) but below every
+     popup band (overlay 1000 < dropdown 2000 < tooltip 3000 < toast 4000)
+     so a drag never buries toasts or open panels. */
+  z-index: var(--hk-z-drag, 950);
   will-change: transform;
 
   > .hk-draggable-grid-cell {

--- a/packages/vue/src/components/HkDraggableList.scss
+++ b/packages/vue/src/components/HkDraggableList.scss
@@ -95,7 +95,10 @@
   background: var(--hi-color-bg-elevated, #161b22);
   backdrop-filter: blur(2px);
   pointer-events: none;
-  z-index: 9999;
+  /* Drag ghost: above page chrome (--z-sidebar 900) but below every
+     popup band (overlay 1000 < dropdown 2000 < tooltip 3000 < toast 4000)
+     so a drag never buries toasts or open panels. */
+  z-index: var(--hk-z-drag, 950);
   will-change: transform;
 
   > .hk-draggable-list-item {

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -2,7 +2,9 @@
   position: fixed;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: var(--hk-breadcrumb-z, 100001);
+  /* Above stacked-modal content (overlay band 1000+), below the dropdown
+     band (2000) so open panels are never covered by the strip. */
+  z-index: var(--hk-breadcrumb-z, 1500);
   display: flex;
   align-items: center;
   gap: var(--hi-space-4, 0.5rem);

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -2,7 +2,9 @@
   position: fixed;
   top: 4rem;
   right: 1rem;
-  z-index: var(--hk-z-toast, 9999);
+  /* Toast band — the topmost popup z band (POPUP_Z_BANDS.toast; mirror in
+     theme.scss). The live value arrives inline from the popup manager. */
+  z-index: var(--hk-z-toast, 4000);
   max-width: 24rem;
   pointer-events: none;
 }

--- a/packages/vue/src/components/HkToast.tsx
+++ b/packages/vue/src/components/HkToast.tsx
@@ -157,9 +157,9 @@ export default defineComponent({
   name: "HkToast",
   setup() {
     const { toasts, remove } = useToast();
-    // The toast stack registers with the popup manager so it takes part
-    // in the unified z-band ladder instead of a hardcoded z that later
-    // modals could overtake.
+    // The toast stack registers with the popup manager (kind "toast") so
+    // it holds the topmost z band (POPUP_Z_BANDS.toast): toasts stay
+    // above every modal/drawer sheet no matter which opened first.
     const manager = usePopupManager();
     let popupHandle: PopupHandle | null = null;
     const containerZ = ref<number | null>(null);

--- a/packages/vue/src/components/HkTooltip.scss
+++ b/packages/vue/src/components/HkTooltip.scss
@@ -12,7 +12,7 @@
 
 .hk-tooltip-popup {
   position: fixed;
-  z-index: var(--hi-z-tooltip, 10000);
+  z-index: var(--hi-z-tooltip, 3000);
   padding: var(--space-4) var(--space-8);
   border: none;
   border-radius: var(--radius-sm);

--- a/packages/vue/src/components/HkTooltip.tsx
+++ b/packages/vue/src/components/HkTooltip.tsx
@@ -16,9 +16,10 @@ export default defineComponent({
     const tooltipStyle = ref<CSSProperties>({});
     let showTimer: ReturnType<typeof setTimeout> | null = null;
 
-    // Registers with the popup manager (kind "tooltip") so tooltips take
-    // part in the unified z-band ladder; the zIndex lands on the popup
-    // element and overrides the --hi-z-tooltip fallback in the SCSS.
+    // Registers with the popup manager (kind "tooltip") so tooltips hold
+    // the tooltip band (above modal/drawer overlays, below toasts); the
+    // zIndex lands on the popup element and overrides the --hi-z-tooltip
+    // fallback in the SCSS.
     const manager = usePopupManager();
     let popupHandle: PopupHandle | null = null;
     const zIndex = ref<number | null>(null);

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -143,6 +143,8 @@ export {
   notifyScrollStart,
   useOverlay,
   usePopupManager,
+  POPUP_Z_BANDS,
+  POPUP_Z_STEP,
   useToast,
   useConfirm,
   useBlockingToast,

--- a/packages/vue/src/runtime/index.ts
+++ b/packages/vue/src/runtime/index.ts
@@ -11,7 +11,7 @@ export {
 } from "./backStack";
 export { useMediaQuery, releaseMediaQuery } from "./useMediaQuery";
 export { useOverlay, closeAll, isOverlayOpen, type OverlayHandle, type UseOverlayOptions } from "./useOverlay";
-export { usePopupManager, type PopupHandle, type PopupKind } from "./usePopupManager";
+export { usePopupManager, POPUP_Z_BANDS, POPUP_Z_STEP, type PopupHandle, type PopupKind } from "./usePopupManager";
 export { useToast, TOAST_DURATION, type ToastItem, type ToastMessage, type ToastType } from "./useToast";
 export { useConfirm } from "./useConfirm";
 export { useBlockingToast, showBlockingToast, resolveBlockingToast, clearBlockingToasts, type BlockingToastItem, type BlockingToastOptions, type BlockingToastVariant } from "./useBlockingToast";

--- a/packages/vue/src/runtime/usePopupManager.test.ts
+++ b/packages/vue/src/runtime/usePopupManager.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 
-import { usePopupManager } from "./usePopupManager";
+import { POPUP_Z_BANDS, POPUP_Z_STEP, usePopupManager } from "./usePopupManager";
 
 const managers: ReturnType<typeof usePopupManager>[] = [];
 
@@ -21,53 +21,94 @@ afterEach(() => {
   document.body.style.overflow = "";
 });
 
-describe("usePopupManager z ladder", () => {
-  it("starts at the base band and steps by Z_STEP while popups stack", () => {
-    const m = freshManager();
-    const a = m.register("dropdown", false);
-    const b = m.register("modal", true);
-
-    expect(a.zIndex).toBe(1000);
-    expect(b.zIndex).toBe(1002);
-    expect(m.isOpen(a.id)).toBe(true);
-    expect(m.isOpen(b.id)).toBe(true);
+describe("usePopupManager z bands", () => {
+  it("bands are ordered overlay < dropdown < tooltip < toast", () => {
+    expect(POPUP_Z_BANDS.modal).toBe(POPUP_Z_BANDS.drawer);
+    expect(POPUP_Z_BANDS.modal).toBeLessThan(POPUP_Z_BANDS.dropdown);
+    expect(POPUP_Z_BANDS.dropdown).toBeLessThan(POPUP_Z_BANDS.tooltip);
+    expect(POPUP_Z_BANDS.tooltip).toBeLessThan(POPUP_Z_BANDS.toast);
   });
 
-  it("reclaims a freed z band instead of drifting upward forever", () => {
+  it("keeps a toast registered first above overlays opened later", () => {
+    // The mobile regression: HkToast mounts once at shell level, so the
+    // old registration-order ladder gave every later modal a higher z and
+    // buried the toast under the phone bottom sheet. Bands must hold the
+    // toast on top regardless of registration order.
     const m = freshManager();
-    // Simulate HkToast's persistent registration: it stays mounted forever,
-    // so the old monotonic counter could never reset.
     const toast = m.register("toast", false);
-    expect(toast.zIndex).toBe(1000);
+    expect(toast.zIndex).toBe(POPUP_Z_BANDS.toast);
 
-    const a = m.register("dropdown", false);
-    expect(a.zIndex).toBe(1002);
-    const b = m.register("dropdown", false);
-    expect(b.zIndex).toBe(1004);
-
-    m.unregister(b.id);
-    // C must reclaim B's band (1004) — NOT drift to 1006.
-    const c = m.register("dropdown", false);
-    expect(c.zIndex).toBe(1004);
-
-    m.unregister(c.id);
-    m.unregister(a.id);
-    // Registry still holds the toast, so the ladder must not reset to base.
-    expect(m.registry.value.size).toBe(1);
-    const d = m.register("tooltip", false);
-    expect(d.zIndex).toBe(1002);
+    const modal = m.register("modal", true);
+    const drawer = m.register("drawer", true);
+    const dropdown = m.register("dropdown", false);
+    expect(modal.zIndex).toBeLessThan(toast.zIndex);
+    expect(drawer.zIndex).toBeLessThan(toast.zIndex);
+    expect(dropdown.zIndex).toBeLessThan(toast.zIndex);
   });
 
-  it("resets to the base band when the registry empties", () => {
+  it("stacks in open order within a band and reclaims freed slots", () => {
     const m = freshManager();
-    const a = m.register("dropdown", false);
-    const b = m.register("dropdown", false);
-    m.unregister(a.id);
-    m.unregister(b.id);
+    const a = m.register("modal", true);
+    const b = m.register("modal", true);
+    expect(a.zIndex).toBe(POPUP_Z_BANDS.modal);
+    expect(b.zIndex).toBe(a.zIndex + POPUP_Z_STEP);
 
-    expect(m.registry.value.size).toBe(0);
-    const c = m.register("tooltip", false);
-    expect(c.zIndex).toBe(1000);
+    m.unregister(b.id);
+    // C must reclaim B's slot — NOT drift upward past it.
+    const c = m.register("modal", true);
+    expect(c.zIndex).toBe(b.zIndex);
+
+    m.unregister(a.id);
+    m.unregister(c.id);
+    // Band empty again → back to the band base.
+    const d = m.register("modal", true);
+    expect(d.zIndex).toBe(POPUP_Z_BANDS.modal);
+  });
+
+  it("shares the overlay band between modal and drawer in open order", () => {
+    const m = freshManager();
+    const modal = m.register("modal", true);
+    const drawer = m.register("drawer", true);
+    // Same band: the drawer opened over the modal paints above it, and a
+    // replacement drawer reclaims the freed slot instead of drifting.
+    expect(modal.zIndex).toBe(POPUP_Z_BANDS.modal);
+    expect(drawer.zIndex).toBe(modal.zIndex + POPUP_Z_STEP);
+
+    m.unregister(drawer.id);
+    const drawer2 = m.register("drawer", true);
+    expect(drawer2.zIndex).toBe(drawer.zIndex);
+  });
+
+  it("keeps a dropdown opened from within an overlay above it", () => {
+    // Select panels portal to <body>; opened from inside a modal they
+    // must paint above the modal that contains them — the whole reason
+    // the dropdown band sits above the overlay band.
+    const m = freshManager();
+    const modal = m.register("modal", true);
+    const panel = m.register("dropdown", false);
+    expect(panel.zIndex).toBeGreaterThan(modal.zIndex);
+
+    m.unregister(panel.id);
+    m.unregister(modal.id);
+
+    // Same guarantee inverted: with the dropdown registered FIRST, the
+    // later modal still lands on its own (lower) overlay band — band
+    // membership, not registration order, decides.
+    const dropdown = m.register("dropdown", false);
+    const modal2 = m.register("modal", true);
+    expect(dropdown.zIndex).toBe(POPUP_Z_BANDS.dropdown);
+    expect(modal2.zIndex).toBe(POPUP_Z_BANDS.modal);
+    expect(modal2.zIndex).toBeLessThan(dropdown.zIndex);
+  });
+
+  it("keeps tooltips above overlays and below toasts", () => {
+    const m = freshManager();
+    const modal = m.register("modal", true);
+    const tooltip = m.register("tooltip", false);
+    const toast = m.register("toast", false);
+    expect(tooltip.zIndex).toBe(POPUP_Z_BANDS.tooltip);
+    expect(tooltip.zIndex).toBeGreaterThan(modal.zIndex);
+    expect(toast.zIndex).toBeGreaterThan(tooltip.zIndex);
   });
 
   it("keeps the scroll lock counter balanced across register/unregister", () => {

--- a/packages/vue/src/runtime/usePopupManager.ts
+++ b/packages/vue/src/runtime/usePopupManager.ts
@@ -2,6 +2,57 @@ import { readonly, ref } from "vue";
 
 export type PopupKind = "dropdown" | "modal" | "drawer" | "tooltip" | "toast";
 
+/**
+ * Kind-priority z bands — the single source of truth for popup stacking.
+ *
+ * Every registered popup lands in its kind's band, so layering is decided
+ * by WHAT a surface is, never by WHEN it happened to register. Bands are
+ * ordered low → high:
+ *
+ *   modal    (1000)  centered dialogs + phone bottom sheets
+ *   drawer   (1000)  edge drawers share the overlay band with modals —
+ *                    inside the band they stack in open order, so a
+ *                    drawer opened over a modal still paints above it
+ *   dropdown (2000)  anchor-attached popovers, select panels, menus —
+ *                    ABOVE the overlay band on purpose: a select panel
+ *                    opened from inside a modal portals to <body> and
+ *                    must paint above the modal that contains it (the
+ *                    common in-modal form flow). A page-level dropdown
+ *                    can only coexist with a modal programmatically (the
+ *                    modal overlay intercepts pointers), so the rare
+ *                    stale-dropdown-over-modal case is accepted, matching
+ *                    Ant Design
+ *   tooltip  (3000)  transient annotations must stay visible above the
+ *                    surfaces they annotate
+ *   toast    (4000)  ALWAYS the topmost surface — a toast must never be
+ *                    buried under a modal/sheet, no matter which opened
+ *                    first (the long-lived HkToast stack registers once
+ *                    at shell mount and must keep its band forever)
+ *
+ * Within a band, entries stack in open order (max live slot + step), and
+ * freed slots are reclaimed automatically because the next z derives from
+ * the CURRENT live entries of that band only — no monotonic counter, no
+ * cross-band coupling (a persistent toast/tooltip registration can no
+ * longer push later modals up the ladder; that ordering bug is what this
+ * band scheme replaces). Overlay roots are spaced one Z_STEP apart so each
+ * overlay's +1 content/panel layer always has a free slot above its own
+ * root and below the next overlay.
+ *
+ * Keep the SCSS fallbacks (`--hi-z-*` / `--hk-z-*` in theme.scss and the
+ * component sheets) in sync with these numbers.
+ */
+export const POPUP_Z_BANDS: Record<PopupKind, number> = {
+  modal: 1000,
+  drawer: 1000,
+  dropdown: 2000,
+  tooltip: 3000,
+  toast: 4000,
+};
+
+/** In-band stacking step. Even numbers leave the odd slot free for the
+ * +1 content/panel layer each overlay puts above its own root. */
+export const POPUP_Z_STEP = 2;
+
 interface PopupEntry {
   id: string;
   kind: PopupKind;
@@ -9,9 +60,6 @@ interface PopupEntry {
   zIndex: number;
   title?: string;
 }
-
-const Z_BASE = 1000;
-const Z_STEP = 2;
 
 function uid(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -21,7 +69,6 @@ function uid(): string {
 }
 
 const registry = ref<Map<string, PopupEntry>>(new Map());
-let nextZ = Z_BASE;
 let scrollLockCount = 0;
 
 function updateBodyScroll() {
@@ -44,21 +91,15 @@ export function usePopupManager() {
     title?: string,
   ): PopupHandle {
     const id = uid();
-    // Reclaim z bands on assignment: the next z derives from the max z of
-    // the CURRENTLY registered entries, so popups that unregister free
-    // their band for the next popup instead of the ladder drifting upward
-    // forever behind a persistent entry (e.g. HkToast's long-lived toast
-    // stack registration). The registry emptying resets to the base band.
-    if (registry.value.size === 0) {
-      nextZ = Z_BASE;
-    } else {
-      let maxZ = 0;
-      for (const entry of registry.value.values()) {
-        if (entry.zIndex > maxZ) maxZ = entry.zIndex;
-      }
-      nextZ = maxZ + Z_STEP;
+    const band = POPUP_Z_BANDS[kind];
+    // Next slot = one step above the highest LIVE entry of the same band.
+    let maxSlot = -1;
+    for (const entry of registry.value.values()) {
+      if (POPUP_Z_BANDS[entry.kind] !== band) continue;
+      const slot = (entry.zIndex - band) / POPUP_Z_STEP;
+      if (slot > maxSlot) maxSlot = slot;
     }
-    const zIndex = nextZ;
+    const zIndex = band + (maxSlot + 1) * POPUP_Z_STEP;
     const entry: PopupEntry = { id, kind, locksScroll, zIndex, title };
     registry.value.set(id, entry);
     if (locksScroll) {
@@ -82,9 +123,6 @@ export function usePopupManager() {
     if (entry.locksScroll) {
       scrollLockCount = Math.max(0, scrollLockCount - 1);
       updateBodyScroll();
-    }
-    if (registry.value.size === 0) {
-      nextZ = Z_BASE;
     }
   }
 

--- a/packages/vue/src/theme/theme.scss
+++ b/packages/vue/src/theme/theme.scss
@@ -5,7 +5,22 @@
 
 :root {
   --hi-z-above: 1;
-  --hi-z-tooltip: 10000;
+
+  // Popup z bands — MUST mirror POPUP_Z_BANDS in
+  // runtime/usePopupManager.ts (the manager hands out dynamic in-band
+  // values inline; these tokens are the static fallbacks used before a
+  // handle resolves or when a host renders the sheets without JS).
+  // overlay (modal/drawer) < dropdown < tooltip < toast (topmost).
+  --hi-z-overlay: 1000;
+  --hi-z-dropdown: 2000;
+  --hi-z-tooltip: 3000;
+  --hk-z-toast: 4000;
+  // Drag ghosts float above page chrome (--z-sidebar 900) but below
+  // every popup band.
+  --hk-z-drag: 950;
+  // Stacked-modal breadcrumb strip: above stacked modal content, below
+  // the dropdown band.
+  --hk-breadcrumb-z: 1500;
 }
 
 [data-mode="dark"] body {


### PR DESCRIPTION
## Problem

On phones, toasts were painted over by the first-level bottom sheet (every popup is a bottom-up sheet under 768px). Root cause: `usePopupManager` assigned z-index by **registration order only** — the long-lived `HkToast` stack registers once at shell mount and held z=1000, while any modal/drawer opened later got 1002+ and covered the toast.

## Fix

Layering is now decided by **popup kind bands** (`POPUP_Z_BANDS`), not registration order:

| Band | Kind | Notes |
|---|---|---|
| 1000 | modal, drawer | shared overlay band, in-band open-order stacking (drawer over modal still works) |
| 2000 | dropdown | above overlays: select panels/menus opened inside a modal portal to `<body>` and must paint over it (Ant Design tradeoff) |
| 3000 | tooltip | above the surfaces they annotate |
| 4000 | toast | always topmost — a toast can never be buried by a sheet again |

- Within a band: next z = band + (max live slot + 1) × 2; freed slots reclaim automatically; odd slots stay free for each overlay's `+1` content/panel layer.
- Static fallbacks aligned with the scale: `HkToast.scss`/`HkBlockingToast.scss` 9999→4000, `HkTooltip.scss` 10000→3000, `HkModalBreadcrumb.scss` 100001→1500, draggable ghosts 9999→`var(--hk-z-drag, 950)`; `theme.scss :root` tokens mirror `POPUP_Z_BANDS`.
- `POPUP_Z_BANDS` / `POPUP_Z_STEP` exported for hosts; tests rewritten to pin the regression, in-band reclaim, shared modal/drawer band, dropdown-above-overlay (both orders), tooltip<toast.

## Notes for downstream

- Hosts that drag items **inside** an open modal/drawer can raise `--hk-z-drag` (ghosts now sit below the overlay bands by design).
- Keep mounting `<HToast />` before `<HkBlockingToast />` (existing convention; the two containers share the toast band base, DOM order breaks the tie).

## Verification

- Full vitest: 59 files / **490 tests PASS**; `vue-tsc --noEmit` PASS.
- Independent review subagent audit of all 8 popup-manager consumers: SHIP, no stacking regressions.
- Version bump 0.13.0 → 0.14.0.