### PR TITLE
🐛 Remove native tooltips that duplicate custom popup surfaces.

### DIFF
--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -306,7 +306,6 @@ export const HkLocalizedInput = defineComponent({
                   "hikari::localizedInput.chooseLanguage",
                   "Choose editing language",
                 )}
-                title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
                 onClick={(e: MouseEvent) => {
                   e.preventDefault();
                   e.stopPropagation();

--- a/packages/vue/src/components/HkModelTag.test.tsx
+++ b/packages/vue/src/components/HkModelTag.test.tsx
@@ -70,11 +70,10 @@ describe("HkModelTag", () => {
     expect(name?.textContent).toBe("qwen3-coder-plus");
   });
 
-  it("carries the full model id on the group title for hover-to-read", () => {
+  it("carries no native title — the hover card is the only tooltip", () => {
     const c = mount(tagNode({ model: "qwen3-coder-plus#8" }));
-    expect(c.querySelector(".s-model-tag-group")?.getAttribute("title")).toBe(
-      "qwen3-coder-plus#8",
-    );
+    const group = c.querySelector(".s-model-tag-group");
+    expect(group?.getAttribute("title")).toBeNull();
   });
 
   it("renders a bare model id without the number segment", () => {

--- a/packages/vue/src/components/HkModelTag.tsx
+++ b/packages/vue/src/components/HkModelTag.tsx
@@ -13,8 +13,9 @@ import "./HkModelTag.scss";
  * divider line at the seam, no gap and no rounding at the junction (outer
  * corners keep the badge radius). The name segment truncates with an
  * ellipsis when the surrounding container is too narrow (min-width floor
- * keeps a couple of characters legible); the native `title` tooltip and
- * the hover card always carry the full model id.
+ * keeps a couple of characters legible). No native `title` here: the
+ * hover card always carries the full model id, and a native tooltip would
+ * fire alongside it (the duplicated-tooltip defect this removed).
  */
 const ModelPill = defineComponent({
   name: "HkModelPill",
@@ -29,7 +30,6 @@ const ModelPill = defineComponent({
       <span
         class="s-model-tag-group"
         data-expanded={props.expanded || undefined}
-        title={props.model}
       >
         {tag && (
           <HBadge variant="primary" size="sm" mono pill={false} class="s-model-tag-num">


### PR DESCRIPTION
Two instances of the same defect class: a native `title` tooltip firing alongside a custom floating surface on the same trigger.

- **HkModelPill** carried the full model id on a native `title` while the hover card (HPopover) already shows it — hovering a model tag fired BOTH, the browser tooltip rendering on top of the custom card (user-reported on the chest cruise dock). The title is removed; the hover card is the only tooltip. Contract test now asserts its absence.
- **HkLocalizedInput** language chip carried a native `title` while the same click opens the HkMenu anchored to it; the identical `aria-label` and the menu panel title already carry the wording.

A project-wide sweep (all of packages/vue/src) found no other title×popup duplicates; the remaining native titles are legitimate single-surface tooltips and were left alone.

Version bump: vue 0.21.2 → 0.21.3.