### PR TITLE
🐛 Keep the fixed token usage pill at least as wide as its content.

### DIFF
--- a/packages/vue/src/components/HkTokenUsageBadge.scss
+++ b/packages/vue/src/components/HkTokenUsageBadge.scss
@@ -7,7 +7,18 @@
   color: rgb(var(--color-muted));
 
   &[data-fixed] {
-    width: 100px;
+    /* Stable-width mode: short values keep the 100px floor (the
+       `justify-content: space-between` spread and row alignment across
+       sibling lines stay put), but the box must be allowed to hug the
+       content when the rendered digits need more room — a hard 100px
+       cap is narrower than two 6-character values ("197.2k" / "38.9k"
+       plus arrows and the inter-stat gap ≈ 112px), and the invisible
+       spill extends every scrollable ancestor's scrollWidth. In the
+       shittim-chest cruise lane label that grew a native horizontal
+       scrollbar under the model row (`overflow-y: auto` implies
+       `overflow-x: auto`). */
+    min-width: 100px;
+    width: max-content;
     justify-content: space-between;
   }
 }

--- a/packages/vue/src/components/HkTokenUsageBadge.test.tsx
+++ b/packages/vue/src/components/HkTokenUsageBadge.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { HkTokenUsageBadge } from "./HkTokenUsageBadge";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+/** Mount with a reactive render closure so controlled updates flow back. */
+function mount(renderNode: () => ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: renderNode });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkTokenUsageBadge", () => {
+  it("renders input and output stats in order with the direction arrows", () => {
+    const c = mount(() => h(HkTokenUsageBadge, { input: 197200, output: 38900 }));
+    const stats = c.querySelectorAll(".s-token-usage-stat");
+    expect(stats.length).toBe(2);
+    expect(stats[0]!.querySelector(".s-token-usage-arrow")?.getAttribute("data-direction")).toBe("in");
+    expect(stats[1]!.querySelector(".s-token-usage-arrow")?.getAttribute("data-direction")).toBe("out");
+    expect(c.querySelector(".s-token-usage")!.getAttribute("data-fixed")).toBeNull();
+  });
+
+  it("marks the stable-width variant via data-fixed", () => {
+    const c = mount(() => h(HkTokenUsageBadge, { input: 1, output: 2, fixed: true }));
+    expect(c.querySelector(".s-token-usage")!.hasAttribute("data-fixed")).toBe(true);
+  });
+
+  it("never caps the fixed variant below its content width", () => {
+    // Source contract (the shittim-chest cruise lane defect): the fixed
+    // variant is a 100px FLOOR with a max-content width, not a hard
+    // 100px cap. A hard cap is narrower than two 6-character values
+    // ("197.2k" / "38.9k" plus arrows and the inter-stat gap ≈ 112px);
+    // the invisible spill extended every scrollable ancestor's
+    // scrollWidth and grew a native horizontal scrollbar inside the
+    // cruise lane label card.
+    const here = dirname(fileURLToPath(import.meta.url));
+    const scss = readFileSync(join(here, "HkTokenUsageBadge.scss"), "utf-8");
+    const fixed = scss.match(/&\[data-fixed\]\s*{[^}]*}/)?.[0] ?? "";
+    expect(fixed).not.toBe("");
+    expect(fixed).toContain("min-width: 100px");
+    expect(fixed).toContain("width: max-content");
+    expect(fixed).not.toMatch(/(^|[^-])width:\s*100px/);
+  });
+});


### PR DESCRIPTION
Retry of #316 (same single commit, rebased so the lint range resolves; the old PR's lint-commits job crashed on a pre-rebase SHA range). Full context and verification records live in #316: data-fixed pill gets `min-width: 100px; width: max-content` instead of a hard 100px cap, plus a source-contract test and the 0.19.1 version bump. Local vitest 506/506, vue-tsc 0 errors.