### PR TITLE
♻️ Align every button group variant on the one pill chrome and generalize the protruding end actions.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/DemoApp.vue
+++ b/packages/vue/src/DemoApp.vue
@@ -207,9 +207,18 @@
     </section>
 
     <section>
-      <h2>HTabs (pill / underline / segmented)</h2>
+      <h2>HTabs — one look, variants pick the working mode (pill = tablist, segmented = radiogroup)</h2>
       <HTabs v-model="tabs.active" :tabs="tabs.items" />
       <p class="result" style="margin-top:8px">Active tab: {{ tabs.active }}</p>
+      <h3>segmented (option picker) + protruding end actions</h3>
+      <HTabs
+        v-model="tabs.active"
+        :tabs="tabs.items"
+        variant="segmented"
+        :start-action="{ label: 'Back' }"
+        :end-action="{ label: 'Add tab' }"
+        @action="(side: string) => console.log('tabs action', side)"
+      />
       <div style="margin-top:12px" />
     </section>
 

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -1,10 +1,15 @@
-/* HkTabs — unified underline / pill tab component */
+/* HkTabs — THE unified button-group / tab-strip primitive.
+ *
+ * ONE look (the centered pill strip of the page-level top/bottom bars)
+ * is shared by every button group, radio group and tab strip. Variants
+ * only switch the working mode (pill = tablist, segmented = radiogroup)
+ * and layout extras (size="sm" / block) — never the visual language. */
 
 .hk-tabs {
   width: 100%;
 }
 
-/* === Scrollable variant === */
+/* === Scrollable (default) === */
 
 /* The scroller (a horizontal HkScrollContainer) bounds the list: it
    sizes to the content up to the available width, then the list
@@ -21,15 +26,16 @@
   width: 100%;
 }
 
-/* === Addable variant === */
+/* === Protruding end actions (startAction / endAction) === */
 
-/* With addable the whole strip sits inside an HkHoverRevealAction host
-   (`.hk-tabs-addwrap`) and the "+" protrudes at the host's right edge
-   (left:100% in HkHoverRevealAction.scss) — outside the scroll viewport,
-   so it never scrolls away. Shrink-wrap the strip the same way the
-   scrollable variant does, so the hover-reveal chain can cap inside
-   constrained flex parents and the tabs keep their safe centering. */
-.hk-tabs[data-addable] {
+/* With an end action the whole strip sits inside an HkHoverRevealAction
+   host (`.hk-tabs-addwrap`) and the button protrudes at the host's edge
+   (left:100% / right:100% in HkHoverRevealAction.scss) — outside the
+   scroll viewport, so it never scrolls away. Shrink-wrap the strip the
+   same way the scrollable variant does, so the hover-reveal chain can
+   cap inside constrained flex parents and the tabs keep their safe
+   centering. */
+.hk-tabs[data-actions] {
   width: auto;
   max-width: 100%;
   min-width: 0;
@@ -38,20 +44,15 @@
 /* The reveal host itself must be able to shrink below its content and
    must not be clipped by rigid parents — mirrors HkHoverRevealAction's
    own min/max rules; no flex shorthand here, the host's natural
-   shrink-wrap keeps the centered-bar geometry of the pre-addable era. */
+   shrink-wrap keeps the centered-bar geometry. */
 .hk-tabs-addwrap {
   min-width: 0;
   max-width: 100%;
 }
 
-/* === Shared list === */
+/* === The one shared track (every variant) === */
 
 .hk-tabs-list {
-  display: flex;
-  gap: var(--space-2);
-}
-
-.hk-tabs-list[data-variant="pill"] {
   position: relative;
   display: inline-flex;
   gap: 0;
@@ -61,15 +62,27 @@
   background: rgb(var(--color-surface) / 60%);
 }
 
-/* === Shared trigger === */
+/* === The one shared trigger (every variant) === */
 
 .hk-tabs-trigger {
-  font-weight: 500;
+  position: relative;
+  /* Paint above the sliding indicator. */
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  flex: none;
+  padding: var(--space-4) var(--space-12);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
   color: rgb(var(--color-muted));
   background: transparent;
   border: none;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
   cursor: pointer;
-  font-family: inherit;
   outline: none;
   transition: color var(--duration-short) ease;
 
@@ -80,47 +93,21 @@
   &[data-active] {
     color: rgb(var(--color-primary));
   }
-}
 
-/* === Underline variant === */
-
-.hk-tabs[data-variant="underline"] .hk-tabs-list {
-  border-bottom: 1px solid rgb(var(--color-border) / 15%);
-}
-
-.hk-tabs[data-variant="underline"] .hk-tabs-trigger {
-  padding: var(--space-8) var(--space-16);
-  font-size: var(--text-base);
-  border-bottom: 2px solid transparent;
-  transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) ease;
-
-  &:hover {
-    background: var(--c-primary-faint);
-  }
-
-  &[data-active] {
-    border-bottom-color: rgb(var(--color-primary));
+  /* Inset ring: the track padding and the scroller's edge-fade mask
+     would clip an outset outline. */
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
   }
 }
 
-/* === Pill variant — mirrors SMorphingTabs exactly === */
-
-.hk-tabs[data-variant="pill"] .hk-tabs-trigger {
-  position: relative;
-  z-index: 1;
-  display: flex;
+.hk-tabs-trigger-icon {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: var(--space-6);
-  flex: none;
-  padding: var(--space-4) var(--space-12);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  border-radius: var(--radius-sm);
-  white-space: nowrap;
 }
 
-/* === Pill sliding indicator === */
+/* === The one shared sliding indicator (every variant) === */
 
 .hk-tabs-indicator {
   position: absolute;
@@ -134,7 +121,7 @@
               width var(--duration-normal) var(--ease-standard);
 }
 
-/* === Panel === */
+/* === Panel (pill / tablist mode) === */
 
 .hk-tabs-panel {
   outline: none;
@@ -144,116 +131,45 @@
   }
 }
 
-.hk-tabs[data-variant="underline"] .hk-tabs-panel {
-  padding: var(--space-16) 0;
+/* === segmented = radiogroup working mode ===
+ * Same chrome; only the form-row layout extras live here: compact
+ * sizing (size="sm") and row-filling (block). */
+
+.hk-tabs-list[data-variant="segmented"][data-size="sm"] .hk-tabs-trigger {
+  font-size: 12px;
+  padding: var(--space-2, 2px) var(--space-10, 10px);
 }
 
-/* === Segmented variant — the compact mode-picker form ===
- * Ported from the retired HkSegmented onto the unified strip: a muted
- * track, equal-weight labels and a solid sliding thumb (the shared
- * indicator element re-skinned). Semantics switch to radiogroup/radio
- * in the component. */
-
-.hk-tabs-list[data-variant="segmented"] {
-  --hk-seg-h: 34px;
-  position: relative;
-  display: inline-flex;
-  align-items: stretch;
-  gap: 2px;
-  padding: 2px;
-  border-radius: 10px;
-  background: rgb(var(--hk-surface-muted, var(--color-surface, 240 240 244)) / 60%);
-}
-
-.hk-tabs-list[data-variant="segmented"][data-size="sm"] {
-  --hk-seg-h: 28px;
-  border-radius: 8px;
-}
-
+/* block outside the scroller (scrollable opted out): legacy fill —
+   triggers may shrink below their content. */
 .hk-tabs-list[data-variant="segmented"][data-block="true"] {
   display: flex;
   width: 100%;
 }
 
-/* Solid thumb: the shared indicator re-skinned for this variant. */
-.hk-tabs-list[data-variant="segmented"] .hk-tabs-indicator {
-  top: 2px;
-  height: calc(100% - 4px);
-  border-radius: 8px;
-  background: rgb(var(--hk-surface, var(--color-surface, 255 255 255)));
-  border: none;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
-}
-
-.hk-tabs-list[data-variant="segmented"][data-size="sm"] .hk-tabs-indicator {
-  border-radius: 6px;
-}
-
-.hk-tabs-list[data-variant="segmented"] .hk-tabs-trigger {
-  height: var(--hk-seg-h);
-  padding: 0 14px;
-  gap: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 400;
-  border-radius: 8px;
-  white-space: nowrap;
+.hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-trigger {
   flex: 1 1 auto;
-  position: relative;
-  z-index: 1;
-  /* Paint above the solid thumb. */
-  color: rgb(var(--hk-text-muted, var(--color-muted, 90 90 100)));
-  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.hk-tabs-list[data-variant="segmented"][data-size="sm"] .hk-tabs-trigger {
-  font-size: 12px;
-  padding: 0 10px;
-  border-radius: 6px;
+/* block inside the scroller (the default): fill the row while it fits,
+   scroll with edge fades when it doesn't — triggers never shrink below
+   their content, so option labels are never clipped. */
+.hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] {
+  width: max-content;
+  min-width: 100%;
 }
 
-.hk-tabs-list[data-variant="segmented"] .hk-tabs-trigger:hover:not(:disabled) {
-  color: rgb(var(--hk-text, var(--color-text, 20 20 26)));
-}
-
-.hk-tabs-list[data-variant="segmented"] .hk-tabs-trigger[data-active] {
-  color: rgb(var(--hk-text, var(--color-text, 20 20 26)));
-}
-
-.hk-tabs-list[data-variant="segmented"] .hk-tabs-trigger:focus-visible {
-  outline: 2px solid rgb(var(--hk-primary, var(--color-primary, 60 120 240)));
-  outline-offset: 1px;
-}
-
-.hk-tabs-trigger-icon {
-  display: inline-flex;
-  align-items: center;
-}
-
-/* Full-bleed touch form (matches the retired segmented mobile rule). */
-@media (max-width: 767px) {
-  .hk-tabs-list[data-variant="segmented"] {
-    display: flex;
-    width: 100%;
-    gap: 0;
-  }
-
-  .hk-tabs-list[data-variant="segmented"] .hk-tabs-trigger {
-    flex: 1 1 0;
-    min-width: 0;
-    height: 40px;
-    font-size: 14px;
-    padding: 0 6px;
-  }
+.hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-trigger {
+  flex: 1 0 auto;
 }
 
 /* === Tail overlay (option locking / live info) ===
  * A passive layer covering the track right of tab[overlayFrom]; measured
  * geometry arrives as inline left/width (equal-share estimate before
- * measurement). Carries the thumb's pill chrome, sits above triggers,
- * click-through except for interactive slot content. */
+ * measurement). Carries the unified pill chrome (opaque surface so the
+ * locked triggers beneath never bleed through, hairline border, the
+ * shared radius), sits above triggers, click-through except for
+ * interactive slot content. */
 .hk-tabs-overlay {
   position: absolute;
   top: 2px;
@@ -263,24 +179,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   background: rgb(var(--hk-surface, var(--color-surface, 255 255 255)));
-  border: 1px solid rgb(var(--color-border, 100 100 100) / 12%);
-  box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
+  border: 1px solid var(--border-faint);
   overflow: hidden;
   pointer-events: none;
 }
 
-.hk-tabs-list[data-size="sm"] .hk-tabs-overlay {
-  border-radius: 6px;
-}
-
 .hk-tabs-overlay :where(button, a, [role="button"]) {
   pointer-events: auto;
-}
-
-@media (max-width: 767px) {
-  .hk-tabs-overlay {
-    border-radius: 8px;
-  }
 }

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -11,7 +11,7 @@ interface TabsHarness {
   setActive: (key: string) => void;
 }
 
-function mountTabs(props: Record<string, unknown> = {}, onAdd?: () => void): TabsHarness {
+function mountTabs(props: Record<string, unknown> = {}, onAction?: (side: string) => void): TabsHarness {
   const container = document.createElement("div");
   document.body.appendChild(container);
   containers.push(container);
@@ -24,7 +24,7 @@ function mountTabs(props: Record<string, unknown> = {}, onAdd?: () => void): Tab
           ...props,
           modelValue: active.value,
           "onUpdate:modelValue": (v: string) => { active.value = v; },
-          onAdd: onAdd,
+          onAction: onAction,
           tabs: [
             { key: "a", label: "Alpha" },
             { key: "b", label: "Beta" },
@@ -47,16 +47,8 @@ afterEach(() => {
 });
 
 describe("HkTabs scrollable", () => {
-  it("renders a bare list without scrollable", () => {
+  it("wraps the list in a centered horizontal scroller by default", () => {
     const t = mountTabs();
-    expect(t.container.querySelector(".hk-tabs[data-scrollable]")).toBeNull();
-    expect(t.container.querySelector(".hk-tabs-scroller")).toBeNull();
-    const list = t.container.querySelector(".hk-tabs-list");
-    expect(list?.parentElement?.classList.contains("hk-scroll-container-viewport")).toBe(false);
-  });
-
-  it("wraps the list in a centered horizontal scroller with scrollable", () => {
-    const t = mountTabs({ scrollable: true });
     const tabs = t.container.querySelector<HTMLElement>(".hk-tabs[data-scrollable]");
     expect(tabs).not.toBeNull();
     const scroller = t.container.querySelector<HTMLElement>(".hk-tabs-scroller");
@@ -69,8 +61,16 @@ describe("HkTabs scrollable", () => {
     expect(aligner?.querySelector(".hk-tabs-list")).not.toBeNull();
   });
 
+  it("renders a bare list with scrollable opted out", () => {
+    const t = mountTabs({ scrollable: false });
+    expect(t.container.querySelector(".hk-tabs[data-scrollable]")).toBeNull();
+    expect(t.container.querySelector(".hk-tabs-scroller")).toBeNull();
+    const list = t.container.querySelector(".hk-tabs-list");
+    expect(list?.parentElement?.classList.contains("hk-scroll-container-viewport")).toBe(false);
+  });
+
   it("keeps the pill indicator tracking the active tab inside the scroller", async () => {
-    const t = mountTabs({ scrollable: true, variant: "pill" });
+    const t = mountTabs({ variant: "pill" });
     const indicator = () => t.container.querySelector<HTMLElement>(".hk-tabs-indicator");
     expect(indicator()).not.toBeNull();
     t.setActive("c");
@@ -85,46 +85,107 @@ describe("HkTabs scrollable", () => {
   });
 
   it("only mounts the auto-hiding overlay scrollbar when opted in", async () => {
-    const plain = mountTabs({ scrollable: true });
+    const plain = mountTabs();
     await nextTick();
     expect(plain.container.querySelector(".hk-scrollbar-track[data-axis='horizontal']")).toBeNull();
 
-    const tracked = mountTabs({ scrollable: true, scrollbar: true });
+    const tracked = mountTabs({ scrollbar: true });
     await nextTick();
     expect(tracked.container.querySelector(".hk-scrollbar-track[data-axis='horizontal']")).not.toBeNull();
   });
+
+  it("drops safe centering for a block (row-filling) segmented strip", () => {
+    const t = mountTabs({ variant: "segmented", block: true });
+    const scroller = t.container.querySelector<HTMLElement>(".hk-tabs-scroller");
+    expect(scroller).not.toBeNull();
+    // align="start": no center aligner — the list stretches to the row.
+    expect(scroller?.getAttribute("data-align")).toBeNull();
+    expect(scroller?.querySelector(".hk-scroll-container-aligner")).toBeNull();
+    const list = t.container.querySelector<HTMLElement>(".hk-tabs-list");
+    expect(list?.getAttribute("data-block")).toBe("true");
+  });
 });
 
-describe("HkTabs addable", () => {
-  it("renders the protruding add button only with addable and wires the add emit", async () => {
-    let adds = 0;
-    const t = mountTabs({ addable: true, addLabel: "Add view" }, () => { adds += 1; });
+describe("HkTabs end actions", () => {
+  it("renders the protruding end button with endAction and emits action('end')", async () => {
+    const sides: string[] = [];
+    const t = mountTabs({ endAction: { label: "Add view" } }, (side) => { sides.push(side); });
 
     // The strip is wrapped in the shared hover-reveal surface and the
     // button lives in its extension slot, outside the tab list.
     const wrap = t.container.querySelector<HTMLElement>(".hk-tabs-addwrap.hk-hover-reveal");
     expect(wrap).not.toBeNull();
-    expect(t.container.querySelector(".hk-tabs[data-addable]")).not.toBeNull();
+    expect(wrap?.getAttribute("data-placement") ?? "right").toBe("right");
+    expect(t.container.querySelector(".hk-tabs[data-actions='end']")).not.toBeNull();
 
     const addBtn = wrap!.querySelector<HTMLButtonElement>(".hk-hover-reveal-extension button");
     expect(addBtn).not.toBeNull();
     expect(addBtn!.getAttribute("aria-label")).toBe("Add view");
     expect(addBtn!.getAttribute("title")).toBe("Add view");
-    // The "+" lives OUTSIDE the scroll viewport, so it never scrolls away.
+    // The button lives OUTSIDE the scroll viewport, so it never scrolls away.
     expect(addBtn!.closest(".hk-scroll-container")).toBeNull();
     expect(addBtn!.closest(".hk-tabs-addwrap")).not.toBeNull();
 
     addBtn!.click();
     await nextTick();
-    expect(adds).toBe(1);
+    expect(sides).toEqual(["end"]);
   });
 
-  it("falls back to the shared label and stays absent without addable", async () => {
+  it("renders the protruding start button with startAction and emits action('start')", async () => {
+    const sides: string[] = [];
+    const t = mountTabs({ startAction: { label: "Collapse" } }, (side) => { sides.push(side); });
+
+    const wrap = t.container.querySelector<HTMLElement>(".hk-tabs-addwrap.hk-hover-reveal");
+    expect(wrap).not.toBeNull();
+    expect(wrap?.getAttribute("data-placement")).toBe("left");
+    expect(t.container.querySelector(".hk-tabs[data-actions='start']")).not.toBeNull();
+
+    const btn = wrap!.querySelector<HTMLButtonElement>(".hk-hover-reveal-extension button");
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("aria-label")).toBe("Collapse");
+    expect(btn!.closest(".hk-scroll-container")).toBeNull();
+
+    btn!.click();
+    await nextTick();
+    expect(sides).toEqual(["start"]);
+  });
+
+  it("supports both ends at once with nested reveal hosts", async () => {
+    const sides: string[] = [];
+    const t = mountTabs(
+      { startAction: { label: "Back" }, endAction: { label: "Add view" } },
+      (side) => { sides.push(side); },
+    );
+
+    expect(t.container.querySelector(".hk-tabs[data-actions='both']")).not.toBeNull();
+    const wraps = t.container.querySelectorAll<HTMLElement>(".hk-tabs-addwrap.hk-hover-reveal");
+    expect(wraps.length).toBe(2);
+    const placements = Array.from(wraps).map((w) => w.getAttribute("data-placement") ?? "right");
+    expect(placements).toContain("left");
+    expect(placements).toContain("right");
+
+    const labels = Array.from(
+      t.container.querySelectorAll<HTMLButtonElement>(".hk-hover-reveal-extension button"),
+    ).map((b) => b.getAttribute("aria-label"));
+    expect(labels).toContain("Back");
+    expect(labels).toContain("Add view");
+    // Both buttons live outside the scroll viewport.
+    for (const b of t.container.querySelectorAll<HTMLButtonElement>(".hk-hover-reveal-extension button")) {
+      expect(b.closest(".hk-scroll-container")).toBeNull();
+    }
+
+    const [first] = t.container.querySelectorAll<HTMLButtonElement>(".hk-hover-reveal-extension button");
+    first!.click();
+    await nextTick();
+    expect(sides.length).toBe(1);
+  });
+
+  it("falls back to the shared label and stays absent without actions", async () => {
     const bare = mountTabs();
     expect(bare.container.querySelector(".hk-tabs-addwrap")).toBeNull();
-    expect(bare.container.querySelector(".hk-tabs[data-addable]")).toBeNull();
+    expect(bare.container.querySelector(".hk-tabs[data-actions]")).toBeNull();
 
-    const t = mountTabs({ addable: true });
+    const t = mountTabs({ endAction: {} });
     const addBtn = t.container.querySelector<HTMLButtonElement>(".hk-hover-reveal-extension button");
     expect(addBtn).not.toBeNull();
     // Default i18n string (test env resolves the en locale).
@@ -187,10 +248,11 @@ describe("HkTabs segmented variant", () => {
     expect(container.querySelector(".hk-tabs-panel")).toBeNull();
   });
 
-  it("keeps tab semantics for pill and underline", () => {
-    const { container } = mountLive({ variant: "pill" });
+  it("keeps tab semantics for pill (the default)", () => {
+    const { container } = mountLive({});
     const list = container.querySelector(".hk-tabs-list")!;
     expect(list.getAttribute("role")).toBe("tablist");
+    expect(list.getAttribute("data-variant")).toBe("pill");
     const trig = container.querySelectorAll(".hk-tabs-trigger");
     expect(trig[0].getAttribute("role")).toBe("tab");
     expect(trig[0].getAttribute("aria-selected")).toBe("true");
@@ -252,8 +314,9 @@ describe("HkTabs segmented variant", () => {
     Object.defineProperty(list, "clientWidth", { value: 182, configurable: true });
     await settle();
     const overlay = container.querySelector<HTMLElement>(".hk-tabs-overlay")!;
-    expect(overlay.style.left).toBe("64px");
-    expect(overlay.style.width).toBe("116px");
+    // Unified chrome: zero inter-trigger gap, 2px track padding.
+    expect(overlay.style.left).toBe("62px");
+    expect(overlay.style.width).toBe("118px");
   });
 
   it("renders a tab icon field before the label", () => {

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -16,6 +16,19 @@ export interface TabItem {
   disabled?: boolean;
 }
 
+/** A protruding icon button at one inline end of the strip (the former
+ *  addable "+" generalized to both ends). Rendered by the shared
+ *  HkHoverRevealAction surface OUTSIDE the scroll viewport, so it never
+ *  scrolls away; hover-revealed on pointer devices, tap-revealed with a
+ *  linger on touch. */
+export interface TabsEndAction {
+  /** Icon vnode — defaults to the Plus glyph (the common add-tab case). */
+  icon?: unknown;
+  /** Accessible label / tooltip (falls back to the shared "Add tab"
+   *  string). */
+  label?: string;
+}
+
 /** Structural stand-in for HkScrollContainer's exposed surface —
  *  imperative expose() types don't flow through render-function
  *  setups, so declare just the method we consume. */
@@ -23,26 +36,35 @@ interface ScrollerExpose {
   getScrollElement?: () => HTMLElement | undefined;
 }
 
-const SEG_GAP = 2;
-const SEG_PAD = 2;
+/** Track geometry constants, kept in sync with HkTabs.scss: the track
+ *  padding (TRACK_PAD) and the inter-trigger gap (TRACK_GAP — 0 in the
+ *  unified chrome). */
+const TRACK_GAP = 0;
+const TRACK_PAD = 2;
 
 /**
- * HTabs — THE button-group / tab-strip primitive. One component carries
- * every extension capability so no parallel implementations can drift
- * apart again:
+ * HTabs — THE button-group / tab-strip primitive. ONE look (the centered
+ * pill strip used by the page-level top/bottom bars) is shared by every
+ * button group, radio group and tab strip; variants only switch the
+ * working mode and layout behaviors, never the visual language:
  *
- * Variants:
- * - `underline` — classic anchored text tabs;
- * - `pill` — the centered pill strip (hairline track, primary-tinted
- *   sliding indicator) used by page-level bars;
- * - `segmented` — the compact mode-picker form (solid sliding thumb on a
- *   muted track) for small mutually exclusive choices. Semantics switch
- *   with it: pill/underline expose `tablist`/`tab`/`aria-selected` while
- *   segmented exposes `radiogroup`/`radio`/`aria-checked`.
+ * Variants (working mode):
+ * - `pill` (default) — tab strip: `tablist`/`tab`/`aria-selected`
+ *   semantics, optional tab panels below;
+ * - `segmented` — mutually exclusive option picker: `radiogroup`/
+ *   `radio`/`aria-checked` semantics, no panels, plus the form-row
+ *   layout extras `size="sm"` (compact) and `block` (fill the row).
  *
  * Capabilities (all variants unless noted):
- * - `scrollable` + `scrollbar` + edge fades (HkScrollContainer) and the
- *   protruding hover-revealed trailing "+" (`addable`, emits `add`);
+ * - `scrollable` (default ON) + `scrollbar` + edge fades
+ *   (HkScrollContainer): the strip stays centered / row-filling while it
+ *   fits and automatically carries the bars' overflow behavior once the
+ *   width runs short — edge fades hint at hidden options, swipe/scroll
+ *   reaches them, and the active tab is scrolled into view on change;
+ * - `startAction` / `endAction` + the `action` emit: optional protruding
+ *   icon buttons at EITHER inline end of the strip (outside the scroll
+ *   viewport), hover/tap-revealed — the page bars' trailing "+" is
+ *   simply `endAction`;
  * - `overlayFrom` + the `#overlay` slot: a measured info layer covering
  *   the track to the right of tab[overlayFrom] — e.g. the theme
  *   toggle's solar-altitude strip replacing the manual halves while
@@ -55,7 +77,10 @@ export default defineComponent({
   props: {
     modelValue: { type: String, required: true },
     tabs: { type: Array as PropType<TabItem[]>, required: true },
-    variant: { type: String as PropType<"underline" | "pill" | "segmented">, default: "underline" },
+    /** Working mode: pill = tab strip (tablist), segmented = mutually
+     *  exclusive option picker (radiogroup). Both share the one unified
+     *  pill chrome. */
+    variant: { type: String as PropType<"pill" | "segmented">, default: "pill" },
     /** Visual size — sm matches form-control heights (segmented). */
     size: { type: String as PropType<"sm" | "md">, default: "md" },
     /** Grow to fill the container width (segmented). */
@@ -65,26 +90,27 @@ export default defineComponent({
     /** Render tab panel slots below the strip. Segmented mode pickers
      *  have no panels — panels are skipped for that variant. */
     renderPanels: { type: Boolean, default: true },
-    /** Wrap the tab list in a horizontal HkScrollContainer. The list
-     *  stays centered while it fits and becomes swipe/scroll-driven
-     *  once it overflows (safe centering — the overflowing start is
-     *  never clipped), with edge fades hinting at hidden tabs and the
-     *  active tab scrolled into view on change. */
-    scrollable: { type: Boolean, default: false },
+    /** Wrap the tab list in a horizontal HkScrollContainer (default ON —
+     *  every strip carries the page bars' overflow behavior). The list
+     *  stays centered (or row-filling with block) while it fits and
+     *  becomes swipe/scroll-driven once it overflows (safe centering —
+     *  the overflowing start is never clipped), with edge fades hinting
+     *  at hidden tabs and the active tab scrolled into view on change.
+     *  Pass false only for a strip that must never scroll. */
+    scrollable: { type: Boolean, default: true },
     /** Show the scroller's auto-hiding overlay scrollbar for the tab
      *  axis (scrollable only). Off by default — the edge fades alone
      *  hint at hidden tabs; opt in where a drag affordance helps
      *  pointer users (dense strips, embedded toolbars). */
     scrollbar: { type: Boolean, default: false },
-    /** Render a trailing "add" button protruding at the right edge of
-     *  the strip — hover-revealed on pointer devices, tap-revealed with
-     *  a linger on touch (the shared HkHoverRevealAction behavior). The
-     *  button lives OUTSIDE the scroll viewport so it never scrolls
-     *  away. Emits `add`. */
-    addable: { type: Boolean, default: false },
-    /** Accessible label / tooltip for the add button (falls back to the
-     *  shared "Add tab" string). */
-    addLabel: { type: String, default: "" },
+    /** Optional protruding icon button at the strip's inline-start end
+     *  (outside the scroll viewport, hover/tap-revealed). Pressing it
+     *  emits `action` with "start". */
+    startAction: { type: Object as PropType<TabsEndAction | null>, default: null },
+    /** Optional protruding icon button at the strip's inline-end end —
+     *  the page bars' trailing "+" (outside the scroll viewport,
+     *  hover/tap-revealed). Pressing it emits `action` with "end". */
+    endAction: { type: Object as PropType<TabsEndAction | null>, default: null },
     /** When ≥ 0 and the `#overlay` slot is provided, render the overlay
      *  layer covering the track to the right of tab[overlayFrom]
      *  (measured geometry; the covered tabs are usually disabled —
@@ -93,8 +119,8 @@ export default defineComponent({
   },
   emits: {
     "update:modelValue": (_value: string) => true,
-    /** The add button was pressed (addable only). */
-    add: () => true,
+    /** A protruding end button was pressed. */
+    action: (_side: "start" | "end") => true,
   },
   setup(props, { emit, slots }) {
     const { t } = useI18n();
@@ -105,6 +131,7 @@ export default defineComponent({
     const listRef = ref<HTMLElement | null>(null);
 
     const isSegmented = computed(() => props.variant === "segmented");
+    const isBlock = computed(() => isSegmented.value && props.block);
     // No active tab (modelValue matches nothing / active disabled): keep
     // the first enabled trigger tabbable so the group stays reachable —
     // otherwise every trigger would be tabindex=-1.
@@ -115,13 +142,13 @@ export default defineComponent({
       if (hasActive) return -1;
       return props.tabs.findIndex((tb) => !tb.disabled);
     });
-    const hasIndicator = computed(() => props.variant !== "underline");
     const hasOverlay = computed(
       () => props.overlayFrom >= 0 && props.overlayFrom < props.tabs.length - 1 && slots.overlay != null,
     );
 
-    const resolvedAddLabel = (): string =>
-      props.addLabel || t("hikari::tabs.add", "Add tab");
+    function resolvedActionLabel(action: TabsEndAction): string {
+      return action.label || t("hikari::tabs.add", "Add tab");
+    }
 
     function setTriggerRef(el: Element | ComponentPublicInstance | null, idx: number) {
       if (el instanceof HTMLElement) {
@@ -132,7 +159,6 @@ export default defineComponent({
     }
 
     function updateIndicator() {
-      if (!hasIndicator.value) return;
       const idx = props.tabs.findIndex((tb) => tb.key === props.modelValue);
       const el = triggerRefs.value.get(idx >= 0 ? idx : 0);
       if (!el) return;
@@ -150,12 +176,12 @@ export default defineComponent({
       const el = triggerRefs.value.get(props.overlayFrom);
       const list = listRef.value;
       if (!el || !list) return;
-      const leftPx = el.offsetLeft + el.offsetWidth + SEG_GAP;
+      const leftPx = el.offsetLeft + el.offsetWidth + TRACK_GAP;
       const listWidth = list.clientWidth;
-      if (el.offsetWidth > 0 && listWidth > leftPx + SEG_PAD) {
+      if (el.offsetWidth > 0 && listWidth > leftPx + TRACK_PAD) {
         overlayStyle.value = {
           left: `${leftPx}px`,
-          width: `${listWidth - leftPx - SEG_PAD}px`,
+          width: `${listWidth - leftPx - TRACK_PAD}px`,
         };
         return;
       }
@@ -197,12 +223,10 @@ export default defineComponent({
 
     onMounted(() => {
       nextTick(refreshGeometry);
-      if (hasIndicator.value) {
-        resizeObserver = new ResizeObserver(() => refreshGeometry());
-        const firstEl = triggerRefs.value.get(0);
-        if (firstEl?.parentElement) {
-          resizeObserver.observe(firstEl.parentElement);
-        }
+      resizeObserver = new ResizeObserver(() => refreshGeometry());
+      const firstEl = triggerRefs.value.get(0);
+      if (firstEl?.parentElement) {
+        resizeObserver.observe(firstEl.parentElement);
       }
       if (props.scrollable) {
         // The indicator observer watches the content-sized list, so a
@@ -298,15 +322,13 @@ export default defineComponent({
         <div
           class="hk-tabs-list"
           ref={listRef}
-          data-variant={props.variant === "underline" ? undefined : props.variant}
+          data-variant={props.variant}
           data-size={isSegmented.value ? props.size : undefined}
-          data-block={isSegmented.value && props.block ? "true" : undefined}
+          data-block={isBlock.value ? "true" : undefined}
           role={isSegmented.value ? "radiogroup" : "tablist"}
           onKeydown={onKeydown}
         >
-          {hasIndicator.value && (
-            <div class="hk-tabs-indicator" style={indicatorStyle.value} />
-          )}
+          <div class="hk-tabs-indicator" style={indicatorStyle.value} />
           {props.tabs.map((tab, idx) => {
             const active = tab.key === props.modelValue;
             const disabled = tab.disabled;
@@ -344,19 +366,26 @@ export default defineComponent({
         </div>
       );
 
-      // Named const, NOT a mutable `strip` binding: the slot closure below
-      // executes during HkHoverRevealAction's render — a closure over a
-      // variable that already holds the wrapper vnode itself would recurse
-      // forever.
+      // Named const, NOT a mutable `strip` binding: the slot closures
+      // below execute during HkHoverRevealAction's render — a closure
+      // over a variable that already holds the wrapper vnode itself
+      // would recurse forever.
+      const actionsAttr = props.startAction && props.endAction ? "both"
+        : props.startAction ? "start"
+        : props.endAction ? "end"
+        : undefined;
       const stripInner = (
-        <div class="hk-tabs" data-variant={props.variant} data-scrollable={props.scrollable || undefined} data-addable={props.addable || undefined}>
+        <div class="hk-tabs" data-variant={props.variant} data-scrollable={props.scrollable || undefined} data-actions={actionsAttr}>
           {props.scrollable ? (
             <HkScrollContainer
               ref={scrollerRef}
               class="hk-tabs-scroller"
               axis="horizontal"
               scrollbar={props.scrollbar}
-              align="center"
+              // A block (row-filling) strip never needs safe centering —
+              // it stretches to the row while it fits; centering is for
+              // inline strips only.
+              align={isBlock.value ? "start" : "center"}
               fade
             >
               {list}
@@ -376,31 +405,54 @@ export default defineComponent({
         </div>
       );
 
-      // The addable button rides the shared hover-reveal surface: the
-      // whole strip is the reveal host and the "+" is its extension, so
-      // it protrudes at the strip's right edge (outside the scroll
-      // viewport) and appears on hover / touch-tap only.
-      if (!props.addable) return stripInner;
+      // Optional protruding icon buttons at either inline end ride the
+      // shared hover-reveal surface: the strip is the reveal host and the
+      // button is its extension, protruding outside the scroll viewport
+      // and appearing on hover / touch-tap only. With BOTH ends present
+      // the two hosts nest (start outer / end inner) — each closure
+      // captures a DIFFERENT named const (stripInner / withEnd), so no
+      // slot ever re-renders the wrapper that owns it.
+      const actionButton = (side: "start" | "end") => {
+        const action = side === "start" ? props.startAction : props.endAction;
+        if (!action) return null;
+        const label = resolvedActionLabel(action);
+        const PlusIcon = iconByName("Plus") as any;
+        const icon = action.icon != null ? action.icon : (PlusIcon ? h(PlusIcon, { size: 14 }) : null);
+        return (
+          <HkIconButton
+            variant="ghost"
+            size={24}
+            aria-label={label}
+            {...{ title: label }}
+            onClick={() => emit("action", side)}
+          >
+            {{ icon: () => icon }}
+          </HkIconButton>
+        );
+      };
 
-      const PlusIcon = iconByName("Plus") as any;
-      return (
+      const withEnd = props.endAction ? (
         <HkHoverRevealAction
           as="span"
           class="hk-tabs-addwrap"
         >
           {{
             default: () => stripInner,
-            extension: () => (
-              <HkIconButton
-                variant="ghost"
-                size={24}
-                aria-label={resolvedAddLabel()}
-                {...{ title: resolvedAddLabel() }}
-                onClick={() => emit("add")}
-              >
-                {{ icon: () => (PlusIcon ? h(PlusIcon, { size: 14 }) : null) }}
-              </HkIconButton>
-            ),
+            extension: () => actionButton("end"),
+          }}
+        </HkHoverRevealAction>
+      ) : stripInner;
+
+      if (!props.startAction) return withEnd;
+      return (
+        <HkHoverRevealAction
+          as="span"
+          class="hk-tabs-addwrap"
+          placement="left"
+        >
+          {{
+            default: () => withEnd,
+            extension: () => actionButton("start"),
           }}
         </HkHoverRevealAction>
       );

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -54,11 +54,11 @@
 }
 
 /*
- * Auto-mode altitude strip: full-bleed content INSIDE the segmented
- * strip's tail overlay (HTabs' overlay layer supplies the pill
- * chrome — surface, hairline border, radius, shadow). It reads passive
- * in the segmented typography, but a press resolves auto to the manual
- * side it currently renders (day → light, night → dark).
+ * Auto-mode altitude strip: full-bleed content INSIDE the strip's tail
+ * overlay (HTabs' overlay layer supplies the unified pill chrome —
+ * surface, hairline border, radius). It reads passive in the shared
+ * compact typography, but a press resolves auto to the manual side it
+ * currently renders (day → light, night → dark).
  */
 .s-theme-mode-autoalt {
   position: absolute;
@@ -103,10 +103,6 @@
 @media (max-width: 767px) {
   .s-theme-mode-row {
     padding: 0 0 var(--space-4, 0.25rem);
-  }
-
-  .s-theme-mode-autoalt {
-    font-size: 14px;
   }
 }
 

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -32,12 +32,13 @@ function geoOnce(): Promise<{ lat: number; lng: number }> {
  * color-mode group and preset/custom theme selection (custom themes are
  * removable), and opens HColorSchemeDialog to create a new custom scheme.
  *
- * Color-mode group: the unified HTabs strip in its segmented form (Auto | Light |
- * Dark). In AUTO mode the Light/Dark half is covered by the strip's
+ * Color-mode group: the unified HTabs strip in segmented (radiogroup)
+ * working mode (Auto | Light | Dark) — same pill chrome as every other
+ * group. In AUTO mode the Light/Dark half is covered by the strip's
  * built-in tail overlay (`overlayFrom` + `#overlay`): a passive-looking
- * solar-altitude strip in the segmented typography — pressing it drops
- * to manual on whichever side auto currently resolves to (day → light,
- * night → dark), so no separate resolve step is ever needed.
+ * solar-altitude strip in the shared compact typography — pressing it
+ * drops to manual on whichever side auto currently resolves to (day →
+ * light, night → dark), so no separate resolve step is ever needed.
  */
 export const HkThemeToggle = defineComponent({
   name: "HkThemeToggle",

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -91,16 +91,13 @@
   --hi-shadow-elevated: 0 2px 16px rgb(0 0 0 / 8%);
 
   /* ── Hk component tokens (theme bridge) ─
-   * Chrome-level component styles (HTabs segmented variant) read these RGB-triplet tokens.
+   * Chrome-level component styles (the HTabs tail overlay) read these RGB-triplet tokens.
    * Without a definition they fall back to hardcoded light-theme values
    * (white surfaces, near-black text, blue focus ring) inside dark
    * themes. Bridging them to the runtime --color-* tokens keeps the
    * controls on the active theme; consumer-local definitions still win
    * by load order. */
   --hk-surface: var(--color-surface, 255 255 255);
-  --hk-surface-muted: var(--color-surface, 240 240 244);
-  --hk-text: var(--color-text, 20 20 26);
-  --hk-text-muted: var(--color-muted, 90 90 100);
   --hk-primary: var(--color-primary, 60 120 240);
 }
 


### PR DESCRIPTION
## User directive (P93e, 2026-08-29)

One component (HTabs), ONE look — the centered pill strip of the page top/bottom bars is the baseline for every button group / radio group / tab strip. Variants only pick the **working mode** (tablist vs radiogroup) and the **overflow behavior** (auto fade+scroll on insufficient width); the visual language never branches. Protruding icon buttons optional at **both** inline ends (the page bars' "+" generalized).

## Changes

- **`HkTabs.tsx`**: `underline` variant deleted (redundant look; zero workspace consumers — chest was the only consumer, 4 default-variant admin views flip to pill as intended). `scrollable` defaults **true** — every strip auto-carries the bars' overflow behavior: centered / row-filling while it fits, edge fades + swipe-scroll when it doesn't (fades only appear on real overflow via `data-h-overflow`). `addable`/`addLabel`/`add` generalize to **`startAction`/`endAction` + `action(side)`**: hover/tap-revealed icon buttons protruding outside the scroll viewport at either end (nested HkHoverRevealAction hosts when both present, placement left/right). Block strips pass `align="start"` to the scroller (row-filling, never center-clipped). Overlay geometry constants synced with the CSS (TRACK_GAP=0 / TRACK_PAD=2).
- **`HkTabs.scss`**: single shared track/trigger/indicator chrome for all variants (byte-identical to the former pill rules); segmented keeps only `size="sm"` compactness and `block` row-fill; block-in-scroller = `width:max-content + min-width:100%` + `flex:1 0 auto` triggers (fills the row when it fits, fade-scrolls when it doesn't, labels never clipped). Tail overlay re-skinned to pill chrome (radius-sm + hairline border, opaque surface, no shadow). Unified inset `:focus-visible` ring. Underline styles and the segmented-era mobile font divergence deleted.
- **Sweeps**: dead `--hk-surface-muted`/`--hk-text`/`--hk-text-muted` bridge tokens removed (`--hk-surface`/`--hk-primary` still consumed); HkThemeToggle comments + mobile 14px autoalt bump dropped; DemoApp updated.
- **Tests**: HkTabs.test.ts reworked to 15 tests (default-scrollable DOM + opt-out, start/end/both end actions with side payloads + nesting, block align=start, radiogroup vs tablist semantics, overlay equal-share fallback + measured 62px/118px geometry, keyboard nav).
- Version **0.19.0**.

## Verification (3-round subagent cycle, all PASS)

- hikari: vitest **59 files / 503 tests**, vue-tsc clean.
- chest consumer wave (paired PR, follows after this merges): vue-tsc clean, vitest **57 files / 532 tests**, eslint 0 — verified against THIS branch via the sibling link.
- Round 2 measured the block/centering/overlay layout math in real Chromium (fills 400px row exactly, overflows at max-content with fade sensing, safe-centering collapse, overlay right edge == clientWidth−2, focus ring unclipped).

## CI note

Only `packages/vue` touched — Rust jobs unaffected. Any environment-only failures (self-hosted queue / toolchain provisioning) are the known §9.4-class issues; local gates above are the green signal.