### PR TITLE
✨ Let a menu leaf select abandon the back-guard rewind so its navigation survives.

### DIFF
--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -158,6 +158,11 @@ afterEach(async () => {
   while (mounts.length) mounts.pop()?.unmount();
   // Unmounting restores history asynchronously; wait for it to land so a
   // pending traversal cannot pop the NEXT test's freshly pushed entries.
+  // Leaf-select tests ABANDON their rewind on purpose, so the marker
+  // entry stays current as an inert dead marker — de-mark it in place
+  // (the same way a landing popstate would) or the until() below would
+  // spin to its timeout on an intentionally kept marker.
+  window.history.replaceState(null, "");
   await until(() => window.history.state?.__hkBack === undefined);
   // happy-dom never fires transitionend, so leave transitions never
   // finish and teleported panels linger on <body> — strip them or the
@@ -466,7 +471,7 @@ describe("HkMenu mobile sheets", () => {
     expect(openRef.value).toBe(true);
   });
 
-  it("selecting a leaf on mobile closes every sheet and restores history", async () => {
+  it("selecting a leaf on mobile closes every sheet and abandons the rewind so a later async navigation survives", async () => {
     window.innerWidth = 390;
     const selected: string[] = [];
     const openRef = ref(true);
@@ -483,8 +488,44 @@ describe("HkMenu mobile sheets", () => {
     expect(selected).toEqual(["two-b"]);
     expect(openRef.value).toBe(false);
     await until(() => document.querySelector(".hk-select-sheet-panel") === null);
-    await until(() => window.history.state?.__hkBack === undefined);
-    expect(window.history.state?.__hkBack).toBeUndefined();
+    // The leaf's back-guard rewinds are abandoned (a leaf select IS an
+    // action — typically a modal or an async router navigation), so no
+    // suppressed traversal fires and the marker entry stays current
+    // until the action's own navigation commits on top of it.
+    await settle();
+    expect(window.history.state?.__hkBack).toBeDefined();
+    const len = window.history.length;
+    // Simulate the async router navigation committing after the flush.
+    window.history.pushState({ router: true }, "");
+    await settle();
+    expect(window.history.length).toBe(len + 1);
+    expect(window.history.state?.router).toBe(true);
+  });
+
+  it("a desktop leaf select driving an async navigation is not bounced by the rewind", async () => {
+    const selected: string[] = [];
+    const openRef = ref(true);
+    mountMenu(openRef, items, {
+      onSelect: (key) => selected.push(key),
+    });
+    await settle();
+
+    rowByLabel("Log out")!.click();
+    await settle();
+
+    expect(selected).toEqual(["logout"]);
+    expect(openRef.value).toBe(false);
+    await settle();
+    // The rewind claim was abandoned: history was NOT rewound (no
+    // suppressed go(-n) racing the consumer's router.push), and the
+    // marker entry is still current when the async navigation finally
+    // commits on top of it.
+    expect(window.history.state?.__hkBack).toBeDefined();
+    const len = window.history.length;
+    window.history.pushState({ router: true }, "");
+    await settle();
+    expect(window.history.length).toBe(len + 1);
+    expect(window.history.state?.router).toBe(true);
   });
 
   it("closes when the viewport crosses the breakpoint while open", async () => {

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -91,6 +91,8 @@ function pointRect(left: number, top: number): DOMRect {
 /** Exposed surface of HkSelectPanel this component consumes. */
 interface PanelInstance {
   panelEl: () => HTMLElement | null;
+  /** Cancel the panel's pending back-guard rewind (see onItem). */
+  abandonBackGuard?: () => void;
 }
 
 export default defineComponent({
@@ -233,6 +235,17 @@ export default defineComponent({
           desktopPath.value = [...desktopPath.value.slice(0, level), item.key];
         }
         return;
+      }
+      // A leaf selection IS the action: the consumer's select handler
+      // opens a modal or drives an async router navigation. Cancel the
+      // panels' pending back-guard rewinds BEFORE closing — the deferred
+      // go(-n) would otherwise run on the next macrotask, before an async
+      // navigation commits its pushState, and bounce the page back onto
+      // the marker entry (the "Admin Panel menu leaf opens /backend and
+      // silently stays on the chat view" regression). Plain close paths
+      // (overlay tap, Escape, branch collapse) keep the release() rewind.
+      for (const inst of Object.values(panelInsts.value)) {
+        inst?.abandonBackGuard?.();
       }
       emit("select", item.key, item);
       closeAll();

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -359,6 +359,16 @@ export default defineComponent({
      * rows (or HkPopupSelect's) could match first. */
     expose({
       panelEl: () => panelRef.value ?? null,
+      /**
+       * Cancel this panel's pending back-guard rewind. Menu-like hosts
+       * (HkMenu) call it when a row selection ITSELF starts an in-page
+       * action — opening a modal or an async router navigation: the
+       * rewind would otherwise win the race (its flush runs before an
+       * async navigation commits) and yank the page back onto the
+       * panel's marker entry, discarding that navigation. Plain
+       * select/close flows keep the default release() rewind.
+       */
+      abandonBackGuard: () => backGuard.abandon(),
     });
 
     return () => {

--- a/packages/vue/src/runtime/backStack.test.ts
+++ b/packages/vue/src/runtime/backStack.test.ts
@@ -268,6 +268,61 @@ describe("createBackGuard", () => {
     g.destroy();
   });
 
+  it("abandon cancels a pending release rewind so a later async navigation survives", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    // Menu closes: release() queues the deferred rewind...
+    g.release();
+    // ...but the leaf's select handler abandons the claim in the same
+    // tick, because it starts an async router navigation that will only
+    // commit its pushState AFTER the flush macrotask has run.
+    g.abandon();
+    await settle();
+    expect(g.entries).toBe(0);
+    // No traversal fired: the marker entry is still current.
+    expect((window.history.state as Record<string, unknown>)[BACK_GUARD_MARKER]).toBe(g.id);
+    const len = window.history.length;
+    // The async navigation finally commits on top of the marker.
+    window.history.pushState({ router: true }, "");
+    await settle();
+    expect(window.history.length).toBe(len + 1);
+    expect((window.history.state as Record<string, unknown>).router).toBe(true);
+    // The guard never fired a back and its claim is gone.
+    expect(onBack).not.toHaveBeenCalled();
+    g.destroy();
+  });
+
+  it("abandon skips the flush entirely for multi-level claims", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    g.push();
+
+    g.abandon();
+    expect(g.entries).toBe(0);
+    const len = window.history.length;
+    await settle();
+    // No go(-2): history untouched, current entry keeps its marker depth.
+    expect(window.history.length).toBe(len);
+    expect((window.history.state as Record<string, unknown>)[BACK_GUARD_DEPTH]).toBe(1);
+    expect(onBack).not.toHaveBeenCalled();
+    g.destroy();
+  });
+
+  it("abandon after release retracts the queued claim (same-tick leaf select)", async () => {
+    const onBack = vi.fn();
+    const g = createBackGuard({ onBack });
+    g.push();
+    g.release(); // close → rewind queued
+    g.abandon(); // select handler cancels it before the flush macrotask
+    await settle();
+    const st = window.history.state as Record<string, unknown> | null;
+    expect(st?.[BACK_GUARD_MARKER]).toBe(g.id);
+    expect(onBack).not.toHaveBeenCalled();
+    g.destroy();
+  });
+
   it("drops the module listener once every guard is gone, and re-adds it later", async () => {
     expect(__backListenerActive()).toBe(false);
     const g = createBackGuard({ onBack: vi.fn() });

--- a/packages/vue/src/runtime/backStack.ts
+++ b/packages/vue/src/runtime/backStack.ts
@@ -90,6 +90,19 @@ export interface BackGuard {
    */
   release(): void;
   /**
+   * Drop every entry claim AND cancel any pending rewind WITHOUT
+   * touching history: for a close that is itself the consequence of an
+   * in-page action started from the surface — a menu leaf whose select
+   * handler opens a modal or drives an async router navigation. The
+   * deferred rewind would otherwise win the race (its flush runs on the
+   * next macrotask, before an async navigation commits its pushState)
+   * and yank the page back onto the closed surface's marker entry,
+   * silently discarding the action's navigation. The pushed markers
+   * stay where they lie as inert dead markers — released in place by
+   * the popstate cleanup if a later traversal ever lands on them.
+   */
+  abandon(): void;
+  /**
    * Drop every entry claim WITHOUT touching history: for a surface
    * that is already closed yet finds itself owning the current (spent)
    * marker — de-marks it so a closed window never owns live history.
@@ -311,6 +324,14 @@ export function createBackGuard(options: BackGuardOptions): BackGuard {
       } else {
         record.count.value = 0;
       }
+    },
+    abandon(): void {
+      // Snap both counters to zero and retract any queued rewind claim —
+      // the flush's `count > desired` re-check then skips this record, so
+      // no go(-n) fires and the markers are left buried (inert).
+      record.desired = 0;
+      record.count.value = 0;
+      rewindQueue.delete(record);
     },
     forget(): void {
       record.count.value = 0;


### PR DESCRIPTION
## Root cause

Clicking a leaf row in an HkMenu popup/sheet (e.g. the user menu's **Admin Panel**, Log out, or the tag menu in BreadcrumbBar) closes the panel and starts the consumer's action in the same tick. Since #289 the panel is a back-gesture layer: opening pushed a marked history entry, and closing queues a deferred rewind whose flush re-validates the history top **on the next macrotask**.

An async `router.push` from the select handler commits its pushState only **after** that flush, so the flush still saw its own marker on top and issued `go(-n)` — bouncing the page back onto the closed menu's entry and silently discarding the navigation. The admin panel (and every other menu leaf that navigates) never opened, on every deployment carrying #289+ (dev + demo both affected; direct URL entry to /backend worked, which masked the break).

## Fix

- `backStack.abandon()`: retract the queued rewind claim and snap the counters **without touching history** — pushed markers stay where they lie as inert dead markers, released in place by the existing popstate cleanup.
- `HkSelectPanel` exposes `abandonBackGuard()`; `HkMenu.onItem` abandons every panel's rewind (desktop popouts + mobile sheets, all cascade levels) before emitting select + closeAll on a leaf click.
- Branch clicks, plain close paths (overlay/Escape/collapse), HkSelect and HkPopupSelect selection flows keep the `release()` rewind — untouched.

Trade-off: a leaf select that does NOT navigate (locale/theme switch) leaves one inert marker — the first back press consumes it silently with no URL change (the module's documented dead-marker contract), the next back works normally. Every leaf select that DOES navigate now works; before, it never did.

## Verification

- vitest 59 files / 514 tests green (3 new abandon unit tests, rewritten mobile leaf-select test, new desktop navigation-bounce regression test)
- vue-tsc --noEmit clean
- Independent verifier subagent: PASS, no blockers; adversarial traces (back-after-leaf, destroy-after-abandon, abandon-then-reopen) all confirmed safe

npm track 0.19.3.