### PR TITLE
🐛 Show locale codes only in menus and unify popup scrollbars.

### DIFF
--- a/packages/theme/styles/_scrollbar.scss
+++ b/packages/theme/styles/_scrollbar.scss
@@ -1,93 +1,72 @@
-// _scrollbar.scss — Custom overlay scrollbar CSS.
-// Adopted from shittim-chest's SScrollContainer overlay system.
-// This hides native scrollbars and provides CSS for the overlay track/thumb
-// that a JS component (or lagrange's vanilla JS) creates imperatively.
+// _scrollbar.scss — the shared overlay scrollbar chrome.
+//
+// ONE scrollbar system for the whole library: the `.hk-scrollbar-track` /
+// `.hk-scrollbar-thumb` DOM is created imperatively by
+// packages/vue/src/composables/useOverlayScrollbar.ts
+// (attachOverlayScrollbars) and styled here. HkScrollContainer keeps its
+// container-specific rules in HkScrollContainer.scss; every other scroll
+// region in the library attaches the same overlay and hides its native
+// bar with the standard two-liner:
+//
+//   scrollbar-width: none;
+//   &::-webkit-scrollbar { display: none; }
 
-// Hide native scrollbar on any element with .hk-scroll-container
-.hk-scroll-container {
-  overflow: auto;
-  scrollbar-width: none !important;
-
-  &::-webkit-scrollbar {
-    display: none !important;
-  }
-}
-
-// Overlay scrollbar track (vertical)
-.hk-obs-track {
+.hk-scrollbar-track {
   position: absolute;
-  top: var(--hi-scroll-inset, 4px);
-  bottom: var(--hi-scroll-inset, 4px);
-  right: var(--hi-scroll-inset, 4px);
-  width: var(--hi-scroll-size, 8px);
+  z-index: 10;
+  background: transparent;
+  /* Click-through while faded: an invisible rail must never steal
+     clicks from the content beneath it (the track hugs the region's
+     edge, exactly where end-of-line links/buttons live). The rail
+     becomes interactive only while it is visible — the flash window
+     after a scroll (and while hovered/dragged within that window). */
   pointer-events: none;
-  z-index: var(--hi-z-floating, 50);
-  transition: width var(--hi-duration-short, 0.15s) var(--hi-ease-out-expo),
-              opacity var(--hi-duration-short, 0.15s);
   opacity: 0;
+  transition: opacity var(--hi-duration-fast, 0.15s) ease;
 
-  &:hover,
-  &.hk-obs-active {
-    width: var(--hi-scroll-size-hover, 14px);
+  &[data-axis="horizontal"] {
+    left: 4px;
+    right: 4px;
+    bottom: 2px;
+    height: 6px;
+  }
+
+  &:not([data-axis="horizontal"]) {
+    top: 4px;
+    bottom: 4px;
+    right: 2px;
+    width: 6px;
+  }
+
+  &.is-scrolling,
+  &.is-hovering {
     opacity: 1;
     pointer-events: auto;
   }
 }
 
-// Overlay scrollbar thumb (vertical)
-.hk-obs-thumb {
+.hk-scrollbar-thumb {
   position: absolute;
-  right: 2px;
-  width: var(--hi-scroll-thumb, 4px);
-  min-height: var(--hi-scroll-thumb-min, 20px);
-  border-radius: var(--hi-radius-full, 9999px);
-  background: rgb(255 255 255 / 25%);
-  cursor: pointer;
-  transition: width var(--hi-duration-short, 0.15s),
-              background var(--hi-duration-short, 0.15s);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--hi-color-muted) 35%, transparent);
+  transition: background var(--hi-duration-fast, 0.15s) ease;
 
-  &:hover {
-    width: var(--hi-scroll-thumb-hover, 6px);
-    background: rgb(255 255 255 / 45%);
-  }
-
-  &:active {
-    background: rgb(255 255 255 / 55%);
+  .is-hovering &,
+  &.is-dragging {
+    background: color-mix(in srgb, var(--hi-color-muted) 55%, transparent);
   }
 }
 
-// Horizontal scrollbar track
-.hk-obs-track-horizontal {
-  position: absolute;
-  left: var(--hi-scroll-inset, 4px);
-  right: var(--hi-scroll-inset, 4px);
-  bottom: var(--hi-scroll-inset, 4px);
-  height: var(--hi-scroll-size, 8px);
-  pointer-events: none;
-  z-index: var(--hi-z-floating, 50);
-  opacity: 0;
-  transition: height var(--hi-duration-short, 0.15s), opacity var(--hi-duration-short, 0.15s);
-
-  &:hover,
-  &.hk-obs-active {
-    height: var(--hi-scroll-size-hover, 14px);
-    opacity: 1;
-    pointer-events: auto;
-  }
+.hk-scrollbar-track[data-axis="horizontal"] .hk-scrollbar-thumb {
+  top: 0;
+  left: 0;
+  height: 100%;
+  min-width: 20px;
 }
 
-.hk-obs-thumb-horizontal {
-  position: absolute;
-  bottom: 2px;
-  height: var(--hi-scroll-thumb, 4px);
-  min-width: var(--hi-scroll-thumb-min, 20px);
-  border-radius: var(--hi-radius-full, 9999px);
-  background: rgb(255 255 255 / 25%);
-  cursor: pointer;
-  transition: height var(--hi-duration-short, 0.15s), background var(--hi-duration-short, 0.15s);
-
-  &:hover {
-    height: var(--hi-scroll-thumb-hover, 6px);
-    background: rgb(255 255 255 / 45%);
-  }
+.hk-scrollbar-track:not([data-axis="horizontal"]) .hk-scrollbar-thumb {
+  top: 0;
+  left: 0;
+  width: 100%;
+  min-height: 20px;
 }

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -152,6 +152,16 @@
   }
 }
 
+/* Track host for the body's overlay scrollbar — owns the flex slot in
+   the panel column so the rail hugs the BODY band, not header/footer. */
+.hk-drawer-body-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
 .hk-drawer-body {
   flex: 1;
   min-height: 0;
@@ -161,17 +171,12 @@
      left edge. */
   padding: var(--hk-drawer-body-padding, var(--hi-space-16, 1rem));
 
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
   &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--hi-color-border, rgba(0, 0, 0, 0.12));
-    border-radius: 3px;
+    display: none;
   }
 }
 

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -1,6 +1,7 @@
 import {
   computed,
   defineComponent,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -16,6 +17,7 @@ import { focusFirst, trapFocus } from "../utils/dom";
 import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 
 type DrawerSide = "left" | "right" | "top" | "bottom";
 
@@ -60,8 +62,42 @@ export default defineComponent({
 
     const handle = ref<{ id: string; zIndex: number } | null>(null);
     const panelRef = ref<HTMLElement>();
+    const bodyRef = ref<HTMLElement>();
+    // Positioned wrapper that contains ONLY the scrolling body — the
+    // overlay rail's host (see the attach call below).
+    const bodyWrapRef = ref<HTMLElement>();
     let unmounted = false;
     let previouslyFocused: HTMLElement | null = null;
+
+    // Overlay scrollbar on the scrolling body (shared chrome). The body
+    // mounts with the panel and survives the leave transition; attach
+    // after the DOM lands, detach on close/unmount so nothing leaks in
+    // the Teleport portal.
+    let bodyScrollbar: OverlayScrollbarHandle | null = null;
+
+    function detachBodyScrollbar(): void {
+      bodyScrollbar?.detach();
+      bodyScrollbar = null;
+    }
+
+    watch(() => props.modelValue, (open) => {
+      if (unmounted) return;
+      if (open) {
+        void nextTick(() => {
+          if (!props.modelValue || !bodyRef.value) return;
+          detachBodyScrollbar();
+          // The wrapper (not the panel) is the track host: the panel also
+          // contains the header/footer bands, and rails spanning those
+          // would light up in the wrong place.
+          bodyScrollbar = attachOverlayScrollbars(bodyRef.value, {
+            axis: "vertical",
+            host: bodyWrapRef.value,
+          });
+        });
+      } else {
+        detachBodyScrollbar();
+      }
+    });
 
     /**
      * Window-first back priority: while this drawer is the topmost open
@@ -167,6 +203,7 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       unmounted = true;
+      detachBodyScrollbar();
       backGuard.destroy();
       cleanup();
     });
@@ -226,7 +263,9 @@ export default defineComponent({
                   ) : null}
                 </div>
               ) : null}
-              <div class="hk-drawer-body">{slots.default?.()}</div>
+              <div ref={bodyWrapRef} class="hk-drawer-body-wrap">
+                <div ref={bodyRef} class="hk-drawer-body">{slots.default?.()}</div>
+              </div>
               {slots.footer ? (
                 <div class="hk-drawer-footer">{slots.footer()}</div>
               ) : null}

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -52,6 +52,12 @@
   }
 }
 
+/* Track host for the results list's overlay scrollbar — hugs the LIST
+   band only (the modal body also holds the search-input row). */
+.hk-kw-search-results-wrap {
+  position: relative;
+}
+
 .hk-kw-search-results {
   display: flex;
   flex-direction: column;
@@ -60,6 +66,13 @@
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0 var(--hi-space-2, 0.125rem);
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .hk-kw-search-result {

--- a/packages/vue/src/components/HkKeywordSearchModal.tsx
+++ b/packages/vue/src/components/HkKeywordSearchModal.tsx
@@ -1,10 +1,11 @@
-import { computed, defineComponent, ref, watch, type PropType } from "vue";
+import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch, type PropType } from "vue";
 
 import { useI18n } from "../i18n/context";
 
 import "./HkKeywordSearchModal.scss";
 import HModal from "./HkModal";
 import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 
 interface FuzzyMatch {
   matched: boolean;
@@ -160,6 +161,15 @@ export default defineComponent({
     }
 
     const resultsRef = ref<HTMLDivElement | null>(null);
+    // Positioned wrapper around ONLY the results list — the rail host.
+    const resultsWrapRef = ref<HTMLDivElement | null>(null);
+    let resultsScrollbar: OverlayScrollbarHandle | null = null;
+
+    onBeforeUnmount(() => {
+      resultsScrollbar?.detach();
+      resultsScrollbar = null;
+      debounceTimer?.disconnect();
+    });
 
     watch(debouncedQuery, (q) => {
       if (semanticActive.value) void runSemantic(q);
@@ -185,6 +195,23 @@ export default defineComponent({
           debouncedQuery.value = "";
           semanticResults.value = [];
           semanticLoading.value = false;
+          // The results list mounts with the modal body — attach the
+          // overlay scrollbar (shared chrome) once the DOM has landed;
+          // detach on close so nothing leaks in the modal portal.
+          void nextTick(() => {
+            if (!props.modelValue || !resultsRef.value) return;
+            resultsScrollbar?.detach();
+            // Exact host = the results wrapper (see the render): the
+            // broader modal body also holds the search-input row, and a
+            // rail spanning that would light up in the wrong place.
+            resultsScrollbar = attachOverlayScrollbars(resultsRef.value, {
+              axis: "vertical",
+              host: resultsWrapRef.value ?? undefined,
+            });
+          });
+        } else {
+          resultsScrollbar?.detach();
+          resultsScrollbar = null;
         }
       },
     );
@@ -251,7 +278,8 @@ export default defineComponent({
             )}
           </div>
 
-          <div class="hk-kw-search-results" ref={resultsRef}>
+          <div class="hk-kw-search-results-wrap" ref={resultsWrapRef}>
+            <div class="hk-kw-search-results" ref={resultsRef}>
             {semanticActive.value ? (
               semanticLoading.value && semanticResults.value.length === 0 ? (
                 <div class="hk-kw-search-empty">
@@ -308,6 +336,7 @@ export default defineComponent({
                 </button>
               ))
             )}
+            </div>
           </div>
         </div>
       </HModal>

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -106,10 +106,35 @@ afterEach(() => {
 });
 
 describe("HkLocalizedInput", () => {
-  it("shows the app-provided label plus code on the chip", () => {
+  it("shows only the language label on the chip, never the code", () => {
     const { container } = mountInput({ modelValue: "Plant overview" });
-    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(queryChip(container).textContent).toContain("English");
+    expect(queryChip(container).textContent).not.toContain("(en)");
     expect(queryField(container).value).toBe("Plant overview");
+  });
+
+  it("carries the locale code only in the opened menu rows", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    // The chip stays code-free while the menu is closed.
+    expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
+    await openMenu(container);
+    const labels = menuRows().map((r) => r.textContent ?? "");
+    // Switch-level rows read "label (code)".
+    expect(labels.some((l) => l.includes("简体中文 (zh-Hans)"))).toBe(true);
+    // "Add language" cascade children carry the code too.
+    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
+    addRow!.click();
+    await nextTick();
+    await nextTick();
+    const childLabels = menuRows().map((r) => r.textContent ?? "");
+    expect(childLabels.some((l) => l.includes("日本語 (ja)"))).toBe(true);
+    // Filled languages are not offered in the add cascade.
+    expect(childLabels.some((l) => l.includes("English (en)"))).toBe(false);
+    // The chip STILL shows no code while the menu is open.
+    expect(queryChip(container).textContent).not.toContain("(");
   });
 
   it("commits the edited text into translations on every input", async () => {
@@ -158,7 +183,8 @@ describe("HkLocalizedInput", () => {
     expect(events.modelValue.at(-1)).toBe("工厂总览");
     expect(events.languagechange.at(-1)).toBe("zh-Hans");
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
-    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+    expect(queryChip(container).textContent).toContain("简体中文");
+    expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
     // Menu closed after the switch.
     expect(menuRows().length).toBe(0);
   });
@@ -183,7 +209,8 @@ describe("HkLocalizedInput", () => {
     expect(events.modelValue.at(-1)).toBe("");
     expect(events.languagechange.at(-1)).toBe("ja");
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
-    expect(queryChip(container).textContent).toContain("日本語 (ja)");
+    expect(queryChip(container).textContent).toContain("日本語");
+    expect(queryChip(container).textContent).not.toContain("(ja)");
     expect(menuRows().length).toBe(0);
   });
 
@@ -339,7 +366,7 @@ describe("HkLocalizedInput", () => {
     const dangerLabels = menuRows()
       .filter((r) => r.hasAttribute("data-danger"))
       .map((r) => r.querySelector(".hk-menu-label")?.textContent ?? "");
-    expect(dangerLabels).toEqual(expect.arrayContaining(["English", "简体中文"]));
+    expect(dangerLabels).toEqual(expect.arrayContaining(["English (en)", "简体中文 (zh-Hans)"]));
   });
 
   it("deletes a non-current language and keeps the edit state untouched", async () => {
@@ -354,7 +381,8 @@ describe("HkLocalizedInput", () => {
     expect(events.modelValue).toEqual([]);
     expect(events.languagechange).toEqual([]);
     expect(queryField(container).value).toBe("Plant overview");
-    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(queryChip(container).textContent).toContain("English");
+    expect(queryChip(container).textContent).not.toContain("(en)");
     expect(menuRows().length).toBe(0);
   });
 
@@ -371,14 +399,16 @@ describe("HkLocalizedInput", () => {
     row!.click();
     await nextTick();
     await nextTick();
-    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+    expect(queryChip(container).textContent).toContain("简体中文");
+    expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
     await openMenu(container);
     await clickDeleteRow("简体中文");
     await nextTick();
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(events.modelValue.at(-1)).toBe("Plant overview");
     expect(events.languagechange.at(-1)).toBe("en");
-    expect(queryChip(container).textContent).toContain("English (en)");
+    expect(queryChip(container).textContent).toContain("English");
+    expect(queryChip(container).textContent).not.toContain("(en)");
     expect(menuRows().length).toBe(0);
     expect(document.activeElement).toBe(queryField(container));
   });
@@ -394,7 +424,8 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)).toEqual({ "zh-Hans": "工厂总览" });
     expect(events.modelValue.at(-1)).toBe("工厂总览");
     expect(events.languagechange.at(-1)).toBe("zh-Hans");
-    expect(queryChip(container).textContent).toContain("简体中文 (zh-Hans)");
+    expect(queryChip(container).textContent).toContain("简体中文");
+    expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
   });
 
   it("deletes the last translation and empties the field", async () => {

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -13,8 +13,9 @@ import "./HkLocalizedInput.scss";
 export interface HkLocaleOption {
   code: string;
   /** Display label — apps pass the SAME text their global language
-   *  switcher shows (e.g. the autonym "简体中文" / "English"), so the
-   *  chip and the system picker never disagree. */
+   *  switcher shows (e.g. the autonym "简体中文" / "English"). The chip
+   *  renders the bare label; menu rows render the label plus the
+   *  parenthesized code, so the code lives only in the opened menu. */
   label: string;
   /** Optional flag glyph rendered in the menu rows, matching the app's
    *  language switcher rows when they carry one. */
@@ -54,8 +55,10 @@ const DELETE_LANGUAGE_KEY = "__hkLocalizedInputDelete";
  *         holds a translation, else to the first remaining translation
  *         (or `sourceLang` itself once the map is empty).
  *
- * The chip label is `{label} ({code})` using the app-provided label, and
- * the popup participates in the shared modal/dropdown stacking contexts
+ * The chip shows ONLY the language label (the app-provided autonym,
+ * e.g. "简体中文"); the locale code appears ONLY in the opened menu rows
+ * ("简体中文 (zh-Hans)") so the code never burns space inside the field.
+ * The popup participates in the shared modal/dropdown stacking contexts
  * via HkMenu's popup-manager integration — safe inside modals.
  *
  * Contract:
@@ -130,10 +133,14 @@ export const HkLocalizedInput = defineComponent({
       return props.localeOptions.find((o) => o.code === code)?.label ?? code;
     }
 
-    /** Chip text: app label + parenthesized code, e.g. "English (en)". */
-    const chipLabel = computed(
-      () => `${localeLabel(editLang.value)} (${editLang.value})`,
-    );
+    /** Chip text: the bare language label, e.g. "English" — the locale
+     *  code appears only in the menu rows. */
+    const chipLabel = computed(() => localeLabel(editLang.value));
+
+    /** Menu-row text: label + parenthesized code, e.g. "English (en)". */
+    function menuLabel(code: string): string {
+      return `${localeLabel(code)} (${code})`;
+    }
 
     /** Languages with an existing translation, excluding the one being
      *  edited — those are the switch targets in the menu's first level. */
@@ -159,7 +166,7 @@ export const HkLocalizedInput = defineComponent({
     const menuItems = computed<HkMenuItem[]>(() => [
       ...switchableCodes.value.map((code) => ({
         key: code,
-        label: localeLabel(code),
+        label: menuLabel(code),
         flag: props.localeOptions.find((o) => o.code === code)?.flag,
       })),
       ...(addableOptions.value.length > 0
@@ -169,7 +176,7 @@ export const HkLocalizedInput = defineComponent({
               label: t("hikari::localizedInput.addLanguage", "Add language"),
               children: addableOptions.value.map((o) => ({
                 key: o.code,
-                label: o.label,
+                label: menuLabel(o.code),
                 flag: o.flag,
               })),
             },
@@ -186,7 +193,7 @@ export const HkLocalizedInput = defineComponent({
               danger: true,
               children: filledCodes.value.map((code) => ({
                 key: deleteKey(code),
-                label: localeLabel(code),
+                label: menuLabel(code),
                 flag: props.localeOptions.find((o) => o.code === code)?.flag,
                 danger: true,
               })),

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -74,13 +74,16 @@
 }
 
 .s-log-viewer-scroll {
+  /* HScrollContainer root: the VIEWPORT child is the scroller (overlay
+     chrome, native bar hidden) — the root itself must never scroll, so
+     no overflow-y here (the stale `auto` this class used to carry would
+     read as a second, native scroll region). */
   flex: 1;
   min-height: 0;
   padding: var(--space-8, 0.5rem);
   border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
   border-radius: var(--radius-md, 8px);
   background: rgb(var(--color-background) / 0.5);
-  overflow-y: auto;
 }
 
 .s-log-empty {

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -43,6 +43,15 @@
   border-radius: 3px;
 }
 
+/* Track host for the code block's horizontal overlay rail — emitted in
+   the generated markup (see renderMarkdown) so the rail hugs the BLOCK
+   instead of spanning the whole markdown body. Deliberately unstyled
+   beyond positioning: no padding/border/overflow means the block's own
+   vertical margins still collapse through it exactly as before. */
+.hk-md-code-wrap {
+  position: relative;
+}
+
 .hk-md-code {
   position: relative;
   margin: 0.75em 0;
@@ -54,6 +63,14 @@
   cursor: pointer;
   overflow-x: auto;
   background: var(--hi-color-bg-subtle, #0d1117);
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .hk-md-code pre {

--- a/packages/vue/src/components/HkMarkdownRenderer.tsx
+++ b/packages/vue/src/components/HkMarkdownRenderer.tsx
@@ -1,5 +1,6 @@
-import { computed, defineComponent, ref, watch } from "vue";
+import { computed, defineComponent, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import HSpinner from "./HkSpinner";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import "./HkMarkdownRenderer.scss";
 
 let _marked: any = null;
@@ -66,7 +67,7 @@ async function renderMarkdown(content: string): Promise<string> {
     const highlighted = tryHighlight(tok.text, tok.lang);
     const langAttr = tok.lang ? ` language-${tok.lang}` : "";
     const langLabel = tok.lang ? `<span class="hk-md-code-lang">${tok.lang}</span>` : "";
-    return `<div class="hk-md-code">${langLabel}<pre><code class="hljs${langAttr}">${highlighted}</code></pre></div>`;
+    return `<div class="hk-md-code-wrap"><div class="hk-md-code">${langLabel}<pre><code class="hljs${langAttr}">${highlighted}</code></pre></div></div>`;
   };
 
   const raw = marked.parse(content, { renderer, async: false });
@@ -109,9 +110,38 @@ export default defineComponent({
       { immediate: true },
     );
 
+    // Overlay scrollbars (shared chrome) on markdown code blocks. The
+    // body is innerHTML-rendered and fully replaced on every parse, so
+    // the attachment set is reconciled after each render pass: handles
+    // whose block left the DOM detach, fresh blocks attach.
+    const bodyRef = ref<HTMLElement>();
+    const codeScrollbars: Array<{ el: HTMLElement; handle: OverlayScrollbarHandle }> = [];
+
+    function syncCodeScrollbars() {
+      for (let i = codeScrollbars.length - 1; i >= 0; i--) {
+        if (!codeScrollbars[i].el.isConnected) {
+          codeScrollbars[i].handle.detach();
+          codeScrollbars.splice(i, 1);
+        }
+      }
+      for (const el of bodyRef.value?.querySelectorAll<HTMLElement>(".hk-md-code") ?? []) {
+        if (codeScrollbars.some((c) => c.el === el)) continue;
+        codeScrollbars.push({ el, handle: attachOverlayScrollbars(el, { axis: "horizontal" }) });
+      }
+    }
+
+    watch(renderedHtml, () => {
+      void nextTick(syncCodeScrollbars);
+    });
+
+    onBeforeUnmount(() => {
+      for (const c of codeScrollbars) c.handle.detach();
+      codeScrollbars.length = 0;
+    });
+
     return () => (
       <div class="hk-markdown" data-plain={props.plain || undefined} data-loading={props.loading}>
-        <div class="hk-markdown-body" innerHTML={renderedHtml.value} />
+        <div ref={bodyRef} class="hk-markdown-body" innerHTML={renderedHtml.value} />
         {props.loading && (
           <div class="hk-markdown-overlay">
             <HSpinner center />

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -119,6 +119,13 @@ function popouts(): HTMLElement[] {
   return Array.from(document.querySelectorAll(".hk-select-popout")) as HTMLElement[];
 }
 
+/** Fixed positioning wrappers around the popouts — the element that
+ *  carries the inline coords + z-index (and hosts the overlay scrollbar
+ *  tracks) since the popout teleports to body. */
+function popoutHosts(): HTMLElement[] {
+  return Array.from(document.querySelectorAll(".hk-select-popout-host")) as HTMLElement[];
+}
+
 function sheets(): HTMLElement[] {
   return Array.from(document.querySelectorAll(".hk-select-sheet-panel")) as HTMLElement[];
 }
@@ -319,14 +326,14 @@ describe("HkMenu on the HkSelectPanel surface", () => {
       ({ top: 10, bottom: 30, left: 40, right: 140, width: 100, height: 20 }) as DOMRect;
     window.dispatchEvent(new Event("resize"));
     await settle();
-    expect(popouts()[0].style.minWidth).toBe("100px");
+    expect(popoutHosts()[0].style.minWidth).toBe("100px");
     first.unmount();
     await settle();
 
     // Default: shrink-to-fit, no anchor width forced.
     mountMenu(ref(true), items);
     await settle();
-    expect(popouts()[0].style.minWidth).toBe("");
+    expect(popoutHosts()[0].style.minWidth).toBe("");
   });
 });
 

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -215,27 +215,12 @@
   overflow-y: auto;
   overflow-x: hidden;
 
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
   &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(
-      --hk-modal-scrollbar-thumb,
-      var(--hi-color-border, rgba(0, 0, 0, 0.12))
-    );
-    border-radius: 3px;
-
-    &:hover {
-      background: var(
-        --hi-color-text-secondary,
-        rgba(0, 0, 0, 0.3)
-      );
-    }
+    display: none;
   }
 }
 

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -1,6 +1,7 @@
 import {
   computed,
   defineComponent,
+  nextTick,
   onBeforeUnmount,
   onMounted,
   ref,
@@ -18,6 +19,7 @@ import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
 import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import HButton from "./HkButton";
 import HFab from "./HkFab";
 import HSpinner from "./HkSpinner";
@@ -430,6 +432,29 @@ export default defineComponent({
 
     // --- Lifecycle ---
 
+    // Overlay scrollbar on the scrolling body (shared chrome). The body
+    // mounts with the modal surface (shouldRender) and survives through
+    // the leave transition; attach after the DOM lands, detach on close
+    // and unmount so nothing leaks inside the Teleport portal.
+    let bodyScrollbar: OverlayScrollbarHandle | null = null;
+
+    function detachBodyScrollbar(): void {
+      bodyScrollbar?.detach();
+      bodyScrollbar = null;
+    }
+
+    watch(shouldRender, (render) => {
+      if (render) {
+        void nextTick(() => {
+          if (!shouldRender.value || !scrollContainerRef.value) return;
+          detachBodyScrollbar();
+          bodyScrollbar = attachOverlayScrollbars(scrollContainerRef.value, { axis: "vertical" });
+        });
+      } else {
+        detachBodyScrollbar();
+      }
+    });
+
     watch(
       () => props.modelValue,
       (val) => {
@@ -483,6 +508,7 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       unmounted = true;
+      detachBodyScrollbar();
       teardownWindowed();
       teardownAutoFollow();
       backGuard.destroy();

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -129,6 +129,14 @@
    * --hk-sheet-footer-gap for its action buttons); this sheet has no
    * footer, so this is the family baseline. */
   padding-bottom: calc(var(--space-12, 0.75rem) + env(safe-area-inset-bottom, 0px));
+
+  /* Overlay scrollbar (useOverlayScrollbar, sheet mode only) — the
+     native chrome is hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .hk-popover-sheet-grabber {

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -16,6 +16,7 @@ import {
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useBreakpoint } from "../runtime/useBreakpoint";
 import { useReportedTransition } from "../composables/useReportedTransition";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { onceFrame } from "../runtime/animationBus";
 import "./HkPopover.scss";
 
@@ -293,11 +294,24 @@ export default defineComponent({
 
     function fullCleanup() {
       cleanup();
+      detachPanelScrollbar();
       coords.value = {};
     }
 
     function onPopupAfterLeave() {
       fullCleanup();
+    }
+
+    // Overlay scrollbar (shared chrome) — only the mobile sheet scrolls
+    // its panel; the fixed positioning wrapper rendered around the panel
+    // (panelHostRef) hosts the tracks, since the panel's own parent is
+    // the teleported body.
+    const panelHostRef = ref<HTMLElement>();
+    let panelScrollbar: OverlayScrollbarHandle | null = null;
+
+    function detachPanelScrollbar(): void {
+      panelScrollbar?.detach();
+      panelScrollbar = null;
     }
 
     watch(
@@ -319,7 +333,19 @@ export default defineComponent({
           if (sheetMode.value) {
             // Bottom sheet: nothing to anchor-measure; the scrim handles
             // dismissal (the outside-click shield is desktop-only).
-            nextTick(() => { panelRef.value?.focus?.(); });
+            nextTick(() => {
+              panelRef.value?.focus?.();
+              // The sheet mounts on this render — attach the overlay
+              // once the DOM has landed (sheet panels scroll; desktop
+              // popovers size to content and need none).
+              if (props.modelValue && sheetMode.value && panelRef.value) {
+                detachPanelScrollbar();
+                panelScrollbar = attachOverlayScrollbars(panelRef.value, {
+                  axis: "vertical",
+                  host: panelHostRef.value,
+                });
+              }
+            });
           } else {
             computeInitialCoords();
             attachObservers();
@@ -358,6 +384,9 @@ export default defineComponent({
     function onDocumentClick(e: MouseEvent) {
       if (!props.closeOnBackdrop || !props.modelValue) return;
       const target = e.target as Node;
+      // panelHostRef wraps the panel AND the overlay scrollbar tracks —
+      // scrolling through the custom bar must not count as a backdrop click.
+      if (panelHostRef.value?.contains(target)) return;
       if (panelRef.value?.contains(target)) return;
       if (props.anchorRef?.contains(target)) return;
       close();
@@ -434,29 +463,30 @@ export default defineComponent({
           onAfterLeave={() => { animBus.cancel(); onPopupAfterLeave(); }}
         >
           {props.modelValue ? (
-            <div
-              ref={panelRef}
-              class={[
-                "hk-popover-panel",
-                ...(sheetMode.value ? ["hk-is-sheet"] : [`hk-popover-${resolvedPlacement.value}`]),
-                props.glass ? "hii-dropdown-content" : "",
-                ...(typeof attrs.class === "string" ? [attrs.class]
-                  : Array.isArray(attrs.class) ? attrs.class as string[]
-                  : attrs.class && typeof attrs.class === "object"
-                    ? Object.entries(attrs.class as Record<string, unknown>)
-                        .filter(([, v]) => v).map(([k]) => k)
-                  : []),
-              ]}
-              style={panelStyle.value}
-              role="dialog"
-              aria-modal={sheetMode.value ? "true" : undefined}
-              tabindex={sheetMode.value ? "-1" : undefined}
-              onKeydown={onPanelKeydown}
-            >
-              {sheetMode.value && (
-                <div class="hk-popover-sheet-grabber" aria-hidden="true" onClick={() => close()} />
-              )}
-              {slots.default?.()}
+            <div ref={panelHostRef} style={panelStyle.value}>
+              <div
+                ref={panelRef}
+                class={[
+                  "hk-popover-panel",
+                  ...(sheetMode.value ? ["hk-is-sheet"] : [`hk-popover-${resolvedPlacement.value}`]),
+                  props.glass ? "hii-dropdown-content" : "",
+                  ...(typeof attrs.class === "string" ? [attrs.class]
+                    : Array.isArray(attrs.class) ? attrs.class as string[]
+                    : attrs.class && typeof attrs.class === "object"
+                      ? Object.entries(attrs.class as Record<string, unknown>)
+                          .filter(([, v]) => v).map(([k]) => k)
+                      : []),
+                ]}
+                role="dialog"
+                aria-modal={sheetMode.value ? "true" : undefined}
+                tabindex={sheetMode.value ? "-1" : undefined}
+                onKeydown={onPanelKeydown}
+              >
+                {sheetMode.value && (
+                  <div class="hk-popover-sheet-grabber" aria-hidden="true" onClick={() => close()} />
+                )}
+                {slots.default?.()}
+              </div>
             </div>
           ) : null}
         </Transition>

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -99,29 +99,13 @@
   overflow: hidden;
 }
 
-/* The viewport is an HkScrollContainer; items live in its inner scroller,
- * whose default hides the bar — a themed thin bar beats the native chrome. */
+/* The viewport is an HkScrollContainer: its overlay scrollbar (the shared
+ * chrome in theme/_scrollbar.scss) draws the bar — no native styling here. */
 .hk-popup-select-viewport .hk-scroll-container-viewport {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
   padding: var(--space-2);
-  scrollbar-width: thin !important;
-  scrollbar-color: rgb(var(--color-border) / 45%) transparent;
-
-  &::-webkit-scrollbar {
-    display: block !important;
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: rgb(var(--color-border) / 45%);
-    border-radius: 3px;
-  }
 }
 
 .hk-popup-select-item {

--- a/packages/vue/src/components/HkProgressDialog.scss
+++ b/packages/vue/src/components/HkProgressDialog.scss
@@ -1,0 +1,29 @@
+// HkProgressDialog.scss — the log pane's chrome. Inline styles cannot
+// carry the `::-webkit-scrollbar` half of the native-bar hide, so the
+// pane's visual block lives here like every other overlay-scroll
+// consumer (see packages/theme/styles/_scrollbar.scss).
+/* Track host: wraps ONLY the log pane so the rail hugs the log band,
+   not the spinner/progress bands above it. */
+.s-progress-dialog-log-wrap {
+  position: relative;
+}
+
+.s-progress-dialog-log {
+  max-height: 10rem;
+  overflow: hidden auto;
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     always hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  border-radius: 0.375rem;
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0.5rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}

--- a/packages/vue/src/components/HkProgressDialog.tsx
+++ b/packages/vue/src/components/HkProgressDialog.tsx
@@ -1,25 +1,53 @@
-import { defineComponent, nextTick, ref, watch } from "vue";
+import { defineComponent, nextTick, onBeforeUnmount, ref, watch } from "vue";
 
 import { useProgressDialog } from "../composables/useProgressDialog";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import HModal from "./HkModal";
 import HProgressBar from "./HkProgressBar";
 import HSpinner from "./HkSpinner";
+import "./HkProgressDialog.scss";
 
 export default defineComponent({
   name: "HkProgressDialog",
   setup() {
     const state = useProgressDialog();
     const logRef = ref<HTMLElement>();
+    // Positioned wrapper around the conditional log pane — the rail host
+    // (the modal body also holds the spinner/progress bands).
+    const logWrapRef = ref<HTMLElement>();
+    // Overlay scrollbar (shared chrome) on the conditional log pane —
+    // attached when it mounts, detached when it unmounts.
+    let logScrollbar: OverlayScrollbarHandle | null = null;
+
+    function syncLogScrollbar() {
+      void nextTick(() => {
+        if (logRef.value) {
+          logScrollbar ??= attachOverlayScrollbars(logRef.value, {
+            axis: "vertical",
+            host: logWrapRef.value,
+          });
+        } else {
+          logScrollbar?.detach();
+          logScrollbar = null;
+        }
+      });
+    }
 
     watch(
       () => state.logs.length,
       () => {
+        syncLogScrollbar();
         nextTick(() => {
           const el = logRef.value;
           if (el) el.scrollTop = el.scrollHeight;
         });
       },
     );
+
+    onBeforeUnmount(() => {
+      logScrollbar?.detach();
+      logScrollbar = null;
+    });
 
     return () => (
       <HModal
@@ -40,24 +68,14 @@ export default defineComponent({
             </div>
           )}
           {state.logs.length > 0 ? (
-            <div
-              ref={logRef}
-              style={{
-                maxHeight: "10rem",
-                overflow: "hidden auto",
-                borderRadius: "0.375rem",
-                background: "rgba(0, 0, 0, 0.06)",
-                padding: "0.5rem",
-                fontFamily: "monospace",
-                fontSize: "0.75rem",
-                lineHeight: "1.5",
-              }}
-            >
-              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
-                {state.logs.map((line, i) => (
-                  <li key={i}>{line}</li>
-                ))}
-              </ul>
+            <div ref={logWrapRef} class="s-progress-dialog-log-wrap">
+              <div ref={logRef} class="s-progress-dialog-log">
+                <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                  {state.logs.map((line, i) => (
+                    <li key={i}>{line}</li>
+                  ))}
+                </ul>
+              </div>
             </div>
           ) : null}
         </div>

--- a/packages/vue/src/components/HkProtocolModal.scss
+++ b/packages/vue/src/components/HkProtocolModal.scss
@@ -13,3 +13,14 @@
   color: rgb(var(--color-success));
   font-size: var(--text-xs, 0.75rem);
 }
+
+/* With `bodyHeight` set the body becomes its own scroll region (nested
+ * inside HkModal's body scroller) — overlay chrome only. */
+.s-protocol-modal {
+  overflow-y: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/packages/vue/src/components/HkProtocolModal.tsx
+++ b/packages/vue/src/components/HkProtocolModal.tsx
@@ -1,7 +1,8 @@
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, onBeforeUnmount, ref, watch } from "vue";
 import { HMarkdownRenderer, HModal, useClipboard, type ModalAction } from "@celestia-island/hikari";
 
 import { useI18n } from "../i18n/context";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 
 import "./HkProtocolModal.scss";
 
@@ -62,6 +63,32 @@ export const HkProtocolModal = defineComponent({
       },
     ]);
 
+    // ── overlay scrollbar (shared chrome) ─────────────────────────
+    // With `bodyHeight` set the body becomes a height-capped scroll
+    // region NESTED inside HkModal's overlay-equipped body scroller —
+    // without the overlay it would be a surviving native bar (the exact
+    // double-scroll this library eliminates). Attach on mount, re-sync
+    // when the cap flips, detach on unmount.
+    const bodyRef = ref<HTMLElement | null>(null);
+    let bodyScrollbar: OverlayScrollbarHandle | null = null;
+    function syncBodyScrollbar(): void {
+      if (props.bodyHeight && bodyRef.value) {
+        if (!bodyScrollbar) bodyScrollbar = attachOverlayScrollbars(bodyRef.value);
+      } else {
+        bodyScrollbar?.detach();
+        bodyScrollbar = null;
+      }
+    }
+    function bindBodyRef(el: unknown): void {
+      bodyRef.value = (el as HTMLElement) ?? null;
+      syncBodyScrollbar();
+    }
+    watch(() => props.bodyHeight, () => syncBodyScrollbar());
+    onBeforeUnmount(() => {
+      bodyScrollbar?.detach();
+      bodyScrollbar = null;
+    });
+
     return () => (
       <HModal
         modelValue={props.modelValue}
@@ -72,8 +99,9 @@ export const HkProtocolModal = defineComponent({
         footerActions={footerActions.value}
       >
         <div
+          ref={bindBodyRef}
           class="s-protocol-modal"
-          style={props.bodyHeight ? { maxHeight: props.bodyHeight, overflowY: "auto" } : undefined}
+          style={props.bodyHeight ? { maxHeight: props.bodyHeight } : undefined}
         >
           {copied.value && <p class="s-protocol-modal-copied">{t("hikari::protocol.copied", "Copied")}</p>}
           <HMarkdownRenderer content={props.content} />

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -9,10 +9,10 @@
   flex: 1;
   min-height: 0;
   overflow: auto;
-  scrollbar-width: none !important;
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
-    display: none !important;
+    display: none;
   }
 }
 
@@ -113,56 +113,6 @@
   z-index: 11;
 }
 
-.hk-scrollbar-track {
-  position: absolute;
-  z-index: 10;
-  background: transparent;
-  pointer-events: auto;
-  opacity: 0;
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
-
-  &[data-axis="horizontal"] {
-    left: 4px;
-    right: 4px;
-    bottom: 2px;
-    height: 6px;
-  }
-
-  &:not([data-axis="horizontal"]) {
-    top: 4px;
-    bottom: 4px;
-    right: 2px;
-    width: 6px;
-  }
-
-  &.is-scrolling,
-  &.is-hovering {
-    opacity: 1;
-  }
-}
-
-.hk-scrollbar-thumb {
-  position: absolute;
-  border-radius: 3px;
-  background: color-mix(in srgb, var(--hi-color-muted) 35%, transparent);
-  transition: background var(--hi-duration-fast, 0.15s) ease;
-
-  .is-hovering &,
-  &.is-dragging {
-    background: color-mix(in srgb, var(--hi-color-muted) 55%, transparent);
-  }
-}
-
-.hk-scrollbar-track[data-axis="horizontal"] .hk-scrollbar-thumb {
-  top: 0;
-  left: 0;
-  height: 100%;
-  min-width: 20px;
-}
-
-.hk-scrollbar-track:not([data-axis="horizontal"]) .hk-scrollbar-thumb {
-  top: 0;
-  left: 0;
-  width: 100%;
-  min-height: 20px;
-}
+// The overlay track/thumb chrome (.hk-scrollbar-track / .hk-scrollbar-thumb)
+// moved to packages/theme/styles/_scrollbar.scss — the single shared set used
+// by every scroll region (see composables/useOverlayScrollbar.ts).

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -11,33 +11,15 @@ import {
 
 import { useI18n } from "../i18n/context";
 import "./HkScrollContainer.scss";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { provideScrollWindow } from "../composables/useScrollWindow";
-import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
-import { notifyScrollStart, onceFrame, scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
+import { scheduleFrame, notifyScrollStart, onceFrame, type AnimationHandle } from "../runtime/animationBus";
 import HFab from "./HkFab";
 
 type ScrollAxis = "vertical" | "horizontal" | "both";
 type ScrollMode = "traditional" | "windowed";
 type ScrollAlign = "start" | "center";
 type OverflowSense = "none" | "start" | "end" | "both";
-
-interface AxisState {
-  track: HTMLElement;
-  thumb: HTMLElement;
-  dragging: boolean;
-  dragStartClient: number;
-  dragStartScroll: number;
-  hideTimer: CronHandle;
-}
-
-interface DragHandlers {
-  onDown: (e: MouseEvent) => void;
-  onMove: (e: MouseEvent) => void;
-  onUp: () => void;
-  onTrackClick: (e: MouseEvent) => void;
-  onEnter: () => void;
-  onLeave: () => void;
-}
 
 /** Which edges of an axis still hide content, derived from live scroll
  *  geometry. "end" = content continues past the end edge (can scroll
@@ -83,12 +65,12 @@ export default defineComponent({
   setup(props, { slots, expose }) {
     const { t } = useI18n();
     const viewportRef = ref<HTMLElement>();
-    let ro: ResizeObserver;
+    let ro: ResizeObserver | null = null;
     let scheduled: AnimationHandle | null = null;
-    let vState: AxisState | null = null;
-    let hState: AxisState | null = null;
-    let vDrag: DragHandlers | null = null;
-    let hDrag: DragHandlers | null = null;
+    // Overlay track/thumb machinery lives in the shared composable;
+    // this component keeps overflow sensing, autoFollow, the aligner,
+    // fade, windowed mode and the scrollbar opt-in.
+    let overlay: OverlayScrollbarHandle | null = null;
 
     // Sensed overflow mirrored onto the root as data-h-overflow /
     // data-v-overflow so consumers can style edge affordances in pure
@@ -142,8 +124,11 @@ export default defineComponent({
       }
     }
 
-    watch(() => [props.align, props.axis] as const, () => {
+    watch(() => [props.align, props.axis] as const, ([, axis], [, prevAxis]) => {
       syncAlignObserver();
+      // Follow an axis change at runtime by rebuilding the overlay
+      // tracks so the enabled axes stay in sync with the viewport.
+      if (axis !== prevAxis && props.scrollbar) mountScrollbars();
       scheduleUpdate();
     }, { flush: "post" });
 
@@ -151,31 +136,15 @@ export default defineComponent({
     function mountScrollbars() {
       const vp = viewportRef.value;
       if (!vp) return;
-      const containerEl = vp.parentElement;
-      if (!containerEl) return;
-      if (hasV()) {
-        vState = makeState(false);
-        containerEl.appendChild(vState.track);
-        vDrag = makeDragHandlers(vState, false);
-        attachAxis(vState, vDrag);
-      }
-      if (hasH()) {
-        hState = makeState(true);
-        containerEl.appendChild(hState.track);
-        hDrag = makeDragHandlers(hState, true);
-        attachAxis(hState, hDrag);
-      }
+      overlay?.detach();
+      overlay = attachOverlayScrollbars(vp, { axis: props.axis });
     }
 
     /** Tear down and rebuild the overlay tracks when the `scrollbar`
      *  opt-in flips at runtime (HkTabs passes the prop through). */
     watch(() => props.scrollbar, (on) => {
-      detachAxis(vState, vDrag);
-      detachAxis(hState, hDrag);
-      vState = null;
-      hState = null;
-      vDrag = null;
-      hDrag = null;
+      overlay?.detach();
+      overlay = null;
       if (on) {
         mountScrollbars();
         update();
@@ -222,23 +191,6 @@ export default defineComponent({
       settleHandle = scheduleFrame(runSettleFrame);
     }
 
-    function makeState(horizontal: boolean): AxisState {
-      const track = document.createElement("div");
-      track.className = "hk-scrollbar-track";
-      if (horizontal) track.setAttribute("data-axis", "horizontal");
-      const thumb = document.createElement("div");
-      thumb.className = "hk-scrollbar-thumb";
-      track.appendChild(thumb);
-      return {
-        track,
-        thumb,
-        dragging: false,
-        dragStartClient: 0,
-        dragStartScroll: 0,
-        hideTimer: undefined as unknown as CronHandle,
-      };
-    }
-
     function scheduleUpdate() {
       scheduled?.disconnect();
       scheduled = scheduleFrame(() => {
@@ -247,11 +199,13 @@ export default defineComponent({
       });
     }
 
+    /** Component-side sensing pass: mirror the live scroll geometry
+     *  onto the root as data-h-overflow / data-v-overflow. The overlay
+     *  thumb geometry is the composable's job (it listens to scroll
+     *  and resizes itself). */
     function update() {
       const vp = viewportRef.value;
       if (!vp) return;
-      if (vState) updateAxis(vp, vState, false);
-      if (hState) updateAxis(vp, hState, true);
       senseOverflow(vp);
     }
 
@@ -273,43 +227,10 @@ export default defineComponent({
       }
     }
 
-    function updateAxis(vp: HTMLElement, s: AxisState, horizontal: boolean) {
-      const scrollSize = horizontal ? vp.scrollWidth : vp.scrollHeight;
-      const clientSize = horizontal ? vp.clientWidth : vp.clientHeight;
-      const scrollPos = horizontal ? vp.scrollLeft : vp.scrollTop;
-      if (scrollSize <= clientSize) {
-        s.track.style.display = "none";
-        return;
-      }
-      s.track.style.display = "";
-      const trackSize = horizontal ? s.track.clientWidth : s.track.clientHeight;
-      const ratio = clientSize / scrollSize;
-      const thumbSize = Math.max(ratio * trackSize, 20);
-      const maxScroll = scrollSize - clientSize;
-      const maxTrack = trackSize - thumbSize;
-      const offset = maxScroll > 0 ? (scrollPos / maxScroll) * maxTrack : 0;
-      if (horizontal) {
-        s.thumb.style.width = `${thumbSize}px`;
-        s.thumb.style.transform = `translateX(${offset}px)`;
-      } else {
-        s.thumb.style.height = `${thumbSize}px`;
-        s.thumb.style.transform = `translateY(${offset}px)`;
-      }
-    }
-
-    function flash(s: AxisState | null) {
-      if (!s) return;
-      s.track.classList.add("is-scrolling");
-      s.hideTimer?.disconnect();
-      s.hideTimer = scheduleCronAfter(() => s.track.classList.remove("is-scrolling"), 1200);
-    }
-
     function onScroll() {
       if (!viewportRef.value) return;
       scheduleUpdate();
       if (props.scrollbar) notifyScrollStart();
-      flash(vState);
-      flash(hState);
       if (props.autoFollow) recomputePinned();
     }
 
@@ -324,74 +245,6 @@ export default defineComponent({
       if (vp.scrollLeft !== prev) {
         e.preventDefault();
       }
-    }
-
-    function makeDragHandlers(s: AxisState, horizontal: boolean): DragHandlers {
-      const onDown = (e: MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const vp = viewportRef.value;
-        if (!vp) return;
-        s.dragging = true;
-        s.dragStartClient = horizontal ? e.clientX : e.clientY;
-        s.dragStartScroll = horizontal ? vp.scrollLeft : vp.scrollTop;
-        s.thumb.classList.add("is-dragging");
-        document.addEventListener("mousemove", onMove);
-        document.addEventListener("mouseup", onUp);
-      };
-      const onMove = (e: MouseEvent) => {
-        const vp = viewportRef.value;
-        if (!vp || !s.dragging) return;
-        const scrollSize = horizontal ? vp.scrollWidth : vp.scrollHeight;
-        const clientSize = horizontal ? vp.clientWidth : vp.clientHeight;
-        const delta = (horizontal ? e.clientX : e.clientY) - s.dragStartClient;
-        const thumbSize = Math.max((clientSize / scrollSize) * clientSize, 20);
-        const trackRange = clientSize - thumbSize;
-        if (trackRange <= 0) return;
-        const target = s.dragStartScroll + (delta / trackRange) * (scrollSize - clientSize);
-        if (horizontal) vp.scrollLeft = target;
-        else vp.scrollTop = target;
-      };
-      const onUp = () => {
-        s.dragging = false;
-        s.thumb.classList.remove("is-dragging");
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-      };
-      const onTrackClick = (e: MouseEvent) => {
-        if (e.target === s.thumb) return;
-        const vp = viewportRef.value;
-        if (!vp) return;
-        const rect = s.track.getBoundingClientRect();
-        const ratio = horizontal
-          ? (e.clientX - rect.left) / rect.width
-          : (e.clientY - rect.top) / rect.height;
-        const max = (horizontal ? vp.scrollWidth : vp.scrollHeight) - (horizontal ? vp.clientWidth : vp.clientHeight);
-        if (horizontal) vp.scrollLeft = ratio * max;
-        else vp.scrollTop = ratio * max;
-      };
-      const onEnter = () => s.track.classList.add("is-hovering");
-      const onLeave = () => s.track.classList.remove("is-hovering");
-      return { onDown, onMove, onUp, onTrackClick, onEnter, onLeave };
-    }
-
-    function attachAxis(s: AxisState, d: DragHandlers) {
-      s.thumb.addEventListener("mousedown", d.onDown);
-      s.track.addEventListener("click", d.onTrackClick);
-      s.track.addEventListener("mouseenter", d.onEnter);
-      s.track.addEventListener("mouseleave", d.onLeave);
-    }
-
-    function detachAxis(s: AxisState | null, d: DragHandlers | null) {
-      if (!s || !d) return;
-      s.thumb.removeEventListener("mousedown", d.onDown);
-      s.track.removeEventListener("click", d.onTrackClick);
-      s.track.removeEventListener("mouseenter", d.onEnter);
-      s.track.removeEventListener("mouseleave", d.onLeave);
-      document.removeEventListener("mousemove", d.onMove);
-      document.removeEventListener("mouseup", d.onUp);
-      s.hideTimer?.disconnect();
-      s.track.remove();
     }
 
     onMounted(() => {
@@ -432,12 +285,13 @@ export default defineComponent({
         vp.removeEventListener("scroll", onScroll);
         vp.removeEventListener("wheel", onWheel);
       }
-      detachAxis(vState, vDrag);
-      detachAxis(hState, hDrag);
+      overlay?.detach();
+      overlay = null;
       scheduled?.disconnect();
       settleHandle?.disconnect();
       settleHandle = null;
       ro?.disconnect();
+      ro = null;
       followRO?.disconnect();
       followRO = null;
       alignRO?.disconnect();
@@ -474,6 +328,7 @@ export default defineComponent({
      *  slot's own children resizing without the aligner box changing,
      *  or non-align consumers swapping content). */
     function refresh(): void {
+      overlay?.update();
       update();
     }
 

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -90,10 +90,26 @@
   transform: rotate(180deg);
 }
 
-.hk-select-popout {
+/* Fixed positioning wrapper around the desktop popout (HkSelectPanel):
+ * carries the inline anchor coords + popup-manager z-index and is the
+ * track host for the overlay scrollbar (the popout teleports to body,
+ * whose box is no positioning context). Geometry-neutral: the popout
+ * shrink-wraps the host exactly as the popout shrink-wrapped itself
+ * when it was the fixed element. The 180px width floor lives HERE, not
+ * on the popout: matchAnchorWidth's inline `min-width` lands on the host,
+ * and a stylesheet floor on the CHILD would override that match for
+ * anchors narrower than 180px (the floor must lose to the inline style,
+ * which can only happen on the same element). */
+.hk-select-popout-host {
   position: fixed;
-  /* z-index comes from the popup manager (inline) — registered overlay. */
   min-width: 180px;
+}
+
+.hk-select-popout {
+  /* Positioning lives on the host wrapper above — the popout is its
+   * static, box-filling child (width resolves from the host, whose
+   * floor/match rule is documented there). */
+  position: static;
   /* Menu/switcher panels overflow a bare 240px cap even on tall viewports
      (user feedback 2026-08-30: identity header + rows ≈ 320px+). Keep 240px
      as the floor for select lists on short viewports, otherwise let the
@@ -113,21 +129,12 @@
   border: 1px solid var(--border-subtle);
   box-shadow: var(--shadow-dropdown);
 
-  /* Themed scrollbar — never the browser-native chrome. */
-  scrollbar-width: thin;
-  scrollbar-color: rgb(var(--color-border) / 45%) transparent;
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     always hidden, never styled. */
+  scrollbar-width: none;
 
   &::-webkit-scrollbar {
-    width: 6px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: rgb(var(--color-border) / 45%);
-    border-radius: 3px;
+    display: none;
   }
 }
 
@@ -243,7 +250,20 @@
   color: rgb(var(--color-muted));
 }
 
+/* Track host for the sheet list's overlay scrollbar — owns the flex
+   slot in the sheet column so the rail hugs the LIST band, not the
+   grabber/title bands above it. */
+.hk-select-sheet-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
 .hk-select-sheet-list {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   /* Side insets so the option blocks (full-row hover pills) read as
@@ -255,6 +275,13 @@
      on top of this family baseline for its action buttons). */
   padding-inline: var(--space-16);
   padding-bottom: calc(var(--space-16) + env(safe-area-inset-bottom, 0px));
+
+  /* Overlay scrollbar (useOverlayScrollbar) — native chrome hidden. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   .hk-select-option {
     padding: var(--space-14) var(--space-16);

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -14,7 +14,7 @@ afterEach(() => {
   // finish and teleported panels linger on <body> — strip them or the
   // next test's querySelector sees this test's panel.
   document.body
-    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-popout, .hk-select-sheet-panel, .hk-select-sheet-scrim")
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim, .hk-select-popout, .hk-select-popout-host, .hk-select-sheet-panel, .hk-select-sheet-scrim")
     .forEach((el) => el.remove());
   setViewport(1200);
 });
@@ -115,6 +115,28 @@ describe("HkSelectPanel custom invocation", () => {
 
     const box = document.body.querySelector<HTMLInputElement>(".hk-select-popout label.row input")!;
     box.click();
+    await nextTick();
+    expect(open.value).toBe(true);
+  });
+
+  it("scrolling through the overlay track does not dismiss the popout", async () => {
+    const { container, open } = mountPanel();
+    await nextTick();
+
+    container.querySelector<HTMLButtonElement>("button")!.click();
+    await nextTick();
+    await nextTick(); // the overlay attaches on a post-open nextTick
+
+    // The track is appended to the fixed HOST wrapper — a sibling of the
+    // popout panel, NOT contained by it. A click there (which reaches the
+    // capture-phase document dismissal listener before any track handler)
+    // must read as inside the panel, exactly like the native scrollbar it
+    // replaced — native bars never emit page-visible clicks.
+    const track = document.body.querySelector<HTMLElement>(
+      ".hk-select-popout-host > .hk-scrollbar-track",
+    );
+    expect(track).toBeTruthy();
+    track!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     await nextTick();
     expect(open.value).toBe(true);
   });
@@ -246,9 +268,11 @@ describe("HkSelectPanel custom invocation", () => {
     app.mount(container);
     await nextTick();
 
-    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
-    expect(popout).toBeTruthy();
-    const z = Number.parseInt(popout.style.zIndex, 10);
+    // Inline geometry (coords + popup-manager z) lives on the fixed
+    // positioning wrapper that hosts the overlay scrollbar tracks.
+    const host = document.body.querySelector<HTMLElement>(".hk-select-popout-host")!;
+    expect(host).toBeTruthy();
+    const z = Number.parseInt(host.style.zIndex, 10);
     expect(z).toBeGreaterThanOrEqual(1000);
   });
 
@@ -262,18 +286,18 @@ describe("HkSelectPanel custom invocation", () => {
     open.value = true;
     await nextTick();
 
-    const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
-    const top = Number.parseInt(popout.style.top, 10);
+    const host = document.body.querySelector<HTMLElement>(".hk-select-popout-host")!;
+    const top = Number.parseInt(host.style.top, 10);
     // Anchor bottom at 520 → a top-start panel sits above 520 (minus offset).
     expect(top).toBeLessThan(520);
-    expect(popout.style.minWidth).toBe("100px");
+    expect(host.style.minWidth).toBe("100px");
 
     // Starved top side flips the panel below the anchor instead.
     anchor.getBoundingClientRect = () =>
       ({ top: 0, bottom: 8, left: 40, right: 140, width: 100, height: 8 }) as DOMRect;
     window.dispatchEvent(new Event("resize"));
     await nextTick();
-    const flipped = Number.parseInt(popout.style.top, 10);
+    const flipped = Number.parseInt(host.style.top, 10);
     expect(flipped).toBeGreaterThan(8);
   });
 
@@ -296,14 +320,17 @@ describe("HkSelectPanel custom invocation", () => {
       await nextTick();
 
       const popout = document.body.querySelector<HTMLElement>(".hk-select-popout")!;
+      const host = document.body.querySelector<HTMLElement>(".hk-select-popout-host")!;
       // happy-dom lays nothing out (offsetHeight 0 → the 200px fallback in
       // positionPanel), so fake the near-max-height box the new cap allows
       // and re-run geometry via the same resize path the cramped test uses.
+      // (positionPanel measures the popout; the applied coords land on the
+      // host wrapper.)
       Object.defineProperty(popout, "offsetHeight", { value: 576, configurable: true });
       window.dispatchEvent(new Event("resize"));
       await nextTick();
 
-      const top = Number.parseInt(popout.style.top, 10);
+      const top = Number.parseInt(host.style.top, 10);
       // Whole panel on-screen: top edge at/inside the viewport pad and the
       // bottom edge inside it too — overflow beyond that is the panel's
       // own internal scroll, never off-screen geometry.

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -14,6 +14,7 @@ import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useOverlay } from "../runtime/useOverlay";
 import { useBreakpoint } from "../runtime/useBreakpoint";
 import { createBackGuard } from "../runtime/backStack";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import "./HkSelect.scss";
 
 /**
@@ -133,7 +134,39 @@ export default defineComponent({
 
     const panelRef = ref<HTMLElement>();
     const sheetListRef = ref<HTMLElement>();
+    // Fixed positioning wrapper around the desktop popout — the overlay
+    // scrollbar's track host (the popout itself teleports to body, whose
+    // box is no positioning context for the tracks).
+    const popoutHostRef = ref<HTMLElement>();
+    // Mobile sheet: positioned wrapper around ONLY the scrolling list —
+    // the sheet panel also carries the grabber + title bands.
+    const sheetBodyRef = ref<HTMLElement>();
     const coords = ref<{ top?: string; left?: string; minWidth?: string }>({});
+
+    // ── overlay scrollbar (shared chrome) ─────────────────────────
+    // Attached per open on whichever surface scrolls — the desktop
+    // popout or the mobile sheet list — and detached on close/unmount
+    // so nothing leaks across the panel's lifetime (the sheet Teleport
+    // stays mounted through its leave transition).
+    let panelScrollbar: OverlayScrollbarHandle | null = null;
+
+    function detachPanelScrollbar(): void {
+      panelScrollbar?.detach();
+      panelScrollbar = null;
+    }
+
+    function attachPanelScrollbar(): void {
+      detachPanelScrollbar();
+      const viewport = sheetMode.value ? sheetListRef.value : panelRef.value;
+      if (!viewport) return;
+      panelScrollbar = attachOverlayScrollbars(viewport, {
+        axis: "vertical",
+        // Both surfaces get an exact host: the popout host (panel + tracks)
+        // and the sheet body wrapper (list only — the sheet panel also
+        // carries the grabber/title bands, which rails must not span).
+        host: sheetMode.value ? sheetBodyRef.value : popoutHostRef.value,
+      });
+    }
 
     // ── sheet duplicate-title filter ───────────────────────────────
     // Composition-slot consumers often open a sheet whose content
@@ -205,6 +238,9 @@ export default defineComponent({
       if (!props.open || sheetMode.value) return;
       const target = e.target as Node;
       if (props.anchorRef?.contains(target)) return;
+      // The host wraps BOTH the panel and the overlay scrollbar tracks —
+      // scrolling a long menu through its custom bar must not dismiss it.
+      if (popoutHostRef.value?.contains(target)) return;
       if (panelRef.value?.contains(target)) return;
       close();
     }
@@ -246,6 +282,14 @@ export default defineComponent({
           // flush rewinds exactly to the fresh entry instead of past it.
           if (backGuard.entries > 0) backGuard.release();
           backGuard.push();
+          // The scrolling surface mounts on this very render (popout
+          // subtree or sheet body) — attach the overlay scrollbar once
+          // the DOM has landed. A same-tick open→close must not arm it
+          // on the leaving panel.
+          void nextTick(() => {
+            if (!props.open) return;
+            attachPanelScrollbar();
+          });
           if (!sheetMode.value) {
             document.addEventListener("click", onDocumentClick, true);
           } else {
@@ -277,6 +321,7 @@ export default defineComponent({
         } else {
           document.removeEventListener("click", onDocumentClick, true);
           window.removeEventListener("resize", onResize);
+          detachPanelScrollbar();
           stopDupTitleSync();
           backGuard.release();
           if (handle.value) {
@@ -295,6 +340,7 @@ export default defineComponent({
     onBeforeUnmount(() => {
       document.removeEventListener("click", onDocumentClick, true);
       window.removeEventListener("resize", onResize);
+      detachPanelScrollbar();
       stopDupTitleSync();
       overlay.close();
       backGuard.destroy();
@@ -363,9 +409,15 @@ export default defineComponent({
     /** The live panel root element — sheet or popout, or null while closed.
      * Lets option-owning consumers (HkSelect) scope row queries to THEIR
      * panel instead of the whole document, where another open panel's
-     * rows (or HkPopupSelect's) could match first. */
+     * rows (or HkPopupSelect's) could match first.
+     * On the desktop popout this returns the fixed HOST — the box that
+     * contains the panel AND the overlay scrollbar tracks — so dismissal
+     * containment (HkMenu's deepestPanelAt) treats scrollbar interaction
+     * as inside the panel, exactly like the native bar it replaces. The
+     * host holds no option rows of its own, so row queries are unaffected. */
     expose({
-      panelEl: () => panelRef.value ?? null,
+      panelEl: () =>
+        (sheetMode.value ? panelRef.value : popoutHostRef.value ?? panelRef.value) ?? null,
       /**
        * Cancel this panel's pending back-guard rewind. Menu-like hosts
        * (HkMenu) call it when a row selection ITSELF starts an in-page
@@ -415,7 +467,9 @@ export default defineComponent({
                   {props.title ? (
                     <div class="hk-select-sheet-title">{props.title}</div>
                   ) : null}
-                  <div class="hk-select-sheet-list" ref={sheetListRef}>{slots.default?.()}</div>
+                  <div class="hk-select-sheet-body" ref={sheetBodyRef}>
+                    <div class="hk-select-sheet-list" ref={sheetListRef}>{slots.default?.()}</div>
+                  </div>
                 </div>
               ) : null}
             </Transition>
@@ -424,18 +478,21 @@ export default defineComponent({
       }
 
       // Desktop popout: no enter/leave transition on master either —
-      // mount on open, unmount on close.
+      // mount on open, unmount on close. The fixed host carries the
+      // inline coords + popup-manager z-index and anchors the overlay
+      // scrollbar tracks; the popout inside keeps every visual rule.
       if (!props.open) return null;
       return (
         <Teleport to="body">
-          <div
-            ref={panelRef}
-            class="hk-select-popout"
-            style={{ ...coords.value, zIndex: popoutZ.value }}
-            aria-label={props.title || undefined}
-            onKeydown={forwardKeydown}
-          >
-            {slots.default?.()}
+          <div ref={popoutHostRef} class="hk-select-popout-host" style={{ ...coords.value, zIndex: popoutZ.value }}>
+            <div
+              ref={panelRef}
+              class="hk-select-popout"
+              aria-label={props.title || undefined}
+              onKeydown={forwardKeydown}
+            >
+              {slots.default?.()}
+            </div>
           </div>
         </Teleport>
       );

--- a/packages/vue/src/components/HkSidebar.scss
+++ b/packages/vue/src/components/HkSidebar.scss
@@ -24,6 +24,16 @@
   align-items: center;
 }
 
+/* Track host for the body's overlay scrollbar — owns the flex slot in
+   the panel column so the rail hugs the BODY band, not header/footer. */
+.hk-sidebar-body-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
 .hk-sidebar-body {
   flex: 1;
   min-height: 0;
@@ -31,17 +41,12 @@
   padding-block: 20px 4px;
   padding-inline: var(--space-12);
 
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
   &::-webkit-scrollbar {
-    width: 4px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--hi-color-border, rgba(0, 0, 0, 0.1));
-    border-radius: 2px;
+    display: none;
   }
 }
 

--- a/packages/vue/src/components/HkSidebar.tsx
+++ b/packages/vue/src/components/HkSidebar.tsx
@@ -1,6 +1,7 @@
-import { computed, defineComponent } from "vue";
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref } from "vue";
 
 import "./HkSidebar.scss";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 
 export default defineComponent({
   name: "HkSidebar",
@@ -14,6 +15,27 @@ export default defineComponent({
   },
   setup(props, { emit, slots }) {
     const panelWidth = computed(() => (props.collapsed ? "56px" : props.width));
+
+    // Persistent layout surface — attach the overlay scrollbar (shared
+    // chrome) once and detach on unmount.
+    const bodyRef = ref<HTMLElement>();
+    // Positioned wrapper containing ONLY the body — the rail host (the
+    // panel also contains the header/footer bands).
+    const bodyWrapRef = ref<HTMLElement>();
+    let bodyScrollbar: OverlayScrollbarHandle | null = null;
+
+    onMounted(() => {
+      if (!bodyRef.value) return;
+      bodyScrollbar = attachOverlayScrollbars(bodyRef.value, {
+        axis: "vertical",
+        host: bodyWrapRef.value,
+      });
+    });
+
+    onBeforeUnmount(() => {
+      bodyScrollbar?.detach();
+      bodyScrollbar = null;
+    });
 
     return () => (
       <aside
@@ -34,7 +56,9 @@ export default defineComponent({
           {slots.header ? (
             <header class="hk-sidebar-header">{slots.header()}</header>
           ) : null}
-          <div class="hk-sidebar-body">{slots.default?.()}</div>
+          <div ref={bodyWrapRef} class="hk-sidebar-body-wrap">
+            <div ref={bodyRef} class="hk-sidebar-body">{slots.default?.()}</div>
+          </div>
           {slots.footer ? (
             <footer class="hk-sidebar-footer">{slots.footer()}</footer>
           ) : null}

--- a/packages/vue/src/components/HkStatusBar.test.tsx
+++ b/packages/vue/src/components/HkStatusBar.test.tsx
@@ -142,13 +142,14 @@ describe("HkStatusBar", () => {
     tag.dispatchEvent(tap());
     await nextTick();
     expect(onRetry).toHaveBeenCalledTimes(1);
-    // happy-dom never fires transitionend, so the panel may still be
-    // mid leave-animation here; assert closure semantics (leaving or
-    // gone), not DOM removal timing.
-    const tail = document.body.querySelector<HTMLElement>(".hk-popover-panel");
-    if (tail) {
-      expect(tail.className).toContain("hk-popover-leave");
-    }
+    // happy-dom never fires transitionend, so the panel is guaranteed to
+    // still be mid leave-animation here (the leave class can only be
+    // removed by the transition's after-leave hook). The Transition's
+    // direct child is the positioning wrapper around the panel, so the
+    // leave class lands on it and the real panel must sit INSIDE it.
+    const tail = document.body.querySelector<HTMLElement>('[class*="hk-popover-leave"]');
+    expect(tail).not.toBeNull();
+    expect(tail?.querySelector(".hk-popover-panel")).not.toBeNull();
   });
 
   it("a scroll-like touch ending over the tag does not retry", async () => {

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -1,6 +1,25 @@
+/* Track host for the wrapper's horizontal overlay rail — the wrapper is
+   the component root, so its DOM parent is consumer markup the rail
+   must never span. */
+.hk-table-host {
+  position: relative;
+}
+
 .hk-table-wrapper {
   width: 100%;
+  /* Horizontal-only region: the wrapper's height grows with the table, so
+     vertical overflow (and a vertical bar) can never arise — keep it that
+     way if a max-height is ever introduced here, or the overlay's
+     vertical axis must be attached alongside. */
   overflow-x: auto;
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .hk-table {

--- a/packages/vue/src/components/HkTable.tsx
+++ b/packages/vue/src/components/HkTable.tsx
@@ -1,6 +1,7 @@
-import { computed, defineComponent, ref, type PropType } from "vue";
+import { computed, defineComponent, onBeforeUnmount, onMounted, ref, type PropType } from "vue";
 
 import { useI18n } from "../i18n/context";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import "./HkTable.scss";
 
 interface Column {
@@ -34,6 +35,28 @@ export default defineComponent({
     const sortKey = ref<string | null>(null);
     const sortDirection = ref<"asc" | "desc">("asc");
     const selectedRowKeys = ref<Set<string>>(new Set());
+
+    // Wide tables scroll horizontally in the wrapper — attach the shared
+    // overlay scrollbar (horizontal track) once on mount.
+    const wrapperRef = ref<HTMLElement>();
+    // Positioned wrapper containing ONLY the scrolling box — the rail
+    // host (the wrapper is the component root; its DOM parent is
+    // consumer markup the rail must not span).
+    const wrapperHostRef = ref<HTMLElement>();
+    let wrapperScrollbar: OverlayScrollbarHandle | null = null;
+
+    onMounted(() => {
+      if (!wrapperRef.value) return;
+      wrapperScrollbar = attachOverlayScrollbars(wrapperRef.value, {
+        axis: "horizontal",
+        host: wrapperHostRef.value,
+      });
+    });
+
+    onBeforeUnmount(() => {
+      wrapperScrollbar?.detach();
+      wrapperScrollbar = null;
+    });
 
     function getRowKey(row: Record<string, unknown>, index: number): string {
       if (props.rowKey && row[props.rowKey] != null) return String(row[props.rowKey]);
@@ -105,7 +128,8 @@ export default defineComponent({
     const totalCols = computed(() => props.columns.length + (props.selectable ? 1 : 0));
 
     return () => (
-      <div class="hk-table-wrapper">
+      <div ref={wrapperHostRef} class="hk-table-host">
+        <div ref={wrapperRef} class="hk-table-wrapper">
         <table class={tableCls.value}>
           {props.caption && <caption class="sr-only">{props.caption}</caption>}
           <thead>
@@ -240,6 +264,7 @@ export default defineComponent({
             )}
           </tbody>
         </table>
+        </div>
       </div>
     );
   },

--- a/packages/vue/src/components/HkTextarea.tsx
+++ b/packages/vue/src/components/HkTextarea.tsx
@@ -77,6 +77,11 @@ export default defineComponent({
 
     return () => (
       <div class={wrapperClass.value}>
+        {/* Editable textarea: the NATIVE scrollbar is deliberately kept.
+         *  It is the only overlay-scrollbar exemption — a live text
+         *  caret, IME composition and drag-selection need the browser's
+         *  own scroller behavior, and no bespoke webkit styling exists
+         *  here to unify (see the 2026-09 overlay-scrollbar wave). */}
         <textarea
           ref={textareaRef}
           class={[

--- a/packages/vue/src/components/HkToolBlock.scss
+++ b/packages/vue/src/components/HkToolBlock.scss
@@ -101,6 +101,14 @@
   white-space: pre-wrap;
   word-break: break-word;
   color: rgb(var(--color-text));
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .s-tool-result {
@@ -122,6 +130,13 @@
   color: rgb(var(--color-text));
 }
 
+/* Track host for the code block's overlay scrollbar — the block has
+   siblings (params/nested/call sections), so the rail must anchor to a
+   wrapper that contains only the block. */
+.s-tool-code-block-wrap {
+  position: relative;
+}
+
 .s-tool-code-block {
   margin: var(--space-4, 0.25rem) 0;
   background: rgb(var(--color-surface) / 0.85);
@@ -135,6 +150,14 @@
   cursor: pointer;
   max-height: 240px;
   overflow: auto;
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   &:active {
     opacity: 0.85;
@@ -235,6 +258,14 @@
   user-select: none;
   max-height: 320px;
   overflow: auto;
+
+  /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
+     hidden, never styled. */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .s-jt-row {

--- a/packages/vue/src/components/HkToolBlock.tsx
+++ b/packages/vue/src/components/HkToolBlock.tsx
@@ -1,10 +1,11 @@
-import { computed, defineComponent, ref, watch, type PropType } from "vue";
+import { computed, defineComponent, onBeforeUnmount, onMounted, onUpdated, ref, watch, type PropType } from "vue";
 import { ChevronDown, ChevronRight } from "lucide-vue-next";
 import { HDivider, useClipboard } from "@celestia-island/hikari";
 
 import type { HToolCallStatus } from "./HkChatTypes";
 import { formatTokenCount } from "../utils/format";
 import { useI18n } from "../i18n/context";
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 
 import "./HkToolBlock.scss";
 
@@ -258,6 +259,33 @@ export const HkToolBlock = defineComponent({
     const expanded = ref(props.defaultExpanded);
     const jsonExpanded = ref(new Set<number>());
 
+    // Overlay scrollbars (shared chrome) on the code panes. The panes
+    // mount/unmount with expansion + status, so the set is reconciled
+    // after every render: handles whose pane left the DOM detach (which
+    // also removes the track from the pane's parent), new panes attach.
+    const rootRef = ref<HTMLElement>();
+    const paneScrollbars: Array<{ el: HTMLElement; handle: OverlayScrollbarHandle }> = [];
+
+    function syncCodePanes() {
+      for (let i = paneScrollbars.length - 1; i >= 0; i--) {
+        if (!paneScrollbars[i].el.isConnected) {
+          paneScrollbars[i].handle.detach();
+          paneScrollbars.splice(i, 1);
+        }
+      }
+      for (const el of rootRef.value?.querySelectorAll<HTMLElement>(".s-tool-code, .s-tool-code-block, .s-tool-json-tree") ?? []) {
+        if (paneScrollbars.some((p) => p.el === el)) continue;
+        paneScrollbars.push({ el, handle: attachOverlayScrollbars(el, { axis: "both" }) });
+      }
+    }
+
+    onMounted(syncCodePanes);
+    onUpdated(syncCodePanes);
+    onBeforeUnmount(() => {
+      for (const p of paneScrollbars) p.handle.detach();
+      paneScrollbars.length = 0;
+    });
+
     watch(() => props.status, (newStatus) => {
       if (newStatus === "done") expanded.value = true;
     });
@@ -474,7 +502,7 @@ export const HkToolBlock = defineComponent({
     }
 
     return () => (
-      <div class={blockClass.value}>
+      <div ref={rootRef} class={blockClass.value}>
         <div class="s-tool-header" onClick={toggleExpand}>
           <span class="s-tool-header-title" onClick={(e) => { e.stopPropagation(); copyTitle(); }}>{displayTitle.value}</span>
           <span class={`s-tool-header-badge is-${props.status}`}>{statusLabel.value}</span>
@@ -502,15 +530,17 @@ export const HkToolBlock = defineComponent({
             )}
 
             {execCodeLines.value && (
-              <div class="s-tool-code-block hljs" onClick={copyExecCode}>
-                <table class="s-tool-code-table">
-                  {execCodeLines.value.map((line, i) => (
-                    <tr key={i}>
-                      <td class="s-tool-code-num"><span>{line.num}</span></td>
-                      <td class="s-tool-code-content" innerHTML={line.html} />
-                    </tr>
-                  ))}
-                </table>
+              <div class="s-tool-code-block-wrap">
+                <div class="s-tool-code-block hljs" onClick={copyExecCode}>
+                  <table class="s-tool-code-table">
+                    {execCodeLines.value.map((line, i) => (
+                      <tr key={i}>
+                        <td class="s-tool-code-num"><span>{line.num}</span></td>
+                        <td class="s-tool-code-content" innerHTML={line.html} />
+                      </tr>
+                    ))}
+                  </table>
+                </div>
               </div>
             )}
 
@@ -527,15 +557,17 @@ export const HkToolBlock = defineComponent({
 
             {props.variant === "default" && props.callText && (
               callHighlighted.value ? (
-                <div class="s-tool-code-block hljs">
-                  <table class="s-tool-code-table">
-                    {callHighlighted.value.map((line, i) => (
-                      <tr key={i}>
-                        <td class="s-tool-code-num"><span>{line.num}</span></td>
-                        <td class="s-tool-code-content" innerHTML={line.html} />
-                      </tr>
-                    ))}
-                  </table>
+                <div class="s-tool-code-block-wrap">
+                  <div class="s-tool-code-block hljs">
+                    <table class="s-tool-code-table">
+                      {callHighlighted.value.map((line, i) => (
+                        <tr key={i}>
+                          <td class="s-tool-code-num"><span>{line.num}</span></td>
+                          <td class="s-tool-code-content" innerHTML={line.html} />
+                        </tr>
+                      ))}
+                    </table>
+                  </div>
                 </div>
               ) : (
                 <div class="s-tool-call">

--- a/packages/vue/src/composables/useOverlayScrollbar.test.ts
+++ b/packages/vue/src/composables/useOverlayScrollbar.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "./useOverlayScrollbar";
+
+const handles: OverlayScrollbarHandle[] = [];
+const containers: HTMLElement[] = [];
+
+/** Mount a viewport (the scrolling element) inside a wrapper inside a
+ *  fresh container: wrapper ← viewport. The wrapper is the track host. */
+function mountViewport(axis: "vertical" | "horizontal" | "both" = "vertical") {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+  const wrapper = document.createElement("div");
+  const viewport = document.createElement("div");
+  wrapper.appendChild(viewport);
+  container.appendChild(wrapper);
+  const handle = attachOverlayScrollbars(viewport, { axis });
+  handles.push(handle);
+  return { container, wrapper, viewport, handle };
+}
+
+/** happy-dom performs no layout, so scroll geometry is stubbed on the
+ *  viewport instance (shadowing the prototype getters) — the same
+ *  trick HkScrollContainer.test.ts uses, plus writable scroll offsets
+ *  so the drag / track-click paths can assert what they scrolled to. */
+function stubGeometry(
+  el: HTMLElement,
+  geom: { scrollHeight?: number; clientHeight?: number; scrollTop?: number; scrollWidth?: number; clientWidth?: number; scrollLeft?: number },
+) {
+  const desc: PropertyDescriptorMap = {};
+  for (const [key, value] of Object.entries(geom)) {
+    if (key === "scrollTop" || key === "scrollLeft") {
+      let current = value;
+      desc[key] = {
+        configurable: true,
+        get: () => current,
+        set: (v: number) => { current = v; },
+      };
+    } else {
+      desc[key] = { configurable: true, get: () => value };
+    }
+  }
+  Object.defineProperties(el, desc);
+}
+
+afterEach(() => {
+  for (const h of handles.splice(0)) h.detach();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+describe("attachOverlayScrollbars", () => {
+  it("creates one vertical track+thumb pair appended to the viewport's parent", () => {
+    const { wrapper } = mountViewport("vertical");
+    const tracks = wrapper.querySelectorAll<HTMLElement>(".hk-scrollbar-track");
+    expect(tracks.length).toBe(1);
+    expect(tracks[0].hasAttribute("data-axis")).toBe(false);
+    expect(tracks[0].querySelector(".hk-scrollbar-thumb")).not.toBeNull();
+  });
+
+  it("creates a horizontal track marked data-axis and both tracks for axis=both", () => {
+    const horizontal = mountViewport("horizontal");
+    const hTracks = horizontal.wrapper.querySelectorAll(".hk-scrollbar-track");
+    expect(hTracks.length).toBe(1);
+    expect(hTracks[0].getAttribute("data-axis")).toBe("horizontal");
+
+    const both = mountViewport("both");
+    expect(both.wrapper.querySelectorAll(".hk-scrollbar-track").length).toBe(2);
+    expect(both.wrapper.querySelectorAll('.hk-scrollbar-track[data-axis="horizontal"]').length).toBe(1);
+  });
+
+  it("hides the track while the content fits and shows it once it overflows", () => {
+    const { viewport, wrapper, handle } = mountViewport("vertical");
+    const track = wrapper.querySelector<HTMLElement>(".hk-scrollbar-track")!;
+    // Fitting content (default 0/0 geometry) → hidden.
+    expect(track.style.display).toBe("none");
+
+    stubGeometry(viewport, { scrollHeight: 300, clientHeight: 100, scrollTop: 0 });
+    handle.update();
+    expect(track.style.display).toBe("");
+
+    // Thumb position maps the scroll ratio (0 → top edge).
+    const thumb = track.querySelector<HTMLElement>(".hk-scrollbar-thumb")!;
+    expect(thumb.style.transform).toContain("translateY(0px)");
+  });
+
+  it("flashes is-scrolling on viewport scroll and drops it when the timer fires", () => {
+    vi.useFakeTimers();
+    try {
+      const { viewport, wrapper } = mountViewport("vertical");
+      stubGeometry(viewport, { scrollHeight: 300, clientHeight: 100, scrollTop: 50 });
+      viewport.dispatchEvent(new Event("scroll"));
+      const track = wrapper.querySelector<HTMLElement>(".hk-scrollbar-track")!;
+      expect(track.classList.contains("is-scrolling")).toBe(true);
+      vi.advanceTimersByTime(1300);
+      expect(track.classList.contains("is-scrolling")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drags the thumb: mousedown + document mousemove scroll the viewport", () => {
+    const { viewport, wrapper, handle } = mountViewport("vertical");
+    stubGeometry(viewport, {
+      scrollHeight: 400, clientHeight: 100, scrollTop: 0,
+      scrollWidth: 100, clientWidth: 100, scrollLeft: 0,
+    });
+    handle.update();
+    const thumb = wrapper.querySelector<HTMLElement>(".hk-scrollbar-thumb")!;
+
+    thumb.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, clientY: 0 }));
+    expect(thumb.classList.contains("is-dragging")).toBe(true);
+
+    // Thumb of a 100px client box: max(100/400*100, 20) = 25 →
+    // trackRange 75 maps onto the 300px scroll range: +20px delta
+    // = +80 scroll.
+    document.dispatchEvent(new MouseEvent("mousemove", { clientY: 20 }));
+    expect(viewport.scrollTop).toBe(80);
+
+    document.dispatchEvent(new MouseEvent("mouseup"));
+    expect(thumb.classList.contains("is-dragging")).toBe(false);
+    // Document listeners released — further moves do nothing.
+    document.dispatchEvent(new MouseEvent("mousemove", { clientY: 60 }));
+    expect(viewport.scrollTop).toBe(80);
+  });
+
+  it("pages when the track (not the thumb) is clicked", () => {
+    const { viewport, wrapper, handle } = mountViewport("vertical");
+    stubGeometry(viewport, {
+      scrollHeight: 400, clientHeight: 100, scrollTop: 0,
+      scrollWidth: 100, clientWidth: 100, scrollLeft: 0,
+    });
+    handle.update();
+    const track = wrapper.querySelector<HTMLElement>(".hk-scrollbar-track")!;
+    // happy-dom getBoundingClientRect is all-zero — simulate a 100px
+    // tall track so the click ratio is deterministic.
+    vi.spyOn(track, "getBoundingClientRect").mockReturnValue({
+      top: 0, left: 0, width: 6, height: 100,
+      bottom: 100, right: 6, x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect);
+    track.dispatchEvent(new MouseEvent("click", { bubbles: true, clientY: 50 }));
+    // Halfway down the track → halfway through the scroll range.
+    expect(viewport.scrollTop).toBe(150);
+  });
+
+  it("marks and unmarks a static parent with inline position:relative (guard)", () => {
+    const { wrapper, handle } = mountViewport("vertical");
+    // happy-dom computes no CSS → position computes "static" → the
+    // guard must promote the host and mark it.
+    expect(wrapper.style.position).toBe("relative");
+    expect(wrapper.hasAttribute("data-hk-overlay-scrollbar-positioned")).toBe(true);
+    // Detach restores the empty inline position and drops the mark.
+    handle.detach();
+    handles.splice(handles.indexOf(handle), 1);
+    expect(wrapper.style.position).toBe("");
+    expect(wrapper.hasAttribute("data-hk-overlay-scrollbar-positioned")).toBe(false);
+  });
+
+  it("keeps an already-positioned host untouched", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const wrapper = document.createElement("div");
+    wrapper.style.position = "absolute";
+    const viewport = document.createElement("div");
+    wrapper.appendChild(viewport);
+    container.appendChild(wrapper);
+    const handle = attachOverlayScrollbars(viewport);
+    handles.push(handle);
+
+    expect(wrapper.style.position).toBe("absolute");
+    expect(wrapper.hasAttribute("data-hk-overlay-scrollbar-positioned")).toBe(false);
+  });
+
+  it("shares the guard across handles on one parent and restores only after the last detach", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+    const wrapper = document.createElement("div");
+    const viewportA = document.createElement("div");
+    const viewportB = document.createElement("div");
+    wrapper.appendChild(viewportA);
+    wrapper.appendChild(viewportB);
+    container.appendChild(wrapper);
+    const handleA = attachOverlayScrollbars(viewportA, { axis: "vertical" });
+    const handleB = attachOverlayScrollbars(viewportB, { axis: "vertical" });
+    handles.push(handleA, handleB);
+    expect(wrapper.style.position).toBe("relative");
+
+    handleA.detach();
+    handles.splice(handles.indexOf(handleA), 1);
+    // B's tracks still live on the wrapper — the promotion survives.
+    expect(wrapper.style.position).toBe("relative");
+    expect(wrapper.hasAttribute("data-hk-overlay-scrollbar-positioned")).toBe(true);
+
+    handleB.detach();
+    handles.splice(handles.indexOf(handleB), 1);
+    // Last handle gone — the wrapper's inline position is restored.
+    expect(wrapper.style.position).toBe("");
+    expect(wrapper.hasAttribute("data-hk-overlay-scrollbar-positioned")).toBe(false);
+  });
+
+  it("detach removes the tracks and is idempotent", () => {
+    const { wrapper, handle } = mountViewport("both");
+    expect(wrapper.querySelectorAll(".hk-scrollbar-track").length).toBe(2);
+    handle.detach();
+    handles.splice(handles.indexOf(handle), 1);
+    expect(wrapper.querySelectorAll(".hk-scrollbar-track").length).toBe(0);
+    expect(() => handle.detach()).not.toThrow();
+  });
+
+  it("returns a no-op handle when the viewport has no parent", () => {
+    const orphan = document.createElement("div");
+    const handle = attachOverlayScrollbars(orphan);
+    handles.push(handle);
+    expect(() => {
+      handle.update();
+      handle.detach();
+    }).not.toThrow();
+  });
+});

--- a/packages/vue/src/composables/useOverlayScrollbar.ts
+++ b/packages/vue/src/composables/useOverlayScrollbar.ts
@@ -1,0 +1,296 @@
+// useOverlayScrollbar — hikari's ONE sanctioned overlay scrollbar engine.
+//
+// Attaches the shared `.hk-scrollbar-track` / `.hk-scrollbar-thumb` chrome
+// (styled in packages/theme/styles/_scrollbar.scss) onto any native
+// scrolling element. The element keeps its own `overflow: auto|scroll`
+// mechanics — this module adds only the overlay; the consumer's CSS is
+// responsible for hiding the native bar
+// (`scrollbar-width: none` + `::-webkit-scrollbar { display: none }`).
+//
+// Features (extracted from HkScrollContainer so every scroll region in
+// the library renders the identical scrollbar):
+//   - geometry-driven thumb sizing/positioning per enabled axis;
+//   - the track hides itself while the content fits;
+//   - `is-scrolling` flash on scroll, `is-hovering` on track hover,
+//     `is-dragging` while the thumb is dragged;
+//   - thumb drag (document-tracked), track-click paging;
+//   - updates on viewport resize (ResizeObserver);
+//   - positioning guard: the tracks are absolutely positioned inside
+//     the viewport's parent — when that parent computes to `static`,
+//     an inline `position: relative` is applied (and restored on
+//     detach), marked with a data attribute.
+//
+// Works inside teleported popups/modals: attach on mount/open and call
+// `detach()` on close/unmount so no DOM or listener leaks.
+
+import { scheduleCronAfter, type CronHandle } from "../runtime/cronBus";
+import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
+
+/** Which axes get an overlay track. Defaults to "vertical". */
+export type OverlayScrollbarAxis = "vertical" | "horizontal" | "both";
+
+export interface OverlayScrollbarOptions {
+  axis?: OverlayScrollbarAxis;
+  /** Element the tracks are appended to — their positioning context.
+   *  MUST be a box wrapping EXACTLY the viewport (the viewport plus the
+   *  rails, nothing else): the rails take their insets from this box, so
+   *  a host that also contains header/footer/sibling bands would draw
+   *  them in the wrong place. Defaults to the viewport's DOM parent,
+   *  which is only correct when the viewport fills that parent; wrap
+   *  the viewport in a dedicated positioned `div` when it does not
+   *  (see HkDrawer/HkSidebar/HkTable for the pattern). Never rely on
+   *  the guard to promote `body`. */
+  host?: HTMLElement;
+}
+
+export interface OverlayScrollbarHandle {
+  /** Re-read the viewport's scroll geometry and reposition the thumbs. */
+  update(): void;
+  /** Remove the tracks and every listener/observer; restore any
+   *  inline positioning the guard applied. Safe to call twice. */
+  detach(): void;
+}
+
+interface AxisState {
+  track: HTMLElement;
+  thumb: HTMLElement;
+  horizontal: boolean;
+  dragging: boolean;
+  dragStartClient: number;
+  dragStartScroll: number;
+  hideTimer: CronHandle;
+}
+
+/** Data attribute marking a parent whose inline `position: relative`
+ *  was set by the guard (so detach can restore it). */
+const POSITION_GUARD_ATTR = "data-hk-overlay-scrollbar-positioned";
+
+/** Per-parent guard bookkeeping. Two handles may share one static parent
+ *  (e.g. sibling code panes reconciled independently); the inline
+ *  `position: relative` must survive until the LAST handle detaches, so
+ *  promotion is reference-counted. */
+const promotedParents = new WeakMap<HTMLElement, { count: number; saved: string }>();
+
+/** Read the scroll geometry of `viewport` for one axis. */
+function axisMetrics(viewport: HTMLElement, horizontal: boolean) {
+  return {
+    scrollSize: horizontal ? viewport.scrollWidth : viewport.scrollHeight,
+    clientSize: horizontal ? viewport.clientWidth : viewport.clientHeight,
+    scrollPos: horizontal ? viewport.scrollLeft : viewport.scrollTop,
+  };
+}
+
+function makeAxisState(horizontal: boolean): AxisState {
+  const track = document.createElement("div");
+  track.className = "hk-scrollbar-track";
+  if (horizontal) track.setAttribute("data-axis", "horizontal");
+  const thumb = document.createElement("div");
+  thumb.className = "hk-scrollbar-thumb";
+  track.appendChild(thumb);
+  return {
+    track,
+    thumb,
+    horizontal,
+    dragging: false,
+    dragStartClient: 0,
+    dragStartScroll: 0,
+    hideTimer: undefined as unknown as CronHandle,
+  };
+}
+
+/** Attach the shared overlay scrollbar chrome to a scrolling viewport.
+ *  Returns a handle; when the viewport has no parent element a no-op
+ *  handle is returned (nothing to position the tracks against). */
+export function attachOverlayScrollbars(
+  viewport: HTMLElement,
+  opts: OverlayScrollbarOptions = {},
+): OverlayScrollbarHandle {
+  const axis = opts.axis ?? "vertical";
+  const parent = opts.host ?? viewport.parentElement;
+  if (!parent) {
+    return { update() {}, detach() {} };
+  }
+
+  const wantV = axis !== "horizontal";
+  const wantH = axis !== "vertical";
+
+  // Positioning guard: the tracks are position:absolute inside the
+  // viewport's parent. A static parent would anchor them to the
+  // nearest positioned ancestor instead — promote it to `relative`
+  // and remember the previous inline value for restore on detach —
+  // reference-counted per parent (see promotedParents) so a sibling
+  // handle's detach cannot strip the positioning out from under the
+  // tracks that remain.
+  // (Real browsers always report "static" for unpositioned elements;
+  // happy-dom reports "" — both mean "no positioning context".)
+  const computedPosition = getComputedStyle(parent).position;
+  if (computedPosition === "static" || computedPosition === "") {
+    if (!promotedParents.has(parent)) {
+      promotedParents.set(parent, { count: 0, saved: parent.style.position });
+      parent.style.position = "relative";
+      parent.setAttribute(POSITION_GUARD_ATTR, "true");
+    }
+  }
+  // Count EVERY handle on a promoted parent — including handles whose
+  // attach sees the parent already `relative` (computed styles reflect
+  // the first handle's inline promotion). Skipping those would let the
+  // first detach strip the positioning out from under surviving tracks.
+  const entry = promotedParents.get(parent);
+  if (entry) entry.count++;
+
+  const states: AxisState[] = [];
+  if (wantV) states.push(makeAxisState(false));
+  if (wantH) states.push(makeAxisState(true));
+  for (const s of states) parent.appendChild(s.track);
+
+  let scheduled: AnimationHandle | null = null;
+  let ro: ResizeObserver | null = null;
+  let detached = false;
+
+  function updateAxis(s: AxisState, horizontal: boolean) {
+    const { scrollSize, clientSize, scrollPos } = axisMetrics(viewport, horizontal);
+    if (scrollSize <= clientSize) {
+      // Content fits — no bar at all.
+      s.track.style.display = "none";
+      return;
+    }
+    s.track.style.display = "";
+    const trackSize = horizontal ? s.track.clientWidth : s.track.clientHeight;
+    const ratio = clientSize / scrollSize;
+    const thumbSize = Math.max(ratio * trackSize, 20);
+    const maxScroll = scrollSize - clientSize;
+    const maxTrack = trackSize - thumbSize;
+    const offset = maxScroll > 0 ? (scrollPos / maxScroll) * maxTrack : 0;
+    if (horizontal) {
+      s.thumb.style.width = `${thumbSize}px`;
+      s.thumb.style.transform = `translateX(${offset}px)`;
+    } else {
+      s.thumb.style.height = `${thumbSize}px`;
+      s.thumb.style.transform = `translateY(${offset}px)`;
+    }
+  }
+
+  function update() {
+    if (detached) return;
+    for (const s of states) updateAxis(s, s.horizontal);
+  }
+
+  function scheduleUpdate() {
+    scheduled?.disconnect();
+    scheduled = scheduleFrame(() => {
+      scheduled = null;
+      update();
+    });
+  }
+
+  /** Flash the track while scrolling; it fades out after a beat. */
+  function flash(s: AxisState) {
+    s.track.classList.add("is-scrolling");
+    s.hideTimer?.disconnect();
+    s.hideTimer = scheduleCronAfter(() => s.track.classList.remove("is-scrolling"), 1200);
+  }
+
+  function onScroll() {
+    scheduleUpdate();
+    for (const s of states) flash(s);
+  }
+
+  function makeDragHandlers(s: AxisState, horizontal: boolean) {
+    const onMove = (e: MouseEvent) => {
+      if (!s.dragging) return;
+      const { scrollSize, clientSize } = axisMetrics(viewport, horizontal);
+      const delta = (horizontal ? e.clientX : e.clientY) - s.dragStartClient;
+      // Mirror updateAxis's RENDER math exactly — the thumb is sized
+      // against the TRACK box, so drag travel must divide by the same
+      // numbers or the thumb slides out of sync under short tracks.
+      // A zero track box counts as unmeasured (no-layout environments)
+      // and falls back to the viewport box.
+      const trackSize = horizontal ? s.track.clientWidth : s.track.clientHeight;
+      const measured = trackSize > 0 ? trackSize : clientSize;
+      const thumbSize = Math.max((clientSize / scrollSize) * measured, 20);
+      const trackRange = measured - thumbSize;
+      if (trackRange <= 0) return;
+      const target = s.dragStartScroll + (delta / trackRange) * (scrollSize - clientSize);
+      if (horizontal) viewport.scrollLeft = target;
+      else viewport.scrollTop = target;
+    };
+    const onUp = () => {
+      s.dragging = false;
+      s.thumb.classList.remove("is-dragging");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    const onDown = (e: MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      s.dragging = true;
+      s.dragStartClient = horizontal ? e.clientX : e.clientY;
+      s.dragStartScroll = horizontal ? viewport.scrollLeft : viewport.scrollTop;
+      s.thumb.classList.add("is-dragging");
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    };
+    return { onDown, onMove, onUp };
+  }
+
+  function attachAxis(s: AxisState) {
+    const horizontal = s.horizontal;
+    const { onDown, onMove, onUp } = makeDragHandlers(s, horizontal);
+    const onTrackClick = (e: MouseEvent) => {
+      if (e.target === s.thumb) return;
+      const rect = s.track.getBoundingClientRect();
+      const ratio = horizontal
+        ? (e.clientX - rect.left) / rect.width
+        : (e.clientY - rect.top) / rect.height;
+      const { scrollSize, clientSize } = axisMetrics(viewport, horizontal);
+      const max = scrollSize - clientSize;
+      if (horizontal) viewport.scrollLeft = ratio * max;
+      else viewport.scrollTop = ratio * max;
+    };
+    const onEnter = () => s.track.classList.add("is-hovering");
+    const onLeave = () => s.track.classList.remove("is-hovering");
+    s.thumb.addEventListener("mousedown", onDown);
+    s.track.addEventListener("click", onTrackClick);
+    s.track.addEventListener("mouseenter", onEnter);
+    s.track.addEventListener("mouseleave", onLeave);
+    return { onDown, onMove, onUp, onTrackClick, onEnter, onLeave };
+  }
+
+  const axisBindings = states.map((s) => ({ state: s, handlers: attachAxis(s) }));
+
+  viewport.addEventListener("scroll", onScroll, { passive: true });
+  ro = new ResizeObserver(scheduleUpdate);
+  ro.observe(viewport);
+  update();
+
+  return {
+    update,
+    detach() {
+      if (detached) return;
+      detached = true;
+      viewport.removeEventListener("scroll", onScroll);
+      ro?.disconnect();
+      ro = null;
+      scheduled?.disconnect();
+      scheduled = null;
+      for (const { state, handlers } of axisBindings) {
+        state.thumb.removeEventListener("mousedown", handlers.onDown);
+        state.track.removeEventListener("click", handlers.onTrackClick);
+        state.track.removeEventListener("mouseenter", handlers.onEnter);
+        state.track.removeEventListener("mouseleave", handlers.onLeave);
+        document.removeEventListener("mousemove", handlers.onMove);
+        document.removeEventListener("mouseup", handlers.onUp);
+        state.hideTimer?.disconnect();
+        state.track.remove();
+      }
+      const entry = promotedParents.get(parent);
+      if (entry && --entry.count <= 0) {
+        // Last handle on this parent is gone — restore its inline
+        // positioning exactly as the guard found it.
+        parent.style.position = entry.saved;
+        parent.removeAttribute(POSITION_GUARD_ATTR);
+        promotedParents.delete(parent);
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Part A — HkLocalizedInput locale chip
The field chip now shows ONLY the language label (简体中文); the parenthesized code appears ONLY in the opened menu rows (简体中文 (zh-Hans)) — switch rows, Add-language and Delete-language cascade children included. Chip stays pinned to the input's right edge (suffix pin from #324). User-reported via the chest add-panel wizard screenshot.

## Part B — one overlay scrollbar system
- New composable `useOverlayScrollbar.ts` (attachOverlayScrollbars) extracts HkScrollContainer's track/thumb engine so every scroll region renders identical overlay chrome; explicit `host` option for teleported popups; reference-counted positioning guard.
- Shared chrome CSS moved to theme `_scrollbar.scss`; dead `.hk-obs-*` legacy system deleted.
- **Zero `!important` added (library policy)**; the old HkPopupSelect `!important` re-enable hack is deleted outright; the pre-existing `::-webkit-scrollbar` thin-bar blocks (HkSelect popout/sheet, HkModal, HkDrawer, HkSidebar) are replaced by plain-declaration native-bar hiding + the overlay.
- Attached across: HkSelectPanel (popout + sheet), HkModal, HkDrawer, HkSidebar, HkPopover, HkKeywordSearchModal, HkToolBlock (3 panes), HkTable (h), HkMarkdownRenderer code blocks (h), HkProgressDialog, HkProtocolModal. Each viewport is wrapped/anchored by an EXACT host box so rails hug their own region only.

## Behavior notes for consumers
- `HkSelectPanel.expose.panelEl()` now returns the fixed host wrapper on desktop (panel + tracks): dismissal containment and row scoping both verified unaffected; track/thumb interaction no longer dismisses the open popup (regression test pinned).
- `matchAnchorWidth` keeps matching anchors narrower than 180px (180px floor moved onto the host element so the inline min-width wins).
- Faded rails are click-through; they become interactive only in the visible flash/hover window.
- HkTextarea deliberately keeps the native bar (editable control). HkLogWindow was already HkScrollContainer-based.
- Version 0.19.9 → 0.19.10. shittim-chest picks this up automatically via the sibling alias on its next build.

## Verification
- 3-round adversarial verify cycle (R1: track-click dismissal blocker + min-width major; R2: mispositioned-rail major + pointer-events minor; R3: SHIP).
- vitest 65 files / 560 tests green · vue-tsc --noEmit clean · `diff | grep '^+' | grep '!important'` = 0 · foundation SCSS compile OK.
- Known pre-existing (not this branch): sass CLI failure of the packages/components chain on master; HkSelect.scss:278 / HkModal.scss:304 legacy !importants documented for a follow-up purge wave.