### PR TITLE
🔧 Drop synchronize from message checks and pin checkout to v7.

### DIFF
--- a/.github/workflows/ci-hosted.yml
+++ b/.github/workflows/ci-hosted.yml
@@ -19,7 +19,7 @@ jobs:
     name: fmt + clippy + test (hosted)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install apt dependencies
         run: sudo apt-get install -y libasound2-dev libudev-dev
@@ -49,7 +49,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install apt dependencies
         run: sudo apt-get install -y libasound2-dev libudev-dev
@@ -84,7 +84,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install apt dependencies
         run: sudo apt-get install -y libasound2-dev libudev-dev

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -28,7 +28,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache MDI icons
         id: mdi-cache

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -2,7 +2,7 @@ name: Commit Message Lint
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache MDI icons
         id: mdi-cache

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # The old recipe (hosted runner + cargo install --branch dev) has failed
       # on every run since 2026-07-28: the lagrange dev branch no longer

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -18,7 +18,7 @@ jobs:
     name: Publish @celestia-island/hikari to npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     name: Verify version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract tag version
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -65,7 +65,7 @@ jobs:
     needs: verify-versions
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Ensure tag is on master
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
     name: cargo audit
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install cargo-audit
         uses: dtolnay/rust-toolchain@stable
@@ -34,7 +34,7 @@ jobs:
     name: cargo deny
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install cargo-deny
         run: cargo install --locked cargo-deny

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Cache MDI icons
         id: mdi-cache


### PR DESCRIPTION
CI slim wave (AGENTS.md 7.4): message-check workflows now trigger only on opened/edited/reopened/ready_for_review instead of every push, and actions/checkout pinned to v7 org-wide. Branch rewritten to a single compliant commit on top of master (merge-commit subject from branch update was rejected by the lint, per AGENTS.md 3).