### PR TITLE
🎨 Keep button label type at the regular size across size variants.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -33,7 +33,10 @@
 /* ---- Size variants ---- */
 /* Height scales WITH the size: a single base min-height made every sm
    button 2.5rem (40px) tall — comically oversized next to page-header
-   text and toolbar rows. */
+   text and toolbar rows. Font size does NOT scale with the size
+   (2026-08-30 user report, Material-Design convention): md and lg share
+   --text-base and lg only grows padding/min-height for a larger touch
+   target; sm keeps its compact --text-xs. */
 
 .hk-btn-sm {
   padding: var(--space-6) var(--space-12);
@@ -49,7 +52,7 @@
 
 .hk-btn-lg {
   padding: var(--space-10) var(--space-24);
-  font-size: var(--text-md);
+  font-size: var(--text-base);
   min-height: 2.75rem;
 }
 

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -414,11 +414,15 @@
     // buttons were too small to tap reliably). lg already clears 44px and
     // keeps its own sizing; the doubled class selector deliberately wins
     // the cascade over the bare .hk-btn-sm/.hk-btn-md component rules.
+    // The lift is padding/min-height only — font-size stays at the regular
+    // --text-base (Material-Design convention, same wave as HkButton lg),
+    // so a lifted sm footer button reads like every other button instead
+    // of jumping to 16px display text.
     .hk-btn-sm,
     .hk-btn-md {
       min-height: 2.75rem;
       padding: var(--space-8) var(--space-16);
-      font-size: var(--text-md);
+      font-size: var(--text-base);
     }
   }
 }


### PR DESCRIPTION
## Summary
Material-Design convention per user report: a larger button must not grow its label type — it only grows padding/min-height to enlarge the touch target.

- `HkButton.scss`: `.hk-btn-lg` label drops `--text-md` (16px) back to `--text-base` (14px), matching `.hk-btn-md`; sm keeps its compact `--text-xs` (12px).
- `HkModal.scss`: the mobile (<=767px) docked-sheet footer 44px touch-target lift for sm/md footer buttons now raises only the box (min-height/padding); label font stays at `--text-base` instead of jumping to `--text-md`. This is the 添加工作区-style sheet footer where lifted sm buttons previously rendered 16px labels.

## Verification
- Full hikari vitest suite green (exit 0); `HkModal.sheetgap.test.ts` contract (doubled `.hk-btn-sm,`.hk-btn-md` selector + 2.75rem min-height) intact, 6/6.
- Independent verification subagent PASS on items A–F: exact-diff audit, byte-compare of padding/min-height vs master, repo-wide sweep found no other size-scaling button-label font (HkFab/HkIconButton/HkAdaptiveDialog/HkAuthSubmitButton clean), token definitions confirmed.
- No hikari test pins button font-size; change is CSS-only, consumed by shittim-chest via vite alias (takes effect on next webui build wave; no rebuild triggered per §7.2).

Version 0.19.5 -> 0.19.6.