### PR TITLE
🐛 Keep centered HkInput text on the box axis by reserving affix clearance symmetrically.

### DIFF
--- a/packages/vue/src/components/HkInput.affix.test.ts
+++ b/packages/vue/src/components/HkInput.affix.test.ts
@@ -1,9 +1,11 @@
 /**
  * Source contract for the input affix reservation (2026-08-30 user
  * report: the localized input's language chip sat at the LEFT edge of
- * the field with the scrolling placeholder sliding underneath it).
+ * the field with the scrolling placeholder sliding underneath it;
+ * 2026-09-01 user report: a lone prefix icon pushed the CENTERED text
+ * line half an icon toward the far side on the sign-in card).
  *
- * Two coupled guarantees, pinned here so a refactor cannot silently
+ * Three coupled guarantees, pinned here so a refactor cannot silently
  * regress them — the same "looks fixed but never shipped" class of
  * failure as the overflow-poll incident:
  *
@@ -14,6 +16,11 @@
  *     window consume the measured affix widths (--hk-input-affix-*-w,
  *     published by HkInput on the box), so text and marquee always end
  *     short of the chip.
+ *  3. The CENTERED default reserves the clearance SYMMETRICALLY (max
+ *     of both affix widths on each side), so icons never shift where
+ *     the centered line sits; only an explicit data-align="start"/
+ *     "end" (HkInput's `align` prop) restores the per-side
+ *     reservation.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -28,12 +35,14 @@ const scss = readFileSync(join(here, "HkInput.scss"), "utf-8");
 
 const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
 
-function mountInput(opts: { slots?: Record<string, Component> } = {}) {
+function mountInput(
+  opts: { slots?: Record<string, Component>; props?: Record<string, unknown> } = {},
+) {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const app = createApp({
     render: () =>
-      h(HkInput, { placeholder: "Short name" }, opts.slots ?? {}),
+      h(HkInput, { placeholder: "Short name", ...opts.props }, opts.slots ?? {}),
   });
   app.mount(container);
   mounts.push({ app, container });
@@ -65,6 +74,80 @@ describe("HkInput affix reservation contract", () => {
     const marquee = scss.match(/\.hk-input-box \.hk-placeholder-marquee\s*{[^}]*}/)?.[0] ?? "";
     expect(marquee, "marquee window rule must exist").toContain("var(--hk-input-affix-end-w");
     expect(marquee).toContain("var(--hk-input-affix-start-w");
+  });
+
+  it("reserves the centered clearance symmetrically so icons never shift the line", () => {
+    // The centered base rule must reserve the SAME clearance on both
+    // sides (max of the two affix widths) — a lone prefix icon would
+    // otherwise push the text-align:center content box half an affix
+    // toward the far side (2026-09-01 sign-in card report).
+    const symmetric =
+      "max(var(--hk-input-affix-start-w, 0px), var(--hk-input-affix-end-w, 0px))";
+    const element = scss.slice(
+      scss.indexOf(".hk-input-element {"),
+      scss.indexOf("&:focus"),
+    );
+    expect(element).toContain("text-align: center");
+    expect(element).toContain("padding-inline");
+    expect(element).toContain(symmetric);
+    expect(element).not.toContain("padding-inline-start");
+    expect(element).not.toContain("padding-inline-end");
+
+    const marquee = scss.match(/\.hk-input-box \.hk-placeholder-marquee\s*{[^}]*}/)?.[0] ?? "";
+    expect(marquee, "marquee window rule must exist").toContain(symmetric);
+  });
+
+  it("restores the per-side reservation only for explicit edge alignments", () => {
+    const shared = scss.match(
+      /\.hk-input-box\[data-align="start"\] \.hk-input-element:not\(\.hk-input-textarea\),\s*\.hk-input-box\[data-align="end"\] \.hk-input-element:not\(\.hk-input-textarea\)\s*{[^}]*}/,
+    )?.[0] ?? "";
+    expect(shared, "edge-align padding rule must exist").toContain(
+      "padding-inline-start: calc(var(--space-12) + var(--hk-input-affix-start-w, 0px))",
+    );
+    expect(shared).toContain(
+      "padding-inline-end: calc(var(--space-12) + var(--hk-input-affix-end-w, 0px))",
+    );
+
+    // The standalone text-align rules must have text-align as the very
+    // first declaration — anchoring the match there skips the shared
+    // rule whose second selector line carries the same prefix.
+    expect(
+      scss.match(/\.hk-input-box\[data-align="start"\] \.hk-input-element:not\(\.hk-input-textarea\)\s*\{\s*text-align:\s*start/),
+      "start alignment rule must exist",
+    ).toBeTruthy();
+    expect(
+      scss.match(/\.hk-input-box\[data-align="end"\] \.hk-input-element:not\(\.hk-input-textarea\)\s*\{\s*text-align:\s*end/),
+      "end alignment rule must exist",
+    ).toBeTruthy();
+
+    // The scrolling window tracks the (off-center) content box too.
+    const marqueeEdge = scss.match(
+      /\.hk-input-box\[data-align="start"\] \.hk-placeholder-marquee,\s*\.hk-input-box\[data-align="end"\] \.hk-placeholder-marquee\s*{[^}]*}/,
+    )?.[0] ?? "";
+    expect(marqueeEdge, "edge-align marquee rule must exist").toContain(
+      "inset-inline-start: calc(var(--space-12) + var(--hk-input-affix-start-w, 0px))",
+    );
+  });
+
+  it("marks the box with data-align only for non-centered alignment", async () => {
+    const centered = mountInput();
+    await nextTick();
+    expect(centered.container.querySelector(".hk-input-box")!.getAttribute("data-align")).toBeNull();
+
+    const start = mountInput({ props: { align: "start" } });
+    await nextTick();
+    expect(start.container.querySelector(".hk-input-box")!.getAttribute("data-align")).toBe("start");
+
+    const end = mountInput({ props: { align: "end" } });
+    await nextTick();
+    expect(end.container.querySelector(".hk-input-box")!.getAttribute("data-align")).toBe("end");
+
+    // Textarea boxes never carry the marker — their element is excluded
+    // by :not() and a textarea-scoped marquee must keep the symmetric
+    // window insets.
+    const ta = mountInput({ props: { align: "start", type: "textarea" } });
+    await nextTick();
+    expect(ta.container.querySelector(".hk-input-box")!.getAttribute("data-align")).toBeNull();
   });
 
   it("leaves the textarea variant's padding out of the affix reservation", () => {

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -73,6 +73,11 @@
   inset: 0;
   width: 100%;
   height: 100%;
+  /* Self-declared so the symmetric-affix centering guarantee never
+   * depends on a host app's global reset: under content-box the
+   * width:100% + padding would push the content box off-axis by the
+   * full padding. Same precedent as HkTextarea/HkDatePicker. */
+  box-sizing: border-box;
   background: transparent;
   border: none;
   outline: none;
@@ -84,15 +89,19 @@
   line-height: 1.5;
   color: rgb(var(--color-text));
   text-align: center;
-  /* Horizontal padding grows by the measured affix widths
-   * (--hk-input-affix-*-w, published by HkInput on the box) so the
-   * caret, typed text and the native placeholder all stay clear of
-   * the prefix/suffix content — e.g. the localized input's language
-   * chip riding the right edge. */
-  padding: var(--space-8)
-    calc(var(--space-12) + var(--hk-input-affix-end-w, 0px))
-    var(--space-8)
-    calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
+  /* Horizontal padding reserves affix clearance SYMMETRICALLY: both
+   * sides grow by the max of the two measured affix widths
+   * (--hk-input-affix-*-w, published by HkInput on the box), so the
+   * content box stays centered on the box axis — a lone prefix icon
+   * (the sign-in username's user glyph) no longer pushes the centered
+   * caret/text half an icon toward the far side — while the line
+   * still never runs underneath a prefix OR suffix affix (e.g. the
+   * localized input's language chip riding the right edge). */
+  padding-block: var(--space-8);
+  padding-inline: calc(
+    var(--space-12) +
+      max(var(--hk-input-affix-start-w, 0px), var(--hk-input-affix-end-w, 0px))
+  );
 
   // The interactive states stay clean too: the shell (.hk-input-box) owns
   // the focus affordance via :focus-within. Without these overrides any
@@ -105,6 +114,27 @@
     outline: none;
     box-shadow: none;
   }
+}
+
+/* Explicit edge alignment (HkInput's `align` prop) opts out of the
+ * symmetric reservation: each side pads only by the affix actually
+ * sitting on it, so a start-aligned field with a lone suffix chip
+ * gains no phantom leading indent (and an end-aligned field with a
+ * lone prefix stays flush to its edge). The textarea variant keeps
+ * its plain padding either way — its affixes sit in flow BESIDE the
+ * element, not overlaid, so there is nothing to reserve against. */
+.hk-input-box[data-align="start"] .hk-input-element:not(.hk-input-textarea),
+.hk-input-box[data-align="end"] .hk-input-element:not(.hk-input-textarea) {
+  padding-inline-start: calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
+  padding-inline-end: calc(var(--space-12) + var(--hk-input-affix-end-w, 0px));
+}
+
+.hk-input-box[data-align="start"] .hk-input-element:not(.hk-input-textarea) {
+  text-align: start;
+}
+
+.hk-input-box[data-align="end"] .hk-input-element:not(.hk-input-textarea) {
+  text-align: end;
 }
 
 .hk-input-element.hk-input-textarea {
@@ -166,16 +196,28 @@
 }
 
 /* The placeholder-marquee window shares the element's content box: inset
- * by the same base padding plus the measured affix widths, so the
- * scrolling strip never slides underneath the affixes either. With no
- * affixes this still insets by the base padding — the window then exactly
- * matches the native placeholder's bounds, so marginal placeholders that
- * "fit" the padded line stay native instead of scrolling. */
+ * by the same base padding plus the affix clearance, so the scrolling
+ * strip never slides underneath the affixes either. Like the element,
+ * the centered default reserves the clearance symmetrically (max of
+ * both affix widths on each side) so the window stays co-centered with
+ * the centered text line. With no affixes this still insets by the base
+ * padding — the window then exactly matches the native placeholder's
+ * bounds, so marginal placeholders that "fit" the padded line stay
+ * native instead of scrolling. */
 .hk-input-box .hk-placeholder-marquee {
-  inset: 0
-    calc(var(--space-12) + var(--hk-input-affix-end-w, 0px))
-    0
-    calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
+  inset-block: 0;
+  inset-inline: calc(
+    var(--space-12) +
+      max(var(--hk-input-affix-start-w, 0px), var(--hk-input-affix-end-w, 0px))
+  );
+}
+
+/* Edge-aligned fields mirror their element's per-side reservation so
+ * the scrolling window tracks the (off-center) content box exactly. */
+.hk-input-box[data-align="start"] .hk-placeholder-marquee,
+.hk-input-box[data-align="end"] .hk-placeholder-marquee {
+  inset-inline-start: calc(var(--space-12) + var(--hk-input-affix-start-w, 0px));
+  inset-inline-end: calc(var(--space-12) + var(--hk-input-affix-end-w, 0px));
 }
 
 .hk-input-error-msg {

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -37,6 +37,19 @@ export default defineComponent({
       default: "text",
     },
     /**
+     * Horizontal alignment of the text line. The centered default
+     * reserves affix clearance SYMMETRICALLY — both sides grow by the
+     * max of the measured affix widths — so the centered caret, typed
+     * text and placeholders stay on the box axis no matter which side
+     * carries an icon. `start` / `end` are the explicit edge
+     * alignments: they opt out of the symmetric reservation and pad
+     * each side only by the affix actually sitting on it.
+     */
+    align: {
+      type: String as () => "center" | "start" | "end",
+      default: "center",
+    },
+    /**
      * Overflow strategy for a placeholder longer than the input line:
      * `marquee` (default) scrolls it like a storefront sign — the text is
      * rendered three times inside a clipping window and the strip is
@@ -109,8 +122,12 @@ export default defineComponent({
     // underneath the affixes (the localized input's language chip used
     // to catch the scrolling placeholder). Both affixes are measured
     // and published as custom properties on the box; the element's
-    // horizontal padding and the marquee window insets consume them,
-    // so the text line always ends short of the chip.
+    // horizontal padding and the marquee window insets consume them.
+    // The CSS keys off the alignment: the centered default reserves
+    // max(start, end) on BOTH sides so the content box stays symmetric
+    // about the box axis (a lone prefix icon must not push the
+    // centered line off-center), while an explicit data-align="start"
+    // / "end" pads each side only by its own affix.
     const prefixEl = ref<HTMLElement | null>(null);
     const suffixEl = ref<HTMLElement | null>(null);
     const affixStartW = ref(0);
@@ -240,6 +257,12 @@ export default defineComponent({
           class={boxClass.value}
           style={boxVars.value}
           data-autogrow={isAutoGrow.value || undefined}
+          // Textarea boxes never carry the marker: their element is
+          // excluded by :not() anyway, and keeping it off also spares
+          // a textarea-scoped marquee from the per-side window insets.
+          data-align={
+            !isTextarea.value && props.align !== "center" ? props.align : undefined
+          }
         >
           {slots.prefix && (
             <span ref={prefixAffixRef} class="hk-input-affix hk-input-prefix">


### PR DESCRIPTION
## Problem (user report, 2026-09-01 screenshot)

The sign-in card's username field (HkSignInCard → HkInput with a lone `prefixIcon` user glyph) rendered the typed text and caret visibly OFF the field's center: `langyo` + caret sat half an icon to the right of the box axis.

Root cause: `.hk-input-element` overlays the whole box (absolute `inset:0`, `text-align:center`) while affix widths are reserved as horizontal padding — previously **asymmetrically** (left = base + start-w, right = base + end-w). With only a prefix affix, the content box center moved right by `affix-width / 2`.

## Fix

- **Centered default = symmetric reservation**: both sides grow by `max(start-w, end-w)` (`padding-inline`), so the centered caret/typed text/native placeholder stay exactly on the box axis no matter which side carries an icon, and the line still never renders under an affix (each side's clearance ≥ that side's affix width).
- The **placeholder-marquee window** gets the same symmetric inset (`inset-block: 0` + symmetric `inset-inline`), staying co-centered with the text line; edge-aligned variants get per-side insets.
- **New `align` prop** (`"center" | "start" | "end"`, default `center`) is the explicit left/right escape hatch: `data-align="start"/"end"` restores per-side reservation + `text-align: start/end`, scoped with `:not(.hk-input-textarea)`; textarea boxes never carry the marker (their affixes sit in flow beside the element, so there is nothing to reserve against).
- `.hk-input-element` now self-declares `box-sizing: border-box` so the centering guarantee does not depend on the host app's global reset (same precedent as HkTextarea/HkDatePicker/HkDateTimePicker).
- All properties are logical (`padding-inline*`, `inset-inline*`, `text-align: start/end`) — strictly better RTL behavior than the removed physical TRBL forms.

## Consumers (all inside hikari; chest inherits via workspace link)

- HkSignInCard username (lone prefix user/mail icon) — the reported bug, pure re-centering.
- HkColorPicker hex row (lone `#` prefix) — re-centered consistently.
- useResourceListModal search (lone Search icon) — re-centered.
- HkLocalizedInput (lone suffix language chip) — centered line stays clear of the chip; **accepted tradeoff**: the usable line loses the chip-width of capacity on the non-affix side.
- Non-affix consumers: `max(0,0)=0` → byte-identical padding to before.

## Verification (3-round cycle, two independent subagent reviews)

- `HkInput.affix.test.ts` contract extended to three guarantees (suffix pinning / affix reservation / **symmetric centered reservation + edge-align opt-out + data-align runtime attr incl. textarea exclusion**) — 9/9 pass.
- Related suites green: HkLocalizedInput 20, HkPlaceholderMarquee, HkColorSchemeEditor — 45/45 across the four files; `vue-tsc --noEmit` clean.
- Full component suite: only pre-existing failures — `HkDatePicker.test.ts:249` ("marks the selected day and today", date-dependent, reproduces 1:1 on clean master) and useTheme/useSolarTime hook-timeout flakes under concurrent NFS load (pass 10/10 in isolation, both on master and here). Recorded as environmental per §7 CI policy.

## Version

0.22.0 → 0.23.0 (new `align` prop API; bump rides the main PR per §6).