### PR TITLE
🐛 Hug mobile modal sheets to their content and enlarge footer touch targets.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -306,16 +306,24 @@
 // Mobile (≤767px, matches useBreakpoint().isMobile) — EVERY modal docks as a
 // bottom sheet. One unified form factor for all popups on phones:
 //   - rises from the bottom edge (translateY reveal, not height-clip)
-//   - never covers the top band reserved for the secondary-window
+//   - hugs its content: docked at the bottom edge, growing upward, and only
+//     stretching when the content actually needs the room (a three-row
+//     detail sheet never carries a screenful of dead body)
+//   - never grows past the top band reserved for the secondary-window
 //     breadcrumb strip (--hk-sheet-top-inset; default 4.25rem keeps the
-//     floating breadcrumb visible above the sheet)
+//     floating breadcrumb visible above a full-height sheet)
 //   - rounded top corners only, full width
 // ------
 @media (max-width: 767px) {
   .hk-modal-content {
     max-width: 100% !important;
     width: 100%;
-    top: var(--hk-sheet-top-inset, 4.25rem);
+    // Bottom-docked, content-hugging: `top: auto` lets the sheet size
+    // itself from its content instead of stretching from the top inset
+    // down to the bottom gap (2026-08-30 user report: the node-detail
+    // modal rendered ~60vh of blank body under three rows). The top inset
+    // now only bounds the sheet via the max-height cap below.
+    top: auto;
     // --hk-sheet-bottom-gap keeps the docked sheet from touching the very
     // bottom edge (host-tunable; chest narrows the default visual gap).
     bottom: var(--hk-sheet-bottom-gap, 0.375rem);
@@ -328,8 +336,16 @@
     border-left: 0;
     border-right: 0;
     border-bottom: 0;
-    // Top inset + bottom gap size the sheet; content scrolls inside.
-    max-height: none;
+    // The top band + bottom gap only BOUND the sheet now (content scrolls
+    // inside once the cap is hit); they no longer stretch it.
+    // Plain-vh fallback first: dvh-less engines (older Android WebView /
+    // Tauri) would drop the whole dvh calc and leave the sheet uncapped.
+    max-height: calc(
+      100vh - var(--hk-sheet-top-inset, 4.25rem) - var(--hk-sheet-bottom-gap, 0.375rem)
+    );
+    max-height: calc(
+      100dvh - var(--hk-sheet-top-inset, 4.25rem) - var(--hk-sheet-bottom-gap, 0.375rem)
+    );
   }
 
   // Sheet slide reveal replaces the height-clip reveal on mobile.
@@ -374,6 +390,16 @@
     padding: 1rem;
   }
 
+  // Lift the desktop 70vh body cap on phones: with a docked sheet the cap
+  // used to strand the height it refused INSIDE the sheet, below the last
+  // flex item — a phantom empty band under the footer (report reply bar) or
+  // under the log tail when the modal has no footer at all. The sheet's own
+  // max-height above is the only clamp now: the body fills the sheet and
+  // scrolls, and the footer always sits on the sheet's bottom edge.
+  .hk-modal-body {
+    max-height: none;
+  }
+
   .hk-modal-footer {
     // --hk-sheet-footer-gap lets a host app tune how far the docked sheet
     // sits off the very bottom edge (chest asked for a visibly narrower
@@ -381,5 +407,18 @@
     // TOP of the gap so home-bar devices never lose tappable chrome.
     padding: 0.625rem 1rem
       calc(0.375rem + var(--hk-sheet-footer-gap, 0.5rem) + env(safe-area-inset-bottom, 0px));
+
+    // Footer actions are the sheet's primary touch targets: lift sm/md
+    // buttons one size up to the 44px class regardless of the caller's
+    // size prop (2026-08-30 user report: the docked sheet's bottom-corner
+    // buttons were too small to tap reliably). lg already clears 44px and
+    // keeps its own sizing; the doubled class selector deliberately wins
+    // the cascade over the bare .hk-btn-sm/.hk-btn-md component rules.
+    .hk-btn-sm,
+    .hk-btn-md {
+      min-height: 2.75rem;
+      padding: var(--space-8) var(--space-16);
+      font-size: var(--text-md);
+    }
   }
 }

--- a/packages/vue/src/components/HkModal.sheetgap.test.ts
+++ b/packages/vue/src/components/HkModal.sheetgap.test.ts
@@ -12,7 +12,7 @@
  * the same class of "looks fixed but never shipped" failure as the
  * overflow-poll incident.
  */
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -34,5 +34,49 @@ describe("HkModal mobile sheet spacing contract", () => {
     const footer = src.match(/\.hk-modal-footer\s*{[^}]*}/g)?.join("\n") ?? "";
     expect(footer).toContain("--hk-sheet-footer-gap");
     expect(footer).toContain("env(safe-area-inset-bottom");
+  });
+
+  // 2026-08-30 user report: the docked sheet stretched from the top inset
+  // down to the bottom gap regardless of content, and the desktop 70vh body
+  // cap stranded the height it refused INSIDE the stretched sheet — a
+  // phantom empty band below the footer (report reply bar) or below the log
+  // tail (footer-less log modal), and a full screen of dead body under a
+  // three-row node-detail sheet. The sheet now hugs its content: docked at
+  // the bottom edge, growing upward, bounded only by the top band.
+  describe("mobile sheet hug-content contract", () => {
+    let block = "";
+    let content = "";
+    let body = "";
+    let footer = "";
+    beforeAll(() => {
+      block = src.slice(src.indexOf("@media (max-width: 767px)"));
+      content = block.match(/\.hk-modal-content\s*{[^}]*}/)?.[0] ?? "";
+      body = block.match(/\.hk-modal-body\s*{[^}]*}/)?.[0] ?? "";
+      footer = block.match(/\.hk-modal-footer\s*{[\s\S]*?^  }/m)?.[0] ?? "";
+    });
+
+    it("docks the sheet at the bottom edge instead of stretching from the top", () => {
+      expect(content).toContain("top: auto");
+      expect(content).toContain("bottom: var(--hk-sheet-bottom-gap");
+    });
+
+    it("caps the sheet with the top band + bottom gap instead of unbounding it", () => {
+      expect(content).toContain("max-height: calc(");
+      expect(content).toContain("100dvh - var(--hk-sheet-top-inset");
+      // dvh-less engines (older Android WebView / Tauri) drop the whole
+      // dvh calc — the plain-vh fallback must stay ahead of it.
+      expect(content).toContain("100vh - var(--hk-sheet-top-inset");
+      expect(content.indexOf("100vh - var(")).toBeLessThan(content.indexOf("100dvh - var("));
+      expect(content).not.toMatch(/max-height:\s*none/);
+    });
+
+    it("lifts the 70vh body cap on phones so the footer sits on the bottom edge", () => {
+      expect(body).toContain("max-height: none");
+    });
+
+    it("lifts sm/md footer buttons to the 44px touch-target class", () => {
+      expect(footer).toMatch(/\.hk-btn-sm,\s*\n\s*\.hk-btn-md/);
+      expect(footer).toContain("min-height: 2.75rem");
+    });
   });
 });


### PR DESCRIPTION
## Problem (user-reported, 2026-08-30, four phone screenshots)

On phones every HkModal docked as a bottom sheet **force-stretched** from `top: var(--hk-sheet-top-inset)` down to `bottom: var(--hk-sheet-bottom-gap)` regardless of content:

- the topology node-detail modal (3 rows + a footer button) rendered ~60vh of blank body;
- the desktop `.hk-modal-body { max-height: 70vh }` cap stranded the height it refused **inside** the stretched sheet as a phantom empty band **below the last flex item** — under the report reply-bar footer, and under the log tail of the footer-less TodoLogModal;
- footer actions render `size="sm"` (28px) — too small to tap at the sheet's bottom corners.

## Fix

- Sheet **hugs its content**: `top: auto`, docked at the bottom gap, growing upward; `max-height: calc(100vh|100dvh - top-inset - bottom-gap)` (vh fallback first for dvh-less engines) keeps the breadcrumb band clear when content is long.
- `.hk-modal-body { max-height: none }` on mobile — the sheet cap is the only clamp; the body fills and scrolls, the footer always sits on the sheet's bottom edge.
- Footer `sm`/`md` buttons lifted to the **44px** touch-target class on phones (`.hk-modal-footer .hk-btn-sm/.hk-btn-md`, (0,2,0) beats the component rules); `lg` untouched.
- Source contract (`HkModal.sheetgap.test.ts`) extended to pin hug-content, the vh/dvh fallback order, the lifted body cap, and the 44px footer rule. Version 0.19.4 → 0.19.5.

Desktop (≥768px) is untouched.

## Verification

- Full hikari vitest 60 files / 521 tests green (×2 runs); vue-tsc clean.
- Real-CSS DOM rig (compiled scss, headless Chrome 390×844): short-content sheet hugs at 285px docked with a 98×44 footer button; long-content sheets cap with body/footer flush (no stranded band); 1280×900 desktop unchanged (centered, footer stays 28px).
- 3 independent verification rounds (adversarial review + consumer scan + final audit): no blockers; the two flagged items (dvh fallback, indentation-sensitive test note) are addressed in this commit.

## Consumer note

shittim-chest compiles hikari sources via vite alias and gets this with zero code changes. Companion chest PR (cruise-sheet close button + report reply footer safe-area) merges **after** this one.