### PR TITLE
♻️ Simplify the font stacks to the Apple-style system batch.

### DIFF
--- a/packages/theme/styles/_layout.scss
+++ b/packages/theme/styles/_layout.scss
@@ -18,20 +18,10 @@
   --text-2xl: 1.5rem;
 
   // ── Font families (body text, mono for version/numbers) ─
-  // Keep in sync with packages/vue/src/theme/fontContext.ts
-  // (HIKARI_FONT_SANS / HIKARI_FONT_MONO / HIKARI_FONT_READING). CJK faces
-  // are matched per-glyph after the Latin faces; they are listed
-  // explicitly because the platform's last-resort fallback is NOT
-  // guaranteed UI-friendly (observed KaiTi-style 楷体 on real devices).
-  // Never add kai/serif faces to these defaults.
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
-  // Pure mono stack (see admin-tokens.scss for the full rationale): no
-  // proportional sans inside — environments without a concrete mono face
-  // (stock Linux, most Androids) must fall to the generic `monospace`,
-  // never to the proportional sans; CJK glyphs land on an explicit
-  // CJK UI face or a CJK-capable mono face.
-  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace;
-  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif; /* = --font-sans; opt-in 书面 slot */
+  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
 
   // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
   --space-1: 0.0625rem;

--- a/packages/theme/styles/variables.scss
+++ b/packages/theme/styles/variables.scss
@@ -11,13 +11,9 @@
 // 2. Typography Variables
 // ------
 
-// Keep in sync with packages/vue/src/theme/fontContext.ts
-// (HIKARI_FONT_SANS / HIKARI_FONT_MONO): CJK UI faces are matched
-// per-glyph after the Latin faces and are listed explicitly because the
-// platform's last-resort fallback is not guaranteed UI-friendly
-// (observed KaiTi-style 楷体 on real devices). Never add kai/serif faces.
-$hikari-font-family-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Microsoft YaHei UI', 'Noto Sans CJK SC', 'Source Han Sans SC', 'Source Han Sans CN', 'WenQuanYi Micro Hei', sans-serif;
-$hikari-font-family-mono: 'Fira Code', ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'Noto Sans Mono CJK SC', 'Sarasa Mono SC', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', 'WenQuanYi Micro Hei', monospace;
+/* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+$hikari-font-family-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
 
 $hikari-font-size-xs: 0.75rem;
 $hikari-font-size-sm: 0.875rem;

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -8,31 +8,10 @@
   --s-footer-height: 3rem;
   --s-header-height: 3rem;
   --z-header: 100;
-  /* Font stacks — keep in sync with packages/vue/src/theme/fontContext.ts
-     (HIKARI_FONT_SANS / HIKARI_FONT_MONO / HIKARI_FONT_READING), which can
-     override these at runtime via initFontContext(). CJK faces are matched
-     per-glyph AFTER the Latin faces, so Latin/digits keep Inter / Fira Code.
-     The CJK UI faces are listed explicitly because the platform's
-     last-resort fallback is NOT guaranteed to be UI-friendly — real devices
-     have been observed resolving uncovered CJK glyphs to a KaiTi-style 楷体
-     face. Kai/serif faces (楷体 / KaiTi / STKaiti / Kaiti SC / 宋体 /
-     SimSun / Songti / Noto Serif …) must NEVER be added to these defaults;
-     the opt-in --font-reading slot exists for a bookish face, and even its
-     default is the UI sans stack.
-     A pure mono stack: every entry is monospace or a CJK UI face, the
-     generic `monospace` keyword is the final catch-all — the proportional
-     sans must NEVER sit inside it. Two prior shapes both broke real
-     devices: (1) sans right after Fira Code made every Fira-Code-less
-     device (all phones) render digits proportionally; (2) sans before the
-     generic keyword still let environments with no concrete mono face
-     installed (stock Linux desktops, most Androids — ui-monospace is
-     Apple-only) hit the proportional sans first. Latin/digits now always
-     land on a real mono face; CJK glyphs land on an explicit CJK UI face
-     (or a CJK-capable mono face such as Noto Sans Mono CJK SC / Sarasa
-     Mono SC) instead of the platform's last-resort font. */
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
-  --font-mono: "Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace;
-  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif; /* = --font-sans; opt-in 书面 slot — keep in sync with fontContext.ts */
+  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
   --blur-sm: 8px;
   --blur-md: 16px;
   --blur-lg: 24px;

--- a/packages/vue/src/theme/fontContext.test.ts
+++ b/packages/vue/src/theme/fontContext.test.ts
@@ -149,6 +149,11 @@ describe("fontContext", () => {
     }
   });
 
+  it("default stacks lead with the Apple-style system heads", () => {
+    expect(fc.HIKARI_FONT_SANS.startsWith("-apple-system, BlinkMacSystemFont")).toBe(true);
+    expect(fc.HIKARI_FONT_MONO.startsWith(`ui-monospace, "SF Mono"`)).toBe(true);
+  });
+
   it("default stacks carry the required CJK UI faces", () => {
     const required = ["PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC"];
     for (const stack of [fc.HIKARI_FONT_SANS, fc.HIKARI_FONT_MONO]) {

--- a/packages/vue/src/theme/fontContext.ts
+++ b/packages/vue/src/theme/fontContext.ts
@@ -6,34 +6,10 @@ import { ref, type Ref } from "vue";
 // inline CSS vars on document.documentElement, so no app has to restate
 // font-family literals.
 
-// ── Canonical stacks ─────────────────────────────────────────────────
-// CJK faces are matched per-glyph AFTER the Latin faces, so Latin text
-// and digits keep Inter / Fira Code and only CJK glyphs walk the list.
-// The CJK entries are deliberately UI-friendly sans faces: the platform's
-// last-resort fallback is NOT guaranteed to be UI-friendly (real devices
-// have been observed resolving CJK to a KaiTi-style 楷体 face), so the
-// faces we want are listed explicitly.
-//
-// NEVER add kai/serif faces (楷体 / KaiTi / STKaiti / Kaiti SC / 宋体 /
-// SimSun / Songti / Noto Serif …) to these default stacks — the reading
-// slot (HIKARI_FONT_READING) is the opt-in place for a bookish face, and
-// even its default is deliberately the same UI-friendly sans stack.
-//
-// Keep the SCSS defaults in sync (they are duplicated by necessity):
-//   packages/vue/src/styles/admin-tokens.scss  (--font-sans / --font-mono)
-//   packages/vue/src/tokens.scss               (--font-sans / --font-reading)
-//   packages/theme/styles/_layout.scss         (--font-sans / --font-mono)
-//   packages/theme/styles/variables.scss       ($hikari-font-family-*)
-export const HIKARI_FONT_SANS =
-  `"Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, ` +
-  `"PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif`;
-
-export const HIKARI_FONT_MONO =
-  `"Fira Code", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", ` +
-  `"Noto Sans Mono CJK SC", "Sarasa Mono SC", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", "WenQuanYi Micro Hei", monospace`;
-
-// Opt-in 书面/reading slot: exists so an app CAN offer a bookish face
-// later via an override, but the default is deliberately the UI sans.
+// Apple-style system stack; the CJK tail keeps non-Apple platforms off kai-style last-resort fallbacks.
+// Kai/serif faces are deliberately never listed.
+export const HIKARI_FONT_SANS = `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif`;
+export const HIKARI_FONT_MONO = `ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace`;
 export const HIKARI_FONT_READING = HIKARI_FONT_SANS;
 
 export interface FontContextOverrides {

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -124,7 +124,7 @@
   --s-footer-height: 3rem;
   --z-header: 30;
   --z-sidebar: 40;
-  /* Keep in sync with packages/vue/src/theme/fontContext.ts (HIKARI_FONT_SANS / HIKARI_FONT_READING) */
-  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
-  --font-reading: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Microsoft YaHei UI", "Noto Sans CJK SC", "Source Han Sans SC", "Source Han Sans CN", "WenQuanYi Micro Hei", sans-serif;
+  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
 }


### PR DESCRIPTION
## What

Follow-up to #331 (user review): replace the hand-rolled font batch with the canonical Apple-style stack, and cut the comment essays down to one-liners.

- `HIKARI_FONT_SANS` → `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial` + CJK UI tail (`PingFang SC / Hiragino Sans GB / Microsoft YaHei / Noto Sans CJK SC`) + `sans-serif`.
- `HIKARI_FONT_MONO` → `ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono` + same CJK tail + `monospace`.
- All four SCSS sites byte-matched; per-site prose replaced by a single keep-in-sync line (net −54 lines).
- No API/behavior change; kai/serif faces remain never-listed (test-enforced). vue 0.21.0 → 0.21.1.

## Verification

vue-tsc exit 0; vitest 44/44 (17 fontContext + 27 tokenGroups); 10/10 SCSS declarations byte-match the TS constants. Legacy non-batch stacks (code highlighters, `_hikari-vars.scss`) deliberately untouched — flagged for a possible follow-up.