### PR TITLE
🐛 Add breathing room between the step flow header and its body.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.9",
+  "version": "0.19.10",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkStepFlow.scss
+++ b/packages/vue/src/components/HkStepFlow.scss
@@ -10,6 +10,16 @@
   --hk-stepflow-duration: 0.2s;
 }
 
+// Breathing room between the step indicator and the step body. Without it
+// the timeline row butts directly against the first body element (modal
+// wizards read as cramped). Tune or remove per host through
+// --hk-stepflow-header-gap; the sticky mode folds the gap into the pinned
+// header's own padding so the surface tint stays continuous while the
+// body scrolls underneath.
+.hk-step-flow > .hk-timeline {
+  margin-bottom: var(--hk-stepflow-header-gap, var(--space-16, 1rem));
+}
+
 // Sticky header mode: keeps the step indicator visible while the body
 // scrolls inside long modal hosts. Surface tint + blur approximate the
 // floating-chrome look; hosts retune through the custom properties.
@@ -22,7 +32,8 @@
     color-mix(in srgb, var(--hi-color-surface, #fff) 95%, transparent)
   );
   backdrop-filter: blur(6px);
-  padding-bottom: var(--hi-space-8, 8px);
+  margin-bottom: 0;
+  padding-bottom: var(--hk-stepflow-header-gap, var(--space-16, 1rem));
 }
 
 .hk-stepflow-body {


### PR DESCRIPTION
## Summary
- HkStepFlow rendered its step-indicator timeline flush against the step body (zero gap), which made modal wizards (e.g. shittim-chest 新建视图/新建标签 wizards, provider wizard) read as cramped — the indicator row nearly touched the first card below it.
- Add a default 16px (`--space-16`) gap between `.hk-step-flow > .hk-timeline` and the body, tunable per host via a new `--hk-stepflow-header-gap` custom property.
- Sticky-header mode folds the gap into the pinned header's `padding-bottom` (replacing the old hardcoded 8px) so the surface tint stays continuous while the body scrolls underneath; `margin-bottom` is zeroed there to avoid double spacing.

## Verification
- `sass` compile of the modified SCSS: clean.
- vitest: HkStepFlow + HkTimeline suites 25/25 green.
- Browser DOM check on a minimal harness with the compiled CSS: non-sticky gap = 16px; sticky mode margin 0 / padding-bottom 16px as designed.
- Project-wide scan: shittim-chest (3 consumers) needs no consumer-side change; arona / plana / e.celestia.world / entelecheia have zero step-flow usage; easy-hydro-erp vendors only HkTimeline (standalone usages, unaffected by the `.hk-step-flow`-scoped selector).

Version bump: packages/vue 0.19.9 → 0.19.10.