### PR TITLE
🎨 Align the remaining legacy font stacks with the canonical batch.

### DIFF
--- a/docs/zh-Hans/design/layer1.md
+++ b/docs/zh-Hans/design/layer1.md
@@ -153,9 +153,9 @@ packages/theme/styles/foundation.scss
 
 ```scss
 :root {
-  // 字体族
-  --hi-font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --hi-font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  // 字体族（与 packages/vue/src/theme/fontContext.ts 保持同步）
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
 
   // 字号
   --hi-font-size-xs: 0.75rem;            // 12px

--- a/packages/components/src/production/code_highlight.rs
+++ b/packages/components/src/production/code_highlight.rs
@@ -411,7 +411,7 @@ impl StyledComponent for CodeHighlightComponent {
 }
 
 .hk-code-highlight-line-number {
-    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 0.875rem;
     line-height: 1.6;
     color: var(--hi-color-text-tertiary, #94a3b8);
@@ -430,13 +430,13 @@ impl StyledComponent for CodeHighlightComponent {
     overflow-x: auto;
     background-color: transparent;
     border: none;
-    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 0.875rem;
     line-height: 1.6;
 }
 
 .hk-code-highlight-code code {
-    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 0.875rem;
     line-height: 1.6;
     color: var(--hi-color-text-primary, #1f2328);

--- a/packages/components/src/production/markdown_editor.rs
+++ b/packages/components/src/production/markdown_editor.rs
@@ -510,7 +510,7 @@ impl StyledComponent for MarkdownEditorComponent {
     border: none;
     outline: none;
     resize: none;
-    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 14px;
     line-height: 1.6;
     color: var(--hi-text-primary);
@@ -549,7 +549,7 @@ impl StyledComponent for MarkdownEditorComponent {
     background-color: var(--hi-color-bg-elevated);
     padding: 2px 6px;
     border-radius: 4px;
-    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 13px;
 }
 

--- a/packages/components/src/styles/animations.scss
+++ b/packages/components/src/styles/animations.scss
@@ -321,7 +321,7 @@ $animation-easing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
   white-space: nowrap;
   border-right: 2px solid currentColor;
   animation: tech-typing-cursor 1s step-end infinite;
-  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
   width: fit-content;
 }
 
@@ -362,7 +362,7 @@ $animation-easing-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
     position: absolute;
     top: -2em;
     right: 1em;
-    font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 0.75em;
     color: rgba(0, 191, 255, 0.3);
     animation: tech-data-flow 3s linear infinite;

--- a/packages/components/src/styles/components/code_block.scss
+++ b/packages/components/src/styles/components/code_block.scss
@@ -25,7 +25,7 @@
     color: var(--hi-color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    font-family: 'Courier New', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
 }
 
 .hk-code-block-content {
@@ -36,7 +36,7 @@
 
 .hk-code-block-code {
     display: block;
-    font-family: 'Courier New', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
     font-size: 0.875rem;
     line-height: 1.6;
     color: var(--hi-color-text-primary);

--- a/packages/components/src/styles/components/demo_block.scss
+++ b/packages/components/src/styles/components/demo_block.scss
@@ -40,7 +40,7 @@
     color: var(--hi-color-text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    font-family: 'Courier New', monospace;
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
 }
 
 // Segmented preview/source toggle (pill variant of the Tabs language).

--- a/packages/components/src/styles/components/markdown_renderer.scss
+++ b/packages/components/src/styles/components/markdown_renderer.scss
@@ -47,7 +47,7 @@
         padding: 1rem;
         margin: 1.5rem 0;
         overflow-x: auto;
-        font-family: 'Courier New', monospace;
+        font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
         font-size: 0.875rem;
         line-height: 1.6;
     }
@@ -63,7 +63,7 @@
         background-color: var(--hi-color-surface-secondary);
         padding: 0.2rem 0.4rem;
         border-radius: 4px;
-        font-family: 'Courier New', monospace;
+        font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
         font-size: 0.875em;
         color: var(--hi-color-accent);
     }
@@ -109,7 +109,7 @@
         background-color: var(--hi-color-surface);
         padding: 0.5rem 0.75rem;
         border-radius: 4px;
-        font-family: 'Courier New', monospace;
+        font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
         font-size: 0.875rem;
         color: var(--hi-color-accent);
         display: inline-block;

--- a/packages/components/src/styles/components/pagination_jump_modal.scss
+++ b/packages/components/src/styles/components/pagination_jump_modal.scss
@@ -63,7 +63,7 @@
 .hk-pagination-jump-modal-header {
   padding: 1rem;
   border-bottom: 1px solid var(--hi-color-border, #e5e7eb);
-  font-family: var(--hi-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  font-family: var(--hi-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif);
   font-size: 1rem;
   font-weight: 600;
   color: var(--hi-color-text-primary, #1f2937);
@@ -83,7 +83,7 @@
 .hk-pagination-jump-modal-input {
   flex: 1;
   padding: 0.625rem 0.75rem;
-  font-family: var(--hi-font-family-mono, 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono', Consolas, monospace);
+  font-family: var(--hi-font-family-mono, ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace);
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--hi-color-text-primary, #1f2937);
@@ -153,7 +153,7 @@
 .hk-pagination-jump-modal-footer {
   padding: 0.75rem 1rem;
   border-top: 1px solid var(--hi-color-border, #e5e7eb);
-  font-family: var(--hi-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif);
+  font-family: var(--hi-font-family-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif);
   font-size: 0.8125rem;
   font-weight: 400;
   color: var(--hi-color-text-secondary, #6b7280);

--- a/packages/extra-components/src/extra/code_highlighter.rs
+++ b/packages/extra-components/src/extra/code_highlighter.rs
@@ -363,7 +363,7 @@ impl CodeHighlighterComponent {
   border: 1px solid var(--hi-color-border, #e0e0e0);
   border-radius: 8px;
   overflow: hidden;
-  font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
   font-size: 0.875rem;
   line-height: 1.6;
 }

--- a/packages/extra-components/src/styles/components/code_highlighter.scss
+++ b/packages/extra-components/src/styles/components/code_highlighter.scss
@@ -9,7 +9,7 @@
   border: 1px solid var(--hi-color-border, #e0e0e0);
   border-radius: 8px;
   overflow: hidden;
-  font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
   font-size: 0.875rem;
   line-height: 1.6;
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -58,7 +58,7 @@
 .s-about-modal-row-value {
   font-size: var(--text-sm, 0.8125rem);
   color: rgb(var(--color-text));
-  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace);
 }
 
 .s-about-modal-links {

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -95,7 +95,7 @@
 
 .s-log-entry {
   padding: var(--space-2, 0.125rem) var(--space-4, 0.25rem);
-  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace);
   font-size: var(--text-xs, 0.75rem);
   line-height: 1.5;
   color: rgb(var(--color-text));

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -197,7 +197,7 @@
   z-index: 2;
   pointer-events: none;
   user-select: none;
-  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
   font-size: 0.8125rem;
   letter-spacing: 0.04em;
   color: var(--hi-color-text-primary, #333);

--- a/packages/vue/src/components/HkSplash.scss
+++ b/packages/vue/src/components/HkSplash.scss
@@ -6,7 +6,7 @@
   min-height: 100vh;
   background: var(--hi-color-bg-canvas, #0d1117);
   color: var(--hi-color-text-primary, #c9d1d9);
-  font-family: system-ui, -apple-system, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
 }
 
 .hk-splash-main {

--- a/packages/vue/src/components/_hikari-vars.scss
+++ b/packages/vue/src/components/_hikari-vars.scss
@@ -1,4 +1,4 @@
-$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif;
 $hikari-font-size-sm: 0.875rem;
 $hikari-radius-fui-sm: 4px;
 $hikari-radius-fui-md: 6px;

--- a/packages/vue/src/demo.scss
+++ b/packages/vue/src/demo.scss
@@ -1,6 +1,6 @@
 body {
   margin: 0; padding: 2rem;
-  font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
+  font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif);
   background: rgb(var(--color-background, 14 15 24));
   color: rgb(var(--color-text, 192 202 245));
 }


### PR DESCRIPTION
## What

Sweeps up the leftovers flagged in #332: every remaining emitted legacy font stack now matches the canonical Apple-style batch from `fontContext.ts` (17 files, +28/−28).

- Listed sites: `_hikari-vars.scss` $vars, `code_highlighter.scss`/`.rs`, `code_highlight.rs` ×3, `demo.scss`, `HkAboutModal.scss`, `HkLogWindow.scss`, `docs/zh-Hans/design/layer1.md` stale token example.
- Extra sweep finds, also aligned: `markdown_editor.rs` ×2, `markdown_renderer.scss` ×3, `code_block.scss` ×2, `demo_block.scss`, `animations.scss` ×2, `pagination_jump_modal.scss` ×3, `HkPasswordInput.scss`, `HkSplash.scss`.
- Generic-keyword-only fallbacks (`var(--font-mono, monospace)` etc.) intentionally untouched — no family list to align.
- Post-change residue grep for Fira Code / JetBrains Mono / Cascadia / SFMono / Roboto Mono / Courier: zero hits.
- No API change; vue 0.21.1 → 0.21.2.

## Verification

vue-tsc exit 0; vitest 44/44; `cargo check -p hikari-components -p hikari-extra-components` exit 0 (offline against shared cargo pool; check only, no build).