### PR TITLE
🐛 Suppress native tooltip titles across the popover anchor subtree.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkPopover.titleSuppress.test.tsx
+++ b/packages/vue/src/components/HkPopover.titleSuppress.test.tsx
@@ -1,0 +1,265 @@
+/**
+ * Source contract: while an HkPopover is open, no native browser tooltip
+ * may fire over the custom popup — the anchor's `title` AND every
+ * descendant `title` are blanked and restored exactly (the model pill of
+ * hikari #338 was a descendant-title case). Restore must be lossless:
+ * elements without a title never gain one, `title=""` stays `title=""`,
+ * and unmounting while open must not leak a blanked title.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkPopover from "./HkPopover";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+  // happy-dom never fires transitionend, so leave transitions never
+  // finish and teleported panels linger on <body> — strip them or the
+  // next test's querySelector sees this test's panel.
+  document.body
+    .querySelectorAll(".hk-popover-panel, .hk-popover-scrim")
+    .forEach((el) => el.remove());
+  vi.restoreAllMocks();
+});
+
+function setViewport(width: number) {
+  window.innerWidth = width;
+  window.dispatchEvent(new Event("resize"));
+}
+
+/**
+ * Mounts an HkPopover whose anchor is a plain DOM node (NOT rendered by
+ * Vue) so tests can decorate it with arbitrary `title` attributes and
+ * observe attribute mutations without Vue's patching interfering.
+ */
+function mountPopover(opts: { open?: boolean; anchor?: HTMLElement } = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const anchor = opts.anchor ?? document.createElement("button");
+  // Only seed text on a fresh anchor — a caller-provided one may already
+  // carry the decorated descendants under test (textContent would wipe them).
+  if (!opts.anchor) anchor.textContent = "anchor";
+  container.appendChild(anchor);
+
+  const open = ref(opts.open ?? false);
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkPopover, {
+          modelValue: open.value,
+          "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          anchorRef: anchor,
+        }, { default: () => h("div", { class: "pop-content" }, "content") });
+    },
+  });
+  const app = createApp(Wrapper);
+  mounts.push(app);
+  app.mount(container);
+  return { open, app, anchor };
+}
+
+describe("HkPopover native title suppression", () => {
+  it("blanks the anchor's and descendants' titles while open and restores both exactly on close", async () => {
+    setViewport(1200);
+    const anchor = document.createElement("button");
+    anchor.setAttribute("title", "anchor tip");
+    const inner = document.createElement("span");
+    inner.setAttribute("title", "inner tip");
+    const nested = document.createElement("em");
+    nested.setAttribute("title", "nested tip");
+    inner.appendChild(nested);
+    anchor.appendChild(inner);
+
+    const { open } = mountPopover({ anchor });
+    await nextTick();
+    expect(anchor.getAttribute("title")).toBe("anchor tip");
+
+    open.value = true;
+    await nextTick();
+    expect(anchor.getAttribute("title")).toBe("");
+    expect(inner.getAttribute("title")).toBe("");
+    expect(nested.getAttribute("title")).toBe("");
+
+    open.value = false;
+    await nextTick();
+    expect(anchor.getAttribute("title")).toBe("anchor tip");
+    expect(inner.getAttribute("title")).toBe("inner tip");
+    expect(nested.getAttribute("title")).toBe("nested tip");
+  });
+
+  it("does not grant a title to an element that never had one", async () => {
+    setViewport(1200);
+    const anchor = document.createElement("button");
+    anchor.setAttribute("title", "anchor tip");
+    const plain = document.createElement("span");
+    anchor.appendChild(plain);
+
+    const { open } = mountPopover({ anchor });
+    open.value = true;
+    await nextTick();
+    open.value = false;
+    await nextTick();
+
+    expect(plain.hasAttribute("title")).toBe(false);
+    expect(plain.getAttribute("title")).toBeNull();
+  });
+
+  it("leaves an existing title=\"\" as title=\"\" (not removed, not filled)", async () => {
+    setViewport(1200);
+    const anchor = document.createElement("button");
+    const empty = document.createElement("span");
+    empty.setAttribute("title", "");
+    anchor.appendChild(empty);
+
+    const { open } = mountPopover({ anchor });
+    open.value = true;
+    await nextTick();
+    expect(empty.hasAttribute("title")).toBe(true);
+    expect(empty.getAttribute("title")).toBe("");
+
+    open.value = false;
+    await nextTick();
+    expect(empty.hasAttribute("title")).toBe(true);
+    expect(empty.getAttribute("title")).toBe("");
+  });
+
+  it("restores the anchor's title when unmounted while open", async () => {
+    setViewport(1200);
+    const anchor = document.createElement("button");
+    anchor.setAttribute("title", "unmount tip");
+
+    const { open, app } = mountPopover({ anchor });
+    open.value = true;
+    await nextTick();
+    expect(anchor.getAttribute("title")).toBe("");
+
+    app.unmount();
+    expect(anchor.getAttribute("title")).toBe("unmount tip");
+  });
+
+  it("performs no title-related DOM mutations when the anchor has no titles anywhere", async () => {
+    setViewport(1200);
+    const anchor = document.createElement("button");
+    const plain = document.createElement("span");
+    anchor.appendChild(plain);
+    const setSpy = vi.spyOn(anchor, "setAttribute");
+    const removeSpy = vi.spyOn(anchor, "removeAttribute");
+
+    const { open } = mountPopover({ anchor });
+    open.value = true;
+    await nextTick();
+    open.value = false;
+    await nextTick();
+
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(anchor.hasAttribute("title")).toBe(false);
+    expect(anchor.querySelector("[title]")).toBeNull();
+  });
+
+  it("restores the retired anchor and suppresses the new one on a mid-open anchorRef swap", async () => {
+    setViewport(1200);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const oldAnchor = document.createElement("button");
+    oldAnchor.setAttribute("title", "old tip");
+    const oldInner = document.createElement("span");
+    oldInner.setAttribute("title", "old inner tip");
+    oldAnchor.appendChild(oldInner);
+    const newAnchor = document.createElement("button");
+    newAnchor.setAttribute("title", "new tip");
+    container.append(oldAnchor, newAnchor);
+
+    const open = ref(false);
+    const anchorRef = ref<HTMLElement | null>(oldAnchor);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkPopover, {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+            anchorRef: anchorRef.value,
+          }, { default: () => h("div", { class: "pop-content" }, "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+
+    open.value = true;
+    await nextTick();
+    expect(oldAnchor.getAttribute("title")).toBe("");
+    expect(oldInner.getAttribute("title")).toBe("");
+
+    anchorRef.value = newAnchor;
+    await nextTick();
+    expect(oldAnchor.getAttribute("title")).toBe("old tip");
+    expect(oldInner.getAttribute("title")).toBe("old inner tip");
+    expect(newAnchor.getAttribute("title")).toBe("");
+
+    open.value = false;
+    await nextTick();
+    expect(newAnchor.getAttribute("title")).toBe("new tip");
+    expect(oldAnchor.getAttribute("title")).toBe("old tip");
+  });
+
+  it("restores the retired subtree when opening and an anchor swap land in the same flush", async () => {
+    setViewport(1200);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    containers.push(container);
+
+    const anchorA = document.createElement("button");
+    anchorA.setAttribute("title", "A tip");
+    const childA = document.createElement("span");
+    childA.setAttribute("title", "A child tip");
+    anchorA.appendChild(childA);
+    const anchorB = document.createElement("button");
+    anchorB.setAttribute("title", "B tip");
+    const childB = document.createElement("span");
+    childB.setAttribute("title", "B child tip");
+    anchorB.appendChild(childB);
+    container.append(anchorA, anchorB);
+
+    const open = ref(false);
+    const anchorRef = ref<HTMLElement | null>(anchorA);
+    const Wrapper = defineComponent({
+      setup() {
+        return () =>
+          h(HkPopover, {
+            modelValue: open.value,
+            "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+            anchorRef: anchorRef.value,
+          }, { default: () => h("div", { class: "pop-content" }, "content") });
+      },
+    });
+    const app = createApp(Wrapper);
+    mounts.push(app);
+    app.mount(container);
+
+    // Same tick: the popover never observes "open while anchored to A" —
+    // open and the swap to B land in one flush together.
+    open.value = true;
+    anchorRef.value = anchorB;
+    await nextTick();
+    expect(anchorA.getAttribute("title")).toBe("A tip");
+    expect(childA.getAttribute("title")).toBe("A child tip");
+    expect(anchorB.getAttribute("title")).toBe("");
+    expect(childB.getAttribute("title")).toBe("");
+
+    open.value = false;
+    await nextTick();
+    expect(anchorA.getAttribute("title")).toBe("A tip");
+    expect(childA.getAttribute("title")).toBe("A child tip");
+    expect(anchorB.getAttribute("title")).toBe("B tip");
+    expect(childB.getAttribute("title")).toBe("B child tip");
+  });
+});

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -95,28 +95,64 @@ export default defineComponent({
 
     const animBus = useReportedTransition(300);
 
-    // Suppress native browser tooltip on the anchor while the popover is open.
-    let savedTitle: string | null = null;
+    // Suppress native browser tooltips while the popover is open — and
+    // not just on the anchor itself: a `title` on ANY descendant fires
+    // the same native tooltip on top of the custom popup surface (the
+    // model pill of hikari #338 was exactly that bug). Only non-empty
+    // titles are blanked: `title=""` fires no native tooltip, so it is
+    // left byte-for-byte as the consumer wrote it (and elements with no
+    // title at all never gain one). Titles added to the subtree while
+    // the popover is already open are NOT suppressed — the popover
+    // content is the consumer's own popup surface, titles inside it are
+    // legitimate. Only the `title` attribute is touched; aria-label and
+    // friends stay as authored.
+    let suppressedTitles: { el: Element; title: string }[] = [];
+
+    function suppressNativeTitles(anchor: HTMLElement) {
+      suppressedTitles = [];
+      // querySelectorAll covers descendants only, so the anchor itself
+      // rides along explicitly.
+      const titled = [anchor, ...Array.from(anchor.querySelectorAll("[title]"))];
+      for (const el of titled) {
+        const title = el.getAttribute("title");
+        if (title === null || title === "") continue;
+        suppressedTitles.push({ el, title });
+        el.setAttribute("title", "");
+      }
+    }
+
+    function restoreNativeTitles() {
+      for (const { el, title } of suppressedTitles) {
+        el.setAttribute("title", title);
+      }
+      suppressedTitles = [];
+    }
+
     watch(
       () => props.modelValue,
       (open) => {
-        const el = props.anchorRef;
-        if (!el) return;
         if (open) {
-          savedTitle = el.getAttribute("title");
-          if (savedTitle !== null && savedTitle !== "") {
-            el.setAttribute("title", "");
-          } else {
-            savedTitle = null;
-          }
+          if (props.anchorRef) suppressNativeTitles(props.anchorRef);
         } else {
-          if (savedTitle !== null) {
-            el.setAttribute("title", savedTitle);
-          } else if (savedTitle === null && el.getAttribute("title") === "") {
-            el.removeAttribute("title");
-          }
-          savedTitle = null;
+          restoreNativeTitles();
         }
+      },
+      // immediate: a consumer can v-if the popover in already open — the
+      // suppression must hold from the very first render, not just from
+      // a false→true flip.
+      { immediate: true },
+    );
+
+    // Anchor swapped while open: hand the retired subtree its titles
+    // back before suppressing the new one, or the old anchor leaks a
+    // blanked title forever (and a null anchor just releases the old
+    // subtree without adopting a new one).
+    watch(
+      () => props.anchorRef,
+      (anchor) => {
+        if (!props.modelValue) return;
+        restoreNativeTitles();
+        if (anchor) suppressNativeTitles(anchor);
       },
     );
 
@@ -397,6 +433,10 @@ export default defineComponent({
     );
 
     onUnmounted(() => {
+      // Unmounting while open (e.g. parent v-if's the popover away) never
+      // runs the close branch of the modelValue watch — restore here or
+      // the anchor keeps its blanked title forever.
+      restoreNativeTitles();
       detachOutsideClickShield();
       fullCleanup();
     });


### PR DESCRIPTION
While an HkPopover is open, the browser's native tooltip is now suppressed across the anchor's ENTIRE subtree, not just the anchor element itself.

**Why**: the old suppression saved and blanked only the anchor's own `title` attribute. Any `title` rendered on a descendant inside the anchor still fired a native tooltip on top of the custom popup surface — the exact defect class behind hikari #338, where the model pill had to remove its `title` at the source because the popover suppression could not cover it.

**What changed** (`packages/vue/src/components/HkPopover.tsx`):
- Snapshot/restore of non-empty `title` attributes on the anchor plus all descendants (`querySelectorAll("[title]")`); elements with no title never gain one, `title=""` is left byte-for-byte intact, only `title` is ever touched.
- `watch(modelValue, { immediate: true })` so a popover mounted already-open is suppressed from the first render.
- New `watch(anchorRef)`: a mid-open anchor swap restores the retired subtree before suppressing the new one (the old code also had a clobber bug here — closing after a swap wrote the old anchor's saved title onto the new anchor).
- `restoreNativeTitles()` in the existing `onUnmounted`: unmounting while open no longer strands `title=""` on the anchor forever.
- Documented limitation: titles added to the subtree while already open are not suppressed — popover content is the consumer's own popup surface.

**Tests**: new `HkPopover.titleSuppress.test.tsx` with 7 contract tests (subtree blank+restore, absent titles stay absent, `title=""` preserved verbatim, unmount-while-open restores, zero DOM mutation when no titles exist, mid-open swap, same-flush open+swap). Full vitest 634 passed / 1 pre-existing failure (`HkDatePicker` date-rollover fixture, fails identically on base 55540d4), `vue-tsc --noEmit` exit 0. Version 0.22.0 → 0.22.1.