### PR TITLE
♻️ Raise every unified button group to the bar height and drop the compact size knob.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -345,7 +345,6 @@ export const HkColorSchemeEditor = defineComponent({
         />
         <HTabs
           variant="segmented"
-          size="sm"
           class="s-scheme-mode-switch"
           modelValue={modeTab.value}
           onUpdate:modelValue={(v: string) => { modeTab.value = v; }}

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -3,7 +3,7 @@
  * ONE look (the centered pill strip of the page-level top/bottom bars)
  * is shared by every button group, radio group and tab strip. Variants
  * only switch the working mode (pill = tablist, segmented = radiogroup)
- * and layout extras (size="sm" / block) — never the visual language. */
+ * and layout extras (block) — never the visual language. */
 
 .hk-tabs {
   width: 100%;
@@ -132,13 +132,8 @@
 }
 
 /* === segmented = radiogroup working mode ===
- * Same chrome; only the form-row layout extras live here: compact
- * sizing (size="sm") and row-filling (block). */
-
-.hk-tabs-list[data-variant="segmented"][data-size="sm"] .hk-tabs-trigger {
-  font-size: 12px;
-  padding: var(--space-2, 2px) var(--space-10, 10px);
-}
+ * Same chrome; only the form-row layout extra lives here:
+ * row-filling (block). */
 
 /* block outside the scroller (scrollable opted out): legacy fill —
    triggers may shrink below their content. */

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -281,7 +281,7 @@ describe("HkTabs segmented variant", () => {
 
   it("renders a measured tail overlay from overlayFrom with slot content", async () => {
     const { container } = mountLive(
-      { variant: "segmented", size: "sm", overlayFrom: 0 },
+      { variant: "segmented", overlayFrom: 0 },
       { overlay: () => h("button", { type: "button", class: "strip" }, "+32.5°") },
     );
     const overlay = container.querySelector<HTMLElement>(".hk-tabs-overlay")!;

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -53,7 +53,7 @@ const TRACK_PAD = 2;
  *   semantics, optional tab panels below;
  * - `segmented` — mutually exclusive option picker: `radiogroup`/
  *   `radio`/`aria-checked` semantics, no panels, plus the form-row
- *   layout extras `size="sm"` (compact) and `block` (fill the row).
+ *   layout extra `block` (fill the row).
  *
  * Capabilities (all variants unless noted):
  * - `scrollable` (default ON) + `scrollbar` + edge fades
@@ -81,8 +81,6 @@ export default defineComponent({
      *  exclusive option picker (radiogroup). Both share the one unified
      *  pill chrome. */
     variant: { type: String as PropType<"pill" | "segmented">, default: "pill" },
-    /** Visual size — sm matches form-control heights (segmented). */
-    size: { type: String as PropType<"sm" | "md">, default: "md" },
     /** Grow to fill the container width (segmented). */
     block: { type: Boolean, default: false },
     /** Disable the whole strip (every trigger). */
@@ -323,7 +321,6 @@ export default defineComponent({
           class="hk-tabs-list"
           ref={listRef}
           data-variant={props.variant}
-          data-size={isSegmented.value ? props.size : undefined}
           data-block={isBlock.value ? "true" : undefined}
           role={isSegmented.value ? "radiogroup" : "tablist"}
           onKeydown={onKeydown}

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -56,9 +56,10 @@
 /*
  * Auto-mode altitude strip: full-bleed content INSIDE the strip's tail
  * overlay (HTabs' overlay layer supplies the unified pill chrome —
- * surface, hairline border, radius). It reads passive in the shared
- * compact typography, but a press resolves auto to the manual side it
- * currently renders (day → light, night → dark).
+ * surface, hairline border, radius). It reads passive in the strip's
+ * own typography (same size/weight as the triggers it covers), but a
+ * press resolves auto to the manual side it currently renders
+ * (day → light, night → dark).
  */
 .s-theme-mode-autoalt {
   position: absolute;
@@ -72,7 +73,8 @@
   background: transparent;
   color: rgb(var(--color-text-secondary, var(--color-muted)));
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
+  font-weight: 600;
   line-height: 1;
   cursor: default;
   user-select: none;

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -36,9 +36,9 @@ function geoOnce(): Promise<{ lat: number; lng: number }> {
  * working mode (Auto | Light | Dark) — same pill chrome as every other
  * group. In AUTO mode the Light/Dark half is covered by the strip's
  * built-in tail overlay (`overlayFrom` + `#overlay`): a passive-looking
- * solar-altitude strip in the shared compact typography — pressing it
- * drops to manual on whichever side auto currently resolves to (day →
- * light, night → dark), so no separate resolve step is ever needed.
+ * solar-altitude strip in the strip's own trigger typography — pressing
+ * it drops to manual on whichever side auto currently resolves to (day
+ * → light, night → dark), so no separate resolve step is ever needed.
  */
 export const HkThemeToggle = defineComponent({
   name: "HkThemeToggle",
@@ -132,9 +132,9 @@ export const HkThemeToggle = defineComponent({
     function modeOptions(): TabItem[] {
       const auto = isAutoMode.value;
       return [
-        { key: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={12} /> },
-        { key: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={12} />, disabled: auto },
-        { key: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={12} />, disabled: auto },
+        { key: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={14} /> },
+        { key: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={14} />, disabled: auto },
+        { key: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={14} />, disabled: auto },
       ];
     }
 
@@ -208,7 +208,6 @@ export const HkThemeToggle = defineComponent({
               <HTabs
                 variant="segmented"
                 block
-                size="sm"
                 tabs={modeOptions()}
                 modelValue={currentMode.value}
                 onUpdate:modelValue={onSelectMode}
@@ -223,7 +222,7 @@ export const HkThemeToggle = defineComponent({
                       aria-label={t("hikari::theme.autoAltitudeTip")}
                       onClick={resolveAutoToManual}
                     >
-                      {altitudeNight.value ? <Moon size={12} /> : <Sun size={12} />}
+                      {altitudeNight.value ? <Moon size={14} /> : <Sun size={14} />}
                       <span class="s-theme-mode-autoalt-value">{altitudeText.value}</span>
                     </button>
                   ),


### PR DESCRIPTION
## User feedback (P93f, 2026-08-29)

The unified groups shipped in #314 render too short — the user实测 wants the MEDIUM (bar) height everywhere instead of the compact minimum.

## Changes

- **All `size="sm"` consumers move to md**: theme popup auto/light/dark, color-scheme light/dark (and every downstream segmented group via the shared chrome) now render the exact top/bottom bar metrics — 13px/600 labels, 4px/12px padding, 14px icons. Identical to the bars by construction: one shared `.hk-tabs-trigger` rule, zero per-variant geometry.
- **The `size` prop and its `data-size` style are deleted from HTabs** — zero consumers remained, and a compact knob beside the one look is pure redundancy.
- **Auto-mode altitude overlay** typography synced to the strip: `var(--text-sm)` + weight 600 + 14px glyphs (was 12px).
- Version **0.19.2** (#315 took 0.19.1).

## Verification

vitest **59 files / 510 tests** (post-#315 baseline), vue-tsc clean, 3-round subagent verify cycle PASS (completeness sweeps: zero `size=` in any of the 31 `<HTabs` sites across hikari+chest; height-equivalence proven by construction; popup geometry + block overflow math re-checked).

Paired chest consumer wave follows after this merges.