### PR TITLE
🐛 Type the custom-theme map callbacks to keep downstream typechecks green.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/theme/useTheme.ts
+++ b/packages/vue/src/theme/useTheme.ts
@@ -55,7 +55,7 @@ function storedThemeId(): ThemeId {
     const known = new Set<string>([
       ...Object.keys(themePresets),
       ...Object.keys(pageDeclaredThemes()),
-      ...customThemes.value.map((c) => c.id),
+      ...customThemes.value.map((c: CustomThemePreset) => c.id),
     ]);
     if (known.has(stored)) return stored as ThemeId;
     // Stale/invalid theme id (e.g. written by an older build): drop it so
@@ -152,7 +152,7 @@ export function useTheme() {
       name: themePresets[id as keyof typeof themePresets].name,
       isCustom: false,
     }));
-    const custom = customThemes.value.map((ct) => ({
+    const custom = customThemes.value.map((ct: CustomThemePreset) => ({
       id: ct.id,
       name: ct.name,
       isCustom: true,


### PR DESCRIPTION
## What

Two callbacks in `useTheme.ts` (`customThemes.value.map((c) => c.id)` at L58 and `(ct)` at L155) surface as **TS7006 implicit-any** when a consumer compiles hikari sources under a stricter tsconfig/lib mix — concretely shittim-chest's webui typecheck (which compiles the sibling sources through its own config) fails on exactly these two lines while hikari's own build stays green (P108 follow-up; found while unblocking chest's check-frontend).

Explicit `CustomThemePreset` annotations make the callbacks independent of lib resolution. No behavior change. Version 0.19.3 → 0.19.4.

## Verification (local)

- `vue-tsc --noEmit` green (hikari)
- `vitest run src/theme` — **27/27**
- chest webui `vue-tsc --noEmit` green against a patched sibling (the motivating consumer)