### PR TITLE
⚡ Cancel superseded workflow runs via concurrency groups.

### DIFF
--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify-versions:
     name: Verify version consistency

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,6 +12,10 @@ on:
   push:
     branches: [master, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clippy:
     name: Clippy

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -6,6 +6,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-commits:
     uses: celestia-island/celestia-devtools/.github/workflows/commit-msg-lint.yml@master

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches: [master, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
     name: Format

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
     name: cargo audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
   push:
     branches: [master, dev]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Adds a `concurrency` group (`workflow name + PR number / ref`) with `cancel-in-progress: true` to the CI workflows so a newer run on the same PR or branch automatically cancels the queued/running predecessor.

Motivation: org runner data (2026-08-28..31) shows 226/495 runs in this repo started after a newer run on the same branch already existed, wasting self-hosted runner slots. Complements the earlier pull_request trigger-type retrofit.

Notes:
- Groups are keyed by workflow name (unique per repo), so ci.yml and ci-hosted.yml keep independent groups.
- workflow_dispatch runs on a branch join that branch's group; a manual dispatch may cancel a running push run on the same branch (intended).
- Release/publish/docs workflows are intentionally untouched.