### PR TITLE
🐛 Align mobile sheet titles with body entries and drop duplicated sheet headings.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -214,7 +214,14 @@
 
 .hk-select-sheet-title {
   flex-shrink: 0;
-  padding: 0 var(--space-16) var(--space-8);
+  /* Left inset tracks the sheet ENTRIES' text edge, not their card
+   * edge: the list pads option blocks in by --space-16 and rows carry
+   * roughly another --space-16 of leading padding inside, so the old
+   * single --space-16 left the title hanging left of every row it
+   * named instead of reading as the list's heading. Hosts tune it via
+   * --hk-sheet-title-inset; the trailing inset stays --space-16. */
+  padding: 0 var(--space-16) var(--space-8)
+    var(--hk-sheet-title-inset, calc(var(--space-16) * 2));
   font-size: var(--text-xs);
   font-weight: 600;
   letter-spacing: 0.02em;
@@ -234,6 +241,13 @@
     padding: var(--space-14) var(--space-16);
     font-size: var(--text-base);
   }
+}
+
+/* Leading in-content heading hidden by the sheet duplicate-title
+ * filter (HkSelectPanel) — must beat any consumer display rule, like
+ * the UA [hidden] contract. */
+.hk-select-sheet-list .hk-sheet-dup-title {
+  display: none !important;
 }
 
 .hk-select-sheet-enter-active {

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -377,3 +377,170 @@ describe("HkSelectPanel back-guard (window-first back priority)", () => {
     expect(window.history.state).toBeNull();
   });
 });
+
+describe("HkSelectPanel mobile-sheet duplicate-title filter", () => {
+  /** Composition-mode rig with a reactive title and arbitrary slot
+   *  content — the shape HkMenu pickers render on phones. */
+  function mountSheet(opts: {
+    title?: ReturnType<typeof ref<string>>;
+    slot?: () => unknown;
+  } = {}) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const open = ref(false);
+    const anchorEl = ref<HTMLElement | null>(null);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h("div", [
+            h("button", {
+              ref: (el: Element | ComponentPublicInstance | null) => {
+                anchorEl.value = el as HTMLElement | null;
+              },
+              type: "button",
+            }, "anchor"),
+            h(
+              HkSelectPanel,
+              {
+                open: open.value,
+                "onUpdate:open": (v: boolean) => { open.value = v; },
+                anchorRef: anchorEl.value,
+                title: opts.title?.value ?? "Workspaces",
+              },
+              { default: opts.slot ?? (() => h("div", { class: "rows" }, "rows")) },
+            ),
+          ]);
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+    return { open, container };
+  }
+
+  /** Mobile viewport + open, settled past the post-open nextTick sync. */
+  async function openSheet(open: ReturnType<typeof ref<boolean>>): Promise<void> {
+    setViewport(375);
+    await nextTick();
+    open.value = true;
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+  }
+
+  it("hides a leading in-content heading that repeats the sheet title", async () => {
+    const { open } = mountSheet({
+      slot: () =>
+        h("div", { class: "menu" }, [
+          h("div", { class: "menu-label" }, "Workspaces"),
+          h("div", { class: "hint" }, "No workspaces found."),
+        ]),
+    });
+    await openSheet(open);
+
+    const list = document.body.querySelector<HTMLElement>(".hk-select-sheet-list")!;
+    // The repeated heading is filtered; the rest of the content stays.
+    expect(list.querySelector<HTMLElement>(".menu-label")!.classList.contains("hk-sheet-dup-title")).toBe(true);
+    expect(list.querySelector<HTMLElement>(".hint")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+    // The sheet header still names the sheet.
+    expect(document.body.querySelector<HTMLElement>(".hk-select-sheet-title")!.textContent).toBe("Workspaces");
+  });
+
+  it("keeps headings that merely contain the title and non-matching text", async () => {
+    const { open } = mountSheet({
+      slot: () =>
+        h("div", { class: "menu" }, [
+          h("div", { class: "menu-label" }, "Workspaces and devices"),
+          h("div", { class: "hint" }, "pick one"),
+        ]),
+    });
+    await openSheet(open);
+
+    const list = document.body.querySelector<HTMLElement>(".hk-select-sheet-list")!;
+    // Partial ("contains") matches are real content — only an exact,
+    // non-interactive match hides.
+    expect(list.querySelector<HTMLElement>(".menu-label")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+    expect(list.querySelector<HTMLElement>(".hint")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+  });
+
+  it("never hides interactive rows or option blocks that say the title", async () => {
+    const { open } = mountSheet({
+      slot: () =>
+        h("div", { class: "menu" }, [
+          h("button", { class: "row", type: "button" }, "Workspaces"),
+          h("div", { class: "hk-select-option" }, "Workspaces"),
+          h("div", { class: "hk-menu-row" }, "Workspaces"),
+        ]),
+    });
+    await openSheet(open);
+
+    for (const sel of ["button.row", ".hk-select-option", ".hk-menu-row"]) {
+      const el = document.body.querySelector<HTMLElement>(`.hk-select-sheet-list ${sel}`)!;
+      expect(el.classList.contains("hk-sheet-dup-title")).toBe(false);
+    }
+  });
+
+  it("does not hide a wrapper whose text matches only via a contained row", async () => {
+    // Data-driven HkMenu shape: a menu level wrapping a single row whose
+    // label equals the title — the wrapper must survive with its row.
+    const { open } = mountSheet({
+      slot: () =>
+        h("div", { class: "hk-menu-level", role: "menu" }, [
+          h("button", { class: "hk-menu-row", type: "button" }, "Workspaces"),
+        ]),
+    });
+    await openSheet(open);
+
+    const list = document.body.querySelector<HTMLElement>(".hk-select-sheet-list")!;
+    expect(list.querySelector<HTMLElement>(".hk-menu-level")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+    expect(list.querySelector<HTMLElement>("button.hk-menu-row")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+  });
+
+  it("keeps the in-content heading on the desktop popout (no dedupe there)", async () => {
+    setViewport(1200);
+    const { open } = mountSheet({
+      slot: () => h("div", { class: "menu-label" }, "Workspaces"),
+    });
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+    expect(popout.querySelector<HTMLElement>(".menu-label")!.classList.contains("hk-sheet-dup-title")).toBe(false);
+  });
+
+  it("re-syncs when late content adds a duplicate heading while open", async () => {
+    const { open } = mountSheet({
+      slot: () => h("div", { class: "hint" }, "loading…"),
+    });
+    await openSheet(open);
+
+    const list = document.body.querySelector<HTMLElement>(".hk-select-sheet-list")!;
+    const late = document.createElement("div");
+    late.className = "menu-label";
+    late.textContent = "Workspaces";
+    list.appendChild(late);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    expect(late.classList.contains("hk-sheet-dup-title")).toBe(true);
+  });
+
+  it("restores the hidden heading when the open sheet is retitled", async () => {
+    const title = ref("Workspaces");
+    const { open } = mountSheet({
+      title,
+      slot: () => h("div", { class: "menu-label" }, "Workspaces"),
+    });
+    await openSheet(open);
+    const label = document.body.querySelector<HTMLElement>(".hk-select-sheet-list .menu-label")!;
+    expect(label.classList.contains("hk-sheet-dup-title")).toBe(true);
+
+    title.value = "Devices";
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    expect(label.classList.contains("hk-sheet-dup-title")).toBe(false);
+  });
+});

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -39,6 +39,12 @@ import "./HkSelect.scss";
  * the two can never drift apart. Content is a plain default slot; keyboard
  * events on the panel surface are forwarded (`keydown`) so owners that own
  * an option model (like HkSelect) can run their own arrow/enter navigation.
+ *
+ * Mobile sheets also run a duplicate-title filter: content that opens with
+ * a non-interactive heading exactly repeating the panel `title` is hidden
+ * (`.hk-sheet-dup-title`) — the sheet header already names the sheet, and
+ * composition-slot consumers (HkMenu pickers) often carry a section label
+ * with the same word. Desktop popouts draw no header and keep the heading.
  */
 
 export type SelectPanelPlacement =
@@ -107,8 +113,89 @@ export default defineComponent({
       if (props.open) emit("update:open", false);
     });
 
+    // A retitled open sheet must re-judge its duplicate heading — the
+    // exact-text match lives against the CURRENT title, so the filter
+    // restores a heading that stopped matching (and re-hides one that
+    // started, via the observer's characterData window below).
+    watch(
+      () => props.title,
+      () => {
+        if (props.open && sheetMode.value) syncDupTitle();
+      },
+    );
+    // Flipping OUT of sheet mode while open (consumer prop, not the
+    // breakpoint flip — that closes the panel) swaps the render branch
+    // and detaches the sheet list; drop the observer promptly instead
+    // of letting it guard a detached subtree.
+    watch(sheetMode, (mode) => {
+      if (!mode) stopDupTitleSync();
+    });
+
     const panelRef = ref<HTMLElement>();
+    const sheetListRef = ref<HTMLElement>();
     const coords = ref<{ top?: string; left?: string; minWidth?: string }>({});
+
+    // ── sheet duplicate-title filter ───────────────────────────────
+    // Composition-slot consumers often open a sheet whose content
+    // starts with a heading repeating the panel title (a workspace
+    // picker renders its own "Workspaces" section label under a sheet
+    // header that already says "Workspaces"). The desktop popout draws
+    // no header, so that in-content heading is the only one there; on
+    // the mobile sheet it doubles the header and reads as a rendering
+    // bug. While a sheet is open, hide the first non-interactive text
+    // element whose EXACT text equals the title — never interactive
+    // rows (buttons, select options, menu items), which legitimately
+    // may say the same word. A MutationObserver re-syncs while open so
+    // async-loaded content can neither miss a late duplicate nor keep
+    // hiding a node that stopped matching.
+    let hiddenDupTitle: HTMLElement | null = null;
+    let dupTitleObserver: MutationObserver | null = null;
+
+    /** Elements that make a candidate "real content": the candidate
+     *  itself matching one of these, OR containing one in its subtree,
+     *  disqualifies it — otherwise a wrapper div around a single row
+     *  labeled like the title would hide the whole sheet body. */
+    const DUP_TITLE_CONTENT =
+      'button,a,input,select,textarea,[role="option"],[role="menuitem"],.hk-select-option,.hk-menu-row';
+
+    function findDupTitle(): HTMLElement | null {
+      const title = props.title.trim();
+      const list = sheetListRef.value;
+      if (!title || !list) return null;
+      for (const el of list.querySelectorAll<HTMLElement>(
+        "h1,h2,h3,h4,h5,h6,p,div,span,strong",
+      )) {
+        if ((el.textContent ?? "").trim() !== title) continue;
+        if (el.matches(DUP_TITLE_CONTENT)) continue;
+        if (el.closest(DUP_TITLE_CONTENT)) continue;
+        if (el.querySelector(DUP_TITLE_CONTENT)) continue;
+        return el;
+      }
+      return null;
+    }
+
+    function syncDupTitle(): void {
+      const dup = findDupTitle();
+      if (hiddenDupTitle && hiddenDupTitle !== dup) {
+        hiddenDupTitle.classList.remove("hk-sheet-dup-title");
+        hiddenDupTitle = null;
+      }
+      if (dup && dup !== hiddenDupTitle) {
+        dup.classList.add("hk-sheet-dup-title");
+        hiddenDupTitle = dup;
+      }
+    }
+
+    function stopDupTitleSync(): void {
+      dupTitleObserver?.disconnect();
+      dupTitleObserver = null;
+      // Deliberately NOT restoring the class here: close keeps the panel
+      // mounted through its slide-down leave, and un-hiding mid-leave
+      // would flash the duplicate heading back in. The element dies with
+      // the panel right after the transition; live restores happen via
+      // the title watcher while the sheet is open.
+      hiddenDupTitle = null;
+    }
 
     function close(): void {
       emit("update:open", false);
@@ -161,11 +248,36 @@ export default defineComponent({
           backGuard.push();
           if (!sheetMode.value) {
             document.addEventListener("click", onDocumentClick, true);
+          } else {
+            // The sheet body mounts on this very render — run the
+            // duplicate-title filter once it has landed, then keep
+            // re-syncing while open (async slot content swaps).
+            void nextTick(() => {
+              // A same-tick open→close must not arm the observer on the
+              // leaving panel (the close branch already ran).
+              if (!props.open || !sheetMode.value) return;
+              syncDupTitle();
+              if (sheetListRef.value && !dupTitleObserver) {
+                dupTitleObserver = new MutationObserver(syncDupTitle);
+                dupTitleObserver.observe(sheetListRef.value, {
+                  childList: true,
+                  characterData: true,
+                  subtree: true,
+                  // A consumer re-render patching className can wipe
+                  // hk-sheet-dup-title mid-open — class mutations
+                  // re-sync it (adding an existing class mutates
+                  // nothing, so the loop converges).
+                  attributes: true,
+                  attributeFilter: ["class"],
+                });
+              }
+            });
           }
           window.addEventListener("resize", onResize);
         } else {
           document.removeEventListener("click", onDocumentClick, true);
           window.removeEventListener("resize", onResize);
+          stopDupTitleSync();
           backGuard.release();
           if (handle.value) {
             manager.unregister(handle.value.id);
@@ -183,6 +295,7 @@ export default defineComponent({
     onBeforeUnmount(() => {
       document.removeEventListener("click", onDocumentClick, true);
       window.removeEventListener("resize", onResize);
+      stopDupTitleSync();
       overlay.close();
       backGuard.destroy();
       if (handle.value) {
@@ -285,7 +398,7 @@ export default defineComponent({
                   {props.title ? (
                     <div class="hk-select-sheet-title">{props.title}</div>
                   ) : null}
-                  <div class="hk-select-sheet-list">{slots.default?.()}</div>
+                  <div class="hk-select-sheet-list" ref={sheetListRef}>{slots.default?.()}</div>
                 </div>
               ) : null}
             </Transition>


### PR DESCRIPTION
## Problem (user-reported, mobile webui)

On phones (<768px) every bottom-sheet popup rendered by `HkSelectPanel` (the shared surface behind `HkSelect` and `HkMenu`) had two top-area defects:

1. **Title outdented from the list it names.** The sheet header title sat at a single `--space-16` left inset while body entries' text sits at ~2× that (16px list inset + 16px row padding), so the title visibly hung left of every entry — it read as a stray caption rather than the list's heading.
2. **Duplicated title.** Composition-slot consumers repeat the panel title inside the content: the chest workspace picker passes `title="工作区"` **and** renders its own `s-ws-menu-label` "工作区" section label; chest's BreadcrumbBar all-tags menu passes `title="All tags"` **and** a header slot with the same text. On the desktop popout no header is drawn so the in-content label is the only one — on the mobile sheet both show and it looks like a rendering bug.

## Fix

- `.hk-select-sheet-title` now pads `var(--hk-sheet-title-inset, calc(var(--space-16) * 2))` on the left (trailing inset unchanged). Hosts can tune via the new CSS var. Visual check at 393px width confirms the title lands exactly on the entries' text edge.
- New duplicate-title filter in `HkSelectPanel` sheet mode: while a sheet is open, the **first** non-interactive element whose trimmed text **exactly** equals the panel title is hidden (`.hk-sheet-dup-title`, `display:none !important`). Never hidden: interactive rows (`button/a/input/...`), select option blocks (`.hk-select-option`), menu rows (`.hk-menu-row`), and wrappers whose text only matches because they contain such rows (`querySelector` guard — a data-driven `HkMenu title="X" items=[{label:"X"}]` keeps its body). Re-synced while open by a `MutationObserver` (childList + characterData + class attributes) plus a `props.title` watcher, so async-loaded lists neither miss a late duplicate nor keep a stale one hidden. Close/unmount disconnect the observer without restoring the class (restoring mid leave-transition would flash the duplicate back in during the slide-down). A same-tick open→close can't arm the observer on the leaving panel, and a `sheetOnMobile` prop flip mid-open tears the filter down with the sheet branch.
- The desktop popout path is untouched (it draws no header, so in-content headings stay there); `HkDrawer` / `HkModal` sheets are not affected (their titles already align with their 16px body insets).

## Consumer impact

shittim-chest compiles hikari from source (vite alias, `workspace:*`), so the chest workspace picker and all-tags sheet are fixed by this PR alone — no chest code change needed. Version bump 0.19.0 → 0.19.1 in-PR per policy.

## Verification

- New tests: 7 `HkSelectPanel` cases (hide exact dup; partial/non-match kept; interactive rows + wrappers + option blocks never hidden; desktop popout untouched; late-added dup hidden via observer; retitle restores).
- Full suite: **59 files / 510 tests green**; `vue-tsc --noEmit` exit 0.
- 3-round independent subagent verification cycle: all PASS (observer convergence, lifecycle ordering, i18n exact-match across 11 locales, chest consumer audit, repo hygiene — no secrets, no CHANGELOG, 4-file diff).
- Visual: static harness at 393px — BEFORE title at 16px with duplicated label; AFTER title on the 32px entry-text edge with the duplicate filtered (group labels with different names preserved).