### PR TITLE
✨ Reserve merged tab options' combined width in the button group strip.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.21.3",
+  "version": "0.22.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -179,14 +179,15 @@
  * row-filling (block). */
 
 /* block outside the scroller (scrollable opted out): legacy fill —
-   triggers may shrink below their content. */
+   triggers may shrink below their content. Each trigger's growth weight
+   comes from its `grow` option (--hk-tabs-grow, default 1). */
 .hk-tabs-list[data-variant="segmented"][data-block="true"] {
   display: flex;
   width: 100%;
 }
 
 .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-trigger {
-  flex: 1 1 auto;
+  flex: var(--hk-tabs-grow, 1) 1 auto;
 }
 
 /* block inside the scroller (the default): fill the row while it fits,
@@ -198,7 +199,7 @@
 }
 
 .hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-trigger {
-  flex: 1 0 auto;
+  flex: var(--hk-tabs-grow, 1) 0 auto;
 }
 
 /* === Merged cell (dynamic merged-option rendering) ===
@@ -210,17 +211,62 @@
  * grammar: NAKED — no border, no own surface; only the sliding
  * indicator ever frames the active option, so a merged cell must never
  * grow a box of its own. Interactive slot content (e.g. the theme
- * toggle's altitude strip) fills the cell and owns its hover/press. */
+ * toggle's altitude strip) fills the cell and owns its hover/press.
+ *
+ * COLSPAN semantics: the cell stacks a hidden SIZER (invisible ghost
+ * triggers mirroring the merged run) and the slot BODY in the same grid
+ * cell, so the cell's intrinsic size equals the run's combined trigger
+ * footprint — toggling a merge on/off never resizes the strip or its
+ * fit-content parent (popover menus), and in stretched rows the cell
+ * grows with the run's summed `grow` weight (--hk-tabs-grow). */
 .hk-tabs-merged {
   position: relative;
   /* Same layer as the triggers, above the sliding indicator. */
   z-index: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: inline-grid;
   flex: none;
   min-width: 0;
   color: rgb(var(--color-muted));
+  font-size: var(--text-sm);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+/* Sizer and body share grid cell 1/1: the (max-content-larger) sizer
+   sets the floor, the body stretches over it and centers the slot. */
+.hk-tabs-merged-body,
+.hk-tabs-merged-sizer {
+  grid-area: 1 / 1;
+  min-width: 0;
+}
+
+.hk-tabs-merged-body {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.hk-tabs-merged-sizer {
+  display: inline-flex;
+  /* Out of every interactive and announced surface — geometry only. */
+  visibility: hidden;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Ghost trigger — mirrors .hk-tabs-trigger's box metrics (padding, gap,
+   typography, nowrap; borderless like the real trigger) so the run's
+   combined footprint, including the strip's cross size, matches the
+   triggers it replaces. Deliberately NOT .hk-tabs-trigger: ghosts must
+   stay invisible to trigger queries, keyboard navigation and a11y. */
+.hk-tabs-ghost-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-12);
   font-size: var(--text-sm);
   font-weight: 600;
   white-space: nowrap;
@@ -232,12 +278,12 @@
   pointer-events: none;
 }
 
-/* block (row-filling) strips: the merged cell shares the triggers'
-   flex growth so it lands on the merged run's share of the row. */
+/* block (row-filling) strips: the merged cell takes its run's summed
+   `grow` weight so it lands on the merged run's share of the row. */
 .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-merged {
-  flex: 1 1 auto;
+  flex: var(--hk-tabs-grow, 1) 1 auto;
 }
 
 .hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-merged {
-  flex: 1 0 auto;
+  flex: var(--hk-tabs-grow, 1) 0 auto;
 }

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -387,6 +387,90 @@ describe("HkTabs segmented variant", () => {
     expect(container.querySelector(".hk-tabs-trigger[data-active]")).toBeNull();
   });
 
+  it("pins the merged cell to the run's combined footprint via a hidden sizer", async () => {
+    const { container } = mountLive(
+      {
+        variant: "segmented",
+        mergeKeys: ["b", "c"],
+        tabs: [
+          { key: "a", label: "Alpha" },
+          { key: "b", label: "Beta", icon: h("i", { class: "glyph-b" }) },
+          { key: "c", label: "Gamma", icon: h("i", { class: "glyph-c" }) },
+        ],
+      },
+      { merged: () => h("span", { class: "strip" }, "m") },
+    );
+    await settle();
+    const sizer = container.querySelector<HTMLElement>(".hk-tabs-merged-sizer")!;
+    expect(sizer).not.toBeNull();
+    // Geometry only: never announced, never interactive.
+    expect(sizer.getAttribute("aria-hidden")).toBe("true");
+    // Ghost triggers mirror the merged run — icons, labels, order.
+    const ghosts = sizer.querySelectorAll(".hk-tabs-ghost-trigger");
+    expect(ghosts).toHaveLength(2);
+    expect(ghosts[0].querySelector(".glyph-b")).not.toBeNull();
+    expect(ghosts[0].textContent).toContain("Beta");
+    expect(ghosts[1].querySelector(".glyph-c")).not.toBeNull();
+    expect(ghosts[1].textContent).toContain("Gamma");
+    // Ghosts never join the radio surface (no role, no button semantics).
+    expect(sizer.querySelector("[role], button")).toBeNull();
+    // The slot body stacks over the sizer in the same grid cell.
+    expect(container.querySelector(".hk-tabs-merged-body .strip")).not.toBeNull();
+    // Clearing the merge removes the sizer with the cell.
+    const bare = mountLive({ variant: "segmented" }, { merged: () => h("span", "x") });
+    expect(bare.container.querySelector(".hk-tabs-merged-sizer")).toBeNull();
+  });
+
+  it("grows merged cells with the run's summed relative weight", async () => {
+    const { container } = mountLive(
+      {
+        variant: "segmented",
+        block: true,
+        mergeKeys: ["b", "c"],
+        tabs: [
+          { key: "a", label: "Alpha" },
+          { key: "b", label: "Beta", grow: 1.2 },
+          { key: "c", label: "Gamma" },
+        ],
+      },
+      { merged: () => h("span", "m") },
+    );
+    await settle();
+    // Colspan: the cell carries the run's summed grow (1.2 + 1).
+    const cell = container.querySelector<HTMLElement>(".hk-tabs-merged")!;
+    expect(cell.style.getPropertyValue("--hk-tabs-grow")).toBe("2.2");
+    // Default-weight triggers keep a clean DOM (var omitted at 1).
+    const alpha = container.querySelector<HTMLElement>(".hk-tabs-trigger")!;
+    expect(alpha.style.getPropertyValue("--hk-tabs-grow")).toBe("");
+    // An explicit per-option weight lands as the CSS var.
+    const weighted = mountLive({
+      variant: "segmented",
+      block: true,
+      tabs: [
+        { key: "a", label: "Alpha", grow: 2 },
+        { key: "b", label: "Beta" },
+        { key: "c", label: "Gamma", disabled: true },
+      ],
+    });
+    const first = weighted.container.querySelector<HTMLElement>(".hk-tabs-trigger")!;
+    expect(first.style.getPropertyValue("--hk-tabs-grow")).toBe("2");
+    // Zero stays legal (fixed-width option); garbage falls back to the
+    // default instead of invalidating the flex shorthand.
+    const guarded = mountLive({
+      variant: "segmented",
+      block: true,
+      tabs: [
+        { key: "a", label: "Alpha", grow: 0 },
+        { key: "b", label: "Beta", grow: Number.NaN },
+        { key: "c", label: "Gamma", grow: -3, disabled: true },
+      ],
+    });
+    const trig = guarded.container.querySelectorAll<HTMLElement>(".hk-tabs-trigger");
+    expect(trig[0].style.getPropertyValue("--hk-tabs-grow")).toBe("0");
+    expect(trig[1].style.getPropertyValue("--hk-tabs-grow")).toBe("");
+    expect(trig[2].style.getPropertyValue("--hk-tabs-grow")).toBe("");
+  });
+
   it("renders a tab icon field before the label", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, nextTick, onBeforeUnmount, onBeforeUpdate, onMounted, ref, watch, TransitionGroup, type ComponentPublicInstance, type PropType } from "vue";
+import { cloneVNode, computed, defineComponent, h, isVNode, nextTick, onBeforeUnmount, onBeforeUpdate, onMounted, ref, watch, TransitionGroup, type ComponentPublicInstance, type PropType, type VNode } from "vue";
 
 import "./HkTabs.scss";
 import HkScrollContainer from "./HkScrollContainer";
@@ -18,6 +18,27 @@ export interface TabItem {
    *  slot wins when provided). */
   icon?: unknown;
   disabled?: boolean;
+  /** Relative width weight (flex-grow) for row-filling segmented strips
+   *  (`variant="segmented"` + `block`). Defaults to 1 — every option
+   *  takes an equal share of the free row space, so plain groups render
+   *  exactly as before. A `mergeKeys` merged cell inherits its run's
+   *  SUMMED weight and reserves the run's combined footprint (colspan
+   *  semantics), so replacing N options always occupies N options'
+   *  worth of the row. */
+  grow?: number;
+}
+
+/** Inline style carrying the option's relative width weight as a CSS
+ *  custom property; the block-strip flex rules consume it. Omitted at
+ *  the default weight of 1 so ordinary groups keep a clean DOM. Garbage
+ *  weights (NaN/Infinity/negative) fall back to the default: inside the
+ *  `flex:` shorthand they would invalidate it at computed-value time
+ *  and silently stop the strip from filling. Zero stays legal (a
+ *  fixed-width option that never takes free space). */
+function growStyle(grow: number): Record<string, string> | undefined {
+  return Number.isFinite(grow) && grow >= 0 && grow !== 1
+    ? { "--hk-tabs-grow": String(grow) }
+    : undefined;
 }
 
 /** A protruding icon button at one inline end of the strip (the former
@@ -69,8 +90,12 @@ interface ScrollerExpose {
  *   while "auto" is active). The cell is a real flex child of the track
  *   (never an absolute cover), so it joins layout AND the animation
  *   context: options/cells fade-swap on merge changes, and the sliding
- *   indicator measures the cell when the active key is merged. Merged
- *   options are skipped by keyboard navigation;
+ *   indicator measures the cell when the active key is merged. The cell
+ *   speaks COLSPAN semantics: an invisible sizer mirrors the merged
+ *   run's triggers, pinning the cell's intrinsic width to the run's
+ *   combined footprint (toggling a merge never resizes the strip or its
+ *   fit-content parent), and its flex-grow is the run's summed `grow`
+ *   weight. Merged options are skipped by keyboard navigation;
  * - full arrow-key navigation (arrows/Home/End, wrapping, disabled tabs
  *   skipped, selection follows focus) and roving tabindex.
  */
@@ -152,6 +177,13 @@ export default defineComponent({
     const mergedRun = computed(() =>
       props.tabs.filter((tb) => mergeSet.value.has(tb.key)).map((tb) => tb.key),
     );
+    /** The merged cell grows with its run's summed relative width
+     *  weight (colspan: replacing N options occupies N options' share
+     *  of the row). */
+    const mergedGrow = computed(() => {
+      const byKey = new Map(props.tabs.map((tb) => [tb.key, tb] as const));
+      return mergedRun.value.reduce((sum, k) => sum + (byKey.get(k)?.grow ?? 1), 0);
+    });
     /** The contract is ONE contiguous run; a scattered selection would
      *  silently swallow the middle options, so degrade to plain
      *  triggers instead. */
@@ -403,6 +435,12 @@ export default defineComponent({
           // surface is the remaining triggers; interactive slot content
           // carries its own semantics.
           if (tab.key === mergedHead) {
+            // The sizer mirrors the merged run's triggers (same icon/label
+            // structure, same metrics via .hk-tabs-ghost-trigger) so the
+            // cell's intrinsic width equals the run's combined footprint.
+            const ghostTabs = mergedRun.value
+              .map((k) => props.tabs.find((tb) => tb.key === k))
+              .filter((gt): gt is TabItem => gt != null);
             listChildren.push(
               <div
                 key="$merged"
@@ -411,8 +449,28 @@ export default defineComponent({
                 role="presentation"
                 data-keys={mergedRun.value.join(" ")}
                 data-disabled={props.disabled || undefined}
+                style={growStyle(mergedGrow.value)}
               >
-                {slots.merged?.({ keys: mergedRun.value })}
+                {/* Invisible width keeper (colspan floor): out of every
+                    interactive and announced surface, it only pins the
+                    cell's intrinsic width — toggling a merge never
+                    resizes the strip or its fit-content parent (the
+                    theme toggle's popover menu). */}
+                <span class="hk-tabs-merged-sizer" aria-hidden="true">
+                  {ghostTabs.map((gt) => (
+                    <span key={gt.key} class="hk-tabs-ghost-trigger">
+                      {slots[`icon-${gt.key}`]?.() ?? (gt.icon != null
+                        ? (
+                          <span class="hk-tabs-trigger-icon">
+                            {isVNode(gt.icon) ? cloneVNode(gt.icon as VNode) : gt.icon}
+                          </span>
+                        )
+                        : null)}
+                      {gt.label ? <span>{gt.label}</span> : null}
+                    </span>
+                  ))}
+                </span>
+                <div class="hk-tabs-merged-body">{slots.merged?.({ keys: mergedRun.value })}</div>
               </div>,
             );
           }
@@ -433,6 +491,7 @@ export default defineComponent({
             class="hk-tabs-trigger"
             data-active={active || undefined}
             data-disabled={props.disabled || disabled || undefined}
+            style={growStyle(tab.grow ?? 1)}
             // Roving tabindex: the active trigger joins the page tab
             // sequence, the others stay arrow-reachable.
             tabindex={active || idx === fallbackTabbableIdx.value ? undefined : -1}


### PR DESCRIPTION
Follow-up to #330, user-reported: the theme popover's color-mode row visibly changed width when toggling auto ↔ manual — in auto mode the Light/Dark options collapse into one merged cell (the solar-altitude strip) that sized itself to its own content (`☾ -27.7°`), so the whole popover jumped.

**Fix — inside HTabs, no consumer changes (colspan semantics for merged cells):**
- A hidden ghost-trigger sizer (`aria-hidden` + `visibility: hidden`, deliberately not using the `.hk-tabs-trigger` class) mirrors the merged run's icons/labels/padding inside the cell, pinning the cell's intrinsic width to the run's combined trigger footprint. Toggling a merge on/off now never resizes the strip or its fit-content parent.
- The cell stacks sizer + slot body (`.hk-tabs-merged-body`) in one grid cell; the body stretches and centers the slot. ⚠️ Downstream CSS targeting direct children of `.hk-tabs-merged` should target the body instead (minor bump 0.22.0).
- The cell's flex-grow is the run's summed weight; new optional `TabItem.grow` gives every option a relative width weight (default 1 — existing groups render exactly as before; garbage weights fall back to the default, zero stays legal).

**HkThemeToggle: zero changes** — the width fix lands for every consumer with the hikari bump.

**Verification (3-round cycle):**
- vitest packages/vue: 67 files / 601 tests pass (incl. 2 new merged-cell/sizer tests + grow weight tests); vue-tsc --noEmit clean.
- Cross-verified by an independent review subagent (SHIP; its hardening finding — non-finite grow clamping — applied in round 3, re-verified).
- Real-browser measurement (happy-dom can't measure layout): auto-mode altitude cell **164.140625px** == manual-mode Light+Dark combined **164.140625px**, pixel-exact; popover box identical across modes (272.609×342.453 @ same x); heights identical (23px rows both modes).