### PR TITLE
✨ Add a delete-language cascade to the localized input editor.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -137,6 +137,23 @@
     </section>
 
     <section>
+      <h2>HLocalizedInput</h2>
+      <div class="row" style="max-width:420px">
+        <HLocalizedInput
+          :model-value="localizedInput.value"
+          @update:model-value="(v: string) => localizedInput.value = v"
+          :source-lang="localizedInput.lang"
+          :translations="localizedInput.translations"
+          @update:translations="(v: Record<string, string>) => localizedInput.translations = v"
+          :locale-options="localeOptions"
+          label="Localized title"
+          placeholder="Localized text..."
+        />
+      </div>
+      <p class="result">Translations: {{ JSON.stringify(localizedInput.translations) }}</p>
+    </section>
+
+    <section>
       <h2>HSkeleton / HSkeletonList</h2>
       <div class="row">
         <HSkeleton width="100px" height="24px" />
@@ -297,6 +314,7 @@ import {
   HProgressBar, HProgressRing, HGaugeRing,
   HInput, HSearchInput, HNumberInput, HPasswordInput, HTextarea,
   HCheckbox, HSwitch, HRadio, HSelect, HSelectPanel,
+  HLocalizedInput,
   HSkeleton, HSkeletonList, HAvatar, HKbd, HDivider,
   HAlert, HEmptyState, HExpansionPanel,
   HTabs, HCard, HTable, HTimeline,
@@ -305,7 +323,7 @@ import {
   type TrendPen, type MinimapBox,
 } from '@celestia-island/hikari'
 
-const totalComponents = 63
+const totalComponents = 64
 
 const icons = ['home', 'settings', 'user', 'search', 'bell', 'heart', 'star', 'mail', 'download', 'upload', 'trash', 'edit', 'plus', 'check', 'x']
 
@@ -315,6 +333,16 @@ const flags = ref({ a: true, b: false, on: false, radio: 'x' })
 const radioOpts = [{ value: 'x', label: 'X' }, { value: 'y', label: 'Y' }]
 const gaugeRings = [{ pct: 45, color: 'rgb(var(--color-primary, 122 162 247))', trackColor: 'rgba(122, 162, 247, 0.15)' }]
 const select = ref({ val: '', opts: [{ value: 'a', label: 'Alpha' }, { value: 'b', label: 'Beta' }, { value: 'c', label: 'Gamma' }] })
+const localizedInput = ref({
+  value: '工厂总览',
+  lang: 'zh-Hans',
+  translations: { en: 'Plant overview', 'zh-Hans': '工厂总览' } as Record<string, string>,
+})
+const localeOptions = [
+  { code: 'en', label: 'English' },
+  { code: 'zh-Hans', label: '简体中文' },
+  { code: 'ja', label: '日本語' },
+]
 const panelAnchor = ref<HTMLElement | null>(null)
 const panel = ref({
   open: false,

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -70,6 +70,33 @@ function menuRows(): HTMLElement[] {
   return [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-row")];
 }
 
+/** The "Delete language" cascade root row (present only when at least
+ *  one translation is filled). */
+function deleteCascadeRow(): HTMLElement | undefined {
+  return menuRows().find((r) => (r.textContent ?? "").includes("Delete language"));
+}
+
+/** Click the cascade root so its danger child rows render. */
+async function openDeleteCascade() {
+  const root = deleteCascadeRow();
+  expect(root, "delete-language cascade root row renders").toBeTruthy();
+  root!.click();
+  await nextTick();
+  await nextTick();
+}
+
+/** Open the delete cascade, then click the danger child row for `code`. */
+async function clickDeleteRow(label: string) {
+  await openDeleteCascade();
+  const child = menuRows().find(
+    (r) => (r.textContent ?? "").includes(label) && r.hasAttribute("data-danger"),
+  );
+  expect(child, `danger delete row for ${label} renders`).toBeTruthy();
+  child!.click();
+  await nextTick();
+  await nextTick();
+}
+
 afterEach(() => {
   for (const { app, container } of mounts.splice(0)) {
     app.unmount();
@@ -161,16 +188,17 @@ describe("HkLocalizedInput", () => {
   });
 
   it("disables the chip when the catalog is exhausted", () => {
-    // Single-language catalog with that language already being edited:
-    // nothing to switch to, nothing to add.
+    // Exhausted = nothing the menu could offer: no translation to
+    // switch to or delete (empty map), and no language left to add
+    // (single-language catalog whose only entry is the source language).
     const container = document.createElement("div");
     document.body.appendChild(container);
     const app = createApp({
       render: () =>
         h(HkLocalizedInput, {
-          modelValue: "Plant overview",
+          modelValue: "",
           sourceLang: "en",
-          translations: { en: "Plant overview" },
+          translations: {},
           localeOptions: [{ code: "en", label: "English" }],
         }),
     });
@@ -298,5 +326,92 @@ describe("HkLocalizedInput", () => {
     expect(events.at(-1)).toBe("zh-Hans");
     expect(queryField(container).value).toBe("工厂总览");
     expect(document.activeElement).not.toBe(queryField(container));
+  });
+
+  it("offers a delete-language cascade listing every filled language as danger rows", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    await openDeleteCascade();
+    // Every filled language is offered — including the edited one.
+    const dangerLabels = menuRows()
+      .filter((r) => r.hasAttribute("data-danger"))
+      .map((r) => r.querySelector(".hk-menu-label")?.textContent ?? "");
+    expect(dangerLabels).toEqual(expect.arrayContaining(["English", "简体中文"]));
+  });
+
+  it("deletes a non-current language and keeps the edit state untouched", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    await clickDeleteRow("简体中文");
+    // The map loses only the deleted language; no edit-state events fire.
+    expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
+    expect(events.modelValue).toEqual([]);
+    expect(events.languagechange).toEqual([]);
+    expect(queryField(container).value).toBe("Plant overview");
+    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(menuRows().length).toBe(0);
+  });
+
+  it("falls back to the source language when the edited language is deleted", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      sourceLang: "en",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    // Switch to zh-Hans first so deleting it means deleting the edited
+    // language while the source still holds a translation.
+    await openMenu(container);
+    const row = menuRows().find((r) => (r.textContent ?? "").includes("简体中文"));
+    row!.click();
+    await nextTick();
+    await nextTick();
+    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+    await openMenu(container);
+    await clickDeleteRow("简体中文");
+    await nextTick();
+    expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
+    expect(events.modelValue.at(-1)).toBe("Plant overview");
+    expect(events.languagechange.at(-1)).toBe("en");
+    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(menuRows().length).toBe(0);
+    expect(document.activeElement).toBe(queryField(container));
+  });
+
+  it("falls back to the first remaining translation when the source language is the one deleted", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      sourceLang: "en",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    await clickDeleteRow("English");
+    expect(events.translations.at(-1)).toEqual({ "zh-Hans": "工厂总览" });
+    expect(events.modelValue.at(-1)).toBe("工厂总览");
+    expect(events.languagechange.at(-1)).toBe("zh-Hans");
+    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+  });
+
+  it("deletes the last translation and empties the field", async () => {
+    const { events, container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview" },
+    });
+    await openMenu(container);
+    await clickDeleteRow("English");
+    expect(events.translations.at(-1)).toEqual({});
+    expect(events.modelValue.at(-1)).toBe("");
+  });
+
+  it("hides the delete cascade when no translation is filled", async () => {
+    const { container } = mountInput({ modelValue: "" });
+    await openMenu(container);
+    const labels = menuRows().map((r) => r.textContent ?? "");
+    expect(labels.some((l) => l.includes("Delete language"))).toBe(false);
   });
 });

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -24,6 +24,11 @@ export interface HkLocaleOption {
 /** Marker key for the "Add language" cascade root (never a real locale). */
 const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
 
+/** Marker prefix for the "Delete language" cascade: children use the
+ *  synthetic key `<prefix>:<code>` so they can never collide with the
+ *  first-level switch rows (whose keys are bare locale codes). */
+const DELETE_LANGUAGE_KEY = "__hkLocalizedInputDelete";
+
 /**
  * HkLocalizedInput — single-field multilingual text editor.
  *
@@ -37,9 +42,17 @@ const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
  *     behavior to the app-level language switcher):
  *       · rows for every language that already has a translation
  *         (click → switch the field to that language and keep editing);
- *       · last row "Add language" cascades into the full locale catalog;
+ *       · an "Add language" cascade into the full locale catalog;
  *         picking one closes the menu and drops the field straight into
- *         edit state for the freshly added language.
+ *         edit state for the freshly added language;
+ *       · a "Delete language" cascade (shown only when at least one
+ *         translation exists) listing EVERY filled language — including
+ *         the one being edited — as danger rows keyed by the synthetic
+ *         `__hkLocalizedInputDelete:<code>` form. Deleting a language
+ *         removes it from `translations`; when it is the language being
+ *         edited the field falls back to `sourceLang` if that still
+ *         holds a translation, else to the first remaining translation
+ *         (or `sourceLang` itself once the map is empty).
  *
  * The chip label is `{label} ({code})` using the app-provided label, and
  * the popup participates in the shared modal/dropdown stacking contexts
@@ -53,6 +66,10 @@ const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
  *   - switching languages commits the current text, swaps `modelValue`
  *     to the target language's stored text ("" when none), and refocuses
  *     the field.
+ *   - deleting a language emits `update:translations` without that key;
+ *     deleting the language being edited additionally swaps `modelValue`
+ *     and emits `languagechange` for the fallback language (sourceLang
+ *     first, then the first remaining translation, else sourceLang).
  */
 export const HkLocalizedInput = defineComponent({
   name: "HkLocalizedInput",
@@ -134,6 +151,11 @@ export const HkLocalizedInput = defineComponent({
       ),
     );
 
+    /** Key of a delete-cascade child for a locale code. */
+    function deleteKey(code: string): string {
+      return `${DELETE_LANGUAGE_KEY}:${code}`;
+    }
+
     const menuItems = computed<HkMenuItem[]>(() => [
       ...switchableCodes.value.map((code) => ({
         key: code,
@@ -149,6 +171,24 @@ export const HkLocalizedInput = defineComponent({
                 key: o.code,
                 label: o.label,
                 flag: o.flag,
+              })),
+            },
+          ]
+        : []),
+      // Every filled language is deletable — including the one being
+      // edited (deleting it falls back to another language, see
+      // `deleteLanguage`).
+      ...(filledCodes.value.length > 0
+        ? [
+            {
+              key: DELETE_LANGUAGE_KEY,
+              label: t("hikari::localizedInput.deleteLanguage", "Delete language"),
+              danger: true,
+              children: filledCodes.value.map((code) => ({
+                key: deleteKey(code),
+                label: localeLabel(code),
+                flag: props.localeOptions.find((o) => o.code === code)?.flag,
+                danger: true,
               })),
             },
           ]
@@ -198,7 +238,38 @@ export const HkLocalizedInput = defineComponent({
       emit("languagechange", code);
     }
 
+    /** Remove a language's translation via the menu's delete cascade:
+     *  drop the key from `translations`, and when the deleted language
+     *  is the one being edited move the field to a fallback — the
+     *  source language if it still holds a translation, else the first
+     *  remaining translation, else the source language itself. Deleting
+     *  another language never disturbs the edit state. Either way the
+     *  menu closes and the field regains focus. */
+    function deleteLanguage(code: string) {
+      const next = { ...props.translations };
+      delete next[code];
+      emit("update:translations", next);
+      if (code === editLang.value) {
+        const remaining = Object.keys(next).filter(
+          (k) => (next[k] ?? "").trim().length > 0,
+        );
+        const target =
+          (next[props.sourceLang] ?? "").trim().length > 0
+            ? props.sourceLang
+            : (remaining[0] ?? props.sourceLang);
+        editLang.value = target;
+        emit("update:modelValue", (next[target] ?? "").trim());
+        emit("languagechange", target);
+      }
+      menuOpen.value = false;
+      focusField();
+    }
+
     function onMenuSelect(key: string) {
+      if (key.startsWith(`${DELETE_LANGUAGE_KEY}:`)) {
+        deleteLanguage(key.slice(`${DELETE_LANGUAGE_KEY}:`.length));
+        return;
+      }
       switchLanguage(key);
     }
 

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "اللغة",
     "hikari::adminHeader.adminGroup": "المسؤولون",
     "hikari::localizedInput.addLanguage": "إضافة لغة",
+    "hikari::localizedInput.deleteLanguage": "حذف اللغة",
     "hikari::localizedInput.chooseLanguage": "اختر لغة التحرير",
     "hikari::statusBar.panel": "اللوحة",
     "hikari::statusBar.engine": "المحرك",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Sprache",
     "hikari::adminHeader.adminGroup": "Administratoren",
     "hikari::localizedInput.addLanguage": "Sprache hinzufügen",
+    "hikari::localizedInput.deleteLanguage": "Sprache löschen",
     "hikari::localizedInput.chooseLanguage": "Bearbeitungssprache wählen",
     "hikari::statusBar.panel": "Panel",
     "hikari::statusBar.engine": "Engine",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Language",
     "hikari::adminHeader.adminGroup": "Administrators",
     "hikari::localizedInput.addLanguage": "Add language",
+    "hikari::localizedInput.deleteLanguage": "Delete language",
     "hikari::localizedInput.chooseLanguage": "Choose editing language",
     "hikari::statusBar.panel": "Panel",
     "hikari::statusBar.engine": "Engine",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Idioma",
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Añadir idioma",
+    "hikari::localizedInput.deleteLanguage": "Eliminar idioma",
     "hikari::localizedInput.chooseLanguage": "Elegir idioma de edición",
     "hikari::statusBar.panel": "Panel",
     "hikari::statusBar.engine": "Motor",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Langue",
     "hikari::adminHeader.adminGroup": "Administrateurs",
     "hikari::localizedInput.addLanguage": "Ajouter une langue",
+    "hikari::localizedInput.deleteLanguage": "Supprimer la langue",
     "hikari::localizedInput.chooseLanguage": "Choisir la langue d’édition",
     "hikari::statusBar.panel": "Panneau",
     "hikari::statusBar.engine": "Moteur",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "言語",
     "hikari::adminHeader.adminGroup": "管理者",
     "hikari::localizedInput.addLanguage": "言語を追加",
+    "hikari::localizedInput.deleteLanguage": "言語を削除",
     "hikari::localizedInput.chooseLanguage": "編集言語を選択",
     "hikari::statusBar.panel": "パネル",
     "hikari::statusBar.engine": "エンジン",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "언어",
     "hikari::adminHeader.adminGroup": "관리자",
     "hikari::localizedInput.addLanguage": "언어 추가",
+    "hikari::localizedInput.deleteLanguage": "언어 삭제",
     "hikari::localizedInput.chooseLanguage": "편집 언어 선택",
     "hikari::statusBar.panel": "패널",
     "hikari::statusBar.engine": "엔진",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Idioma",
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Adicionar idioma",
+    "hikari::localizedInput.deleteLanguage": "Excluir idioma",
     "hikari::localizedInput.chooseLanguage": "Escolher idioma de edição",
     "hikari::statusBar.panel": "Painel",
     "hikari::statusBar.engine": "Motor",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "Язык",
     "hikari::adminHeader.adminGroup": "Администраторы",
     "hikari::localizedInput.addLanguage": "Добавить язык",
+    "hikari::localizedInput.deleteLanguage": "Удалить язык",
     "hikari::localizedInput.chooseLanguage": "Выбрать язык редактирования",
     "hikari::statusBar.panel": "Панель",
     "hikari::statusBar.engine": "Движок",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "语言",
     "hikari::adminHeader.adminGroup": "管理员",
     "hikari::localizedInput.addLanguage": "添加新语言",
+    "hikari::localizedInput.deleteLanguage": "删除语言",
     "hikari::localizedInput.chooseLanguage": "选择编辑语言",
     "hikari::statusBar.panel": "面板",
     "hikari::statusBar.engine": "引擎",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -109,6 +109,7 @@
     "hikari::adminHeader.language": "語言",
     "hikari::adminHeader.adminGroup": "管理員",
     "hikari::localizedInput.addLanguage": "新增語言",
+    "hikari::localizedInput.deleteLanguage": "刪除語言",
     "hikari::localizedInput.chooseLanguage": "選擇編輯語言",
     "hikari::statusBar.panel": "面板",
     "hikari::statusBar.engine": "引擎",


### PR DESCRIPTION
## 背景

P94 Phase 1 —— HkLocalizedInput（导出名 HLocalizedInput）正式化的第一波：补齐用户点名的「删除已有语言」能力。此前删除语义是「切到该语言并清空文本即剪枝」，无显式入口。

## 变更

- **HkLocalizedInput**：语言菜单新增「Delete language」级联（HkMenu popup，桌面锚定弹层 / 移动端底部 sheet 行为不变）——children 为全部已有翻译语言（含当前编辑语言），`danger` 行，合成键 `__hkLocalizedInputDelete:<code>` 与切换行键隔离，`onMenuSelect` 前缀路由。删除语义：先 emit 删后 `translations`；删当前编辑语言时回落 sourceLang（仍持翻译）→ 首个剩余翻译 → sourceLang，并同步 `modelValue`/`languagechange`；删其他语言不动编辑态；任何情形关菜单并回焦输入框。props/emits 契约零改动，HkMenu 源码零改动。
- **测试**：13 → 19 例。修正「catalog 耗尽」用例前提（无翻译可切/删 + 无可添加才算耗尽），新增 6 例（级联列表含全 filled 且 danger、删非当前语言编辑态不动、删当前回落 sourceLang、删 sourceLang 回落首个剩余、删空、空翻译隐藏级联）。
- **i18n**：`hikari::localizedInput.deleteLanguage` × 11 locale（en/zh-Hans/zh-Hant/ja/ko/de/fr/es/pt/ar/ru）。
- **DemoApp**：新增 HLocalizedInput 演示 section，totalComponents 63 → 64。
- **版本**：0.17.0 → 0.18.0。

## 验证

- 单文件 vitest 19/19；全量 500/500（59 文件）；vue-tsc --noEmit 0 错误（`pnpm build` 等价脚本）。
- 独立交叉验证子代理复跑三件套并逐条规格核对（含 key 串扰、回落基于删后 map、事件序列边角），裁决 PASS。
- §7.2 编译禁令期内未做任何部署构建；文档页未新增（docs/*.md 属冻结遗留树，近 4 个组件均无 doc 页），以 JSDoc + DemoApp 为文档。

后续：Phase 2-4（celestia-integration 数据重排 → evernight/chest wire 透传 → webui 渲染与编辑面）见 PLAN.md P94。