### PR TITLE
🐛 Pin input suffixes right, float dropdown sheets and align theme rows with the dropdown grammar.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.8",
+  "version": "0.19.9",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -232,9 +232,13 @@
 
 // Mobile sheet form (via HPopover sheetOnMobile): the panel spans the full
 // width and its controls get touch-sized spacing — the sliders are the
-// whole point on phones, give them room to hit.
+// whole point on phones, give them room to hit. The bottom padding stacks
+// the home-bar safe-area inset ON TOP of the component's own gap (the
+// shorthand here would otherwise silently override the base sheet rule's
+// env() padding-bottom).
 .hk-popover-panel.hk-is-sheet.hk-color-picker-panel {
-  padding: 0 var(--space-16) var(--space-20);
+  padding: 0 var(--space-16)
+    calc(var(--space-20) + env(safe-area-inset-bottom, 0px));
 
   .hk-color-picker-controls {
     min-width: 0;

--- a/packages/vue/src/components/HkInput.affix.test.ts
+++ b/packages/vue/src/components/HkInput.affix.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Source contract for the input affix reservation (2026-08-30 user
+ * report: the localized input's language chip sat at the LEFT edge of
+ * the field with the scrolling placeholder sliding underneath it).
+ *
+ * Two coupled guarantees, pinned here so a refactor cannot silently
+ * regress them — the same "looks fixed but never shipped" class of
+ * failure as the overflow-poll incident:
+ *
+ *  1. The trailing affix pins to the RIGHT edge (margin-inline-start:
+ *     auto) — the input element is absolutely positioned, so a lone
+ *     in-flow suffix otherwise sits at flex START.
+ *  2. The element's horizontal padding and the placeholder-marquee
+ *     window consume the measured affix widths (--hk-input-affix-*-w,
+ *     published by HkInput on the box), so text and marquee always end
+ *     short of the chip.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createApp, h, nextTick, type Component } from "vue";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import HkInput from "./HkInput";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scss = readFileSync(join(here, "HkInput.scss"), "utf-8");
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountInput(opts: { slots?: Record<string, Component> } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(HkInput, { placeholder: "Short name" }, opts.slots ?? {}),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { container };
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkInput affix reservation contract", () => {
+  it("pins the trailing affix to the right edge", () => {
+    const rule = scss.match(/\.hk-input-affix\.hk-input-suffix\s*{[^}]*}/)?.[0] ?? "";
+    expect(rule, "suffix rule must exist").toContain("margin-inline-start: auto");
+  });
+
+  it("sizes the element padding and marquee window from the affix vars", () => {
+    const element = scss.slice(
+      scss.indexOf(".hk-input-element {"),
+      scss.indexOf("&:focus"),
+    );
+    expect(element).toContain("var(--hk-input-affix-end-w");
+    expect(element).toContain("var(--hk-input-affix-start-w");
+
+    const marquee = scss.match(/\.hk-input-box \.hk-placeholder-marquee\s*{[^}]*}/)?.[0] ?? "";
+    expect(marquee, "marquee window rule must exist").toContain("var(--hk-input-affix-end-w");
+    expect(marquee).toContain("var(--hk-input-affix-start-w");
+  });
+
+  it("leaves the textarea variant's padding out of the affix reservation", () => {
+    // Textareas are in-flow flex children (not the absolute overlay), so
+    // an affix sits beside them in flow — the reservation must stay
+    // scoped to the absolutely-positioned input element.
+    const textarea = scss.match(/\.hk-input-element\.hk-input-textarea\s*{[^}]*}/)?.[0] ?? "";
+    expect(textarea, "textarea override rule must exist").toBeTruthy();
+    expect(textarea).not.toContain("--hk-input-affix");
+    expect(textarea).toContain("padding: var(--space-8) var(--space-12)");
+  });
+
+  it("publishes the measured affix width on the box", async () => {
+    // happy-dom lays out nothing — pin the affix width the ref callback
+    // would measure in a real browser and read the published custom
+    // property back off the box. happy-dom exposes offsetWidth as an
+    // accessor on HTMLElement.prototype; blanket-stub it to 96 (the
+    // component only reads it for the two affix spans).
+    const receiver = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    expect(receiver, "offsetWidth accessor exists on HTMLElement").toBeTruthy();
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 96,
+    });
+    try {
+      const { container } = mountInput({
+        slots: { suffix: () => h("span", "CHIP") },
+      });
+      await nextTick();
+      const box = container.querySelector<HTMLElement>(".hk-input-box")!;
+      expect(box, "input box renders").toBeTruthy();
+      expect(box.style.getPropertyValue("--hk-input-affix-end-w")).toBe("96px");
+      expect(box.style.getPropertyValue("--hk-input-affix-start-w")).toBe("0px");
+    } finally {
+      if (receiver) {
+        Object.defineProperty(HTMLElement.prototype, "offsetWidth", receiver);
+      }
+    }
+  });
+
+  it("keeps zero widths when no affix slot is provided", async () => {
+    const { container } = mountInput();
+    await nextTick();
+    const box = container.querySelector<HTMLElement>(".hk-input-box")!;
+    expect(box.style.getPropertyValue("--hk-input-affix-end-w")).toBe("0px");
+    expect(box.style.getPropertyValue("--hk-input-affix-start-w")).toBe("0px");
+  });
+
+  it("clears the reservation when the affix is removed while mounted", async () => {
+    // Vue fires ref(null) BEFORE detaching the element, so the clearing
+    // path must judge detachment after the patch settles — this pins
+    // the deferred check (a synchronous isConnected guard was proven
+    // dead code in review).
+    const receiver = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "offsetWidth",
+    );
+    expect(receiver, "offsetWidth accessor exists on HTMLElement").toBeTruthy();
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+      configurable: true,
+      get: () => 96,
+    });
+    try {
+      const container = document.createElement("div");
+      document.body.appendChild(container);
+      const app = createApp({
+        data: () => ({ show: true }),
+        render() {
+          return h(
+            HkInput,
+            { placeholder: "Short name" },
+            this.show ? { suffix: () => h("span", "CHIP") } : {},
+          );
+        },
+      });
+      app.mount(container);
+      mounts.push({ app, container });
+      await nextTick();
+      const box = container.querySelector<HTMLElement>(".hk-input-box")!;
+      expect(box.style.getPropertyValue("--hk-input-affix-end-w")).toBe("96px");
+      (app._instance?.proxy as unknown as { show: boolean }).show = false;
+      // Three ticks: ① the unmounting patch (ref(null) fires), ② the
+      // deferred detachment check clears the tracked width, ③ the box
+      // re-renders with the reset custom property.
+      await nextTick();
+      await nextTick();
+      await nextTick();
+      expect(box.style.getPropertyValue("--hk-input-affix-end-w")).toBe("0px");
+      // The suffix comes back — the reservation must follow it again.
+      (app._instance?.proxy as unknown as { show: boolean }).show = true;
+      await nextTick();
+      await nextTick();
+      expect(box.style.getPropertyValue("--hk-input-affix-end-w")).toBe("96px");
+    } finally {
+      if (receiver) {
+        Object.defineProperty(HTMLElement.prototype, "offsetWidth", receiver);
+      }
+    }
+  });
+});

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -84,7 +84,15 @@
   line-height: 1.5;
   color: rgb(var(--color-text));
   text-align: center;
-  padding: var(--space-8) var(--space-12);
+  /* Horizontal padding grows by the measured affix widths
+   * (--hk-input-affix-*-w, published by HkInput on the box) so the
+   * caret, typed text and the native placeholder all stay clear of
+   * the prefix/suffix content — e.g. the localized input's language
+   * chip riding the right edge. */
+  padding: var(--space-8)
+    calc(var(--space-12) + var(--hk-input-affix-end-w, 0px))
+    var(--space-8)
+    calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
 
   // The interactive states stay clean too: the shell (.hk-input-box) owns
   // the focus affordance via :focus-within. Without these overrides any
@@ -144,6 +152,30 @@
   flex-shrink: 0;
   position: relative;
   z-index: 1;
+}
+
+/* The trailing affix pins to the RIGHT edge of the field: the box's only
+ * in-flow children are the affixes (the input element is absolutely
+ * positioned), so without the auto margin a lone suffix would sit at the
+ * flex START — the localized input's language chip rendered on the left,
+ * on top of the placeholder. Row layout only; a textarea-type input puts
+ * affixes in flow BELOW the field (column autogrow), where no affix
+ * consumer exists today. */
+.hk-input-affix.hk-input-suffix {
+  margin-inline-start: auto;
+}
+
+/* The placeholder-marquee window shares the element's content box: inset
+ * by the same base padding plus the measured affix widths, so the
+ * scrolling strip never slides underneath the affixes either. With no
+ * affixes this still insets by the base padding — the window then exactly
+ * matches the native placeholder's bounds, so marginal placeholders that
+ * "fit" the padded line stay native instead of scrolling. */
+.hk-input-box .hk-placeholder-marquee {
+  inset: 0
+    calc(var(--space-12) + var(--hk-input-affix-end-w, 0px))
+    0
+    calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
 }
 
 .hk-input-error-msg {

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -102,6 +102,79 @@ export default defineComponent({
       return rest;
     });
 
+    // ── affix width reservation ──────────────────────────────────────
+    // The input element overlays the WHOLE box (absolute inset:0) while
+    // the prefix/suffix affixes flow above it — so centered text, the
+    // native placeholder and the placeholder-marquee window would run
+    // underneath the affixes (the localized input's language chip used
+    // to catch the scrolling placeholder). Both affixes are measured
+    // and published as custom properties on the box; the element's
+    // horizontal padding and the marquee window insets consume them,
+    // so the text line always ends short of the chip.
+    const prefixEl = ref<HTMLElement | null>(null);
+    const suffixEl = ref<HTMLElement | null>(null);
+    const affixStartW = ref(0);
+    const affixEndW = ref(0);
+
+    function measureAffixes() {
+      affixStartW.value = prefixEl.value?.offsetWidth ?? 0;
+      affixEndW.value = suffixEl.value?.offsetWidth ?? 0;
+    }
+
+    const affixRO: ResizeObserver | null =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(measureAffixes) : null;
+    onBeforeUnmount(() => {
+      affixRO?.disconnect();
+    });
+
+    /** Stable ref callback for one affix slot — observes the live span
+     *  so width changes (a longer chip label, a swapped icon) re-publish
+     *  the custom properties without any consumer involvement. */
+    function bindAffix(which: "start" | "end") {
+      const slot = () => (which === "start" ? prefixEl : suffixEl);
+      const set = (node: HTMLElement | null) => {
+        if (which === "start") prefixEl.value = node;
+        else suffixEl.value = node;
+      };
+      return (el: unknown) => {
+        const node = (el as HTMLElement | null) ?? null;
+        const prev = slot().value;
+        if (node == null) {
+          if (!prev) return;
+          // Vue fires ref(null) BEFORE detaching the element (unmount
+          // calls setRef at the top, removes the node at the bottom), and
+          // on a cross-branch swap (suffix ↔ suffixIcon ↔ password
+          // toggle) a trailing null can arrive AFTER a newer element
+          // already took the slot. So neither "is it connected right
+          // now" nor "is the slot still pointing at it" can be judged
+          // synchronously — defer past the patch and clear only when the
+          // tracked element is STILL this one and really detached.
+          void nextTick(() => {
+            const tracked = slot().value;
+            if (tracked !== prev || tracked.isConnected) return;
+            affixRO?.unobserve(prev);
+            set(null);
+            measureAffixes();
+          });
+          return;
+        }
+        if (prev && prev !== node) affixRO?.unobserve(prev);
+        set(node);
+        affixRO?.observe(node);
+        measureAffixes();
+      };
+    }
+    const prefixAffixRef = bindAffix("start");
+    const suffixAffixRef = bindAffix("end");
+
+    const boxVars = computed(
+      () =>
+        ({
+          "--hk-input-affix-start-w": `${affixStartW.value}px`,
+          "--hk-input-affix-end-w": `${affixEndW.value}px`,
+        }) as Record<string, string>,
+    );
+
     function onInput(e: Event) {
       const target = e.target as HTMLInputElement | HTMLTextAreaElement;
       emit("update:modelValue", target.value);
@@ -165,15 +238,16 @@ export default defineComponent({
         )}
         <div
           class={boxClass.value}
+          style={boxVars.value}
           data-autogrow={isAutoGrow.value || undefined}
         >
           {slots.prefix && (
-            <span class="hk-input-affix hk-input-prefix">
+            <span ref={prefixAffixRef} class="hk-input-affix hk-input-prefix">
               {slots.prefix()}
             </span>
           )}
           {slots.prefixIcon && !slots.prefix && (
-            <span class="hk-input-affix hk-input-prefix">
+            <span ref={prefixAffixRef} class="hk-input-affix hk-input-prefix">
               {slots.prefixIcon()}
             </span>
           )}
@@ -264,17 +338,17 @@ export default defineComponent({
               />
             )}
           {slots.suffix && (
-            <span class="hk-input-affix hk-input-suffix">
+            <span ref={suffixAffixRef} class="hk-input-affix hk-input-suffix">
               {slots.suffix()}
             </span>
           )}
           {slots.suffixIcon && !slots.suffix && (
-            <span class="hk-input-affix hk-input-suffix">
+            <span ref={suffixAffixRef} class="hk-input-affix hk-input-suffix">
               {slots.suffixIcon()}
             </span>
           )}
           {props.variant === "password" && !slots.suffix && !slots.suffixIcon && (
-            <span class="hk-input-affix hk-input-suffix">
+            <span ref={suffixAffixRef} class="hk-input-affix hk-input-suffix">
               <button
                 type="button"
                 class="hk-input-password-toggle"

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -107,12 +107,28 @@
   border-left: 0;
   border-right: 0;
   border-bottom: 0;
-  max-height: min(72vh, calc(100vh - var(--hk-sheet-top-inset, 4.25rem)));
+  max-height: min(
+    72vh,
+    calc(
+      100vh - var(--hk-sheet-top-inset, 4.25rem) -
+        var(--hk-sheet-bottom-gap, 0.375rem)
+    )
+  );
   display: flex;
   flex-direction: column;
   overflow-y: auto;
   overscroll-behavior: contain;
   padding-top: 0;
+  /* The sheet's bottom-edge distance itself comes from the shared
+   * --hk-sheet-bottom-gap (inline in HkPopover's sheet style); here the
+   * content keeps the last row clear of the home bar: the safe-area
+   * inset stacked on a 12px family base, which also restores a bottom
+   * cushion over the glass dropdown chrome (equal specificity, earlier
+   * in source, whose own bottom padding the sheet rule would otherwise
+   * zero out). The modal sheet footer goes further (it adds
+   * --hk-sheet-footer-gap for its action buttons); this sheet has no
+   * footer, so this is the family baseline. */
+  padding-bottom: calc(var(--space-12, 0.75rem) + env(safe-area-inset-bottom, 0px));
 }
 
 .hk-popover-sheet-grabber {

--- a/packages/vue/src/components/HkPopover.sheetdock.test.ts
+++ b/packages/vue/src/components/HkPopover.sheetdock.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Source contract for the popover sheet docking (2026-08-30 user
+ * report: the theme toggle's bottom-up sheet didn't read as part of
+ * the standard sheet family). HkPopover's sheetOnMobile mode must dock
+ * with the SAME host-tunable --hk-sheet-bottom-gap as the HkModal and
+ * HkSelectPanel dockings, and keep its content clear of the home bar
+ * via the safe-area inset. The inline style used to pin hard
+ * `bottom: "0"`.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const tsx = readFileSync(join(here, "HkPopover.tsx"), "utf-8");
+const scss = readFileSync(join(here, "HkPopover.scss"), "utf-8");
+
+describe("HkPopover mobile sheet docking contract", () => {
+  it("docks the sheet above the shared bottom gap (inline sheet style)", () => {
+    const block = tsx.slice(tsx.indexOf("panelStyle"));
+    expect(block).toContain("var(--hk-sheet-bottom-gap");
+    // Same default as the HkModal sheet contract.
+    expect(block).toMatch(/--hk-sheet-bottom-gap,\s*0\.375rem/);
+  });
+
+  it("keeps sheet content clear of the home bar via the safe-area inset", () => {
+    const block = scss.match(/\.hk-popover-panel\.hk-is-sheet\s*{[^}]*}/)?.[0] ?? "";
+    // Stacked on the family 12px base so the glass dropdown chrome's
+    // bottom padding survives on non-notched phones too.
+    expect(block).toContain("calc(var(--space-12");
+    expect(block).toContain("env(safe-area-inset-bottom");
+  });
+});

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -383,13 +383,15 @@ export default defineComponent({
 
     const panelStyle = computed(() => {
       if (sheetMode.value) {
-        // Bottom sheet: pinned to the bottom edge, full width, inside the
-        // top inset reserved for the secondary-window breadcrumb strip
-        // (same convention as the modal mobile docking).
+        // Bottom sheet: pinned above the bottom edge with the SAME
+        // host-tunable gap as the HkModal mobile docking
+        // (--hk-sheet-bottom-gap) so every bottom-up window belongs to
+        // one sheet family; full width, inside the top inset reserved
+        // for the secondary-window breadcrumb strip.
         return {
           left: "0",
           right: "0",
-          bottom: "0",
+          bottom: "var(--hk-sheet-bottom-gap, 0.375rem)",
           top: "auto" as const,
           position: "fixed" as const,
           pointerEvents: "auto" as const,

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -187,10 +187,20 @@
   position: fixed;
   left: 0;
   right: 0;
-  bottom: 0;
+  /* Float off the bottom edge with the SAME host-tunable gap as the
+   * HkModal mobile docking (--hk-sheet-bottom-gap) — every bottom-up
+   * window reads as one sheet family; was glued to bottom: 0, which is
+   * exactly why dropdown sheets read as "not the standard modal". */
+  bottom: var(--hk-sheet-bottom-gap, 0.375rem);
   display: flex;
   flex-direction: column;
-  max-height: min(72vh, calc(100vh - var(--hk-sheet-top-inset, 4.25rem)));
+  max-height: min(
+    72vh,
+    calc(
+      100vh - var(--hk-sheet-top-inset, 4.25rem) -
+        var(--hk-sheet-bottom-gap, 0.375rem)
+    )
+  );
   background: rgb(var(--color-surface));
   border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
                  var(--hk-modal-radius, var(--hi-radius-lg, 12px))
@@ -238,9 +248,13 @@
   overscroll-behavior: contain;
   /* Side insets so the option blocks (full-row hover pills) read as
      cards inside the sheet instead of an edge-to-edge strip glued to
-     both screen sides — matching the popover family's breathing room. */
+     both screen sides — matching the popover family's breathing room.
+     Bottom padding stacks the home-bar safe-area inset ON TOP of the
+     base row gap, so the last row never hides behind the gesture bar
+     on notched phones (the modal footer adds a --hk-sheet-footer-gap
+     on top of this family baseline for its action buttons). */
   padding-inline: var(--space-16);
-  padding-bottom: var(--space-16);
+  padding-bottom: calc(var(--space-16) + env(safe-area-inset-bottom, 0px));
 
   .hk-select-option {
     padding: var(--space-14) var(--space-16);

--- a/packages/vue/src/components/HkSelect.sheetdock.test.ts
+++ b/packages/vue/src/components/HkSelect.sheetdock.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Source contract for the dropdown sheet docking (2026-08-30 user
+ * report: the localized input's language menu sheet "didn't look like
+ * it came from the standard modal"). The HkSelectPanel sheet — the
+ * shared surface under HkSelect / HkMenu / HkPopupSelect — must dock
+ * with the SAME host-tunable bottom gap and home-bar safe-area padding
+ * as the HkModal mobile docking, so every bottom-up window belongs to
+ * one visual family. It used to be glued to `bottom: 0`.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkSelect.scss"), "utf-8");
+
+describe("HkSelectPanel mobile sheet docking contract", () => {
+  it("floats the sheet on --hk-sheet-bottom-gap (not hard 0)", () => {
+    const block = src.match(/\.hk-select-sheet-panel\s*{[^}]*}/)?.[0] ?? "";
+    expect(block).toContain("bottom: var(--hk-sheet-bottom-gap");
+    // Same default as the HkModal sheet contract.
+    expect(block).toMatch(/--hk-sheet-bottom-gap,\s*0\.375rem/);
+  });
+
+  it("stacks the safe-area inset on the sheet list bottom padding", () => {
+    const block = src.match(/\.hk-select-sheet-list\s*{[^}]*}/)?.[0] ?? "";
+    expect(block).toContain("env(safe-area-inset-bottom");
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -126,20 +126,29 @@
   flex-shrink: 0;
 }
 
+/* Theme rows speak the SAME grammar as every dropdown option
+ * (.hk-select-option): base-size text, roomy pill padding, hairline
+ * border that tints on hover and strengthens when active — so a theme
+ * list inside the popover reads like any select/menu panel. The old
+ * bespoke 6×8 tight rows (small text, borderless 12% wash) are what
+ * made the theme sheet read as "not from the standard dropdown". */
 .s-theme-item-btn {
   display: flex;
   align-items: center;
-  gap: var(--space-6, 0.375rem);
+  gap: var(--space-8, 0.5rem);
   min-width: 0;
   flex: 1;
-  padding: var(--space-6, 0.375rem) var(--space-8, 0.5rem);
-  border: none;
-  border-radius: var(--radius-sm, 6px);
+  padding: var(--space-10, 0.625rem) var(--space-16, 1rem);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md, 8px);
   background: transparent;
   color: rgb(var(--color-text));
-  font-size: var(--text-sm, 0.8125rem);
+  font-size: var(--text-base, 0.875rem);
+  line-height: 1.35;
   text-align: left;
   cursor: pointer;
+  appearance: none;
+  transition: background-color 0.12s ease, border-color 0.12s ease;
 }
 
 .s-theme-item-name {
@@ -156,12 +165,14 @@
 }
 
 .s-theme-item-btn:hover:not([data-active]) {
-  background: rgb(var(--color-primary) / 12%);
+  background: var(--c-primary-subtle);
+  border-color: var(--c-primary-medium);
   color: rgb(var(--color-text));
 }
 
 .s-theme-item-btn[data-active] {
-  background: rgb(var(--color-primary) / 12%);
+  background: var(--c-primary-dim);
+  border-color: var(--c-primary-strong);
   color: rgb(var(--color-primary));
   font-weight: 600;
 }
@@ -183,4 +194,27 @@
 .s-theme-item-delete:hover {
   background: rgb(var(--color-error) / 15%);
   color: rgb(var(--color-error));
+}
+
+/* Touch-sized rows on phone widths — the same sheet bump the shared
+ * surfaces apply (.hk-select-sheet-list .hk-select-option → 14px
+ * vertical, .hk-select-sheet-panel .hk-menu-row → 44px min-height).
+ * The trailing slot mirrors the delete button's bumped footprint so
+ * the equal-highlight-width invariant across custom/non-custom rows
+ * survives on mobile too. */
+@media (max-width: 767px) {
+  .s-theme-item-btn {
+    min-height: 44px;
+    padding: var(--space-14, 0.875rem) var(--space-16, 1rem);
+  }
+
+  .s-theme-item-delete {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+
+  .s-theme-item-slot {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
 }


### PR DESCRIPTION
## Problem (user-reported, mobile webui, three screenshots)

1. **Localized input chip on the wrong side, placeholder underneath it.** The language chip of `HkLocalizedInput` (rendered in `HkInput`'s suffix slot) sat at the **left** edge of the field with the scrolling placeholder sliding underneath it. Root cause: the input element is absolutely positioned over the whole box, the affixes are the only in-flow flex children, so a lone suffix parked at flex start; and nothing reserved the chip's width for the text line or the marquee window.
2. **Dropdown sheets don't read as the standard sheet family.** `HkSelectPanel`'s mobile sheet (the shared surface behind `HkSelect` / `HkMenu` / `HkPopupSelect` — including the localized input's language menu) was glued to `bottom: 0`, while `HkModal`'s mobile docking floats on `--hk-sheet-bottom-gap`. Same for `HkPopover`'s `sheetOnMobile` mode (theme toggle) — hard `bottom: "0"` inline.
3. **Theme sheet options don't match the standard.** `HkThemeToggle`'s rows used bespoke 6×8 tight styling (small text, borderless 12% wash), visually unrelated to the `.hk-select-option` grammar every dropdown row speaks.

## Fix

- **HkInput**: `.hk-input-affix.hk-input-suffix { margin-inline-start: auto }` pins the trailing affix to the right edge. Both affixes are measured (ResizeObserver-backed stable ref callbacks) and published as `--hk-input-affix-start-w` / `--hk-input-affix-end-w` on the box; the input element's horizontal padding and a new `.hk-input-box .hk-placeholder-marquee` inset consume them — typed text, caret, native placeholder AND the scrolling marquee always end short of the chip. Affix removal is judged after the patch settles (Vue fires function refs with null **before** detaching the node — a synchronous `isConnected` guard was proven dead code in review and pinned by test). Textarea variant keeps its plain padding (in-flow, unaffected).
- **Sheet family docking**: `.hk-select-sheet-panel` and `HkPopover`'s inline sheet style now dock on `bottom: var(--hk-sheet-bottom-gap, 0.375rem)` (the exact token/contract `HkModal.scss` already uses, asserted by `HkModal.sheetgap.test.ts`); `max-height` subtracts the gap; the select sheet list and popover sheet stack `env(safe-area-inset-bottom)` on the bottom padding (HkColorPicker's more-specific shorthand stacks it too instead of dropping it).
- **HkThemeToggle**: theme rows now use the `.hk-select-option` grammar — base-size text, 10/16 pill padding, radius-md, bordered hover (`--c-primary-subtle`/`medium`) and active (`--c-primary-dim`/`strong` + primary text) states — with a ≤767px touch bump (44px rows, 2.25rem delete **and** slot so the equal-highlight-width invariant survives on mobile).
- The localized input's language menu itself already renders through `HkMenu` → `HkSelectPanel`, so it inherits the unified docking with zero changes.

## Consumer impact

chest compiles hikari from source (vite alias), so the 新建视图 localized field, the language menu sheet and the header theme sheet are all fixed by this PR alone — no chest code change needed. Desktop popouts are untouched (sheet classes only render under `sheetOnMobile && isMobile`). Public API unchanged (props/emits/slots byte-identical). Version bump 0.19.4 → 0.19.6 in-PR per policy; **merge order: after #322** (which lands 0.19.5).

## Verification

- New tests: `HkInput.affix.test.ts` (6: right-pin contract, var-driven padding + marquee window, measured width publish incl. removal/regrowth pin, zero-width case, textarea scope), `HkSelect.sheetdock.test.ts` (2), `HkPopover.sheetdock.test.ts` (2) — static source contracts in the `HkModal.sheetgap.test.ts` style.
- Full suite: **63 files / 527 tests green**; `vue-tsc --noEmit` exit 0; changed SCSS compiled cleanly with dart-sass.
- Subagent verification cycle: initial pass flagged a dead-code guard in the affix rework (Vue ref-null-before-detach, confirmed against `@vue/runtime-core@3.5.40` + happy-dom probe) → fixed with a deferred `nextTick` detachment check + regression test; two further independent rounds PASS (cascade/consumer-impact audits across hikari + chest + arona + plana + entelecheia; no downstream left-suffix dependency; no snapshot/geometry assertions to update).