### PR TITLE
🐛 Tighten mobile sheet spacing and bottom-anchor autoFollow content.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -318,7 +318,7 @@
     top: var(--hk-sheet-top-inset, 4.25rem);
     // --hk-sheet-bottom-gap keeps the docked sheet from touching the very
     // bottom edge (host-tunable; chest narrows the default visual gap).
-    bottom: var(--hk-sheet-bottom-gap, 0.5rem);
+    bottom: var(--hk-sheet-bottom-gap, 0.375rem);
     left: 0;
     right: 0;
     transform: none;
@@ -380,6 +380,6 @@
     // gap than body bottom + safe area on phones). Safe area is added ON
     // TOP of the gap so home-bar devices never lose tappable chrome.
     padding: 0.625rem 1rem
-      calc(0.5rem + var(--hk-sheet-footer-gap, 0.75rem) + env(safe-area-inset-bottom, 0px));
+      calc(0.375rem + var(--hk-sheet-footer-gap, 0.5rem) + env(safe-area-inset-bottom, 0px));
   }
 }

--- a/packages/vue/src/components/HkModal.sheetgap.test.ts
+++ b/packages/vue/src/components/HkModal.sheetgap.test.ts
@@ -25,7 +25,9 @@ describe("HkModal mobile sheet spacing contract", () => {
     const block = src.slice(src.indexOf("@media (max-width: 767px)"));
     expect(block).toContain("bottom: var(--hk-sheet-bottom-gap");
     // Default keeps a small visible gap; hosts may narrow or zero it.
-    expect(block).toMatch(/--hk-sheet-bottom-gap,\s*0\.5rem/);
+    // (2026-08-29 user request: the docked sheet sat too far off the
+    // bottom — default tightened from 0.5rem to 0.375rem.)
+    expect(block).toMatch(/--hk-sheet-bottom-gap,\s*0\.375rem/);
   });
 
   it("keeps the footer gap host-tunable and stacks the safe-area inset", () => {

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -75,8 +75,16 @@
   );
 }
 
+/* autoFollow content is bottom-anchored while it fits the viewport: the
+   newest row hugs the bottom edge (a tail-following console, e.g. the
+   agent thinking-step stream) instead of hanging at the top with a dead
+   band below. Once the content overflows, min-height grows with it and
+   the flex-end grouping is a no-op — ordinary scroll + follow resumes. */
 .hk-scroll-container-autofollow-content {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  min-height: 100%;
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## User feedback (P93g, 2026-08-29)

Mobile popups with bottom control buttons docked too far off the screen bottom, and the node chat-history thinking-records list left too much distance from the bottom in auto (follow) mode.

## Changes

- **Sheet spacing**: `--hk-sheet-bottom-gap` default 0.5rem → 0.375rem; footer padding base `calc(0.5rem + var(--hk-sheet-footer-gap, 0.75rem) + env(safe-area-inset-bottom))` → `calc(0.375rem + var(--hk-sheet-footer-gap, 0.5rem) + env(...))`. Both hooks stay host-tunable; the safe-area inset still stacks on top so home-bar devices never lose tappable chrome.
- **autoFollow content bottom-anchors while it fits** (`.hk-scroll-container-autofollow-content`: flex column + justify-end + min-height:100%): the agent thinking-step stream hugs the panel bottom in auto mode instead of top-hanging with a dead band; once content overflows the wrapper grows and ordinary scroll + follow resumes (inert flex-end).
- Contract test pins the new default. vitest **59/510**, vue-tsc clean, 3-round subagent verify PASS. Version **0.19.3**.

Paired chest consumer wave follows.