### PR TITLE
✨ Add a font context facility with UI-friendly CJK font stacks.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -18,13 +18,20 @@
   --text-2xl: 1.5rem;
 
   // ── Font families (body text, mono for version/numbers) ─
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  // Keep in sync with packages/vue/src/theme/fontContext.ts
+  // (HIKARI_FONT_SANS / HIKARI_FONT_MONO / HIKARI_FONT_READING). CJK faces
+  // are matched per-glyph after the Latin faces; they are listed
+  // explicitly because the platform's last-resort fallback is NOT
+  // guaranteed UI-friendly (observed KaiTi-style 楷体 on real devices).
+  // Never add kai/serif faces to these defaults.
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
   // Pure mono stack (see admin-tokens.scss for the full rationale): no
-  // sans inside — environments without a concrete mono face (stock Linux,
-  // most Androids) must fall to the generic `monospace`, never to the
-  // proportional sans; CJK glyphs fall through to the platform's
-  // last-resort CJK font (= the UI sans CJK on modern platforms).
-  --font-mono: ui-monospace, "JetBrains Mono", "Fira Code", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", monospace;
+  // proportional sans inside — environments without a concrete mono face
+  // (stock Linux, most Androids) must fall to the generic `monospace`,
+  // never to the proportional sans; CJK glyphs land on an explicit
+  // CJK UI face or a CJK-capable mono face.
+  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace;
+  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif; /* = --font-sans; opt-in 书面 slot */
 
   // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
   --space-1: 0.0625rem;

--- a/packages/theme/styles/variables.scss
+++ b/packages/theme/styles/variables.scss
@@ -11,8 +11,13 @@
 // 2. Typography Variables
 // ------
 
-$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-$hikari-font-family-mono: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, 'Courier New', monospace;
+// Keep in sync with packages/vue/src/theme/fontContext.ts
+// (HIKARI_FONT_SANS / HIKARI_FONT_MONO): CJK UI faces are matched
+// per-glyph after the Latin faces and are listed explicitly because the
+// platform's last-resort fallback is not guaranteed UI-friendly
+// (observed KaiTi-style 楷体 on real devices). Never add kai/serif faces.
+$hikari-font-family-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Microsoft YaHei UI', 'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN', 'WenQuanYi Micro Hei', sans-serif;
+$hikari-font-family-mono: 'Fira Code', ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono CJK SC', 'Sarasa Mono SC', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', 'WenQuanYi Micro Hei', monospace;
 
 $hikari-font-size-xs: 0.75rem;
 $hikari-font-size-sm: 0.875rem;

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -116,12 +116,15 @@ export {
   allGroupSlots, resolveLocalizedText, parseTokenGroupConfig, registerTokenGroupConfig,
   startLuminanceSampler, stopLuminanceSampler, sampleLuminanceNow, invalidateLuminanceCache,
   getTimePeriod, getGeolocation, solarAltitude, DEFAULT_GEO_LOCATION,
+  initFontContext, applyFontContext, resetFontContext, useFontContext,
+  HIKARI_FONT_SANS, HIKARI_FONT_MONO, HIKARI_FONT_READING,
   type ThemeTokenRGB, type ThemeSchemeTokens, type ThemePreset, type ThemeMode,
   type ThemeId, type ThemeTokens, type CustomThemePreset, type TimePeriod,
   type ThemeTokenGroupValues, type ThemeTokenGroupModes,
   type TokenGroupDefinition, type TokenGroupSlot, type TokenGroupSection, type HueClamp,
   type ResolvedGroupTokens, type ColorHSL,
   type LocalizedText, type ParseTokenGroupResult,
+  type FontContextOverrides,
 } from "./theme";
 
 // Runtime systems

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -8,23 +8,31 @@
   --s-footer-height: 3rem;
   --s-header-height: 3rem;
   --z-header: 100;
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  /* A pure mono stack: every entry is monospace, the generic `monospace`
-     keyword is the final catch-all — the UI sans must NEVER sit inside it.
-     Two prior shapes both broke real devices: (1) sans right after Fira
-     Code made every Fira-Code-less device (all phones) render digits
-     proportionally; (2) sans before the generic keyword still let
-     environments with no concrete mono face installed (stock Linux
-     desktops, most Androids — ui-monospace is Apple-only) hit the
-     proportional sans first. Latin/digits now always land on a real mono
-     face (Fira Code → ui-monospace/SF Mono on Apple, Consolas on Windows,
-     DejaVu/Liberation on Linux, the generic monospace = Roboto Mono-ish on
-     Android). CJK glyphs are not covered by any latin mono face, so they
-     fall through to the platform's last-resort CJK font — on every modern
-     platform that resolves to the UI sans CJK, not kai. */
-  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono",
-    "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono",
-    monospace;
+  /* Font stacks — keep in sync with packages/vue/src/theme/fontContext.ts
+     (HIKARI_FONT_SANS / HIKARI_FONT_MONO / HIKARI_FONT_READING), which can
+     override these at runtime via initFontContext(). CJK faces are matched
+     per-glyph AFTER the Latin faces, so Latin/digits keep Inter / Fira Code.
+     The CJK UI faces are listed explicitly because the platform's
+     last-resort fallback is NOT guaranteed to be UI-friendly — real devices
+     have been observed resolving uncovered CJK glyphs to a KaiTi-style 楷体
+     face. Kai/serif faces (楷体 / KaiTi / STKaiti / Kaiti SC / 宋体 /
+     SimSun / Songti / Noto Serif …) must NEVER be added to these defaults;
+     the opt-in --font-reading slot exists for a bookish face, and even its
+     default is the UI sans stack.
+     A pure mono stack: every entry is monospace or a CJK UI face, the
+     generic `monospace` keyword is the final catch-all — the proportional
+     sans must NEVER sit inside it. Two prior shapes both broke real
+     devices: (1) sans right after Fira Code made every Fira-Code-less
+     device (all phones) render digits proportionally; (2) sans before the
+     generic keyword still let environments with no concrete mono face
+     installed (stock Linux desktops, most Androids — ui-monospace is
+     Apple-only) hit the proportional sans first. Latin/digits now always
+     land on a real mono face; CJK glyphs land on an explicit CJK UI face
+     (or a CJK-capable mono face such as Noto Sans Mono CJK SC / Sarasa
+     Mono SC) instead of the platform's last-resort font. */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
+  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace;
+  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif; /* = --font-sans; opt-in 书面 slot — keep in sync with fontContext.ts */
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;

--- a/packages/vue/src/theme/fontContext.test.ts
+++ b/packages/vue/src/theme/fontContext.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The module keeps singleton state (initialized flag + refs), so every
+// test gets a fresh module instance via vi.resetModules + dynamic import.
+type FontContextModule = typeof import("./fontContext");
+
+describe("fontContext", () => {
+  let fc: FontContextModule;
+
+  const el = () => document.documentElement;
+  const applied = (name: string) => el().style.getPropertyValue(name);
+
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+    el().style.cssText = "";
+    el().removeAttribute("data-font-context");
+    fc = await import("./fontContext");
+  });
+
+  it("init applies the default stacks as inline vars and sets data-font-context", () => {
+    fc.initFontContext();
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+    expect(applied("--font-mono")).toBe(fc.HIKARI_FONT_MONO);
+    expect(applied("--font-reading")).toBe(fc.HIKARI_FONT_READING);
+    expect(el().getAttribute("data-font-context")).toBe("on");
+  });
+
+  it("is idempotent: a repeated bare init does not fall back to defaults", () => {
+    localStorage.setItem(
+      "hikari-font-context",
+      JSON.stringify({ sans: '"Stored Sans", sans-serif' }),
+    );
+    fc.initFontContext();
+    fc.initFontContext();
+    fc.initFontContext();
+    expect(applied("--font-sans")).toBe('"Stored Sans", sans-serif');
+  });
+
+  it("applies localStorage overrides", () => {
+    localStorage.setItem(
+      "hikari-font-context",
+      JSON.stringify({
+        sans: '"A Sans", sans-serif',
+        mono: '"A Mono", monospace',
+        reading: '"A Reading", serif',
+      }),
+    );
+    fc.initFontContext();
+    expect(applied("--font-sans")).toBe('"A Sans", sans-serif');
+    expect(applied("--font-mono")).toBe('"A Mono", monospace');
+    expect(applied("--font-reading")).toBe('"A Reading", serif');
+  });
+
+  it("explicit options beat stored overrides on first init", () => {
+    localStorage.setItem(
+      "hikari-font-context",
+      JSON.stringify({ sans: '"Stored Sans", sans-serif' }),
+    );
+    fc.initFontContext({ sans: '"Explicit Sans", sans-serif' });
+    expect(applied("--font-sans")).toBe('"Explicit Sans", sans-serif');
+  });
+
+  it("merges explicit options from a repeated init", () => {
+    fc.initFontContext();
+    fc.initFontContext({ mono: '"Later Mono", monospace' });
+    expect(applied("--font-mono")).toBe('"Later Mono", monospace');
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+  });
+
+  it("rejects injection-shaped values and falls back to the next source", () => {
+    localStorage.setItem(
+      "hikari-font-context",
+      JSON.stringify({
+        sans: 'evil; } { --',
+        mono: "",
+        reading: "x".repeat(501),
+      }),
+    );
+    fc.initFontContext({ sans: '"Also; Evil", sans-serif' });
+    // sans: explicit rejected → stored rejected → default.
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+    // mono/reading: stored rejected → default.
+    expect(applied("--font-mono")).toBe(fc.HIKARI_FONT_MONO);
+    expect(applied("--font-reading")).toBe(fc.HIKARI_FONT_READING);
+  });
+
+  it("explicit options rejected by sanitization fall through to the stored override", () => {
+    localStorage.setItem(
+      "hikari-font-context",
+      JSON.stringify({ sans: '"Good Sans", sans-serif' }),
+    );
+    fc.initFontContext({ sans: '"Bad; Sans"' });
+    expect(applied("--font-sans")).toBe('"Good Sans", sans-serif');
+  });
+
+  it("ignores malformed stored JSON", () => {
+    localStorage.setItem("hikari-font-context", "{not json");
+    fc.initFontContext();
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+  });
+
+  it("exposes refs whose setters persist and re-apply", () => {
+    fc.initFontContext();
+    const ctx = fc.useFontContext();
+    ctx.setSans('"My Sans", sans-serif');
+    expect(ctx.sans.value).toBe('"My Sans", sans-serif');
+    expect(applied("--font-sans")).toBe('"My Sans", sans-serif');
+    const stored = JSON.parse(localStorage.getItem("hikari-font-context") ?? "{}");
+    expect(stored.sans).toBe('"My Sans", sans-serif');
+  });
+
+  it("setter rejects unsanitizable values without persisting", () => {
+    fc.initFontContext();
+    const ctx = fc.useFontContext();
+    ctx.setSans('"Bad; Sans"');
+    expect(ctx.sans.value).toBe(fc.HIKARI_FONT_SANS);
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+    expect(localStorage.getItem("hikari-font-context")).toBeNull();
+  });
+
+  it("reset clears storage and restores the built-in defaults", () => {
+    fc.initFontContext();
+    const ctx = fc.useFontContext();
+    ctx.setMono('"My Mono", monospace');
+    expect(applied("--font-mono")).toBe('"My Mono", monospace');
+    ctx.reset();
+    expect(localStorage.getItem("hikari-font-context")).toBeNull();
+    expect(applied("--font-mono")).toBe(fc.HIKARI_FONT_MONO);
+    expect(ctx.mono.value).toBe(fc.HIKARI_FONT_MONO);
+    expect(el().getAttribute("data-font-context")).toBe("on");
+  });
+
+  it("applyFontContext re-applies the current state over DOM mutations", () => {
+    fc.initFontContext();
+    el().style.setProperty("--font-sans", "junk");
+    fc.applyFontContext();
+    expect(applied("--font-sans")).toBe(fc.HIKARI_FONT_SANS);
+  });
+
+  it("is a safe no-op in non-browser environments", () => {
+    vi.stubGlobal("document", undefined);
+    try {
+      expect(() => fc.initFontContext({ sans: '"X", sans-serif' })).not.toThrow();
+      expect(() => fc.applyFontContext()).not.toThrow();
+      expect(() => fc.resetFontContext()).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("default stacks carry the required CJK UI faces", () => {
+    const required = ["PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC"];
+    for (const stack of [fc.HIKARI_FONT_SANS, fc.HIKARI_FONT_MONO]) {
+      for (const face of required) {
+        expect(stack.toLowerCase()).toContain(face.toLowerCase());
+      }
+    }
+  });
+
+  it("default stacks never name a kai or serif face", () => {
+    const banned = ["KaiTi", "STKaiti", "Kaiti SC", "SimSun", "Songti", "Noto Serif", "Source Han Serif"];
+    for (const stack of [fc.HIKARI_FONT_SANS, fc.HIKARI_FONT_MONO, fc.HIKARI_FONT_READING]) {
+      for (const face of banned) {
+        // Assert absence of the whole quoted family name, case-insensitively.
+        expect(stack.toLowerCase()).not.toContain(`"${face.toLowerCase()}"`);
+      }
+    }
+  });
+
+  it("reading defaults to the UI sans stack", () => {
+    expect(fc.HIKARI_FONT_READING).toBe(fc.HIKARI_FONT_SANS);
+  });
+});

--- a/packages/vue/src/theme/fontContext.ts
+++ b/packages/vue/src/theme/fontContext.ts
@@ -1,0 +1,193 @@
+import { ref, type Ref } from "vue";
+
+// fontContext.ts — bootstrap-level font facility, distributed like the
+// startup hooks (initTheme / applyViewportPolicy): every webui calls
+// initFontContext() once at bootstrap and the canonical stacks land as
+// inline CSS vars on document.documentElement, so no app has to restate
+// font-family literals.
+
+// ── Canonical stacks ─────────────────────────────────────────────────
+// CJK faces are matched per-glyph AFTER the Latin faces, so Latin text
+// and digits keep Inter / Fira Code and only CJK glyphs walk the list.
+// The CJK entries are deliberately UI-friendly sans faces: the platform's
+// last-resort fallback is NOT guaranteed to be UI-friendly (real devices
+// have been observed resolving CJK to a KaiTi-style 楷体 face), so the
+// faces we want are listed explicitly.
+//
+// NEVER add kai/serif faces (楷体 / KaiTi / STKaiti / Kaiti SC / 宋体 /
+// SimSun / Songti / Noto Serif …) to these default stacks — the reading
+// slot (HIKARI_FONT_READING) is the opt-in place for a bookish face, and
+// even its default is deliberately the same UI-friendly sans stack.
+//
+// Keep the SCSS defaults in sync (they are duplicated by necessity):
+//   packages/vue/src/styles/admin-tokens.scss  (--font-sans / --font-mono)
+//   packages/vue/src/tokens.scss               (--font-sans / --font-reading)
+//   packages/theme/styles/_layout.scss         (--font-sans / --font-mono)
+//   packages/theme/styles/variables.scss       ($hikari-font-family-*)
+export const HIKARI_FONT_SANS =
+  `"Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, ` +
+  `"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif`;
+
+export const HIKARI_FONT_MONO =
+  `"Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", ` +
+  `"Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace`;
+
+// Opt-in 书面/reading slot: exists so an app CAN offer a bookish face
+// later via an override, but the default is deliberately the UI sans.
+export const HIKARI_FONT_READING = HIKARI_FONT_SANS;
+
+export interface FontContextOverrides {
+  sans?: string;
+  mono?: string;
+  reading?: string;
+}
+
+const STORAGE_KEY = "hikari-font-context";
+const MAX_VALUE_LENGTH = 500;
+// CSS-injection guard: font-family lists never need these characters.
+const FORBIDDEN_CHARS = /[;{}]/;
+
+type FontSlot = keyof FontContextOverrides;
+
+const FONT_VAR: Record<FontSlot, string> = {
+  sans: "--font-sans",
+  mono: "--font-mono",
+  reading: "--font-reading",
+};
+
+// Shared singleton state (mirrors useTheme's module-level refs): every
+// useFontContext() call in the app sees the same stacks.
+const sansRef = ref<string>(HIKARI_FONT_SANS);
+const monoRef = ref<string>(HIKARI_FONT_MONO);
+const readingRef = ref<string>(HIKARI_FONT_READING);
+
+function slotRef(slot: FontSlot): Ref<string> {
+  return slot === "sans" ? sansRef : slot === "mono" ? monoRef : readingRef;
+}
+
+function isBrowser(): boolean {
+  return typeof document !== "undefined";
+}
+
+// Sanitize a candidate value: empty, over-long, or injection-shaped
+// values are rejected (the caller falls back to the next source).
+function sanitizeFontValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_VALUE_LENGTH) return null;
+  if (FORBIDDEN_CHARS.test(trimmed)) return null;
+  return trimmed;
+}
+
+function readStoredOverrides(): FontContextOverrides {
+  if (!isBrowser() || typeof localStorage === "undefined") return {};
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return {};
+  }
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed JSON: ignore it; the next setter overwrites the key.
+    return {};
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+  const record = parsed as Record<string, unknown>;
+  const out: FontContextOverrides = {};
+  for (const slot of Object.keys(FONT_VAR) as FontSlot[]) {
+    const value = sanitizeFontValue(record[slot]);
+    if (value) out[slot] = value;
+  }
+  return out;
+}
+
+function persistOverrides(overrides: FontContextOverrides): void {
+  if (!isBrowser() || typeof localStorage === "undefined") return;
+  const merged: FontContextOverrides = { ...readStoredOverrides(), ...overrides };
+  const hasAny = (Object.keys(FONT_VAR) as FontSlot[]).some((slot) => merged[slot]);
+  try {
+    if (hasAny) localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Storage unavailable (private mode etc.): vars still apply inline.
+  }
+}
+
+// Re-apply the current state as inline CSS vars. Safe to call any time.
+export function applyFontContext(): void {
+  if (!isBrowser()) return;
+  const el = document.documentElement;
+  el.style.setProperty(FONT_VAR.sans, sansRef.value);
+  el.style.setProperty(FONT_VAR.mono, monoRef.value);
+  el.style.setProperty(FONT_VAR.reading, readingRef.value);
+  el.setAttribute("data-font-context", "on");
+}
+
+let initialized = false;
+
+// Bootstrap hook. Idempotent via a module-level flag like initTheme, BUT
+// explicit options on any call (including repeated ones) always win: they
+// are merged into the current state and re-applied. Explicit options are
+// not persisted — persistence belongs to the useFontContext setters.
+export function initFontContext(options?: FontContextOverrides): void {
+  if (!isBrowser()) return;
+  const explicit: FontContextOverrides = {};
+  if (options) {
+    for (const slot of Object.keys(FONT_VAR) as FontSlot[]) {
+      const value = sanitizeFontValue(options[slot]);
+      if (value) explicit[slot] = value;
+    }
+  }
+  if (!initialized) {
+    initialized = true;
+    const stored = readStoredOverrides();
+    sansRef.value = explicit.sans ?? stored.sans ?? HIKARI_FONT_SANS;
+    monoRef.value = explicit.mono ?? stored.mono ?? HIKARI_FONT_MONO;
+    readingRef.value = explicit.reading ?? stored.reading ?? HIKARI_FONT_READING;
+  } else {
+    // Repeated call: merge the explicit options over the current state.
+    if (explicit.sans) sansRef.value = explicit.sans;
+    if (explicit.mono) monoRef.value = explicit.mono;
+    if (explicit.reading) readingRef.value = explicit.reading;
+  }
+  applyFontContext();
+}
+
+// Clear the persisted override and restore the built-in defaults.
+export function resetFontContext(): void {
+  sansRef.value = HIKARI_FONT_SANS;
+  monoRef.value = HIKARI_FONT_MONO;
+  readingRef.value = HIKARI_FONT_READING;
+  if (isBrowser() && typeof localStorage !== "undefined") {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+  }
+  applyFontContext();
+}
+
+export function useFontContext() {
+  function setSlot(slot: FontSlot, value: string): void {
+    const clean = sanitizeFontValue(value);
+    if (!clean) return; // rejected: don't persist, don't apply
+    slotRef(slot).value = clean;
+    persistOverrides({ [slot]: clean });
+    applyFontContext();
+  }
+
+  return {
+    sans: sansRef,
+    mono: monoRef,
+    reading: readingRef,
+    setSans: (value: string) => setSlot("sans", value),
+    setMono: (value: string) => setSlot("mono", value),
+    setReading: (value: string) => setSlot("reading", value),
+    reset: resetFontContext,
+  };
+}

--- a/packages/vue/src/theme/index.ts
+++ b/packages/vue/src/theme/index.ts
@@ -1,4 +1,6 @@
 export { initTheme, useTheme } from "./useTheme";
+export { initFontContext, applyFontContext, resetFontContext, useFontContext, HIKARI_FONT_SANS, HIKARI_FONT_MONO, HIKARI_FONT_READING } from "./fontContext";
+export type { FontContextOverrides } from "./fontContext";
 export { themePresets, tokensToCSSVars, getThemeTokens, loadCustomThemes, saveCustomThemes, addCustomTheme, removeCustomTheme } from "./presets";
 export type { ThemeTokenRGB, ThemeSchemeTokens, ThemePreset, CustomThemePreset, ThemeId, ThemeMode, ThemeTokenGroupValues, ThemeTokenGroupModes } from "./presets";
 export type { ThemeTokens } from "./presets";

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -124,5 +124,7 @@
   --s-footer-height: 3rem;
   --z-header: 30;
   --z-sidebar: 40;
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  /* Keep in sync with packages/vue/src/theme/fontContext.ts (HIKARI_FONT_SANS / HIKARI_FONT_READING) */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
+  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
 }


### PR DESCRIPTION
## What

- New font context module (`initFontContext` / `useFontContext` / `applyFontContext` / `resetFontContext`) distributing canonical font stacks as inline CSS vars + a `data-font-context` marker, following the existing startup-hook pattern (initTheme / applyViewportPolicy). Per-slot resolution: explicit option > localStorage (`hikari-font-context`) > built-in; CSS-injection guard on values.
- All default stacks (`--font-sans` / `--font-mono`, SCSS $vars, `--font-reading` slot) now list UI-friendly CJK faces explicitly (PingFang SC / Hiragino Sans GB / Microsoft YaHei / Noto Sans CJK SC / Source Han Sans / WenQuanYi Micro Hei). Kai/serif faces are never listed — observed devices resolve uncovered CJK through the platform last resort to a KaiTi-style face (楷体). The reading slot defaults to the UI sans stack (opt-in only).
- Stale admin-tokens comment claiming the last-resort fallback is always the UI sans corrected. Keep-in-sync notes point at fontContext.ts.
- Version: packages/vue 0.20.0 → 0.21.0.

## Verification

- vue-tsc --noEmit exit 0; vitest 43/43 (16 new fontContext cases incl. banned-face assertions); scoped sass compile of edited SCSS exit 0. Theme engine confirmed to never write `--font-*` (no clobber of inline vars).

## Consumers

shittim-chest and e.celestia.world adopt `initFontContext()` at bootstrap in follow-up PRs.