### PR TITLE
✨ Add tablist semantics and a measured tail overlay to the segmented group.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSegmented.scss
+++ b/packages/vue/src/components/HkSegmented.scss
@@ -154,3 +154,45 @@
     transition: none;
   }
 }
+
+/* ── Tail overlay ──────────────────────────────────────────────────────
+ * A passive info layer covering everything right of option[overlayFrom]
+ * (geometry measured by the same pass as the thumb). Carries the thumb's
+ * pill chrome so it reads as part of the group, sits above the segments,
+ * and is click-through — interactive content inside the slot re-enables
+ * pointer events per element. The component always supplies an inline
+ * `left`: an equal-share estimate before measurement (SSR/hidden), the
+ * measured px (plus width) once real layout exists — same cadence as the
+ * thumb, so the fallback never fights the measured geometry. */
+.hk-segmented__overlay {
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  right: 2px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgb(var(--hk-surface, 255 255 255));
+  border: 1px solid rgb(var(--color-border, 100 100 100) / 12%);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.hk-segmented[data-size="sm"] .hk-segmented__overlay {
+  border-radius: 6px;
+}
+
+/* Interactive overlay content opts back into hit testing. */
+.hk-segmented__overlay :where(button, a, [role="button"]) {
+  pointer-events: auto;
+}
+
+/* Full-bleed touch form: radius matches the touch segments. */
+@media (max-width: 767px) {
+  .hk-segmented__overlay {
+    border-radius: 8px;
+  }
+}

--- a/packages/vue/src/components/HkSegmented.test.tsx
+++ b/packages/vue/src/components/HkSegmented.test.tsx
@@ -22,10 +22,12 @@ const options = [
  *  assert against the DOM). */
 function mountSegmented(
   props: Record<string, unknown>,
+  slots?: { overlay?: () => unknown },
 ): { root: HTMLElement; unmount: () => void } {
   const Host = defineComponent({
     setup() {
-      return () => h(HkSegmented as never, { options, ...props });
+      return () =>
+        h(HkSegmented as never, { options, ...props }, slots ?? {});
     },
   });
   const el = document.createElement("div");
@@ -94,6 +96,167 @@ describe("HkSegmented", () => {
       .toBe("true");
     expect((segments(r2)[1] as HTMLButtonElement).disabled).toBe(true);
     u2();
+  });
+});
+
+describe("HkSegmented tablist semantics", () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  function mountTabs(): {
+    root: HTMLElement;
+    modelValue: ReturnType<typeof ref<string>>;
+    unmount: () => void;
+  } {
+    const modelValue = ref("a");
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(HkSegmented as never, {
+            options,
+            semantics: "tablist",
+            modelValue: modelValue.value,
+            "onUpdate:modelValue": (v: string) => { modelValue.value = v; },
+          });
+      },
+    });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const app = createApp(Host);
+    app.mount(el);
+    return { root: el, modelValue, unmount: () => { app.unmount(); el.remove(); } };
+  }
+
+  function key(el: Element, k: string): void {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: k, bubbles: true, cancelable: true }));
+  }
+
+  it("exposes tab roles with aria-selected and roving tabindex", () => {
+    const { root, modelValue, unmount } = mountTabs();
+    const group = root.querySelector(".hk-segmented")!;
+    expect(group.getAttribute("role")).toBe("tablist");
+    const segs = segments(root);
+    expect(segs[0].getAttribute("role")).toBe("tab");
+    expect(segs[0].getAttribute("aria-selected")).toBe("true");
+    expect(segs[0].getAttribute("tabindex")).toBeNull();
+    expect(segs[1].getAttribute("aria-selected")).toBe("false");
+    expect(segs[1].getAttribute("tabindex")).toBe("-1");
+    expect(segs[0].getAttribute("aria-checked")).toBeNull();
+    void modelValue;
+    unmount();
+  });
+
+  it("moves selection with arrow keys and skips disabled options", async () => {
+    const { root, modelValue, unmount } = mountTabs();
+    const segs = segments(root);
+    key(segs[0], "ArrowRight");
+    await settle();
+    expect(modelValue.value).toBe("b");
+    // "c" is disabled: a further step wraps around to "a".
+    key(segs[1], "ArrowRight");
+    await settle();
+    expect(modelValue.value).toBe("a");
+    key(segs[0], "ArrowLeft");
+    await settle();
+    expect(modelValue.value).toBe("b");
+    unmount();
+  });
+
+  it("jumps with Home and End", async () => {
+    const { root, modelValue, unmount } = mountTabs();
+    const group = root.querySelector(".hk-segmented")!;
+    key(group, "Home");
+    await settle();
+    expect(modelValue.value).toBe("a");
+    key(group, "End");
+    await settle();
+    // "c" is disabled — End lands on the last enabled option.
+    expect(modelValue.value).toBe("b");
+    unmount();
+  });
+
+  it("also gives radio groups arrow-key navigation", async () => {
+    const modelValue = ref("a");
+    const Host = defineComponent({
+      setup() {
+        return () =>
+          h(HkSegmented as never, {
+            options,
+            modelValue: modelValue.value,
+            "onUpdate:modelValue": (v: string) => { modelValue.value = v; },
+          });
+      },
+    });
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const app = createApp(Host);
+    app.mount(el);
+    const segs = segments(el);
+    expect(el.querySelector(".hk-segmented")!.getAttribute("role")).toBe("radiogroup");
+    key(segs[0], "ArrowRight");
+    await settle();
+    expect(modelValue.value).toBe("b");
+    app.unmount();
+    el.remove();
+  });
+});
+
+describe("HkSegmented tail overlay", () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length) cleanups.pop()!();
+  });
+
+  const overlaySlot = () =>
+    h("button", { type: "button", class: "strip" }, "+32.5°");
+
+  it("renders no overlay by default", () => {
+    const { root, unmount } = mountSegmented({ modelValue: "a" });
+    expect(root.querySelector(".hk-segmented__overlay")).toBeNull();
+    unmount();
+  });
+
+  it("renders the slot content with an equal-share fallback left", () => {
+    const { root, unmount } = mountSegmented(
+      { modelValue: "a", overlayFrom: 0 },
+      { overlay: overlaySlot },
+    );
+    const overlay = root.querySelector(".hk-segmented__overlay") as HTMLElement;
+    expect(overlay).not.toBeNull();
+    // happy-dom has no layout: pre-measurement fallback — after option 0
+    // of 3 ≈ one third of the track.
+    expect(overlay.style.left).toBe("33.3333%");
+    expect(overlay.querySelector(".strip")).not.toBeNull();
+    unmount();
+  });
+
+  it("spans measured geometry from the anchor option to the track end", async () => {
+    const { root, unmount } = mountSegmented(
+      { modelValue: "a", overlayFrom: 0 },
+      { overlay: overlaySlot },
+    );
+    cleanups.push(stubSegmentGeometry(root, [14, 64, 114], 48));
+    const group = root.querySelector(".hk-segmented") as HTMLElement;
+    // Track inner width for the overlay pass (clientWidth on the root).
+    Object.defineProperty(group, "clientWidth", { value: 182, configurable: true });
+    await settle();
+    const overlay = root.querySelector(".hk-segmented__overlay") as HTMLElement;
+    expect(overlay.getAttribute("data-ready")).toBe("true");
+    // From option 0's right edge (14+48) + gap 2 … to 182 - 2 padding.
+    expect(overlay.style.left).toBe("64px");
+    expect(overlay.style.width).toBe("116px");
+    unmount();
+  });
+
+  it("drops the overlay when overlayFrom anchors at the last option", () => {
+    const { root, unmount } = mountSegmented(
+      { modelValue: "a", overlayFrom: 2 },
+      { overlay: overlaySlot },
+    );
+    expect(root.querySelector(".hk-segmented__overlay")).toBeNull();
+    unmount();
   });
 });
 

--- a/packages/vue/src/components/HkSegmented.tsx
+++ b/packages/vue/src/components/HkSegmented.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, type PropType } from "vue";
+import { computed, defineComponent, nextTick, ref, type PropType } from "vue";
 
 import { useMeasuredHighlight } from "../composables/useMeasuredHighlight";
 import "./HkSegmented.scss";
@@ -20,8 +20,22 @@ export interface HkSegmentedOption {
  * full-bleed tappable segments (larger hit areas), so touch users are not
  * left with sub-target tap zones.
  *
- * Semantics: this is a *mode picker*, not navigation (use HkTabs for nav)
- * and not a long option list (use HkPopupSelect / HkSelect).
+ * Semantics: two flavors over one visual primitive —
+ * - `radiogroup` (default): a mode picker (ARIA radio group);
+ * - `tablist`: a compact tab strip (ARIA tabs) for a handful of panels —
+ *   for scrollable tab bars with overflow affordances use [HTabs] instead.
+ *
+ * Both flavors get full arrow-key navigation (arrows/Home/End, wrapping,
+ * disabled options skipped, selection follows focus).
+ *
+ * Overlay: `overlayFrom` plus the `#overlay` slot render a passive info
+ * layer covering the tail of the track — everything right of option
+ * `overlayFrom` — e.g. a live readout that replaces the remaining
+ * segments while an "auto" option is active. The layer uses the same
+ * measured geometry pass as the sliding thumb (real offsets, re-measured
+ * on resize and font load), carries the thumb's pill chrome, and is
+ * click-through by default (`pointer-events: none`); interactive content
+ * inside the slot opts back in per element.
  */
 export default defineComponent({
   name: "HkSegmented",
@@ -41,6 +55,15 @@ export default defineComponent({
     },
     /** Grow to fill the container width (segments share it equally). */
     block: { type: Boolean, default: false },
+    /** Interaction semantics: ARIA radio group (default) or tab strip. */
+    semantics: {
+      type: String as PropType<"radiogroup" | "tablist">,
+      default: "radiogroup",
+    },
+    /** When ≥ 0 and the `#overlay` slot is provided, render the overlay
+     *  layer covering the track to the right of option[overlayFrom]
+     *  (measured geometry). -1 disables the layer. */
+    overlayFrom: { type: Number, default: -1 },
     /** Override the viewport breakpoint (default 768px) under which the
      *  touch-optimized full-bleed form renders. */
     mobileBreakpoint: { type: Number, default: 768 },
@@ -48,8 +71,10 @@ export default defineComponent({
   emits: {
     "update:modelValue": (_value: string) => true,
   },
-  setup(props, { emit }) {
+  setup(props, { emit, slots }) {
     const rootRef = ref<HTMLElement | null>(null);
+    const segmentRefs = ref<HTMLElement[]>([]);
+    const isTabs = computed(() => props.semantics === "tablist");
     // -1 (no match, e.g. the default "") clears the thumb instead of
     // pointing it at the first segment — mirrors aria-checked all-false.
     const activeIndex = computed(() =>
@@ -70,12 +95,102 @@ export default defineComponent({
       width: `${width.value}px`,
     }));
 
+    // ── Tail overlay geometry ─────────────────────────────────────────
+    // A second measurement pass anchored on the boundary option: the
+    // overlay spans from that option's right edge to the track's right
+    // padding. The segment gap and track padding constants mirror the
+    // SCSS so the math lives here once — consumers never hand-roll calc().
+    const SEG_GAP = 2;
+    const TRACK_PAD = 2;
+    const overlayActive = computed(
+      () => props.overlayFrom >= 0 && props.overlayFrom < props.options.length - 1,
+    );
+    const overlayAnchor = computed(() => (overlayActive.value ? props.overlayFrom : -1));
+    const overlayMeasure = useMeasuredHighlight({
+      container: rootRef,
+      activeIndex: overlayAnchor,
+      itemSelector: ".hk-segmented__segment",
+      extraSources: [() => props.options, () => props.overlayFrom],
+    });
+    const overlayStyle = computed(() => {
+      if (!overlayActive.value) return undefined;
+      // Measured geometry: from the anchor option's right edge (plus the
+      // segment gap) to the track's right padding.
+      if (overlayMeasure.ready.value) {
+        const left = overlayMeasure.x.value + overlayMeasure.width.value + SEG_GAP;
+        const trackWidth = overlayMeasure.containerWidth.value;
+        if (trackWidth > left + TRACK_PAD) {
+          return { left: `${left}px`, width: `${trackWidth - left - TRACK_PAD}px` };
+        }
+      }
+      // Pre-measurement fallback: equal-share estimate of the tail.
+      const share = (props.overlayFrom + 1) / props.options.length;
+      return { left: `${(share * 100).toFixed(4)}%` };
+    });
+    const hasOverlay = computed(() => overlayActive.value && slots.overlay != null);
+
     function select(v: string) {
       if (props.disabled) return;
       const opt = props.options.find((o) => o.value === v);
       if (opt?.disabled) return;
       if (v === props.modelValue) return;
       emit("update:modelValue", v);
+    }
+
+    // ── Keyboard navigation (radio group + tab strip) ─────────────────
+    // role=radio/tab buttons get no native arrow behavior — the group
+    // owns it. Selection follows focus; disabled options are skipped;
+    // Home/End jump to the first/last enabled option.
+    function focusSegment(idx: number) {
+      void nextTick(() => segmentRefs.value[idx]?.focus());
+    }
+    function moveSelection(from: number, delta: number) {
+      const n = props.options.length;
+      if (n === 0) return;
+      let idx = from;
+      for (let step = 0; step < n; step += 1) {
+        idx = (idx + delta + n) % n;
+        if (!props.options[idx].disabled) {
+          select(props.options[idx].value);
+          focusSegment(idx);
+          return;
+        }
+      }
+    }
+    function onKeydown(e: KeyboardEvent) {
+      if (props.disabled) return;
+      const current = activeIndex.value < 0 ? 0 : activeIndex.value;
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          moveSelection(current, 1);
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          moveSelection(current, -1);
+          break;
+        case "Home": {
+          const first = props.options.findIndex((o) => !o.disabled);
+          if (first >= 0) {
+            select(props.options[first].value);
+            focusSegment(first);
+          }
+          break;
+        }
+        case "End": {
+          for (let i = props.options.length - 1; i >= 0; i -= 1) {
+            if (!props.options[i].disabled) {
+              select(props.options[i].value);
+              focusSegment(i);
+              break;
+            }
+          }
+          break;
+        }
+        default:
+          return;
+      }
+      e.preventDefault();
     }
 
     return () => (
@@ -86,25 +201,46 @@ export default defineComponent({
         data-block={props.block || undefined}
         data-disabled={props.disabled || undefined}
         data-ready={ready.value ? "true" : undefined}
-        role="radiogroup"
+        data-semantics={props.semantics}
+        role={isTabs.value ? "tablist" : "radiogroup"}
+        onKeydown={onKeydown}
       >
         <span class="hk-segmented__thumb" aria-hidden="true" style={thumbStyle.value} />
-        {props.options.map((opt) => (
-          <button
-            key={opt.value}
-            type="button"
-            class="hk-segmented__segment"
-            role="radio"
-            aria-checked={opt.value === props.modelValue}
-            data-checked={opt.value === props.modelValue || undefined}
-            data-disabled={props.disabled || opt.disabled || undefined}
-            disabled={props.disabled || opt.disabled}
-            onClick={() => select(opt.value)}
+        {props.options.map((opt, i) => {
+          const checked = opt.value === props.modelValue;
+          return (
+            <button
+              key={opt.value}
+              ref={(el) => { if (el) segmentRefs.value[i] = el as HTMLElement; }}
+              type="button"
+              class="hk-segmented__segment"
+              role={isTabs.value ? "tab" : "radio"}
+              aria-checked={isTabs.value ? undefined : checked}
+              aria-selected={isTabs.value ? checked : undefined}
+              aria-disabled={opt.disabled || undefined}
+              // Roving tabindex (tab-strip convention): the selected tab
+              // stays in the page tab sequence, the others remain
+              // arrow-reachable only.
+              tabindex={isTabs.value && !checked ? -1 : undefined}
+              data-checked={checked || undefined}
+              data-disabled={props.disabled || opt.disabled || undefined}
+              disabled={props.disabled || opt.disabled}
+              onClick={() => select(opt.value)}
+            >
+              {opt.icon != null && <span class="hk-segmented__icon">{opt.icon as any}</span>}
+              <span class="hk-segmented__label">{opt.label}</span>
+            </button>
+          );
+        })}
+        {hasOverlay.value && (
+          <span
+            class="hk-segmented__overlay"
+            data-ready={overlayMeasure.ready.value ? "true" : undefined}
+            style={overlayStyle.value}
           >
-            {opt.icon != null && <span class="hk-segmented__icon">{opt.icon as any}</span>}
-            <span class="hk-segmented__label">{opt.label}</span>
-          </button>
-        ))}
+            {slots.overlay?.()}
+          </span>
+        )}
       </div>
     );
   },

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -47,31 +47,52 @@
   padding: var(--space-4, 0.25rem) var(--space-6, 0.375rem);
 }
 
-/* ── Color-mode group (plain shared HkSegmented + auto hint row) ──────── */
+/* ── Color-mode group (shared HkSegmented + auto tail overlay) ────────── */
 
 .s-theme-mode-row {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-4, 0.25rem);
   padding: 0 var(--space-6, 0.375rem) var(--space-4, 0.25rem);
 }
 
 /*
- * Auto-mode altitude readout: a passive caption row BELOW the segmented
- * group, in the segmented typography. Non-interactive by design — the
- * group above stays the only control surface (pressing Light/Dark while
- * auto is active IS the switch to that manual side).
+ * Auto-mode altitude strip: full-bleed content INSIDE the segmented
+ * group's tail overlay (HkSegmented's overlay layer supplies the pill
+ * chrome — surface, hairline border, radius, shadow). It reads passive
+ * in the segmented typography, but a press resolves auto to the manual
+ * side it currently renders (day → light, night → dark).
  */
 .s-theme-mode-autoalt {
+  position: absolute;
+  inset: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-4, 0.25rem);
-  color: rgb(var(--color-muted));
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: rgb(var(--color-text-secondary, var(--color-muted)));
+  font: inherit;
   font-size: 12px;
   line-height: 1;
+  cursor: default;
   user-select: none;
   -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  appearance: none;
+  padding: 0;
+}
+
+.s-theme-mode-autoalt:hover {
+  color: rgb(var(--color-text));
+}
+
+.s-theme-mode-autoalt:active {
+  background: rgb(var(--color-primary) / 8%);
+}
+
+.s-theme-mode-autoalt:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: -2px;
 }
 
 .s-theme-mode-autoalt-value {

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -75,7 +75,7 @@ function modeSegments(): HTMLButtonElement[] {
   return [...document.body.querySelectorAll<HTMLButtonElement>(".s-theme-mode-row .hk-segmented__segment")];
 }
 
-function altitudeHint(): HTMLElement | null {
+function altitudeOverlay(): HTMLElement | null {
   return document.body.querySelector<HTMLElement>(".s-theme-mode-autoalt");
 }
 
@@ -126,7 +126,7 @@ describe("HkThemeToggle external customization", () => {
 });
 
 describe("HkThemeToggle color-mode group", () => {
-  it("renders three enabled segments and shows the altitude hint only in auto", async () => {
+  it("renders three segments with the altitude overlay only in auto mode", async () => {
     useTheme().setMode("dark");
     const { container } = mountToggle(true);
     await settle();
@@ -134,48 +134,49 @@ describe("HkThemeToggle color-mode group", () => {
     openMenu(container);
     await settle();
 
-    // Manual mode: plain three-way group, no hint row.
+    // Manual mode: plain three-way group, no cover strip.
     expect(modeSegments()).toHaveLength(3);
-    expect(altitudeHint()).toBeNull();
+    expect(altitudeOverlay()).toBeNull();
     const dark = modeSegments().find((b) => b.textContent?.includes("Dark"));
     const lightSeg = modeSegments().find((b) => b.textContent?.includes("Light"));
     expect(dark?.getAttribute("aria-checked")).toBe("true");
     expect(lightSeg?.disabled).toBe(false);
 
-    // Back to auto: the segments stay enabled (a side press IS the switch
-    // to manual) and a passive altitude readout rides below the group.
+    // Back to auto: the group's tail overlay covers the Light/Dark halves
+    // with the altitude strip (HkSegmented overlayFrom + #overlay).
     modeSegments()
       .find((b) => b.textContent?.includes("Auto"))!
       .click();
     await settle();
 
-    const hint = altitudeHint();
-    expect(hint).toBeTruthy();
-    expect(hint!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
-    expect(lightSeg?.disabled).toBe(false);
-    expect(dark?.disabled).toBe(false);
+    const overlay = altitudeOverlay();
+    expect(overlay).toBeTruthy();
+    expect(overlay!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
+    // The overlay rides inside the segmented group's overlay layer.
+    expect(overlay!.closest(".hk-segmented__overlay")).toBeTruthy();
+    // Covered segments sit out of the tab order; the strip is the single
+    // pointer surface while auto is active.
+    expect(lightSeg?.disabled).toBe(true);
+    expect(dark?.disabled).toBe(true);
   });
 
-  it("switches straight to the pressed manual side while auto is active", async () => {
+  it("resolves auto to a manual side when the altitude strip is pressed", async () => {
     useTheme().setMode("system");
     const { container } = mountToggle(true);
     await settle();
 
     openMenu(container);
     await settle();
-    expect(altitudeHint()).toBeTruthy();
+    expect(altitudeOverlay()).toBeTruthy();
 
-    // Pressing Light directly drops out of auto into manual light —
-    // no intermediate resolve surface involved.
-    modeSegments()
-      .find((b) => b.textContent?.includes("Light"))!
-      .click();
+    altitudeOverlay()!.click();
     await settle();
 
-    expect(localStorage.getItem(MODE_KEY)).toBe("light");
-    expect(altitudeHint()).toBeNull();
+    expect(altitudeOverlay()).toBeNull();
+    const stored = localStorage.getItem(MODE_KEY);
+    expect(["light", "dark"]).toContain(stored);
     const active = modeSegments().find((b) => b.getAttribute("aria-checked") === "true");
-    expect(active?.textContent).toContain("Light");
+    expect(active?.textContent).toContain(stored === "light" ? "Light" : "Dark");
   });
 
   it("keeps every theme row footprint uniform for list highlights", async () => {

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -32,13 +32,12 @@ function geoOnce(): Promise<{ lat: number; lng: number }> {
  * color-mode group and preset/custom theme selection (custom themes are
  * removable), and opens HColorSchemeDialog to create a new custom scheme.
  *
- * Color-mode group: a plain shared HkSegmented button group (Auto | Light
- * | Dark) — every segment stays enabled, so switching out of auto is a
- * direct segment press (the day/night side is the user's choice, no
- * separate resolve step). While AUTO is active a passive solar-altitude
- * readout rides BELOW the group in the same typography: it explains which
- * side auto currently resolves to and is deliberately non-interactive —
- * the segments remain the only control surface.
+ * Color-mode group: a shared HkSegmented button group (Auto | Light |
+ * Dark). In AUTO mode the Light/Dark half is covered by the group's
+ * built-in tail overlay (`overlayFrom` + `#overlay`): a passive-looking
+ * solar-altitude strip in the segmented typography — pressing it drops
+ * to manual on whichever side auto currently resolves to (day → light,
+ * night → dark), so no separate resolve step is ever needed.
  */
 export const HkThemeToggle = defineComponent({
   name: "HkThemeToggle",
@@ -124,20 +123,36 @@ export const HkThemeToggle = defineComponent({
     /**
      * Fresh option objects (and fresh icon vnodes) on every call — never
      * cache icon vnodes across renders, or closing/reopening the popover
-     * would re-mount the same vnode instances. Every segment stays
-     * enabled: pressing Light/Dark while auto is active is itself the
-     * switch to that manual side (setMode leaves "system").
+     * would re-mount the same vnode instances. In AUTO mode the Light/
+     * Dark segments are disabled: their area is covered by the group's
+     * tail overlay (the altitude strip), and the strip's press resolves
+     * to whichever manual side auto currently renders.
      */
     function modeOptions(): HkSegmentedOption[] {
+      const auto = isAutoMode.value;
       return [
         { value: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={12} /> },
-        { value: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={12} /> },
-        { value: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={12} /> },
+        { value: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={12} />, disabled: auto },
+        { value: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={12} />, disabled: auto },
       ];
     }
 
     function onSelectMode(value: string) {
       setMode(value as "light" | "dark" | "system");
+    }
+
+    /**
+     * Pressing the altitude strip in auto mode drops back to manual and
+     * selects whichever side auto currently resolves to (day → light,
+     * night → dark). Debounced: input synthesis may deliver both a
+     * pointer sequence and a click for one physical press.
+     */
+    let lastManualSwitchAt = 0;
+    function resolveAutoToManual() {
+      const now = Date.now();
+      if (now - lastManualSwitchAt < 700) return;
+      lastManualSwitchAt = now;
+      setMode(effectiveMode.value);
     }
 
     function onSelectTheme(id: ThemeId) {
@@ -195,13 +210,23 @@ export const HkThemeToggle = defineComponent({
                 options={modeOptions()}
                 modelValue={currentMode.value}
                 onUpdate:modelValue={onSelectMode}
-              />
-              {isAutoMode.value && (
-                <div class="s-theme-mode-autoalt" title={t("hikari::theme.autoAltitudeTip")}>
-                  {altitudeNight.value ? <Moon size={12} /> : <Sun size={12} />}
-                  <span class="s-theme-mode-autoalt-value">{altitudeText.value}</span>
-                </div>
-              )}
+                overlayFrom={isAutoMode.value ? 0 : -1}
+              >
+                {{
+                  overlay: () => (
+                    <button
+                      type="button"
+                      class="s-theme-mode-autoalt"
+                      title={t("hikari::theme.autoAltitudeTip")}
+                      aria-label={t("hikari::theme.autoAltitudeTip")}
+                      onClick={resolveAutoToManual}
+                    >
+                      {altitudeNight.value ? <Moon size={12} /> : <Sun size={12} />}
+                      <span class="s-theme-mode-autoalt-value">{altitudeText.value}</span>
+                    </button>
+                  ),
+                }}
+              </HkSegmented>
             </div>
 
             <HDivider spacing="md" />

--- a/packages/vue/src/composables/useMeasuredHighlight.ts
+++ b/packages/vue/src/composables/useMeasuredHighlight.ts
@@ -22,6 +22,10 @@ export interface MeasuredHighlight {
   x: Ref<number>;
   /** Measured width (px) of the active item; 0 before a successful measure. */
   width: Ref<number>;
+  /** Inner width (px) of the container, refreshed on every measurement
+   *  pass — lets callers derive end-anchored geometry (e.g. a tail
+   *  overlay spanning to the track end) without a second observer. */
+  containerWidth: Ref<number>;
   /** True once a non-zero width has been measured — i.e. real layout was
    *  available (stays false under jsdom/happy-dom/SSR, where reads are 0). */
   ready: Ref<boolean>;
@@ -72,6 +76,7 @@ function offsetWithin(item: HTMLElement, container: HTMLElement): number {
 export function useMeasuredHighlight(opts: UseMeasuredHighlightOptions): MeasuredHighlight {
   const x = ref(0);
   const width = ref(0);
+  const containerWidth = ref(0);
   const ready = ref(false);
 
   let observer: ResizeObserver | null = null;
@@ -79,6 +84,7 @@ export function useMeasuredHighlight(opts: UseMeasuredHighlightOptions): Measure
   function measure(): void {
     const containerEl = opts.container.value;
     if (!containerEl) return;
+    containerWidth.value = Number.isFinite(containerEl.clientWidth) ? containerEl.clientWidth : 0;
     const items = containerEl.querySelectorAll<HTMLElement>(opts.itemSelector);
     if (items.length === 0) {
       width.value = 0;
@@ -140,5 +146,5 @@ export function useMeasuredHighlight(opts: UseMeasuredHighlightOptions): Measure
     observer = null;
   });
 
-  return { x, width, ready };
+  return { x, width, containerWidth, ready };
 }

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "داكن",
     "hikari::theme.modeAuto": "تلقائي",
     "hikari::theme.themes": "سمات الألوان",
-    "hikari::theme.autoAltitudeTip": "يتبع الوضع التلقائي ارتفاع الشمس.",
+    "hikari::theme.autoAltitudeTip": "يتبع الوضع التلقائي ارتفاع الشمس. اضغط للتبديل إلى الوضع اليدوي.",
     "hikari::theme.editScheme": "تعديل نظام الألوان…",
     "hikari::theme.customize": "تخصيص",
     "hikari::theme.themeName": "اسم السمة",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Dunkel",
     "hikari::theme.modeAuto": "Automatisch",
     "hikari::theme.themes": "Farbschemata",
-    "hikari::theme.autoAltitudeTip": "Der Automatikmodus folgt dem Sonnenstand.",
+    "hikari::theme.autoAltitudeTip": "Der Automatikmodus folgt dem Sonnenstand. Zum manuellen Wechsel drücken.",
     "hikari::theme.editScheme": "Farbschema bearbeiten…",
     "hikari::theme.customize": "Anpassen",
     "hikari::theme.themeName": "Designname",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Dark",
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Color themes",
-    "hikari::theme.autoAltitudeTip": "Auto follows the sun altitude.",
+    "hikari::theme.autoAltitudeTip": "Auto follows the sun altitude. Press to switch to manual.",
     "hikari::theme.editScheme": "Edit color scheme…",
     "hikari::theme.customize": "Customize",
     "hikari::theme.themeName": "Theme name",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Oscuro",
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de color",
-    "hikari::theme.autoAltitudeTip": "El modo automático sigue la altitud del sol.",
+    "hikari::theme.autoAltitudeTip": "El modo automático sigue la altitud del sol. Pulsa para pasar a manual.",
     "hikari::theme.editScheme": "Editar esquema de color…",
     "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nombre del tema",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Sombre",
     "hikari::theme.modeAuto": "Auto",
     "hikari::theme.themes": "Thèmes de couleurs",
-    "hikari::theme.autoAltitudeTip": "Le mode auto suit l'altitude du soleil.",
+    "hikari::theme.autoAltitudeTip": "Le mode auto suit l'altitude du soleil. Appuyez pour passer en manuel.",
     "hikari::theme.editScheme": "Modifier le schéma de couleurs…",
     "hikari::theme.customize": "Personnaliser",
     "hikari::theme.themeName": "Nom du thème",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "ダーク",
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色テーマ",
-    "hikari::theme.autoAltitudeTip": "自動モードは太陽高度に追従しています。",
+    "hikari::theme.autoAltitudeTip": "自動モードは太陽高度に追従します。押すと手動に切り替わります。",
     "hikari::theme.editScheme": "配色を編集…",
     "hikari::theme.customize": "カスタマイズ",
     "hikari::theme.themeName": "テーマ名",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "다크",
     "hikari::theme.modeAuto": "자동",
     "hikari::theme.themes": "색상 테마",
-    "hikari::theme.autoAltitudeTip": "자동 모드는 태양 고도를 따릅니다.",
+    "hikari::theme.autoAltitudeTip": "자동 모드는 태양 고도를 따릅니다. 눌러서 수동으로 전환하세요.",
     "hikari::theme.editScheme": "색 구성표 편집…",
     "hikari::theme.customize": "사용자 지정",
     "hikari::theme.themeName": "테마 이름",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Escuro",
     "hikari::theme.modeAuto": "Automático",
     "hikari::theme.themes": "Temas de cores",
-    "hikari::theme.autoAltitudeTip": "O modo automático segue a altitude do sol.",
+    "hikari::theme.autoAltitudeTip": "O modo automático segue a altitude do sol. Pressione para mudar para manual.",
     "hikari::theme.editScheme": "Editar esquema de cores…",
     "hikari::theme.customize": "Personalizar",
     "hikari::theme.themeName": "Nome do tema",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "Тёмная",
     "hikari::theme.modeAuto": "Авто",
     "hikari::theme.themes": "Цветовые темы",
-    "hikari::theme.autoAltitudeTip": "Автоматический режим следует за высотой солнца.",
+    "hikari::theme.autoAltitudeTip": "Автоматический режим следует за высотой солнца. Нажмите, чтобы перейти на ручной.",
     "hikari::theme.editScheme": "Изменить цветовую схему…",
     "hikari::theme.customize": "Настроить",
     "hikari::theme.themeName": "Название темы",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "深色",
     "hikari::theme.modeAuto": "自动",
     "hikari::theme.themes": "配色主题",
-    "hikari::theme.autoAltitudeTip": "自动模式跟随太阳高度角。",
+    "hikari::theme.autoAltitudeTip": "自动模式跟随太阳高度角，点按切回手动。",
     "hikari::theme.editScheme": "编辑配色方案…",
     "hikari::theme.customize": "自定义",
     "hikari::theme.themeName": "主题名称",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -21,7 +21,7 @@
     "hikari::theme.modeDark": "深色",
     "hikari::theme.modeAuto": "自動",
     "hikari::theme.themes": "配色主題",
-    "hikari::theme.autoAltitudeTip": "自動模式跟隨太陽高度角。",
+    "hikari::theme.autoAltitudeTip": "自動模式跟隨太陽高度角，點按切回手動。",
     "hikari::theme.editScheme": "編輯配色方案…",
     "hikari::theme.customize": "自訂",
     "hikari::theme.themeName": "主題名稱",


### PR DESCRIPTION
## Summary
Makes HkSegmented strong enough to be THE button group for both roles the apps need — a mode picker (radio group) and a compact tab strip — and adds the group-internal info layer the theme toggle's auto mode wants:

1. **`semantics="tablist"`** — same visual primitive as ARIA tabs: `role=tablist`/`role=tab`, `aria-selected`, roving tabindex; for scrollable tab bars with overflow/add affordances HTabs stays the tool.
2. **Arrow-key navigation for both semantics** — arrows/Home/End, wrapping, disabled options skipped, selection follows focus (role=radio/tab buttons get no native arrow behavior; this closes a pre-existing a11y gap for radiogroup mode too).
3. **`overlayFrom` + `#overlay` tail overlay** — a passive info layer covering everything right of option[overlayFrom], measured by the same geometry pass as the sliding thumb (useMeasuredHighlight gains `containerWidth`), carrying the thumb's pill chrome, click-through except for interactive slot content. Pre-measurement it falls back to an equal-share estimate, same cadence as the thumb.
4. **HkThemeToggle auto mode rides the overlay again** — the solar-altitude strip covers the Light/Dark half of the group (autoAltitudeTip restored to explain the press), pressing it resolves to the manual side auto currently renders; the #308 below-group hint row is gone. The strip is now built on the shared group's own capability instead of hand-rolled absolute geometry (`calc((100% - 8px) / 3 + 4px)`).

npm 0.15.1 → 0.16.0.

## Test plan
- [x] tablist roles/aria-selected/roving tabindex; arrows skip disabled + wrap; Home/End; radiogroup also gains arrows
- [x] overlay: absent by default, slot content rendered, equal-share fallback left, measured px geometry (stubbed layout), dropped at last-option anchor
- [x] theme toggle: overlay only in auto, covered segments disabled, press resolves to a manual side (either side accepted — timezone-dependent)
- [x] Full suite 509/509, vue-tsc clean, commit-msg lint PASS