### PR TITLE
🐛 Define theme-aware Hk component tokens and make the scroll container scrollbar prop reactive.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkScrollContainer.test.ts
+++ b/packages/vue/src/components/HkScrollContainer.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createApp, defineComponent, h, ref } from "vue";
+import { createApp, defineComponent, h, nextTick, reactive, ref } from "vue";
 
 import HkScrollContainer from "./HkScrollContainer";
 
@@ -126,5 +126,35 @@ describe("HkScrollContainer overflow sensing", () => {
     stubGeometry(m.viewport, { scrollWidth: 300, clientWidth: 100, scrollLeft: 0 });
     m.instance?.refresh();
     expect(m.root.getAttribute("data-h-overflow")).toBe("none");
+  });
+});
+
+describe("HkScrollContainer scrollbar reactivity", () => {
+  it("builds and tears down the overlay tracks when the scrollbar prop flips", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const props = reactive<Record<string, unknown>>({ scrollbar: false });
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkScrollContainer, { ...props }, { default: () => h("span", "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+
+    const root = container.querySelector<HTMLElement>(".hk-scroll-container")!;
+    expect(root.querySelectorAll(".hk-scrollbar-track").length).toBe(0);
+
+    props.scrollbar = true;
+    await nextTick();
+    expect(root.querySelectorAll(".hk-scrollbar-track").length).toBeGreaterThan(0);
+
+    props.scrollbar = false;
+    await nextTick();
+    expect(root.querySelectorAll(".hk-scrollbar-track").length).toBe(0);
   });
 });

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -147,6 +147,41 @@ export default defineComponent({
       scheduleUpdate();
     }, { flush: "post" });
 
+    /** Build the overlay tracks for the enabled axes (scrollbar on). */
+    function mountScrollbars() {
+      const vp = viewportRef.value;
+      if (!vp) return;
+      const containerEl = vp.parentElement;
+      if (!containerEl) return;
+      if (hasV()) {
+        vState = makeState(false);
+        containerEl.appendChild(vState.track);
+        vDrag = makeDragHandlers(vState, false);
+        attachAxis(vState, vDrag);
+      }
+      if (hasH()) {
+        hState = makeState(true);
+        containerEl.appendChild(hState.track);
+        hDrag = makeDragHandlers(hState, true);
+        attachAxis(hState, hDrag);
+      }
+    }
+
+    /** Tear down and rebuild the overlay tracks when the `scrollbar`
+     *  opt-in flips at runtime (HkTabs passes the prop through). */
+    watch(() => props.scrollbar, (on) => {
+      detachAxis(vState, vDrag);
+      detachAxis(hState, hDrag);
+      vState = null;
+      hState = null;
+      vDrag = null;
+      hDrag = null;
+      if (on) {
+        mountScrollbars();
+        update();
+      }
+    }, { flush: "post" });
+
     function recomputePinned() {
       const vp = viewportRef.value;
       if (!vp) return;
@@ -362,22 +397,9 @@ export default defineComponent({
     onMounted(() => {
       const vp = viewportRef.value;
       if (!vp) return;
-      const containerEl = vp.parentElement;
-      if (!containerEl) return;
 
       if (props.scrollbar) {
-        if (hasV()) {
-          vState = makeState(false);
-          containerEl.appendChild(vState.track);
-          vDrag = makeDragHandlers(vState, false);
-          attachAxis(vState, vDrag);
-        }
-        if (hasH()) {
-          hState = makeState(true);
-          containerEl.appendChild(hState.track);
-          hDrag = makeDragHandlers(hState, true);
-          attachAxis(hState, hDrag);
-        }
+        mountScrollbars();
       }
 
       vp.addEventListener("scroll", onScroll, { passive: true });

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -89,6 +89,19 @@
   --hi-color-white-10: rgb(255 255 255 / 0.1);
   --hi-shadow-button: 0 4px 14px rgb(var(--color-primary) / 35%);
   --hi-shadow-elevated: 0 2px 16px rgb(0 0 0 / 8%);
+
+  /* ── Hk component tokens (theme bridge) ─
+   * Chrome-level components (HkSegmented) read these RGB-triplet tokens.
+   * Without a definition they fall back to hardcoded light-theme values
+   * (white surfaces, near-black text, blue focus ring) inside dark
+   * themes. Bridging them to the runtime --color-* tokens keeps the
+   * controls on the active theme; consumer-local definitions still win
+   * by load order. */
+  --hk-surface: var(--color-surface, 255 255 255);
+  --hk-surface-muted: var(--color-surface, 240 240 244);
+  --hk-text: var(--color-text, 20 20 26);
+  --hk-text-muted: var(--color-muted, 90 90 100);
+  --hk-primary: var(--color-primary, 60 120 240);
 }
 
 /* Global reset (opt-in: import this explicitly) */


### PR DESCRIPTION
## Summary
Two chrome-correctness follow-ups from the P93 wave (chest reported segmented controls rendering with washed-out hardcoded light colors inside dark themes):

1. **Theme bridge for the `--hk-*` component tokens.** `HkSegmented` reads `--hk-surface` / `--hk-surface-muted` / `--hk-text` / `--hk-text-muted` / `--hk-primary`, but nothing defined them — every consumer fell through to hardcoded light-theme fallbacks (white surfaces, near-black text, blue focus ring). `admin-tokens.scss` now bridges them to the runtime `--color-*` tokens (same RGB-triplet convention, original values kept as fallbacks; consumer-local definitions still win by load order).
2. **`HkScrollContainer` `scrollbar` is now reactive.** The overlay tracks were built once in `onMounted`; toggling the prop did nothing until remount. The mount path is factored into `mountScrollbars()` and a post-flush watcher tears down and rebuilds the tracks on flips (this is what `HkTabs`' `scrollbar` pass-through forwards to).

## Test plan
- [x] New test: flipping `scrollbar` builds the `.hk-scrollbar-track` elements and removes them on flip-back
- [x] Affected suites (HkScrollContainer / HkSegmented / HkTabs / HkThemeToggle): 30/30
- [x] Full suite 500/500 green + one timing-flaky `HkDateTimePicker` case that passes 3/3 in isolation (unrelated to this change; 50ms stepper timer under full-suite load)
- [x] `vue-tsc --noEmit` clean; commit-msg lint PASS
- [x] npm version 0.15.0 → 0.15.1