### PR TITLE
🐛 Keep the fixed token usage pill at least as wide as its content.

### DIFF
--- a/packages/vue/src/components/HkTokenUsageBadge.scss
+++ b/packages/vue/src/components/HkTokenUsageBadge.scss
@@ -7,7 +7,18 @@
   color: rgb(var(--color-muted));
 
   &[data-fixed] {
-    width: 100px;
+    /* Stable-width mode: short values keep the 100px floor (the
+       `justify-content: space-between` spread and row alignment across
+       sibling lines stay put), but the box must be allowed to hug the
+       content when the rendered digits need more room — a hard 100px
+       cap is narrower than two 6-character values ("197.2k" / "38.9k"
+       plus arrows and the inter-stat gap ≈ 112px), and the invisible
+       spill extends every scrollable ancestor's scrollWidth. In the
+       shittim-chest cruise lane label that grew a native horizontal
+       scrollbar under the model row (`overflow-y: auto` implies
+       `overflow-x: auto`). */
+    min-width: 100px;
+    width: max-content;
     justify-content: space-between;
   }
 }

--- a/packages/vue/src/components/HkTokenUsageBadge.test.tsx
+++ b/packages/vue/src/components/HkTokenUsageBadge.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { HkTokenUsageBadge } from "./HkTokenUsageBadge";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+/** Mount with a reactive render closure so controlled updates flow back. */
+function mount(renderNode: () => ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: renderNode });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkTokenUsageBadge", () => {
+  it("renders input and output stats in order with the direction arrows", () => {
+    const c = mount(() => h(HkTokenUsageBadge, { input: 197200, output: 38900 }));
+    const stats = c.querySelectorAll(".s-token-usage-stat");
+    expect(stats.length).toBe(2);
+    expect(stats[0]!.querySelector(".s-token-usage-arrow")?.getAttribute("data-direction")).toBe("in");
+    expect(stats[1]!.querySelector(".s-token-usage-arrow")?.getAttribute("data-direction")).toBe("out");
+    expect(c.querySelector(".s-token-usage")!.getAttribute("data-fixed")).toBeNull();
+  });
+
+  it("marks the stable-width variant via data-fixed", () => {
+    const c = mount(() => h(HkTokenUsageBadge, { input: 1, output: 2, fixed: true }));
+    expect(c.querySelector(".s-token-usage")!.hasAttribute("data-fixed")).toBe(true);
+  });
+
+  it("never caps the fixed variant below its content width", () => {
+    // Source contract (the shittim-chest cruise lane defect): the fixed
+    // variant is a 100px FLOOR with a max-content width, not a hard
+    // 100px cap. A hard cap is narrower than two 6-character values
+    // ("197.2k" / "38.9k" plus arrows and the inter-stat gap ≈ 112px);
+    // the invisible spill extended every scrollable ancestor's
+    // scrollWidth and grew a native horizontal scrollbar inside the
+    // cruise lane label card.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const scss = readFileSync(join(here, "HkTokenUsageBadge.scss"), "utf-8");
+    const fixed = scss.match(/&\[data-fixed\]\s*{[^}]*}/)?.[0] ?? "";
+    expect(fixed).not.toBe("");
+    expect(fixed).toContain("min-width: 100px");
+    expect(fixed).toContain("width: max-content");
+    expect(fixed).not.toMatch(/(^|[^-])width:\s*100px/);
+  });
+});


### PR DESCRIPTION
## Problem

The cruise "nodes" board in shittim-chest showed a native horizontal scrollbar (with OS arrow buttons) inside every lane label card, below the model row.

Root cause: the `data-fixed` variant of `HkTokenUsageBadge` capped the pill at a hard `width: 100px`, but two 6-character values (`197.2k` / `38.9k`) plus the arrows and the inter-stat gap render ≈112px. The pill's box stayed at 100px (consumers set `flex-shrink: 0`), so its content spilled ~12px invisibly past the box — and that spill extends the scrollable overflow area of every ancestor. The lane label's model-lines list sets `overflow-y: auto`, which makes `overflow-x` compute to `auto` as well, so the 12px spill rendered a real horizontal scrollbar.

## Fix

- `[data-fixed]`: `width: 100px` → `min-width: 100px; width: max-content`. Short values keep the 100px floor (the `space-between` spread and row alignment across sibling lines stay put — the anti-jitter intent), longer values hug their content so nothing spills.
- Pin the contract with a new `HkTokenUsageBadge.test.tsx` (render tests + a source-contract test forbidding a hard 100px cap).
- Version bump 0.19.0 → 0.19.1.

## Verification

- `vitest run src/components/HkTokenUsageBadge.test.tsx`: 3/3 green.
- Full hikari suite: 506/506 green.
- `vue-tsc --noEmit`: 0 errors.
- DOM measurement rig against the deployed CSS confirmed: before the fix `scrollWidth` exceeded `clientWidth` by 12px in every width case; after the fix scrollWidth == clientWidth and the culprit list is empty.
- Consumer audit (round-1 + round-2 verification subagents): the only `fixed` consumers are shittim-chest's CruiseDock (no scroll containers, ~318px inner) and MindMapView lane label / mobile group card (identical shrink chains); TodoLogModal and the node-card stats row never pass `fixed`. Worst-case line at the 232px card floor ≈183px ≤ 198px inner — the model tag ellipsizes first, nothing visible clips.

Downstream: shittim-chest adds an explicit `overflow-x: hidden` on the model-lines list and will pair with this version (its CI clones hikari master fresh).