### PR TITLE
✨ Add a go-to-frontend menu row and a drawer close hook to the admin shell.

### DIFF
--- a/packages/vue/src/components/HkAdminHeader.test.tsx
+++ b/packages/vue/src/components/HkAdminHeader.test.tsx
@@ -140,6 +140,30 @@ describe("HkAdminHeader", () => {
     expect(c.textContent.toLowerCase()).not.toContain("emergency");
   });
 
+  it("renders the goToFrontend row above logout and emits goToFrontend", async () => {
+    const onGoToFrontend = vi.fn();
+    const c = mount(headerNode({
+      logoutLabel: "Log out",
+      goToFrontendLabel: "Go to Frontend",
+      onGoToFrontend,
+    }));
+    // Opt-in: absent without the label prop…
+    const bare = mount(headerNode({ logoutLabel: "Log out" }));
+    await click(avatarButton(bare));
+    expect(bare.textContent).not.toContain("Go to Frontend");
+
+    // …and present (directly above logout, mirroring the drawer user
+    // panel's row order) with the label prop.
+    await click(avatarButton(c));
+    const rows = [...c.querySelectorAll(".s-popup-menu-item")];
+    const labels = rows.map((r) => r.textContent?.trim());
+    expect(labels.indexOf("Go to Frontend")).toBeGreaterThan(-1);
+    expect(labels.indexOf("Log out")).toBe(labels.indexOf("Go to Frontend") + 1);
+
+    await click(rows[labels.indexOf("Go to Frontend")]);
+    expect(onGoToFrontend).toHaveBeenCalledTimes(1);
+  });
+
   it("passes the locale trigger ref OBJECT through the slot so the picker anchors to the button", async () => {
     let captured: unknown = null;
     const c = mount(headerNode(

--- a/packages/vue/src/components/HkAdminHeader.tsx
+++ b/packages/vue/src/components/HkAdminHeader.tsx
@@ -1,5 +1,5 @@
 import { defineComponent, ref, type PropType, type VNode } from "vue";
-import { Camera, Languages, LogOut, Menu } from "lucide-vue-next";
+import { Camera, ExternalLink, Languages, LogOut, Menu } from "lucide-vue-next";
 import { HBadge, HButton, HPopover, HSpinner } from "@celestia-island/hikari";
 import { useI18n } from "../i18n/context";
 
@@ -53,9 +53,15 @@ export const HkAdminHeader = defineComponent({
     localeMenuLabel: { type: String, default: undefined },
     logoutLabel: { type: String, default: undefined },
     adminGroupLabel: { type: String, default: undefined },
+    /** "Go to frontend" menu row (external-face link, rendered directly
+     *  above logout). Hidden unless a label is provided — admin-only
+     *  panels without a consumer-facing face simply omit the prop and
+     *  keep the menu at avatar/language/logout. */
+    goToFrontendLabel: { type: String, default: undefined },
   },
   emits: {
     logout: () => true,
+    goToFrontend: () => true,
     hamburger: () => true,
     avatarClick: () => true,
     emergencyStop: () => true,
@@ -221,6 +227,22 @@ export const HkAdminHeader = defineComponent({
                 triggerRef: localeTriggerRef,
               })}
               {slots["user-menu-extra"]?.()}
+              {/* Frontend link — mirrors the drawer user panel's
+                  "go to frontend" row (same icon/position: directly
+                  above logout). Opt-in via the label prop so admin-only
+                  panels keep the menu at avatar/language/logout. */}
+              {props.goToFrontendLabel ? (
+                <button
+                  class="s-popup-menu-item"
+                  onClick={() => {
+                    userMenuOpen.value = false;
+                    emit("goToFrontend");
+                  }}
+                >
+                  <ExternalLink size={14} />
+                  {props.goToFrontendLabel}
+                </button>
+              ) : null}
               <button
                 class="s-popup-menu-item"
                 onClick={() => {

--- a/packages/vue/src/components/HkAdminShell.test.tsx
+++ b/packages/vue/src/components/HkAdminShell.test.tsx
@@ -148,6 +148,40 @@ describe("HkAdminShell", () => {
     expect(c.querySelector(".drawer-stub.my-drawer")).toBeTruthy();
   });
 
+  it("hands the userPanel slot an onNavigate that closes the drawer", async () => {
+    setWidth(500);
+    let openDrawer: (() => void) | null = null;
+    let userPanelNavigate: (() => void) | null = null;
+    const c = mount(shellNode(
+      { navTitle: "Navigation" },
+      {
+        header: (ctx: { onOpenDrawer: () => void }) => {
+          openDrawer = ctx.onOpenDrawer;
+          return null;
+        },
+        sidebar: NAV,
+        userPanel: (ctx: { onNavigate: () => void }) => {
+          userPanelNavigate = ctx.onNavigate;
+          return h("div", { class: "s-drawer-user-panel" }, "USER-PANEL");
+        },
+        content: CONTENT,
+      },
+    ));
+    openDrawer!();
+    await nextTick();
+    await nextTick();
+    expect(c.querySelector(".drawer-stub")).toBeTruthy();
+    // The slot scope carries the drawer-close callback (mirrors the
+    // sidebar slot's onNavigate contract)…
+    expect(userPanelNavigate).toBeTruthy();
+    // …and invoking it dismisses the drawer (a "go to frontend" row
+    // must not leave the drawer hovering over the swapped layout).
+    userPanelNavigate!();
+    await nextTick();
+    await nextTick();
+    expect(c.querySelector(".drawer-stub")).toBeNull();
+  });
+
   it("omits the drawer footer wrapper when no userPanel slot is given", async () => {
     setWidth(500);
     let openDrawer: (() => void) | null = null;

--- a/packages/vue/src/components/HkAdminShell.tsx
+++ b/packages/vue/src/components/HkAdminShell.tsx
@@ -96,12 +96,16 @@ export const HkAdminShell = defineComponent({
               {/* The drawer body carries the nav; a `userPanel` slot rides
                   the drawer footer (identity + account actions) so mobile
                   gets the same content the desktop user menu exposes.
-                  `inDrawer` lets the sidebar slot fill the drawer width. */}
+                  `inDrawer` lets the sidebar slot fill the drawer width.
+                  The userPanel receives `onNavigate` (closes the drawer)
+                  so its action rows — e.g. "go to frontend", which swaps
+                  the whole layout underneath — can dismiss the drawer
+                  instead of leaving it hovering over the new page. */}
               {{
                 default: () =>
                   slots.sidebar?.({ collapsed: false, onNavigate: closeSidebar, inDrawer: true }),
                 footer: slots.userPanel
-                  ? () => slots.userPanel!()
+                  ? () => slots.userPanel!({ onNavigate: closeSidebar })
                   : undefined,
               }}
             </HDrawer>


### PR DESCRIPTION
## What

Two small admin-shell API additions, upstream-first for the chest fix of the missing desktop **go-to-frontend** entry (user report: the mobile drawer has the row, the desktop avatar dropdown does not).

### HkAdminHeader
- New opt-in `goToFrontendLabel` prop + `goToFrontend` emit.
- When the label is provided, renders an `ExternalLink` row **directly above logout** — mirroring the drawer user panel's row order (avatar → language → go to frontend → logout).
- Admin-only panels that omit the prop keep the menu at avatar/language/logout, so existing consumers are unaffected.

### HkAdminShell
- The `userPanel` drawer-footer slot now receives `{ onNavigate }` (closes the drawer), matching the sidebar slot's existing `onNavigate` contract. Callers can dismiss the drawer when an action row swaps the layout underneath (e.g. navigating to the frontend) instead of leaving the drawer hovering over the new page.
- Backward compatible: existing `userPanel` slots ignore the scope object.

## Verification
- `vue-tsc --noEmit` clean.
- vitest full suite: **60 files / 523 tests green** (includes 2 new tests: header row render/emit/ordering + opt-out; shell onNavigate closes the drawer).

## Consumer
chest AdminLayout wiring lands in a follow-up chest PR once this merges (workspace sibling link).