### PR TITLE
✨ Merge dynamic option runs into the tab strip and complete button-group motion.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.19.10",
+  "version": "0.20.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -84,10 +84,17 @@
   white-space: nowrap;
   cursor: pointer;
   outline: none;
-  transition: color var(--duration-short) ease;
+  transition: color var(--duration-short) ease,
+              transform var(--duration-short) ease;
 
   &:hover {
     color: rgb(var(--color-text));
+  }
+
+  /* Tactile press feedback — every button-group click animates, even
+     before the sliding indicator arrives. */
+  &:active:not([data-disabled]) {
+    transform: scale(0.96);
   }
 
   &[data-active] {
@@ -107,8 +114,9 @@
   align-items: center;
 }
 
-/* === The one shared sliding indicator (every variant) === */
-
+/* === The one shared sliding indicator (every variant) ===
+ * Starts transparent: the first measured frame only fades it in (no
+ * pop-in from a stale corner), later frames slide via left/width. */
 .hk-tabs-indicator {
   position: absolute;
   top: 2px;
@@ -117,8 +125,43 @@
   background: rgb(var(--color-primary) / 12%);
   pointer-events: none;
   z-index: 0;
+  opacity: 0;
   transition: left var(--duration-normal) var(--ease-standard),
-              width var(--duration-normal) var(--ease-standard);
+              width var(--duration-normal) var(--ease-standard),
+              opacity var(--duration-short) ease;
+}
+
+.hk-tabs-indicator[data-ready] {
+  opacity: 1;
+}
+
+/* === Option swap transitions (dynamic options / merged cell) ===
+ * Entering options/cells fade and settle in; leaving ones fade out
+ * absolutely so siblings reflow at once. Geometry motion belongs to
+ * the sliding indicator, so there is deliberately no move FLIP. */
+.hk-tabs-swap-enter-active,
+.hk-tabs-swap-leave-active {
+  transition: opacity var(--duration-short) ease,
+              transform var(--duration-short) ease;
+}
+
+.hk-tabs-swap-enter-from {
+  opacity: 0;
+  transform: scale(0.96);
+}
+
+.hk-tabs-swap-leave-to {
+  opacity: 0;
+}
+
+/* Child-selector form, NOT the bare `.hk-tabs-swap-leave-active`: the
+   leaving element may be a trigger or the merged cell whose own rules
+   (`.hk-tabs-trigger` / `.hk-tabs-merged`, position:relative) share the
+   same one-class specificity and could win by source order — the
+   two-class selector lifts the ghost to absolute regardless of order. */
+.hk-tabs-list > .hk-tabs-swap-leave-active {
+  position: absolute;
+  z-index: 0;
 }
 
 /* === Panel (pill / tablist mode) === */
@@ -158,29 +201,43 @@
   flex: 1 0 auto;
 }
 
-/* === Tail overlay (option locking / live info) ===
- * A passive layer covering the track right of tab[overlayFrom]; measured
- * geometry arrives as inline left/width (equal-share estimate before
- * measurement). Carries the unified pill chrome (opaque surface so the
- * locked triggers beneath never bleed through, hairline border, the
- * shared radius), sits above triggers, click-through except for
- * interactive slot content. */
-.hk-tabs-overlay {
-  position: absolute;
-  top: 2px;
-  bottom: 2px;
-  right: 2px;
-  z-index: 2;
+/* === Merged cell (dynamic merged-option rendering) ===
+ * The contiguous run of options listed in `mergeKeys` collapses into ONE
+ * combined cell (the #merged slot) — a REAL flex child of the track,
+ * not an absolute cover: it joins layout and the animation context
+ * (hk-tabs-swap enter/leave + the sliding indicator measures it when
+ * the active option is merged). Chrome follows the unselected-option
+ * grammar: NAKED — no border, no own surface; only the sliding
+ * indicator ever frames the active option, so a merged cell must never
+ * grow a box of its own. Interactive slot content (e.g. the theme
+ * toggle's altitude strip) fills the cell and owns its hover/press. */
+.hk-tabs-merged {
+  position: relative;
+  /* Same layer as the triggers, above the sliding indicator. */
+  z-index: 1;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-sm);
-  background: rgb(var(--hk-surface, var(--color-surface, 255 255 255)));
-  border: 1px solid var(--border-faint);
-  overflow: hidden;
+  flex: none;
+  min-width: 0;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-sm);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Whole-strip disabled mutes the cell's interactive slot content too —
+   the triggers get the native disabled attribute, the cell gets this. */
+.hk-tabs-merged[data-disabled] {
   pointer-events: none;
 }
 
-.hk-tabs-overlay :where(button, a, [role="button"]) {
-  pointer-events: auto;
+/* block (row-filling) strips: the merged cell shares the triggers'
+   flex growth so it lands on the merged run's share of the row. */
+.hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-merged {
+  flex: 1 1 auto;
+}
+
+.hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-merged {
+  flex: 1 0 auto;
 }

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -207,7 +207,7 @@ describe("HkTabs segmented variant", () => {
   /** Mount with a live v-model and per-test tabs/slots. */
   function mountLive(
     extra: Record<string, unknown>,
-    slots?: Record<string, () => unknown>,
+    slots?: Record<string, (...args: any[]) => unknown>,
   ): { container: HTMLElement; active: ReturnType<typeof ref<string>> } {
     const active = ref("a");
     const container = document.createElement("div");
@@ -279,44 +279,112 @@ describe("HkTabs segmented variant", () => {
     expect(active.value).toBe("a");
   });
 
-  it("renders a measured tail overlay from overlayFrom with slot content", async () => {
+  it("collapses mergeKeys into one merged cell with slot content", async () => {
     const { container } = mountLive(
-      { variant: "segmented", overlayFrom: 0 },
-      { overlay: () => h("button", { type: "button", class: "strip" }, "+32.5°") },
+      { variant: "segmented", mergeKeys: ["b", "c"] },
+      { merged: ({ keys }: { keys: string[] }) => h("button", { type: "button", class: "strip" }, `merged:${keys.join("+")}`) },
     );
-    const overlay = container.querySelector<HTMLElement>(".hk-tabs-overlay")!;
-    expect(overlay).not.toBeNull();
-    expect(overlay.querySelector(".strip")).not.toBeNull();
-    // The geometry pass runs one tick after mount: happy-dom has no
-    // layout, so the equal-share fallback (tab 0 of 3) applies.
     await settle();
-    expect(overlay.style.left).toBe("33.3333%");
-    // Dropping the anchor disables the layer entirely.
-    const bare = mountLive({ variant: "segmented", overlayFrom: -1 },
-      { overlay: () => h("span", "x") });
-    expect(bare.container.querySelector(".hk-tabs-overlay")).toBeNull();
-    // Anchoring at the last tab leaves no tail to cover.
-    const last = mountLive({ variant: "segmented", overlayFrom: 2 },
-      { overlay: () => h("span", "x") });
-    expect(last.container.querySelector(".hk-tabs-overlay")).toBeNull();
+    const cell = container.querySelector<HTMLElement>(".hk-tabs-merged")!;
+    expect(cell).not.toBeNull();
+    expect(cell.getAttribute("data-keys")).toBe("b c");
+    // A real flex child of the track — never an absolute cover layer.
+    expect(cell.parentElement?.classList.contains("hk-tabs-list")).toBe(true);
+    const strip = cell.querySelector<HTMLElement>(".strip");
+    expect(strip?.textContent).toBe("merged:b+c");
+    // The merged options' triggers are gone; only Alpha renders.
+    const triggers = container.querySelectorAll(".hk-tabs-trigger");
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0].textContent).toContain("Alpha");
+    // The retired absolute overlay layer is gone for good.
+    expect(container.querySelector(".hk-tabs-overlay")).toBeNull();
+    // Clearing mergeKeys restores every trigger.
+    const bare = mountLive({ variant: "segmented" },
+      { merged: () => h("span", "x") });
+    expect(bare.container.querySelector(".hk-tabs-merged")).toBeNull();
+    expect(bare.container.querySelectorAll(".hk-tabs-trigger")).toHaveLength(3);
   });
 
-  it("spans measured geometry once layout exists", async () => {
+  it("renders mergeKeys as ordinary triggers without the merged slot", () => {
+    // Graceful degradation: keys listed but no slot → plain group.
+    const { container } = mountLive({ variant: "segmented", mergeKeys: ["b", "c"] });
+    expect(container.querySelector(".hk-tabs-merged")).toBeNull();
+    const triggers = container.querySelectorAll(".hk-tabs-trigger");
+    expect(triggers).toHaveLength(3);
+  });
+
+  it("degrades to plain triggers when mergeKeys are not contiguous", () => {
+    // "a"+"c" skip over "b": a scattered selection would swallow the
+    // middle option, so the group refuses to merge.
     const { container } = mountLive(
-      { variant: "segmented", overlayFrom: 0 },
-      { overlay: () => h("button", { class: "strip" }, "x") },
+      { variant: "segmented", mergeKeys: ["a", "c"] },
+      { merged: () => h("span", "m") },
     );
-    const list = container.querySelector<HTMLElement>(".hk-tabs-list")!;
-    const trig = container.querySelectorAll<HTMLElement>(".hk-tabs-trigger");
-    // Stub layout: trigger 0 at 14px wide 48, list inner width 182.
-    Object.defineProperty(trig[0], "offsetLeft", { value: 14, configurable: true });
-    Object.defineProperty(trig[0], "offsetWidth", { value: 48, configurable: true });
-    Object.defineProperty(list, "clientWidth", { value: 182, configurable: true });
+    expect(container.querySelector(".hk-tabs-merged")).toBeNull();
+    expect(container.querySelectorAll(".hk-tabs-trigger")).toHaveLength(3);
+  });
+
+  it("skips merged options in keyboard navigation", async () => {
+    const { container, active } = mountLive(
+      {
+        variant: "segmented",
+        tabs: [
+          { key: "a", label: "Alpha" },
+          { key: "b", label: "Beta" },
+          { key: "c", label: "Gamma" },
+        ],
+        mergeKeys: ["b"],
+      },
+      { merged: () => h("span", { class: "strip" }, "m") },
+    );
     await settle();
-    const overlay = container.querySelector<HTMLElement>(".hk-tabs-overlay")!;
-    // Unified chrome: zero inter-trigger gap, 2px track padding.
-    expect(overlay.style.left).toBe("62px");
-    expect(overlay.style.width).toBe("118px");
+    const trig = container.querySelectorAll<HTMLElement>(".hk-tabs-trigger");
+    expect(trig).toHaveLength(2);
+    // ArrowRight from Alpha skips the merged-away Beta and lands Gamma.
+    key(trig[0], "ArrowRight");
+    await settle();
+    expect(active.value).toBe("c");
+    key(trig[1], "ArrowRight");
+    await settle();
+    expect(active.value).toBe("a");
+    // End/Home only consider rendered (navigable) options.
+    key(trig[0], "End");
+    await settle();
+    expect(active.value).toBe("c");
+    key(trig[1], "Home");
+    await settle();
+    expect(active.value).toBe("a");
+    // Keydowns from merged-cell content never drive strip navigation.
+    const stripEl = container.querySelector<HTMLElement>(".hk-tabs-merged .strip")!;
+    key(stripEl, "ArrowRight");
+    await settle();
+    expect(active.value).toBe("a");
+  });
+
+  it("frames the merged cell with the indicator when the active key is merged", async () => {
+    const { container, active } = mountLive(
+      { variant: "segmented", mergeKeys: ["b", "c"] },
+      { merged: () => h("span", { class: "strip" }, "m") },
+    );
+    await settle();
+    const cell = container.querySelector<HTMLElement>(".hk-tabs-merged")!;
+    // Stub layout: the merged cell sits at 96px, 84px wide.
+    Object.defineProperty(cell, "offsetLeft", { value: 96, configurable: true });
+    Object.defineProperty(cell, "offsetWidth", { value: 84, configurable: true });
+    active.value = "b";
+    await settle();
+    const indicator = container.querySelector<HTMLElement>(".hk-tabs-indicator")!;
+    // The sliding indicator measures the cell — the merged render fully
+    // participates in the group's animation context.
+    expect(indicator.style.left).toBe("96px");
+    expect(indicator.style.width).toBe("84px");
+    expect(indicator.hasAttribute("data-ready")).toBe(true);
+    // With the active option merged away, the group stays keyboard
+    // reachable: the first navigable trigger keeps the roving tabindex
+    // slot (no tabindex attribute) and no trigger claims data-active.
+    const alpha = container.querySelector<HTMLElement>(".hk-tabs-trigger")!;
+    expect(alpha.hasAttribute("tabindex")).toBe(false);
+    expect(container.querySelector(".hk-tabs-trigger[data-active]")).toBeNull();
   });
 
   it("renders a tab icon field before the label", () => {

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, nextTick, onBeforeUnmount, onMounted, ref, watch, type ComponentPublicInstance, type PropType } from "vue";
+import { computed, defineComponent, h, nextTick, onBeforeUnmount, onBeforeUpdate, onMounted, ref, watch, TransitionGroup, type ComponentPublicInstance, type PropType } from "vue";
 
 import "./HkTabs.scss";
 import HkScrollContainer from "./HkScrollContainer";
@@ -6,8 +6,12 @@ import HkHoverRevealAction from "./HkHoverRevealAction";
 import HkIconButton from "./HkIconButton";
 import { iconByName } from "../composables/iconRegistry";
 import { useI18n } from "../i18n/context";
+import { clearLeaveGeometry, pinLeaveGeometry, type LeaveBoxSnapshot } from "../utils/dom";
 
 export interface TabItem {
+  /** Unique option key. `$indicator` and `$merged` are reserved — they
+   *  key the strip's internal indicator and the merged cell inside the
+   *  swap TransitionGroup. */
   key: string;
   label: string;
   /** Optional icon vnode rendered before the label (the `icon-${key}`
@@ -36,12 +40,6 @@ interface ScrollerExpose {
   getScrollElement?: () => HTMLElement | undefined;
 }
 
-/** Track geometry constants, kept in sync with HkTabs.scss: the track
- *  padding (TRACK_PAD) and the inter-trigger gap (TRACK_GAP — 0 in the
- *  unified chrome). */
-const TRACK_GAP = 0;
-const TRACK_PAD = 2;
-
 /**
  * HTabs — THE button-group / tab-strip primitive. ONE look (the centered
  * pill strip used by the page-level top/bottom bars) is shared by every
@@ -65,10 +63,14 @@ const TRACK_PAD = 2;
  *   icon buttons at EITHER inline end of the strip (outside the scroll
  *   viewport), hover/tap-revealed — the page bars' trailing "+" is
  *   simply `endAction`;
- * - `overlayFrom` + the `#overlay` slot: a measured info layer covering
- *   the track to the right of tab[overlayFrom] — e.g. the theme
- *   toggle's solar-altitude strip replacing the manual halves while
- *   "auto" is active (options "locked" by disabling their tabs);
+ * - `mergeKeys` + the `#merged` slot: DYNAMIC MERGED-OPTION rendering —
+ *   a contiguous run of options collapses into ONE combined cell (e.g.
+ *   the theme toggle's solar-altitude strip replacing the manual halves
+ *   while "auto" is active). The cell is a real flex child of the track
+ *   (never an absolute cover), so it joins layout AND the animation
+ *   context: options/cells fade-swap on merge changes, and the sliding
+ *   indicator measures the cell when the active key is merged. Merged
+ *   options are skipped by keyboard navigation;
  * - full arrow-key navigation (arrows/Home/End, wrapping, disabled tabs
  *   skipped, selection follows focus) and roving tabindex.
  */
@@ -109,11 +111,21 @@ export default defineComponent({
      *  the page bars' trailing "+" (outside the scroll viewport,
      *  hover/tap-revealed). Pressing it emits `action` with "end". */
     endAction: { type: Object as PropType<TabsEndAction | null>, default: null },
-    /** When ≥ 0 and the `#overlay` slot is provided, render the overlay
-     *  layer covering the track to the right of tab[overlayFrom]
-     *  (measured geometry; the covered tabs are usually disabled —
-     *  "option locking"). -1 disables the layer. */
-    overlayFrom: { type: Number, default: -1 },
+    /** Keys of a contiguous run of options that currently collapse into
+     *  ONE merged cell rendered by the `#merged` slot (dynamic
+     *  merged-option rendering). Merged triggers are not rendered and
+     *  are skipped by keyboard navigation; the cell takes the first
+     *  merged option's place as a real flex child of the track, joining
+     *  layout AND the animation context (swap transitions + the sliding
+     *  indicator measures it when the active key is merged). Pass
+     *  undefined/empty to disable. A single-key run is allowed — note
+     *  the cell is role=presentation, so that option leaves the radio/
+     *  keyboard surface while merged. The keys MUST be a contiguous
+     *  run — non-contiguous keys degrade to plain triggers (no cell).
+     *  Without the `#merged` slot the listed options render as ordinary
+     *  triggers (graceful degradation). In pill mode the merged
+     *  options' panels are not rendered while merged. */
+    mergeKeys: { type: Array as PropType<string[]>, default: undefined },
   },
   emits: {
     "update:modelValue": (_value: string) => true,
@@ -124,25 +136,56 @@ export default defineComponent({
     const { t } = useI18n();
     const triggerRefs = ref<Map<number, HTMLElement>>(new Map());
     const indicatorStyle = ref<Record<string, string>>({});
-    const overlayStyle = ref<Record<string, string> | undefined>(undefined);
+    /** The indicator fades in once real geometry first lands (no pop-in
+     *  on mount), then slides via its left/width transition. */
+    const indicatorReady = ref(false);
+    /** The merged cell element — measured by the indicator when the
+     *  active key is one of the merged options. */
+    const mergedCellRef = ref<HTMLElement | null>(null);
     const scrollerRef = ref<ScrollerExpose | null>(null);
     const listRef = ref<HTMLElement | null>(null);
 
     const isSegmented = computed(() => props.variant === "segmented");
     const isBlock = computed(() => isSegmented.value && props.block);
-    // No active tab (modelValue matches nothing / active disabled): keep
-    // the first enabled trigger tabbable so the group stays reachable —
-    // otherwise every trigger would be tabindex=-1.
+    const mergeSet = computed(() => new Set(props.mergeKeys ?? []));
+    /** Merged keys actually present in `tabs`, in tab order. */
+    const mergedRun = computed(() =>
+      props.tabs.filter((tb) => mergeSet.value.has(tb.key)).map((tb) => tb.key),
+    );
+    /** The contract is ONE contiguous run; a scattered selection would
+     *  silently swallow the middle options, so degrade to plain
+     *  triggers instead. */
+    const mergedContiguous = computed(() => {
+      const idxs = props.tabs
+        .map((tb, i) => (mergeSet.value.has(tb.key) ? i : -1))
+        .filter((i) => i >= 0);
+      return idxs.length <= 1 || idxs[idxs.length - 1] - idxs[0] === idxs.length - 1;
+    });
+    /** The merged cell only exists with BOTH keys present in `tabs` (as
+     *  one contiguous run) AND the `#merged` slot provided — otherwise
+     *  the listed options render as ordinary triggers (degradation
+     *  path). */
+    const hasMergedCell = computed(
+      () => mergedRun.value.length > 0 && mergedContiguous.value && slots.merged != null,
+    );
+    function isMergedTab(tab: TabItem): boolean {
+      return hasMergedCell.value && mergeSet.value.has(tab.key);
+    }
+    /** Navigable = rendered trigger: not disabled, not whole-strip
+     *  disabled upstream, and not collapsed into the merged cell. */
+    function isNavigable(tab: TabItem): boolean {
+      return !tab.disabled && !isMergedTab(tab);
+    }
+    // No active tab (modelValue matches nothing / active disabled or
+    // merged): keep the first enabled trigger tabbable so the group
+    // stays reachable — otherwise every trigger would be tabindex=-1.
     const fallbackTabbableIdx = computed(() => {
       const hasActive = props.tabs.some(
-        (tb) => tb.key === props.modelValue && !tb.disabled,
+        (tb) => tb.key === props.modelValue && isNavigable(tb),
       );
       if (hasActive) return -1;
-      return props.tabs.findIndex((tb) => !tb.disabled);
+      return props.tabs.findIndex((tb) => isNavigable(tb));
     });
-    const hasOverlay = computed(
-      () => props.overlayFrom >= 0 && props.overlayFrom < props.tabs.length - 1 && slots.overlay != null,
-    );
 
     function resolvedActionLabel(action: TabsEndAction): string {
       return action.label || t("hikari::tabs.add", "Add tab");
@@ -156,38 +199,33 @@ export default defineComponent({
       }
     }
 
-    function updateIndicator() {
+    function setMergedCellRef(el: Element | ComponentPublicInstance | null) {
+      mergedCellRef.value = el instanceof HTMLElement ? el : null;
+    }
+
+    /** The element the indicator should frame: the merged cell when the
+     *  active option is collapsed into it, otherwise the active trigger
+     *  (falling back to the first option's render — trigger OR cell —
+     *  while no geometry exists). */
+    function activeFrameEl(): HTMLElement | undefined {
       const idx = props.tabs.findIndex((tb) => tb.key === props.modelValue);
-      const el = triggerRefs.value.get(idx >= 0 ? idx : 0);
+      const i = idx >= 0 ? idx : 0;
+      const tab = props.tabs[i];
+      if (tab && isMergedTab(tab)) {
+        return mergedCellRef.value ?? undefined;
+      }
+      return triggerRefs.value.get(i);
+    }
+
+    function updateIndicator() {
+      const el = activeFrameEl();
       if (!el) return;
       const left = `${el.offsetLeft}px`;
       const width = `${el.offsetWidth}px`;
-      if (indicatorStyle.value.left === left && indicatorStyle.value.width === width) return;
-      indicatorStyle.value = { left, width };
-    }
-
-    function updateOverlay() {
-      if (!hasOverlay.value) {
-        overlayStyle.value = undefined;
-        return;
+      if (indicatorStyle.value.left !== left || indicatorStyle.value.width !== width) {
+        indicatorStyle.value = { left, width };
       }
-      const el = triggerRefs.value.get(props.overlayFrom);
-      const list = listRef.value;
-      if (!el || !list) return;
-      const leftPx = el.offsetLeft + el.offsetWidth + TRACK_GAP;
-      const listWidth = list.clientWidth;
-      if (el.offsetWidth > 0 && listWidth > leftPx + TRACK_PAD) {
-        overlayStyle.value = {
-          left: `${leftPx}px`,
-          width: `${listWidth - leftPx - TRACK_PAD}px`,
-        };
-        return;
-      }
-      // Pre-measurement fallback (SSR / hidden / layout-less): cover the
-      // tail by equal-share estimate, like the indicator's zero-geometry
-      // phase — the measured style takes over once real layout exists.
-      const share = (props.overlayFrom + 1) / props.tabs.length;
-      overlayStyle.value = { left: `${(share * 100).toFixed(4)}%` };
+      indicatorReady.value = true;
     }
 
     /** Nudge the scroller so the active trigger is fully visible with
@@ -197,8 +235,7 @@ export default defineComponent({
     function scrollActiveIntoView() {
       const vp = scrollerRef.value?.getScrollElement?.();
       if (!vp) return;
-      const idx = props.tabs.findIndex((tb) => tb.key === props.modelValue);
-      const el = triggerRefs.value.get(idx >= 0 ? idx : 0);
+      const el = activeFrameEl();
       if (!el) return;
       const left = el.offsetLeft;
       const right = left + el.offsetWidth;
@@ -212,7 +249,6 @@ export default defineComponent({
 
     function refreshGeometry() {
       updateIndicator();
-      updateOverlay();
       if (props.scrollable) scrollActiveIntoView();
     }
 
@@ -222,9 +258,10 @@ export default defineComponent({
     onMounted(() => {
       nextTick(refreshGeometry);
       resizeObserver = new ResizeObserver(() => refreshGeometry());
-      const firstEl = triggerRefs.value.get(0);
-      if (firstEl?.parentElement) {
-        resizeObserver.observe(firstEl.parentElement);
+      // Observe the track itself (tab[0] may be merged away, so a
+      // trigger-derived parent is not a reliable anchor anymore).
+      if (listRef.value) {
+        resizeObserver.observe(listRef.value);
       }
       if (props.scrollable) {
         // The indicator observer watches the content-sized list, so a
@@ -253,18 +290,49 @@ export default defineComponent({
       nextTick(refreshGeometry);
     }, { deep: true });
 
-    watch(() => props.overlayFrom, () => nextTick(refreshGeometry));
+    watch(() => props.mergeKeys, () => nextTick(refreshGeometry));
+
+    /** Pre-patch geometry of every track child, refreshed on every
+     *  update (the DOM is still the pre-patch tree at onBeforeUpdate).
+     *  During a multi-option leave (e.g. Light+Dark collapsing into the
+     *  merged cell), Vue's patch lifts the first leaving sibling to
+     *  position:absolute SYNCHRONOUSLY before the next sibling's
+     *  beforeLeave hook runs — a live offset read there would freeze
+     *  the already-reflowed position and overlap the ghosts. */
+    const preSwapBoxes = new WeakMap<Element, LeaveBoxSnapshot>();
+    onBeforeUpdate(() => {
+      const list = listRef.value;
+      if (!list) return;
+      for (const child of Array.from(list.children)) {
+        const e = child as HTMLElement;
+        preSwapBoxes.set(e, {
+          top: e.offsetTop,
+          left: e.offsetLeft,
+          width: e.offsetWidth,
+          height: e.offsetHeight,
+        });
+      }
+    });
+
+    /** Leaving options/cells are pinned at their in-flow geometry by
+     *  the shared leave-pin util (left-anchored: the track's
+     *  inline-start edge stays put while a middle/tail removal
+     *  collapses the right side) so the absolute leave ghost fades in
+     *  place; a cancelled leave drops the pins again. */
+    function pinLeaving(el: Element) {
+      pinLeaveGeometry(el, { anchorX: "left", box: preSwapBoxes.get(el) });
+    }
 
     // ── Keyboard navigation ─────────────────────────────────────────
     // role=tab/radio buttons have no native arrow behavior — the strip
-    // owns it. Selection follows focus; disabled tabs are skipped;
-    // Home/End jump to the first/last enabled tab.
+    // owns it. Selection follows focus; disabled and merged-away options
+    // are skipped; Home/End jump to the first/last navigable option.
     function focusTrigger(idx: number) {
       void nextTick(() => triggerRefs.value.get(idx)?.focus());
     }
     function selectIndex(idx: number) {
       const tb = props.tabs[idx];
-      if (!tb || tb.disabled || tb.key === props.modelValue) return;
+      if (!tb || !isNavigable(tb) || props.disabled || tb.key === props.modelValue) return;
       emit("update:modelValue", tb.key);
       focusTrigger(idx);
     }
@@ -274,15 +342,16 @@ export default defineComponent({
       let idx = from;
       for (let step = 0; step < n; step += 1) {
         idx = (idx + delta + n) % n;
-        if (!props.tabs[idx].disabled) {
+        if (isNavigable(props.tabs[idx])) {
           selectIndex(idx);
           return;
         }
       }
     }
     function onKeydown(e: KeyboardEvent) {
-      // Only drive strip navigation from triggers — interactive overlay
-      // content (inputs, sliders inside the #overlay slot) keeps its keys.
+      // Only drive strip navigation from triggers — interactive merged
+      // cell content (buttons, inputs inside the #merged slot) keeps
+      // its keys.
       const target = e.target as HTMLElement | null;
       if (!target || !target.closest(".hk-tabs-trigger")) return;
       const current = Math.max(0, props.tabs.findIndex((tb) => tb.key === props.modelValue));
@@ -296,13 +365,13 @@ export default defineComponent({
           moveSelection(current, -1);
           break;
         case "Home": {
-          const first = props.tabs.findIndex((tb) => !tb.disabled);
+          const first = props.tabs.findIndex((tb) => isNavigable(tb));
           if (first >= 0) selectIndex(first);
           break;
         }
         case "End": {
           for (let i = props.tabs.length - 1; i >= 0; i -= 1) {
-            if (!props.tabs[i].disabled) {
+            if (isNavigable(props.tabs[i])) {
               selectIndex(i);
               break;
             }
@@ -316,6 +385,67 @@ export default defineComponent({
     }
 
     return () => {
+      const mergedHead = mergedRun.value[0];
+      const listChildren = [
+        <div
+          key="$indicator"
+          class="hk-tabs-indicator"
+          style={indicatorStyle.value}
+          data-ready={indicatorReady.value || undefined}
+        />,
+      ];
+      props.tabs.forEach((tab, idx) => {
+        if (isMergedTab(tab)) {
+          // The merged run renders as ONE combined cell at its first
+          // option's position — a real flex child of the track (joins
+          // layout and the swap/indicator animation context), never an
+          // absolute cover. role=presentation: the radiogroup's a11y
+          // surface is the remaining triggers; interactive slot content
+          // carries its own semantics.
+          if (tab.key === mergedHead) {
+            listChildren.push(
+              <div
+                key="$merged"
+                class="hk-tabs-merged"
+                ref={setMergedCellRef}
+                role="presentation"
+                data-keys={mergedRun.value.join(" ")}
+                data-disabled={props.disabled || undefined}
+              >
+                {slots.merged?.({ keys: mergedRun.value })}
+              </div>,
+            );
+          }
+          return;
+        }
+        const active = tab.key === props.modelValue;
+        const disabled = tab.disabled;
+        const icon = slots[`icon-${tab.key}`]?.() ?? (tab.icon != null ? <span class="hk-tabs-trigger-icon">{tab.icon as any}</span> : null);
+        listChildren.push(
+          <button
+            key={tab.key}
+            ref={(el) => setTriggerRef(el, idx)}
+            type="button"
+            role={isSegmented.value ? "radio" : "tab"}
+            aria-checked={isSegmented.value ? active : undefined}
+            aria-selected={isSegmented.value ? undefined : active}
+            aria-disabled={disabled || undefined}
+            class="hk-tabs-trigger"
+            data-active={active || undefined}
+            data-disabled={props.disabled || disabled || undefined}
+            // Roving tabindex: the active trigger joins the page tab
+            // sequence, the others stay arrow-reachable.
+            tabindex={active || idx === fallbackTabbableIdx.value ? undefined : -1}
+            disabled={props.disabled || disabled}
+            onClick={() => {
+              if (!props.disabled && !disabled && tab.key !== props.modelValue) emit("update:modelValue", tab.key);
+            }}
+          >
+            {icon}
+            {tab.label && <span>{tab.label}</span>}
+          </button>,
+        );
+      });
       const list = (
         <div
           class="hk-tabs-list"
@@ -325,41 +455,12 @@ export default defineComponent({
           role={isSegmented.value ? "radiogroup" : "tablist"}
           onKeydown={onKeydown}
         >
-          <div class="hk-tabs-indicator" style={indicatorStyle.value} />
-          {props.tabs.map((tab, idx) => {
-            const active = tab.key === props.modelValue;
-            const disabled = tab.disabled;
-            const icon = slots[`icon-${tab.key}`]?.() ?? (tab.icon != null ? <span class="hk-tabs-trigger-icon">{tab.icon as any}</span> : null);
-            return (
-              <button
-                key={tab.key}
-                ref={(el) => setTriggerRef(el, idx)}
-                type="button"
-                role={isSegmented.value ? "radio" : "tab"}
-                aria-checked={isSegmented.value ? active : undefined}
-                aria-selected={isSegmented.value ? undefined : active}
-                aria-disabled={disabled || undefined}
-                class="hk-tabs-trigger"
-                data-active={active || undefined}
-                data-disabled={props.disabled || disabled || undefined}
-                // Roving tabindex: the active trigger joins the page tab
-                // sequence, the others stay arrow-reachable.
-                tabindex={active || idx === fallbackTabbableIdx.value ? undefined : -1}
-                disabled={props.disabled || disabled}
-                onClick={() => {
-                  if (!props.disabled && !disabled && tab.key !== props.modelValue) emit("update:modelValue", tab.key);
-                }}
-              >
-                {icon}
-                {tab.label && <span>{tab.label}</span>}
-              </button>
-            );
-          })}
-          {hasOverlay.value && (
-            <div class="hk-tabs-overlay" style={overlayStyle.value}>
-              {slots.overlay?.()}
-            </div>
-          )}
+          {/* Tagless group: the track stays a plain element (ref/CSS/
+              keydown unchanged) while option/cell inserts and removals
+              run through the hk-tabs-swap transitions. */}
+          <TransitionGroup name="hk-tabs-swap" onBeforeLeave={pinLeaving} onLeaveCancelled={clearLeaveGeometry}>
+            {listChildren}
+          </TransitionGroup>
         </div>
       );
 
@@ -389,7 +490,7 @@ export default defineComponent({
             </HkScrollContainer>
           ) : list}
 
-          {props.renderPanels && !isSegmented.value && props.tabs.map((tab) => (
+          {props.renderPanels && !isSegmented.value && props.tabs.filter((tab) => !isMergedTab(tab)).map((tab) => (
             <div
               key={tab.key}
               role="tabpanel"

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -47,41 +47,46 @@
   padding: var(--space-4, 0.25rem) var(--space-6, 0.375rem);
 }
 
-/* ── Color-mode group (unified HTabs segmented + auto tail overlay) ──── */
+/* ── Color-mode group (unified HTabs segmented + merged auto cell) ──── */
 
 .s-theme-mode-row {
   padding: 0 var(--space-6, 0.375rem) var(--space-4, 0.25rem);
 }
 
 /*
- * Auto-mode altitude strip: full-bleed content INSIDE the strip's tail
- * overlay (HTabs' overlay layer supplies the unified pill chrome —
- * surface, hairline border, radius). It reads passive in the strip's
- * own typography (same size/weight as the triggers it covers), but a
- * press resolves auto to the manual side it currently renders
- * (day → light, night → dark).
+ * Auto-mode altitude strip: the full-bleed content of the segmented
+ * group's merged cell (HTabs `mergeKeys` + `#merged`). The cell itself
+ * stays NAKED like every unselected option — no border, no own surface,
+ * no box: only the sliding indicator ever frames the active option.
+ * The strip reads passive in the strip's own typography (same
+ * size/weight as the triggers it replaces), but a press resolves auto
+ * to the manual side it currently renders (day → light, night → dark).
  */
 .s-theme-mode-autoalt {
-  position: absolute;
-  inset: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-4, 0.25rem);
+  width: 100%;
+  height: 100%;
+  /* No min-height: the track's cross size stays trigger-driven in BOTH
+     modes (the cell stretches, the strip fills it), so toggling auto ↔
+     manual never grows or shrinks the strip. */
+  padding: var(--space-4, 0.25rem) var(--space-12, 0.75rem);
   border: 0;
-  border-radius: inherit;
+  border-radius: var(--radius-sm, 6px);
   background: transparent;
   color: rgb(var(--color-text-secondary, var(--color-muted)));
   font: inherit;
   font-size: var(--text-sm);
   font-weight: 600;
   line-height: 1;
-  cursor: default;
+  cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
   appearance: none;
-  padding: 0;
+  transition: color 0.15s ease, background 0.15s ease, transform 0.12s ease;
 }
 
 .s-theme-mode-autoalt:hover {
@@ -90,6 +95,7 @@
 
 .s-theme-mode-autoalt:active {
   background: rgb(var(--color-primary) / 8%);
+  transform: scale(0.97);
 }
 
 .s-theme-mode-autoalt:focus-visible {

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -53,7 +53,9 @@ function mountToggle(externalCustomize: boolean): Mounted {
 
 async function settle(): Promise<void> {
   await nextTick();
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  // Leave transitions in the tab strip resolve through a ~1ms fallback
+  // timer in happy-dom — give swap transitions a real macrotask window.
+  await new Promise((resolve) => setTimeout(resolve, 20));
   await nextTick();
 }
 
@@ -75,7 +77,7 @@ function modeSegments(): HTMLButtonElement[] {
   return [...document.body.querySelectorAll<HTMLButtonElement>(".s-theme-mode-row .hk-tabs-trigger")];
 }
 
-function altitudeOverlay(): HTMLElement | null {
+function altitudeStrip(): HTMLElement | null {
   return document.body.querySelector<HTMLElement>(".s-theme-mode-autoalt");
 }
 
@@ -126,7 +128,7 @@ describe("HkThemeToggle external customization", () => {
 });
 
 describe("HkThemeToggle color-mode group", () => {
-  it("renders three segments with the altitude overlay only in auto mode", async () => {
+  it("renders three segments with the naked altitude cell only in auto mode", async () => {
     useTheme().setMode("dark");
     const { container } = mountToggle(true);
     await settle();
@@ -134,30 +136,36 @@ describe("HkThemeToggle color-mode group", () => {
     openMenu(container);
     await settle();
 
-    // Manual mode: plain three-way group, no cover strip.
+    // Manual mode: plain three-way group, no merged cell.
     expect(modeSegments()).toHaveLength(3);
-    expect(altitudeOverlay()).toBeNull();
+    expect(altitudeStrip()).toBeNull();
     const dark = modeSegments().find((b) => b.textContent?.includes("Dark"));
     const lightSeg = modeSegments().find((b) => b.textContent?.includes("Light"));
     expect(dark?.getAttribute("aria-checked")).toBe("true");
     expect(lightSeg?.disabled).toBe(false);
 
-    // Back to auto: the group's tail overlay covers the Light/Dark halves
-    // with the altitude strip (HTabs overlayFrom + #overlay).
+    // Back to auto: the Light/Dark options merge into the group's
+    // merged cell carrying the altitude strip (HTabs mergeKeys +
+    // #merged) — a real track child, NOT the retired absolute overlay.
     modeSegments()
       .find((b) => b.textContent?.includes("Auto"))!
       .click();
     await settle();
 
-    const overlay = altitudeOverlay();
-    expect(overlay).toBeTruthy();
-    expect(overlay!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
-    // The overlay rides inside the segmented group's overlay layer.
-    expect(overlay!.closest(".hk-tabs-overlay")).toBeTruthy();
-    // Covered segments sit out of the tab order; the strip is the single
-    // pointer surface while auto is active.
-    expect(lightSeg?.disabled).toBe(true);
-    expect(dark?.disabled).toBe(true);
+    const strip = altitudeStrip();
+    expect(strip).toBeTruthy();
+    expect(strip!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
+    const cell = strip!.closest(".hk-tabs-merged");
+    expect(cell).toBeTruthy();
+    expect(cell!.getAttribute("data-keys")).toBe("light dark");
+    expect(cell!.parentElement?.classList.contains("hk-tabs-list")).toBe(true);
+    expect(document.body.querySelector(".hk-tabs-overlay")).toBeNull();
+    // The merged Light/Dark triggers leave the radio order entirely —
+    // the strip is the single pointer surface while auto is active.
+    const segments = modeSegments();
+    expect(segments).toHaveLength(1);
+    expect(segments[0].textContent).toContain("Auto");
+    expect(segments[0].getAttribute("aria-checked")).toBe("true");
   });
 
   it("resolves auto to a manual side when the altitude strip is pressed", async () => {
@@ -167,16 +175,18 @@ describe("HkThemeToggle color-mode group", () => {
 
     openMenu(container);
     await settle();
-    expect(altitudeOverlay()).toBeTruthy();
+    expect(altitudeStrip()).toBeTruthy();
 
-    altitudeOverlay()!.click();
+    altitudeStrip()!.click();
     await settle();
 
-    expect(altitudeOverlay()).toBeNull();
+    expect(altitudeStrip()).toBeNull();
     const stored = localStorage.getItem(MODE_KEY);
     expect(["light", "dark"]).toContain(stored);
     const active = modeSegments().find((b) => b.getAttribute("aria-checked") === "true");
     expect(active?.textContent).toContain(stored === "light" ? "Light" : "Dark");
+    // All three plain triggers are back in the radio order.
+    expect(modeSegments()).toHaveLength(3);
   });
 
   it("keeps every theme row footprint uniform for list highlights", async () => {

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -23,6 +23,11 @@ function geoOnce(): Promise<{ lat: number; lng: number }> {
   return geoPromise;
 }
 
+/** The auto-mode merged run, hoisted: a fresh array literal per render
+ *  would re-fire HTabs' mergeKeys watcher (one redundant geometry
+ *  refresh) on every altitude tick. */
+const AUTO_MERGE_KEYS = ["light", "dark"];
+
 /**
  * HkThemeToggle — light/dark/auto theme control over hikari's theme engine.
  *
@@ -34,11 +39,14 @@ function geoOnce(): Promise<{ lat: number; lng: number }> {
  *
  * Color-mode group: the unified HTabs strip in segmented (radiogroup)
  * working mode (Auto | Light | Dark) — same pill chrome as every other
- * group. In AUTO mode the Light/Dark half is covered by the strip's
- * built-in tail overlay (`overlayFrom` + `#overlay`): a passive-looking
+ * group. In AUTO mode the Light/Dark halves merge into the strip's
+ * merged cell (`mergeKeys` + `#merged`): a passive-looking
  * solar-altitude strip in the strip's own trigger typography — pressing
  * it drops to manual on whichever side auto currently resolves to (day
  * → light, night → dark), so no separate resolve step is ever needed.
+ * The cell is NAKED like every unselected option (no border/surface of
+ * its own) and joins the group's animation context (swap transitions +
+ * the sliding indicator).
  */
 export const HkThemeToggle = defineComponent({
   name: "HkThemeToggle",
@@ -65,7 +73,7 @@ export const HkThemeToggle = defineComponent({
     const triggerRef = ref<HTMLElement | null>(null);
     const schemeDialogOpen = ref(false);
 
-    // ── Solar-altitude readout (auto-mode overlay) ──────────────────────
+    // ── Solar-altitude readout (auto-mode merged cell) ──────────────
     const geo = ref<{ lat: number; lng: number }>({ ...DEFAULT_GEO_LOCATION });
     const altTick = ref(0);
 
@@ -125,9 +133,10 @@ export const HkThemeToggle = defineComponent({
      * Fresh option objects (and fresh icon vnodes) on every call — never
      * cache icon vnodes across renders, or closing/reopening the popover
      * would re-mount the same vnode instances. In AUTO mode the Light/
-     * Dark segments are disabled: their area is covered by the group's
-     * tail overlay (the altitude strip), and the strip's press resolves
-     * to whichever manual side auto currently renders.
+     * Dark options collapse into the group's merged cell (the altitude
+     * strip) via `mergeKeys`; they stay flagged disabled for the
+     * degradation path (merge requested without the #merged slot) and
+     * for semantic clarity.
      */
     function modeOptions(): TabItem[] {
       const auto = isAutoMode.value;
@@ -211,10 +220,10 @@ export const HkThemeToggle = defineComponent({
                 tabs={modeOptions()}
                 modelValue={currentMode.value}
                 onUpdate:modelValue={onSelectMode}
-                overlayFrom={isAutoMode.value ? 0 : -1}
+                mergeKeys={isAutoMode.value ? AUTO_MERGE_KEYS : undefined}
               >
                 {{
-                  overlay: () => (
+                  merged: () => (
                     <button
                       type="button"
                       class="s-theme-mode-autoalt"

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -91,12 +91,14 @@
   --hi-shadow-elevated: 0 2px 16px rgb(0 0 0 / 8%);
 
   /* ── Hk component tokens (theme bridge) ─
-   * Chrome-level component styles (the HTabs tail overlay) read these RGB-triplet tokens.
+   * Chrome-level component styles read these RGB-triplet tokens.
    * Without a definition they fall back to hardcoded light-theme values
    * (white surfaces, near-black text, blue focus ring) inside dark
    * themes. Bridging them to the runtime --color-* tokens keeps the
    * controls on the active theme; consumer-local definitions still win
-   * by load order. */
+   * by load order. (--hk-surface's only in-tree consumer — the retired
+   * HTabs tail overlay — is gone; the token stays published for
+   * external plana-ui readers.) */
   --hk-surface: var(--color-surface, 255 255 255);
   --hk-primary: var(--color-primary, 60 120 240);
 }

--- a/packages/vue/src/utils/dom.test.ts
+++ b/packages/vue/src/utils/dom.test.ts
@@ -4,10 +4,14 @@ import { clearLeaveGeometry, pinLeaveGeometry } from "./dom";
 
 /**
  * pinLeaveGeometry contract:
- * - freezes the in-flow box (right/top/width/height + border-box) of a
- *   leaving list item against its offsetParent, anchored to the
- *   containing block's right padding-box edge
- *   (right = clientWidth - (offsetLeft + offsetWidth))
+ * - freezes the in-flow box (right|left/top/width/height + border-box)
+ *   of a leaving list item against its offsetParent — anchored to the
+ *   containing block's right padding-box edge by default
+ *   (right = clientWidth - (offsetLeft + offsetWidth)), or left-pinned
+ *   with anchorX:"left" for inline-start-stable hosts (the tab track)
+ * - a supplied LeaveBoxSnapshot (pre-patch) wins over live reads, so a
+ *   later sibling's pin survives the synchronous absolute-lift of an
+ *   earlier leaving sibling in the same patch pass
  * - reads every metric before writing any style, so no intermediate
  *   write can skew a later read (content-box rewrap hazard)
  * - is a no-op when layout info is unavailable (offsetParent null)
@@ -71,17 +75,53 @@ describe("pinLeaveGeometry", () => {
     expect(el.style).toEqual({});
   });
 
+  it("pins left-anchored when anchorX is 'left' (tab-track hosts)", () => {
+    const parent = { clientWidth: 400 };
+    const el = stubEl(parent, { offsetTop: 2, offsetLeft: 96, offsetWidth: 84, offsetHeight: 28 });
+
+    pinLeaveGeometry(el as unknown as Element, { anchorX: "left" });
+
+    // No right pin: a middle removal's ghost must sit at its in-flow
+    // left offset, not re-anchored to the collapsing right edge.
+    expect(el.style.right).toBeUndefined();
+    expect(el.style.left).toBe("96px");
+    expect(el.style.top).toBe("2px");
+    expect(el.style.width).toBe("84px");
+    expect(el.style.height).toBe("28px");
+    expect(el.style.boxSizing).toBe("border-box");
+  });
+
+  it("prefers a supplied pre-patch box snapshot over live reads", () => {
+    // Live metrics simulate the post-lift reflow (sibling already
+    // absolute → this element shifted left by 60px); the snapshot must
+    // win so the ghost pins where the option actually was.
+    const parent = { clientWidth: 400 };
+    const el = stubEl(parent, { offsetTop: 2, offsetLeft: 36, offsetWidth: 84, offsetHeight: 28 });
+
+    pinLeaveGeometry(el as unknown as Element, {
+      anchorX: "left",
+      box: { top: 2, left: 96, width: 84, height: 28 },
+    });
+
+    expect(el.style.left).toBe("96px");
+    expect(el.style.top).toBe("2px");
+    expect(el.style.width).toBe("84px");
+    expect(el.style.height).toBe("28px");
+    expect(el.style.boxSizing).toBe("border-box");
+  });
+
   it("clearLeaveGeometry strips exactly the pins pinLeaveGeometry wrote", () => {
     const parent = { clientWidth: 384 };
     const el = stubEl(parent, { offsetWidth: 384, offsetHeight: 83 });
     el.style.marginLeft = "4px"; // foreign style must survive the clear.
 
-    pinLeaveGeometry(el as unknown as Element);
+    pinLeaveGeometry(el as unknown as Element, { anchorX: "left" });
     clearLeaveGeometry(el as unknown as Element);
 
     // On a real CSSStyleDeclaration an empty string removes the
     // property; the stub keeps the keys, so assert emptiness.
     expect(el.style.right).toBe("");
+    expect(el.style.left).toBe("");
     expect(el.style.top).toBe("");
     expect(el.style.width).toBe("");
     expect(el.style.height).toBe("");

--- a/packages/vue/src/utils/dom.ts
+++ b/packages/vue/src/utils/dom.ts
@@ -38,6 +38,19 @@ export function scrollToElement(selector: string, opts?: ScrollIntoViewOptions):
   el?.scrollIntoView(opts ?? { block: "nearest" });
 }
 
+/** Pre-measured in-flow box for {@link pinLeaveGeometry}. Snapshot the
+ *  leaving elements BEFORE the patch that removes them (e.g. the host
+ *  component's onBeforeUpdate): during a multi-element removal the
+ *  first sibling's leave-active class (position:absolute) lands
+ *  synchronously in the same patch pass, so a later sibling's live
+ *  offset* read would freeze an already-reflowed position. */
+export interface LeaveBoxSnapshot {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
 /**
  * Pin a leaving list item's geometry before its `*-leave-active` rule
  * switches it to `position: absolute`.
@@ -52,21 +65,30 @@ export function scrollToElement(selector: string, opts?: ScrollIntoViewOptions):
  * sliver across the screen while it fades — the closing-toast "flash".
  *
  * Recording the in-flow box makes the leave transition play as a true
- * mirror of the entrance instead. The pin is anchored to the RIGHT
- * inner edge of the containing block (the relative transition-group
- * wrapper, which is also the element's offsetParent): right-anchored
- * hosts keep that edge put while the left edge collapses, so a
- * `right + width` pin survives the collapse that defeats a `left`
- * pin. All metrics come from the offset* family — layout boxes that
- * ignore transforms, so a concurrent FLIP move cannot skew the pin —
- * and the width/height pins are paired with an inline
- * `box-sizing: border-box` so they reproduce the measured border-box
- * exactly for content-box items.
+ * mirror of the entrance instead. The pin is anchored by `anchorX`:
+ * - `"right"` (default): anchored to the RIGHT inner edge of the
+ *   containing block (the relative transition-group wrapper, which is
+ *   also the element's offsetParent). Right-anchored hosts keep that
+ *   edge put while the left edge collapses, so a `right + width` pin
+ *   survives the collapse that defeats a `left` pin (toast columns).
+ * - `"left"`: anchored to the LEFT inner edge — for hosts whose
+ *   inline-start edge stays put in LTR flow (the tab track), where a
+ *   right pin would misplace a middle removal by the removed width.
+ *
+ * Metrics come from `opts.box` when supplied (a pre-patch snapshot —
+ * see {@link LeaveBoxSnapshot}), otherwise from the offset* family —
+ * layout boxes that ignore transforms, so a concurrent FLIP move
+ * cannot skew the pin — and the width/height pins are paired with an
+ * inline `box-sizing: border-box` so they reproduce the measured
+ * border-box exactly for content-box items.
  *
  * No-op when layout information is unavailable (no offsetParent:
  * hidden subtrees, detached nodes, non-layout environments).
  */
-export function pinLeaveGeometry(el: Element): void {
+export function pinLeaveGeometry(
+  el: Element,
+  opts?: { anchorX?: "left" | "right"; box?: LeaveBoxSnapshot },
+): void {
   const node = el as HTMLElement;
   const parent = node.offsetParent as HTMLElement | null;
   if (parent == null) return;
@@ -75,15 +97,19 @@ export function pinLeaveGeometry(el: Element): void {
   // content-box element an intermediate `width` write silently changes
   // the wrap width — a height read after it would freeze a transient
   // rewrap instead of the box the user is looking at.
-  const top = node.offsetTop;
-  const left = node.offsetLeft;
-  const width = node.offsetWidth;
-  const height = node.offsetHeight;
-  // CSS `right` for an absolutely positioned box is measured from the
-  // containing block's right padding-box edge; offsetLeft/offsetWidth
-  // place the item's right border edge within that same padding box.
-  const right = parent.clientWidth - (left + width);
-  node.style.right = `${right}px`;
+  const top = opts?.box?.top ?? node.offsetTop;
+  const left = opts?.box?.left ?? node.offsetLeft;
+  const width = opts?.box?.width ?? node.offsetWidth;
+  const height = opts?.box?.height ?? node.offsetHeight;
+  if (opts?.anchorX === "left") {
+    node.style.left = `${left}px`;
+  } else {
+    // CSS `right` for an absolutely positioned box is measured from the
+    // containing block's right padding-box edge; offsetLeft/offsetWidth
+    // place the item's right border edge within that same padding box.
+    const right = parent.clientWidth - (left + width);
+    node.style.right = `${right}px`;
+  }
   node.style.top = `${top}px`;
   node.style.width = `${width}px`;
   node.style.height = `${height}px`;
@@ -93,12 +119,13 @@ export function pinLeaveGeometry(el: Element): void {
 /**
  * Drop the pins written by {@link pinLeaveGeometry}. Wire this to the
  * transition's leave-cancelled hook: when a leave is aborted and the
- * element re-enters the flow, stale right/width/height pins would
+ * element re-enters the flow, stale left/right/width/height pins would
  * freeze its geometry even as its content changes.
  */
 export function clearLeaveGeometry(el: Element): void {
   const node = el as HTMLElement;
   node.style.right = "";
+  node.style.left = "";
   node.style.top = "";
   node.style.width = "";
   node.style.height = "";


### PR DESCRIPTION
## What

The theme-mode segmented control framed its auto-mode solar-altitude strip with an unwanted box (the retired `overlayFrom`/`#overlay` layer carried its own border + opaque surface), and button-group click motion was only half wired. This PR gives HTabs first-class **dynamic merged-option rendering** and completes the motion system.

## Changes

- **HTabs**: new `mergeKeys` prop + `#merged` slot — a contiguous run of options collapses into ONE merged cell (`.hk-tabs-merged`), a real flex child of the track with naked unselected-option chrome. `overlayFrom`/`#overlay`/`.hk-tabs-overlay` are removed (0.20.0 breaking).
- **Merged cell joins the animation context**: the sliding indicator measures it when the active key is merged; option/cell inserts and removals cross-fade via the tagless `hk-tabs-swap` TransitionGroup.
- **Geometry-pinned leave ghosts**: `pinLeaveGeometry` gains `anchorX`/`box` options; HkTabs snapshots child boxes in `onBeforeUpdate` (Vue 3.5 lifts the first leaving sibling to `position:absolute` synchronously in the same patch pass — live reads would freeze reflowed positions), and cancelled leaves drop the pins. Specificity-safe ghost lift via `.hk-tabs-list > .hk-tabs-swap-leave-active`.
- **A11y/robustness**: keyboard nav + roving tabindex skip merged options and the group stays reachable when the active option is merged; whole-strip `disabled` mutes the cell; non-contiguous or slot-less `mergeKeys` degrade to plain triggers.
- **All button groups complete the click motion**: indicator fades in on first measurement (no pop-in), triggers give tactile `:active` scale feedback, dynamic option changes cross-fade.
- **HkThemeToggle**: the altitude strip fills the merged cell (full-bleed press, pointer cursor, press feedback); track height stays trigger-driven across auto↔manual; hoisted `AUTO_MERGE_KEYS` kills redundant watcher fires.
- **Tests**: 552/552 green incl. new merge-cell, contiguity-degradation, keyboard-skip, indicator-framing, roving-tabindex and dom-util anchorX/box/clear contracts; `vue-tsc --noEmit` clean; sass compiles clean.

## Verification

3-round subagent verify cycle (restarted twice on found defects — CSS specificity blocker + multi-leave ghost mis-pin — both fixed and re-verified; final 3 consecutive SHIP rounds incl. end-to-end Vue 3.5.40 runtime simulation of both swap flows and compiled-CSS specificity inventory). Per §7.2 no builds; deployment rides the next malkuth wave.

## Downstream propagation

- shittim-chest / e.celestia.world / erp.celestia.world consume hikari via `workspace:*` links — no code changes needed (no `overlayFrom`/overlay CSS usage anywhere downstream, verified by grep).
- easy-hydro-erp vendor snapshot sync follows in its own PR.