### PR TITLE
🐛 Keep the modal breadcrumb visible across menus and stacked sheets.

### DIFF
--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -2,9 +2,10 @@
   position: fixed;
   left: 50%;
   transform: translate(-50%, -50%);
-  /* Above stacked-modal content (overlay band 1000+), below the dropdown
-     band (2000) so open panels are never covered by the strip. */
-  z-index: var(--hk-breadcrumb-z, 1500);
+  /* Above every popup band's scrim (modal 1000+, dropdown 2000+; in-band
+     steps of 2 keep real stacks far below this) so multi-layer windows
+     never bury the strip; still below tooltip (3000) / toast (4000). */
+  z-index: var(--hk-breadcrumb-z, 2500);
   display: flex;
   align-items: center;
   gap: var(--hi-space-4, 0.5rem);

--- a/packages/vue/src/components/HkModalBreadcrumb.tsx
+++ b/packages/vue/src/components/HkModalBreadcrumb.tsx
@@ -14,10 +14,18 @@ export default defineComponent({
   setup(props) {
     const manager = usePopupManager();
 
+    /** Every popup band except tooltips/toasts participates in the
+     *  window-stack breadcrumb: modals and drawers (1000-band), and
+     *  menus/sheets/popouts (2000-band). A modal opened from a menu, a
+     *  sheet stacked over a sheet, or a dialog over a dialog are all
+     *  multi-layer situations the user navigates — the strip must show
+     *  where they are. */
+    const STACK_KINDS: ReadonlySet<string> = new Set(["modal", "drawer", "dropdown"]);
+
     const modalEntries = computed(() => {
       const entries: { id: string; zIndex: number; title?: string }[] = [];
       for (const [, entry] of manager.registry.value) {
-        if (entry.kind === "modal") {
+        if (STACK_KINDS.has(entry.kind)) {
           entries.push({ id: entry.id, zIndex: entry.zIndex, title: entry.title });
         }
       }

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -147,7 +147,10 @@ export default defineComponent({
       () => props.open,
       (open) => {
         if (open) {
-          handle.value = manager.register("dropdown", false);
+          // Register with the panel title so the modal breadcrumb can
+          // label this layer ("User menu / Account security / …") instead
+          // of a generic "Layer N".
+          handle.value = manager.register("dropdown", false, props.title);
           overlay.open();
           // Release-then-push (the HkMenu normalizer form): a same-tick
           // close→reopen must not leave the reopened panel unguarded —

--- a/packages/vue/src/theme/theme.scss
+++ b/packages/vue/src/theme/theme.scss
@@ -18,9 +18,11 @@
   // Drag ghosts float above page chrome (--z-sidebar 900) but below
   // every popup band.
   --hk-z-drag: 950;
-  // Stacked-modal breadcrumb strip: above stacked modal content, below
-  // the dropdown band.
-  --hk-breadcrumb-z: 1500;
+  // Stacked-modal breadcrumb strip: above every popup band's content and
+  // scrim (modal 1000+, dropdown 2000+; in-band steps of 2 mean real
+  // stacks stay dozens of levels below the strip) but below tooltips
+  // (3000) and toasts (4000).
+  --hk-breadcrumb-z: 2500;
 }
 
 [data-mode="dark"] body {


### PR DESCRIPTION
**P93 — the floating window-stack breadcrumb stopped appearing (and then stopped being visible at all).**

Two independent legs, both surfaced by the P91 menu/sheet unification:

1. **Gate blindness** — `HkModalBreadcrumb` only counted `kind === "modal"` registry entries and rendered at >1. Menus, sheets and popouts (`HkSelectPanel`) registered as `dropdown` with no title, so the classic "modal opened from the user menu" was a single modal entry (strip hidden), and sheet-over-sheet stacks were zero entries.
2. **Z burial** — the strip's fallback z (1500) sits *below* the dropdown band (2000+): every open level paints a fixed `rgba(0 0 0 / 40%)` scrim over it. Before the z fallback was lowered, 100001 masked leg 1 whenever the gate passed; now both hit at once.

Fix:
- `HkModalBreadcrumb`: stack segments now count `modal + drawer + dropdown` (tooltips/toasts excluded) — menu → submenu → dialog, sheet → sheet, dialog over dialog all qualify.
- `HkSelectPanel`: registers with `props.title` so layers get real labels ("User menu / Account security / Manage passkeys") instead of "Layer N".
- `--hk-breadcrumb-z` 1500 → 2500: above every popup band's content and scrim (in-band steps of 2 keep real stacks dozens of levels below), still under tooltip (3000) / toast (4000). Mobile already reserves the top band for it (`--hk-sheet-top-inset`).

Gates: vitest 500/500 (61 files).