### PR TITLE
🎨 Standardize mono font fallbacks on the shared family variable.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/DemoApp.tsx
+++ b/packages/vue/src/DemoApp.tsx
@@ -2,6 +2,7 @@
 // house rule: no SFCs in the tree). Render-only showcase of every exported
 // component; state is local and throwaway.
 import { computed, defineComponent, ref } from "vue";
+import { HIKARI_FONT_MONO } from "./theme/fontContext";
 import {
   HButton, HIconButton, HTooltip, HBadge, HTag, HIcon, HSpinner,
   HProgressBar, HProgressRing, HGaugeRing,
@@ -134,7 +135,7 @@ export default defineComponent({
     <circle cx="800" cy="450" r="180" fill="rgba(122,162,247,0.35)" stroke="#7aa2f7" stroke-width="3"/>
     <circle cx="800" cy="450" r="90" fill="rgba(122,162,247,0.2)" stroke="#7aa2f7" stroke-width="2" stroke-dasharray="6 4"/>
     <circle cx="800" cy="450" r="12" fill="#f7768e"/>
-    <text x="800" y="700" fill="#9aa5ce" font-family="monospace" font-size="28" text-anchor="middle">Hikari — zoom / pan demo</text>
+    <text x="800" y="700" fill="#9aa5ce" style="font-family: var(--font-mono, ${HIKARI_FONT_MONO})" font-size="28" text-anchor="middle">Hikari — zoom / pan demo</text>
   </svg>`);
     const zoomState = ref({ zoom: 1.6, panX: -40, panY: -18, canIn: true, canOut: true, zoomed: true });
     function syncZoom() {

--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-about-modal {
   display: flex;
   flex-direction: column;
@@ -58,7 +61,7 @@
 .s-about-modal-row-value {
   font-size: var(--text-sm, 0.8125rem);
   color: rgb(var(--color-text));
-  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
 }
 
 .s-about-modal-links {

--- a/packages/vue/src/components/HkErrorBoundary.scss
+++ b/packages/vue/src/components/HkErrorBoundary.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .hk-error-boundary {
   display: flex;
   align-items: center;
@@ -43,7 +46,7 @@
   border-radius: 4px;
   background: rgb(from var(--hi-color-error, #f85149) r g b / 0.12);
   color: var(--hi-color-error, #f85149);
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
 }
 
 .hk-error-boundary-msg {
@@ -53,7 +56,7 @@
   opacity: 0.85;
   word-break: break-word;
   white-space: pre-wrap;
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
 }
 
 .hk-error-boundary-actions {

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-log-viewer {
   display: flex;
   flex-direction: column;
@@ -95,7 +98,7 @@
 
 .s-log-entry {
   padding: var(--space-2, 0.125rem) var(--space-4, 0.25rem);
-  font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-xs, 0.75rem);
   line-height: 1.5;
   color: rgb(var(--color-text));

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .hk-markdown {
   font-size: 0.875rem;
   line-height: 1.7;
@@ -36,7 +39,7 @@
 }
 
 .hk-markdown code {
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: 0.85em;
   background: var(--hi-color-bg-subtle, #21262d);
   padding: 0.15em 0.35em;
@@ -93,7 +96,7 @@
 .hk-md-plain {
   margin: 0;
   padding: 0.5rem 0;
-  font-family: ui-monospace, monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: 0.75rem;
   line-height: 1.6;
   color: var(--hi-color-text-primary, #c9d1d9);

--- a/packages/vue/src/components/HkModelTag.scss
+++ b/packages/vue/src/components/HkModelTag.scss
@@ -3,6 +3,8 @@
 // only. The group itself may shrink to the container width (max-width:
 // 100% + min-width: 0) so the name segment can ellipsize instead of
 // forcing the container to overflow (the #008 / qwen3-coder-plus case).
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
 .s-model-tag-group {
   display: inline-flex;
   align-items: center;
@@ -89,7 +91,7 @@
 
 .s-model-card-col2 {
   text-align: right;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-variant-numeric: tabular-nums;
 }
 

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -1,4 +1,5 @@
 @use "./HkPlaceholderMarquee" as placeholder-marquee;
+@use "./hikari-vars" as vars;
 .hk-pwd-wrapper {
   display: block;
   width: 100%;
@@ -197,7 +198,7 @@
   z-index: 2;
   pointer-events: none;
   user-select: none;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: 0.8125rem;
   letter-spacing: 0.04em;
   color: var(--hi-color-text-primary, #333);

--- a/packages/vue/src/components/HkProgressDialog.scss
+++ b/packages/vue/src/components/HkProgressDialog.scss
@@ -2,6 +2,8 @@
 // carry the `::-webkit-scrollbar` half of the native-bar hide, so the
 // pane's visual block lives here like every other overlay-scroll
 // consumer (see packages/theme/styles/_scrollbar.scss).
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
 /* Track host: wraps ONLY the log pane so the rail hugs the log band,
    not the spinner/progress bands above it. */
 .s-progress-dialog-log-wrap {
@@ -23,7 +25,7 @@
   border-radius: 0.375rem;
   background: rgba(0, 0, 0, 0.06);
   padding: 0.5rem;
-  font-family: monospace;
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: 0.75rem;
   line-height: 1.5;
 }

--- a/packages/vue/src/components/HkRichInput.scss
+++ b/packages/vue/src/components/HkRichInput.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-rich-input {
   display: flex;
   flex-direction: column;
@@ -81,7 +84,7 @@
 
 .s-rich-input-attachment-chip-size {
   color: rgb(var(--color-muted));
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
 }
 
 .s-rich-input-attachment-remove {

--- a/packages/vue/src/components/HkStatusBar.tsx
+++ b/packages/vue/src/components/HkStatusBar.tsx
@@ -2,6 +2,7 @@ import { defineComponent, ref, type PropType } from "vue";
 import { Wifi, WifiOff, Globe, Cable, Monitor, Cog, Plug } from "lucide-vue-next";
 
 import { useI18n } from "../i18n/context";
+import { HIKARI_FONT_MONO } from "../theme/fontContext";
 
 import HPopover from "./HkPopover";
 import type { HkConnectionInfo } from "./HkConnectionInfo";
@@ -300,7 +301,7 @@ export const HkStatusBar = defineComponent({
                       {statusText}
                     </span>
                     {latency !== null && (
-                      <span style={{ marginLeft: "auto", color: latencyColor(latency), fontFamily: "var(--font-mono, monospace)", fontWeight: 600, fontSize: "0.6875rem" }}>
+                      <span style={{ marginLeft: "auto", color: latencyColor(latency), fontFamily: `var(--font-mono, ${HIKARI_FONT_MONO})`, fontWeight: 600, fontSize: "0.6875rem" }}>
                         {latency} ms
                       </span>
                     )}
@@ -313,7 +314,7 @@ export const HkStatusBar = defineComponent({
                           .replace("{maxRetries}", String(info.maxRetries > 0 ? info.maxRetries : 3))}
                       </span>
                       {countdown > 0 && (
-                        <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", fontFamily: "var(--font-mono, monospace)", marginLeft: "8px" }}>
+                        <span style={{ display: "inline-flex", alignItems: "center", gap: "4px", fontFamily: `var(--font-mono, ${HIKARI_FONT_MONO})`, marginLeft: "8px" }}>
                           <HkCountdownDigit value={countdown} />
                         </span>
                       )}
@@ -329,13 +330,13 @@ export const HkStatusBar = defineComponent({
                       <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
                         <Monitor size={12} style={{ opacity: 0.5, flexShrink: 0 }} />
                         <span style={{ opacity: 0.5, marginRight: "auto" }}>{t("hikari::statusBar.panel", "Panel")}</span>
-                        <span style={{ fontFamily: "var(--font-mono, monospace)" }}>{pv}</span>
+                        <span style={{ fontFamily: `var(--font-mono, ${HIKARI_FONT_MONO})` }}>{pv}</span>
                       </div>
                       {ev && (
                         <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
                           <Cog size={12} style={{ opacity: 0.5, flexShrink: 0 }} />
                           <span style={{ opacity: 0.5, marginRight: "auto" }}>{t("hikari::statusBar.engine", "Engine")}</span>
-                          <span style={{ fontFamily: "var(--font-mono, monospace)" }}>{fmtVer(ev, props.engineBuildHash)}</span>
+                          <span style={{ fontFamily: `var(--font-mono, ${HIKARI_FONT_MONO})` }}>{fmtVer(ev, props.engineBuildHash)}</span>
                         </div>
                       )}
                     </>

--- a/packages/vue/src/components/HkStatusPill.scss
+++ b/packages/vue/src/components/HkStatusPill.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .hk-status-pill {
   display: inline-flex;
   align-items: center;
@@ -63,7 +66,7 @@
 
 .hk-status-pill-version {
   color: rgb(var(--color-muted) / 80%);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/vue/src/components/HkTokenUsageBadge.scss
+++ b/packages/vue/src/components/HkTokenUsageBadge.scss
@@ -1,8 +1,11 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-token-usage {
   display: inline-flex;
   align-items: center;
   gap: var(--space-10, 0.625rem);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-2xs, 0.625rem);
   color: rgb(var(--color-muted));
 

--- a/packages/vue/src/components/HkTokenUsagePanel.scss
+++ b/packages/vue/src/components/HkTokenUsagePanel.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-token-panel {
   display: flex;
   flex-direction: column;
@@ -41,7 +44,7 @@
 }
 
 .s-token-panel-num {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-variant-numeric: tabular-nums;
 }
 
@@ -74,7 +77,7 @@
 
 .s-token-panel-model-count {
   color: rgb(var(--color-muted));
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   flex-shrink: 0;
 }
 

--- a/packages/vue/src/components/HkToolBlock.scss
+++ b/packages/vue/src/components/HkToolBlock.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .s-tool-block {
   border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
   border-radius: var(--radius-md, 8px);
@@ -24,7 +27,7 @@
 }
 
 .s-tool-header-title {
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-weight: 600;
   color: rgb(var(--color-text));
   min-width: 0;
@@ -77,7 +80,7 @@
 .s-tool-param-line {
   font-size: var(--text-2xs, 0.625rem);
   line-height: 1.5;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   white-space: pre-wrap;
   word-break: break-word;
   color: rgb(var(--color-text));
@@ -95,7 +98,7 @@
   overflow: auto;
   border-radius: var(--radius-sm, 4px);
   background: rgb(0 0 0 / 4%);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-2xs, 0.625rem);
   line-height: 1.5;
   white-space: pre-wrap;
@@ -122,7 +125,7 @@
 
 .s-tool-result-line {
   font-size: var(--text-2xs, 0.625rem);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   line-height: 1.5;
   padding: var(--space-1, 0.0625rem) 0;
   white-space: pre-wrap;
@@ -142,7 +145,7 @@
   background: rgb(var(--color-surface) / 0.85);
   border-radius: var(--radius-sm, 4px);
   border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-2xs, 0.625rem);
   line-height: 1.65;
   color: rgb(var(--color-text));
@@ -249,7 +252,7 @@
   --jt-toggle: 14px;
   margin: var(--space-4, 0.25rem) 0;
   padding: var(--space-6, 0.375rem);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-2xs, 0.625rem);
   line-height: 1.55;
   background: rgb(var(--color-surface) / 0.5);
@@ -414,7 +417,7 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   color: rgb(var(--color-muted));
 }
 

--- a/packages/vue/src/components/HkZoomToolbar.scss
+++ b/packages/vue/src/components/HkZoomToolbar.scss
@@ -1,3 +1,6 @@
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .hk-zoom-toolbar {
   display: flex;
   align-items: center;
@@ -21,7 +24,7 @@
 
 .hk-zoom-label {
   font-size: var(--text-2xs);
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
   color: rgb(var(--color-muted));
   min-width: 32px;
   text-align: center;

--- a/packages/vue/src/components/_hikari-vars.scss
+++ b/packages/vue/src/components/_hikari-vars.scss
@@ -1,4 +1,6 @@
 $hikari-font-family-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', 'Noto Sans CJK SC', sans-serif;
+// Keep in sync with HIKARI_FONT_MONO in packages/vue/src/theme/fontContext.ts.
+$hikari-font-family-mono: ui-monospace, 'SF Mono', Menlo, Consolas, 'DejaVu Sans Mono', 'Liberation Mono', 'PingFang SC', 'Microsoft YaHei', 'Noto Sans CJK SC', monospace;
 $hikari-font-size-sm: 0.875rem;
 $hikari-radius-fui-sm: 4px;
 $hikari-radius-fui-md: 6px;


### PR DESCRIPTION
## What

Follow-up to #332/#334 (user request): the remaining hand-written `var(--font-mono, monospace)`-style fallbacks now reference a single shared variable instead of per-site literals.

- `_hikari-vars.scss` gains `-font-family-mono` (the canonical batch; keep-in-sync note → `theme/fontContext.ts`).
- 22 SCSS sites across 13 files → `font-family: var(--font-mono, vars.-font-family-mono);` with `@use "./hikari-vars" as vars;` (existing HkBreadcrumb convention). Re-grep also collapsed 3 hand-copied full-batch fallbacks (HkAboutModal, HkLogWindow, HkPasswordInput).
- 5 TSX sites (DemoApp data-URI SVG, HkStatusBar ×4) use the exported `HIKARI_FONT_MONO` constant.
- Post-change sweep: zero hits for `var(--font-mono, monospace)` / bare `monospace` / `ui-monospace, monospace` in packages/vue/src.
- No behavior change when `--font-mono` is set (always is, via initFontContext/bootstrap token); standalone components now degrade to the same canonical batch. vue 0.21.2 → 0.21.3.

## Verification

14/14 touched SCSS compile under dart-sass (no deprecation warning; emitted line proves the fallback expands to the full batch); vue-tsc exit 0; vitest 44/44.