### PR TITLE
🐛 Let menu panels size to the viewport and clamp flipped panels on-screen.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.7",
+  "version": "0.19.8",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -94,7 +94,12 @@
   position: fixed;
   /* z-index comes from the popup manager (inline) — registered overlay. */
   min-width: 180px;
-  max-height: 240px;
+  /* Menu/switcher panels overflow a bare 240px cap even on tall viewports
+     (user feedback 2026-08-30: identity header + rows ≈ 320px+). Keep 240px
+     as the floor for select lists on short viewports, otherwise let the
+     panel size to its content up to a viewport-relative ceiling. */
+  max-height: max(240px, min(36rem, calc(100vh - 32px)));
+  max-height: max(240px, min(36rem, calc(100dvh - 32px)));
   display: flex;
   flex-direction: column;
   gap: var(--space-2);

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -276,6 +276,43 @@ describe("HkSelectPanel custom invocation", () => {
     const flipped = Number.parseInt(popout.style.top, 10);
     expect(flipped).toBeGreaterThan(8);
   });
+
+  it("clamps a tall flipped popout into the viewport instead of going negative", async () => {
+    // The taller viewport-relative CSS cap admits ~576px panels: anchored
+    // mid-viewport (top 380 / bottom 424 on an 800px-tall viewport), a
+    // bottom-start panel cannot fit below (428 + 576 > 792) and flips
+    // top-side into 380 - 4 - 576 = -200 — the single flip never
+    // re-checks, and the raw negative top used to be applied verbatim.
+    const prevHeight = window.innerHeight;
+    window.innerHeight = 800;
+    try {
+      const { container, open } = mountPanel({ placement: "bottom-start" });
+      await nextTick();
+
+      const anchor = container.querySelector<HTMLButtonElement>("button")!;
+      anchor.getBoundingClientRect = () =>
+        ({ top: 380, bottom: 424, left: 40, right: 140, width: 100, height: 44 }) as DOMRect;
+      open.value = true;
+      await nextTick();
+
+      const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+      // happy-dom lays nothing out (offsetHeight 0 → the 200px fallback in
+      // positionPanel), so fake the near-max-height box the new cap allows
+      // and re-run geometry via the same resize path the cramped test uses.
+      Object.defineProperty(popout, "offsetHeight", { value: 576, configurable: true });
+      window.dispatchEvent(new Event("resize"));
+      await nextTick();
+
+      const top = Number.parseInt(popout.style.top, 10);
+      // Whole panel on-screen: top edge at/inside the viewport pad and the
+      // bottom edge inside it too — overflow beyond that is the panel's
+      // own internal scroll, never off-screen geometry.
+      expect(top).toBeGreaterThanOrEqual(8);
+      expect(top + 576).toBeLessThanOrEqual(800 - 8);
+    } finally {
+      window.innerHeight = prevHeight;
+    }
+  });
 });
 
 describe("HkSelectPanel back-guard (window-first back priority)", () => {

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -329,6 +329,13 @@ export default defineComponent({
         side = "bottom";
         top = r.bottom + props.offset;
       }
+      // One flip never re-checks: taller menu panels (the viewport-relative
+      // CSS cap) made this band reachable — a mid-viewport anchor flips
+      // bottom→top into a negative top that was applied verbatim. Clamp so
+      // the whole panel stays on-screen; when content exceeds the CSS cap
+      // the panel's own internal scroll takes over.
+      const maxTop = Math.max(VIEWPORT_PAD, window.innerHeight - VIEWPORT_PAD - ph);
+      top = Math.min(Math.max(top, VIEWPORT_PAD), maxTop);
       let left = props.placement.endsWith("-end") ? r.right - pw : r.left;
       const maxLeft = Math.max(VIEWPORT_PAD, window.innerWidth - VIEWPORT_PAD - pw);
       left = Math.min(Math.max(left, VIEWPORT_PAD), maxLeft);


### PR DESCRIPTION
## What

The desktop dropdown popout (`.hk-select-popout`) was hard-capped at `max-height: 240px` — right for small select lists, but it clips richer panels:

- **User account menu** (HkMenu levels render inside HkSelectPanel popouts): identity header + menu rows ≈ 320px+ → a pointless scrollbar even on tall viewports (user screenshot feedback 2026-08-30).
- **Platform switcher** (chest, custom content inside HkSelectPanel): tail rows scrolled away.

## Fix

1. **`HkSelect.scss`** — the cap is now viewport-relative with the old 240px as floor:
   ```scss
   max-height: max(240px, min(36rem, calc(100vh - 32px)));
   max-height: max(240px, min(36rem, calc(100dvh - 32px)));
   ```
   vh line first as the fallback for engines without `dvh` — same two-declaration convention as HkModal's sheet styles. The mobile bottom-sheet sizing is untouched.
2. **`HkSelectPanel.tsx`** — the taller ceiling exposed a latent gap in `positionPanel()`: the single bottom→top flip never re-checked the result, and the final `top` was applied verbatim, so a mid-viewport anchor with a near-max panel could flip into a **negative top** (panel header off-screen). The final top is now clamped into `[VIEWPORT_PAD, innerHeight − VIEWPORT_PAD − ph]`; internal popout scroll takes over when content exceeds the CSS cap.
3. Version 0.19.6 → 0.19.8 (rebased over #325, which took 0.19.7).

## Verification

- `vue-tsc --noEmit`: clean.
- `vitest run`: HkSelectPanel 20/20 (incl. new negative-top clamp test — verified it fails with `expected -200 to be ≥ 8` when the clamp is disabled), HkMenu 24/24, HkSelect/HkSelectSheet/HkModal.sheetgap all green (56/56 across the related suites).
- sass compiles both declarations verbatim; the dvh-fallback ordering convention is enforced by the existing HkModal.sheetgap test.
- Independent cross-review passed (CSS math validity, consumer sweep, version-sync check).

CI is reference-only per workspace policy; local verification above is the gate.