### PR TITLE
✨ Unify popup open and close animations across modal surfaces.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkBlockingToast.tsx
+++ b/packages/vue/src/components/HkBlockingToast.tsx
@@ -34,6 +34,7 @@ import {
 import { useI18n } from "../i18n/context";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { clearLeaveGeometry, pinLeaveGeometry } from "../utils/dom";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 import {
   resolveBlockingToast,
   useBlockingToast,
@@ -105,6 +106,10 @@ export default defineComponent({
   setup() {
     const { queue } = useBlockingToast();
     const manager = usePopupManager();
+    // Card enter/leave motion reported into the unified animation
+    // context, mirroring HkToast's TransitionGroup wiring (shared track,
+    // self-healing cron — see HkToast for the caveat).
+    const itemHooks = useSurfaceTransition(320).hooks();
     const handles = new Map<number, PopupHandle>();
 
     // Keep one popup-manager entry (kind "toast") per visible card so
@@ -144,8 +149,17 @@ export default defineComponent({
           <TransitionGroup
             tag="div"
             name="hk-blocking-toast"
-            onBeforeLeave={pinLeaveGeometry}
-            onLeaveCancelled={clearLeaveGeometry}
+            onBeforeEnter={itemHooks.onBeforeEnter}
+            onAfterEnter={itemHooks.onAfterEnter}
+            onBeforeLeave={(el: Element) => {
+              itemHooks.onBeforeLeave();
+              pinLeaveGeometry(el);
+            }}
+            onAfterLeave={itemHooks.onAfterLeave}
+            onLeaveCancelled={(el: Element) => {
+              itemHooks.onLeaveCancelled();
+              clearLeaveGeometry(el);
+            }}
           >
             {queue.map((item) => (
               <div

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -18,6 +18,7 @@ import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 
 type DrawerSide = "left" | "right" | "top" | "bottom";
 
@@ -52,6 +53,11 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const { t } = useI18n();
     const manager = usePopupManager();
+    // Open/close motion reported into the unified animation context
+    // (animationBus) — scrim and sliding panel on separate tracks.
+    const surf = useSurfaceTransition(320);
+    const scrimHooks = surf.hooks("scrim");
+    const panelHooks = surf.hooks("panel");
     const overlayHook = useOverlay({
       name: "hk-drawer",
       // A global closeAll() must be able to actually close this drawer
@@ -224,7 +230,14 @@ export default defineComponent({
 
     return () => (
       <Teleport to="body">
-        <Transition name="hk-drawer-overlay" appear>
+        <Transition
+          name="hk-drawer-overlay"
+          appear
+          onBeforeEnter={scrimHooks.onBeforeEnter}
+          onAfterEnter={scrimHooks.onAfterEnter}
+          onBeforeLeave={scrimHooks.onBeforeLeave}
+          onAfterLeave={scrimHooks.onAfterLeave}
+        >
           {props.modelValue && props.overlay ? (
             <div
               class="hk-drawer-overlay"
@@ -233,7 +246,20 @@ export default defineComponent({
             />
           ) : null}
         </Transition>
-        <Transition name={`hk-drawer-${props.side}`} appear onAfterEnter={onDrawerAfterEnter} onAfterLeave={onDrawerAfterLeave}>
+        <Transition
+          name={`hk-drawer-${props.side}`}
+          appear
+          onBeforeEnter={panelHooks.onBeforeEnter}
+          onAfterEnter={() => {
+            panelHooks.onAfterEnter();
+            onDrawerAfterEnter();
+          }}
+          onBeforeLeave={panelHooks.onBeforeLeave}
+          onAfterLeave={() => {
+            panelHooks.onAfterLeave();
+            onDrawerAfterLeave();
+          }}
+        >
           {props.modelValue ? (
             <div
               ref={panelRef}

--- a/packages/vue/src/components/HkLocalePicker.scss
+++ b/packages/vue/src/components/HkLocalePicker.scss
@@ -1,0 +1,37 @@
+/* HkLocalePicker — the inline hand-rolled dropdown joins the pop motion
+ * family (--hk-pop-* tokens in theme/theme.scss): it grows out of its
+ * trigger (below-right) and retracts into it, matching the popover /
+ * select-panel surfaces instead of appearing bare. */
+.hk-locale-picker-dropdown {
+  transform-origin: top right;
+}
+
+.hk-locale-picker-enter-active {
+  transition:
+    opacity var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-opacity-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-transform-ease, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.hk-locale-picker-leave-active {
+  transition:
+    opacity var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1)),
+    transform var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1));
+}
+
+.hk-locale-picker-enter-from,
+.hk-locale-picker-leave-to {
+  opacity: 0;
+  transform: translateY(calc(-1 * var(--hk-pop-offset, 4px)))
+    scale(var(--hk-pop-scale, 0.97));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-locale-picker-enter-active,
+  .hk-locale-picker-leave-active {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkLocalePicker.tsx
+++ b/packages/vue/src/components/HkLocalePicker.tsx
@@ -1,4 +1,7 @@
-import { defineComponent, ref, type PropType } from "vue";
+import { defineComponent, ref, Transition, type PropType } from "vue";
+
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import "./HkLocalePicker.scss";
 
 export interface LocaleOption {
   code: string;
@@ -20,6 +23,10 @@ export const HkLocalePicker = defineComponent({
   emits: ["select"],
   setup(props, { emit }) {
     const open = ref(false);
+    // Open/close motion reported into the unified animation context —
+    // this little dropdown moves like the rest of the pop family
+    // instead of appearing bare.
+    const anim = useSurfaceTransition(250).hooks();
 
     function handleSelect(code: string) {
       emit("select", code);
@@ -52,9 +59,18 @@ export const HkLocalePicker = defineComponent({
             <path d="M2 3.5l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.2" />
           </svg>
         </button>
-        {open.value && (
-          <div
-            style={{
+        <Transition
+          name="hk-locale-picker"
+          appear
+          onBeforeEnter={anim.onBeforeEnter}
+          onAfterEnter={anim.onAfterEnter}
+          onBeforeLeave={anim.onBeforeLeave}
+          onAfterLeave={anim.onAfterLeave}
+        >
+          {open.value && (
+            <div
+              class="hk-locale-picker-dropdown"
+              style={{
               position: "absolute",
               top: "calc(100% + 4px)",
               right: 0,
@@ -109,7 +125,8 @@ export const HkLocalePicker = defineComponent({
               </button>
             ))}
           </div>
-        )}
+          )}
+        </Transition>
       </div>
     );
   },

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -70,6 +70,16 @@ function menuRows(): HTMLElement[] {
   return [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-row")];
 }
 
+/** Wait for the menu's leave-transition window to finish — rows linger
+ *  briefly after a close while the popout animates shut. */
+async function untilMenuSettled(): Promise<void> {
+  const deadline = Date.now() + 800;
+  while (menuRows().length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await nextTick();
+  }
+}
+
 /** The "Delete language" cascade root row (present only when at least
  *  one translation is filled). */
 function deleteCascadeRow(): HTMLElement | undefined {
@@ -185,7 +195,9 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
     expect(queryChip(container).textContent).toContain("简体中文");
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
-    // Menu closed after the switch.
+    // Menu closed after the switch (rows linger briefly through
+    // the popout's close animation).
+    await untilMenuSettled();
     expect(menuRows().length).toBe(0);
   });
 
@@ -211,6 +223,7 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
     expect(queryChip(container).textContent).toContain("日本語");
     expect(queryChip(container).textContent).not.toContain("(ja)");
+    await untilMenuSettled();
     expect(menuRows().length).toBe(0);
   });
 
@@ -383,6 +396,7 @@ describe("HkLocalizedInput", () => {
     expect(queryField(container).value).toBe("Plant overview");
     expect(queryChip(container).textContent).toContain("English");
     expect(queryChip(container).textContent).not.toContain("(en)");
+    await untilMenuSettled();
     expect(menuRows().length).toBe(0);
   });
 
@@ -409,6 +423,7 @@ describe("HkLocalizedInput", () => {
     expect(events.languagechange.at(-1)).toBe("en");
     expect(queryChip(container).textContent).toContain("English");
     expect(queryChip(container).textContent).not.toContain("(en)");
+    await untilMenuSettled();
     expect(menuRows().length).toBe(0);
     expect(document.activeElement).toBe(queryField(container));
   });

--- a/packages/vue/src/components/HkMenu.test.ts
+++ b/packages/vue/src/components/HkMenu.test.ts
@@ -431,9 +431,11 @@ describe("HkMenu mobile sheets", () => {
     await settle();
     expect(sheets().length).toBe(2);
 
-    // Browser/system back closes ONE level: back to the root sheet.
+    // Browser/system back closes ONE level: back to the root sheet. The
+    // popped sheet lingers briefly through its slide-down leave — count
+    // once it settles.
     window.history.back();
-    await settle();
+    await until(() => sheets().length === 1);
     expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
     expect(window.history.state?.__hkBack).toEqual(expect.any(String));
@@ -442,6 +444,10 @@ describe("HkMenu mobile sheets", () => {
     window.history.back();
     await until(() => openRef.value === false);
     await until(() => window.history.state?.__hkBack === undefined);
+    // The sheet panel lingers briefly through its slide-down leave
+    // (HkMenu keeps the panel tree mounted for the leave window after a
+    // close) — the unmount lands when that window expires.
+    await until(() => document.querySelector(".hk-select-sheet-panel") === null, 800);
     expect(document.querySelector(".hk-select-sheet-panel")).toBeNull();
   });
 
@@ -471,9 +477,10 @@ describe("HkMenu mobile sheets", () => {
     expect(scrims().length).toBe(2);
 
     // The topmost scrim belongs to the pushed layer; tapping it pops one
-    // level and keeps the root sheet open.
+    // level and keeps the root sheet open. The dismissed sheet lingers
+    // briefly through its slide-down leave — count once it settles.
     scrims()[scrims().length - 1].click();
-    await settle();
+    await until(() => sheets().length === 1);
     expect(sheets().length).toBe(1);
     expect(openRef.value).toBe(true);
   });
@@ -702,5 +709,71 @@ describe("HkMenu sidebar variant", () => {
     await settle();
     expect(container.textContent).toContain("Products");
     expect(container.textContent).not.toContain("General");
+  });
+});
+
+describe("HkMenu close linger (leave-transition window)", () => {
+  it("keeps the panel tree mounted briefly after close, then unmounts", async () => {
+    const openRef = ref(true);
+    mountMenu(openRef, items);
+    await settle();
+    expect(popouts()).toHaveLength(1);
+
+    openRef.value = false;
+    // nextTick only: no rAF may run before the assertion, so the
+    // mid-leave presence check is deterministic (happy-dom completes
+    // Vue's CSS-less leave fallback on a later animation frame).
+    await nextTick();
+    // Still rendering — the popout is mid pop-out leave (its HkSelectPanel
+    // stays mounted through the leave window). A synchronous unmount here
+    // would kill the close animation (the pre-linger regression).
+    expect(popouts().length).toBeGreaterThanOrEqual(1);
+
+    // The leave (and the linger window behind it) settles for real.
+    await until(() => popouts().length === 0, 800);
+    expect(popouts()).toHaveLength(0);
+  });
+
+  it("reopening resets the cascade instead of showing stale sub-levels", async () => {
+    const openRef = ref(true);
+    mountMenu(openRef, items);
+    await settle();
+
+    // Open the Language cascade → two popouts.
+    rowByLabel("Language")!.click();
+    await settle();
+    expect(popouts().length).toBe(2);
+
+    // Close and reopen within the linger window.
+    openRef.value = false;
+    await settle();
+    openRef.value = true;
+    await settle();
+    // Fresh menu: only the root level, the stale sub-level is gone.
+    expect(popouts().length).toBe(1);
+  });
+
+  it("closing a desktop sub-panel animates it shut instead of unmounting instantly", async () => {
+    const openRef = ref(true);
+    mountMenu(openRef, items);
+    await settle();
+
+    rowByLabel("Language")!.click();
+    await settle();
+    expect(popouts().length).toBe(2);
+
+    // Escape on the sub-panel closes just that level — deferred: the
+    // panel keeps rendering (mid-leave) right after the request.
+    // nextTick only (deterministic mid-leave window, no rAF yet).
+    const sub = popouts()[1];
+    sub.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await nextTick();
+    expect(popouts().length).toBe(2); // still mounted, animating shut
+
+    // After the leave window the level is swept for real.
+    await until(() => popouts().length === 1, 800);
+    expect(popouts().length).toBe(1);
   });
 });

--- a/packages/vue/src/components/HkMenu.tsx
+++ b/packages/vue/src/components/HkMenu.tsx
@@ -149,8 +149,111 @@ export default defineComponent({
 
     /** Open submenu path on desktop, e.g. ["theme", "dark"] → panel chain. */
     const desktopPath = ref<string[]>([]);
+    /**
+     * Desktop cascade levels >= this 1-based level are animating shut —
+     * their path entries stay (so the panels keep rendering through their
+     * leave transition) but render open=false. Swept for real once the
+     * leave finishes. -1 = none closing.
+     */
+    const closedFrom = ref(-1);
+    /** A pushed mobile sheet layer, optionally mid-leave. */
+    interface StackEntry {
+      item: HkMenuItem;
+      closing: boolean;
+    }
     /** Pushed sheet chain on mobile: the branch item of each level. */
-    const mobileStack = ref<HkMenuItem[]>([]);
+    const mobileStack = ref<StackEntry[]>([]);
+
+    // ── leave-transition bookkeeping ─────────────────────────────────
+    // Panels animate closed inside HkSelectPanel; this component must
+    // therefore stay RENDERED a beat longer than `open` — unmounting the
+    // tree the instant open flips false would snap every panel shut.
+    // `linger` keeps the panel tree mounted for the leave window after a
+    // close; the deferred sweeps below clear the per-level state the
+    // same way. Plain timers (not the animation bus): they gate DOM
+    // lifecycle, not per-frame motion, and must fire even when the tab
+    // is throttling RAF.
+    const POP_LEAVE_MS = 320;
+
+    const lingering = ref(false);
+    let lingerTimer: ReturnType<typeof setTimeout> | null = null;
+    let sweepTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function clearTimers(): void {
+      if (lingerTimer !== null) {
+        clearTimeout(lingerTimer);
+        lingerTimer = null;
+      }
+      if (sweepTimer !== null) {
+        clearTimeout(sweepTimer);
+        sweepTimer = null;
+      }
+    }
+
+    function resetLevels(): void {
+      desktopPath.value = [];
+      mobileStack.value = [];
+      closedFrom.value = -1;
+    }
+
+    /** Drop sub-levels whose leave has finished (armed by the deferred
+     *  close paths below). Re-derived against CURRENT state so a level
+     *  re-opened during the window survives the sweep. */
+    function runSweep(): void {
+      sweepTimer = null;
+      if (closedFrom.value > 0) {
+        const lvl = closedFrom.value;
+        closedFrom.value = -1;
+        desktopPath.value = desktopPath.value.slice(0, lvl - 1);
+      }
+      if (mobileStack.value.some((e) => e.closing)) {
+        mobileStack.value = mobileStack.value.filter((e) => !e.closing);
+      }
+    }
+
+    function scheduleSweep(): void {
+      if (sweepTimer !== null) clearTimeout(sweepTimer);
+      sweepTimer = setTimeout(runSweep, POP_LEAVE_MS);
+    }
+
+    /** Any synchronous path mutation (branch open / sibling switch)
+     *  cancels pending deferred closes — menubar cascade switches stay
+     *  instant by convention; the closing levels were replaced anyway. */
+    function cancelDeferredCloses(): void {
+      if (sweepTimer !== null) {
+        clearTimeout(sweepTimer);
+        sweepTimer = null;
+      }
+      closedFrom.value = -1;
+      for (const e of mobileStack.value) e.closing = false;
+    }
+
+    watch(
+      () => props.open,
+      (open) => {
+        if (open) {
+          clearTimers();
+          lingering.value = true;
+          resetLevels();
+        } else {
+          lingering.value = true;
+          if (lingerTimer !== null) clearTimeout(lingerTimer);
+          lingerTimer = setTimeout(() => {
+            lingerTimer = null;
+            lingering.value = false;
+            resetLevels();
+          }, POP_LEAVE_MS);
+          // Levels already mid-leave ride along with the whole-menu
+          // close; the linger expiry clears them.
+          if (sweepTimer !== null) {
+            clearTimeout(sweepTimer);
+            sweepTimer = null;
+          }
+        }
+      },
+    );
+
+    onBeforeUnmount(clearTimers);
 
     // ── outside-click attribution ────────────────────────────────────
     // Each HkSelectPanel closes on clicks landing outside ITS OWN surface,
@@ -201,8 +304,8 @@ export default defineComponent({
     });
 
     function closeAll(): void {
-      desktopPath.value = [];
-      mobileStack.value = [];
+      // State clearing is deferred to the linger expiry / next open so
+      // every level stays mounted through its leave transition.
       emit("update:open", false);
     }
 
@@ -215,20 +318,30 @@ export default defineComponent({
     /** Desktop sub-panel at `level` asked to close. */
     function onSubCloseRequest(level: number): void {
       if (clickLevel.value > level) return; // a deeper panel owns this click
-      desktopPath.value = desktopPath.value.slice(0, level - 1);
+      // Keep the path (panels keep rendering) but close every level from
+      // here down; the sweep drops them once their leaves finish.
+      closedFrom.value = level;
+      scheduleSweep();
     }
 
     /** Mobile sheet layer `index` (level = index + 1) asked to close. */
     function onStackCloseRequest(index: number): void {
       if (clickLevel.value > index + 1) return;
-      mobileStack.value = mobileStack.value.slice(0, index);
+      mobileStack.value = mobileStack.value.map((e, i) =>
+        i >= index ? { ...e, closing: true } : e,
+      );
+      scheduleSweep();
     }
 
     function onItem(item: HkMenuItem, level: number): void {
       if (item.disabled) return;
       if (item.children?.length) {
+        cancelDeferredCloses();
         if (isMobile.value) {
-          mobileStack.value = [...mobileStack.value.slice(0, level), item];
+          mobileStack.value = [
+            ...mobileStack.value.slice(0, level),
+            { item, closing: false },
+          ];
         } else {
           // Replace the path at the clicked row's level — clicking a
           // sibling in a shallower panel switches the cascade to it.
@@ -257,6 +370,7 @@ export default defineComponent({
       if (isMobile.value) return;
       if (desktopPath.value.length <= level) return;
       if (desktopPath.value[level] === item.key) return;
+      cancelDeferredCloses();
       desktopPath.value = item.children?.length
         ? [...desktopPath.value.slice(0, level), item.key]
         : desktopPath.value.slice(0, level);
@@ -448,9 +562,12 @@ export default defineComponent({
           const list = itemsAtLevel(level);
           if (!list.length) continue;
           const branch = branchAt(level);
+          // Levels mid-deferred-close render open=false so their panel
+          // plays the pop leave instead of unmounting instantly.
+          const levelOpen = props.open && (closedFrom.value < 0 || level < closedFrom.value);
           panels.push(
             <HkSelectPanel
-              open
+              open={levelOpen}
               anchorRef={
                 rowAnchor(level - 1, desktopPath.value[level - 1]) as unknown as HTMLElement
               }
@@ -489,14 +606,14 @@ export default defineComponent({
           {levelSurface(0, props.items)}
         </HkSelectPanel>,
       ];
-      mobileStack.value.forEach((branch, i) => {
+      mobileStack.value.forEach((entry, i) => {
         const level = i + 1;
         sheets.push(
           <HkSelectPanel
-            open
+            open={props.open && !entry.closing}
             // Sub-levels carry no title of their own — the parent item's
             // label names the sheet.
-            title={branch.label}
+            title={entry.item.label}
             onUpdate:open={(v: boolean) => {
               if (!v) onStackCloseRequest(i);
             }}
@@ -504,7 +621,7 @@ export default defineComponent({
               panelInsts.value[level] = inst as PanelInstance | null;
             }}
           >
-            {levelSurface(level, branch.children ?? [])}
+            {levelSurface(level, entry.item.children ?? [])}
           </HkSelectPanel>,
         );
       });
@@ -641,7 +758,10 @@ export default defineComponent({
 
     return () => {
       if (props.variant === "sidebar") return renderSidebar();
-      if (!props.open) return null;
+      // Stay mounted through the leave window after a close (`lingering`)
+      // so every level's HkSelectPanel can play its pop/slide-out —
+      // unmounting here would snap the whole cascade shut.
+      if (!props.open && !lingering.value) return null;
       // Each level renders through its own HkSelectPanel, which teleports
       // itself to body — desktop popouts / mobile sheet layers alike.
       return isMobile.value ? <>{renderSheets()}</> : <>{renderPanels()}</>;

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -20,6 +20,7 @@ import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
 import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 import HButton from "./HkButton";
 import HFab from "./HkFab";
 import HSpinner from "./HkSpinner";
@@ -66,6 +67,12 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const { t } = useI18n();
     const manager = usePopupManager();
+    // Open/close motion reported into the unified animation context
+    // (animationBus) — scrim and content on separate tracks so each
+    // layer's report arms/cancels independently.
+    const surf = useSurfaceTransition(320);
+    const overlayHooks = surf.hooks("overlay");
+    const contentHooks = surf.hooks("content");
     const overlay = useOverlay({
       name: "hk-modal",
       // A global closeAll() must be able to actually close this modal
@@ -560,7 +567,14 @@ export default defineComponent({
             style={{ zIndex: overlayZ.value }}
             onKeydown={onKeydown}
           >
-            <Transition name="hk-modal-overlay" appear>
+            <Transition
+              name="hk-modal-overlay"
+              appear
+              onBeforeEnter={overlayHooks.onBeforeEnter}
+              onAfterEnter={overlayHooks.onAfterEnter}
+              onBeforeLeave={overlayHooks.onBeforeLeave}
+              onAfterLeave={overlayHooks.onAfterLeave}
+            >
               {props.modelValue && (
                 <div
                   class="hk-modal-overlay"
@@ -571,8 +585,16 @@ export default defineComponent({
             <Transition
               name="hk-modal-content"
               appear
-              onAfterEnter={onAfterEnter}
-              onAfterLeave={onAfterLeave}
+              onBeforeEnter={contentHooks.onBeforeEnter}
+              onAfterEnter={() => {
+                contentHooks.onAfterEnter();
+                onAfterEnter();
+              }}
+              onBeforeLeave={contentHooks.onBeforeLeave}
+              onAfterLeave={() => {
+                contentHooks.onAfterLeave();
+                onAfterLeave();
+              }}
             >
               {props.modelValue && (
                 <div

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -9,26 +9,35 @@
   max-height: min(70vh, calc(100vh - 2 * 8px));
 }
 
+/* Pop motion family tokens (--hk-pop-* in theme.scss) — the reference
+ * consumer. HkSelectPanel's desktop popout and HkTooltip use the same
+ * set so every anchored surface pops with one curve. */
 .hk-popover-enter-active {
   transition:
-    opacity 0.2s cubic-bezier(0.16, 1, 0.3, 1),
-    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+    opacity var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-opacity-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-transform-ease, cubic-bezier(0.34, 1.56, 0.64, 1));
 }
 
 .hk-popover-leave-active {
   transition:
-    opacity 0.15s cubic-bezier(0.4, 0, 1, 1),
-    transform 0.15s cubic-bezier(0.4, 0, 1, 1);
+    opacity var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1)),
+    transform var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1));
 }
 
 .hk-popover-enter-from {
   opacity: 0;
-  transform: translateY(-4px) scale(0.97);
+  transform: translateY(calc(-1 * var(--hk-pop-offset, 4px)))
+    scale(var(--hk-pop-scale, 0.97));
 }
 
 .hk-popover-leave-to {
   opacity: 0;
-  transform: translateY(4px) scale(0.97);
+  transform: translateY(var(--hk-pop-offset, 4px))
+    scale(var(--hk-pop-scale, 0.97));
 }
 
 /* Glass dropdown content — used when `glass` prop is true.

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -15,7 +15,7 @@ import {
 
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useBreakpoint } from "../runtime/useBreakpoint";
-import { useReportedTransition } from "../composables/useReportedTransition";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { onceFrame } from "../runtime/animationBus";
 import "./HkPopover.scss";
@@ -93,7 +93,11 @@ export default defineComponent({
       if (props.sheetOnMobile && props.modelValue) close();
     });
 
-    const animBus = useReportedTransition(300);
+    // Open/close motion reported into the unified animation context
+    // through the same standard hook wiring every surface shares
+    // (useSurfaceTransition) — this component was the pattern's
+    // origin and now consumes it like the rest.
+    const anim = useSurfaceTransition(300).hooks();
 
     // Suppress native browser tooltips while the popover is open — and
     // not just on the anchor itself: a `title` on ANY descendant fires
@@ -530,10 +534,15 @@ export default defineComponent({
         <Transition
           name={sheetMode.value ? "hk-popover-sheet" : "hk-popover"}
           appear
-          onBeforeEnter={() => animBus.run()}
-          onAfterEnter={() => animBus.cancel()}
-          onBeforeLeave={() => animBus.run()}
-          onAfterLeave={() => { animBus.cancel(); onPopupAfterLeave(); }}
+          onBeforeEnter={anim.onBeforeEnter}
+          onAfterEnter={anim.onAfterEnter}
+          onBeforeLeave={anim.onBeforeLeave}
+          onAfterLeave={() => {
+            anim.onAfterLeave();
+            onPopupAfterLeave();
+          }}
+          onEnterCancelled={anim.onEnterCancelled}
+          onLeaveCancelled={anim.onLeaveCancelled}
         >
           {props.modelValue ? (
             <div ref={panelHostRef} style={panelStyle.value}>

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -103,6 +103,66 @@
 .hk-select-popout-host {
   position: fixed;
   min-width: 180px;
+
+  /* Pop motion family — the popout grows out of the anchor edge it sits
+   * on (data-side/data-align are set by HkSelectPanel from the RESOLVED
+   * placement, including after an auto-flip) and retracts back into it.
+   * Same tokens as HkPopover/HkTooltip so every anchored surface moves
+   * with one curve. */
+  &[data-side="bottom"] { transform-origin: top left; }
+  &[data-side="bottom"][data-align="end"] { transform-origin: top right; }
+  &[data-side="top"] { transform-origin: bottom left; }
+  &[data-side="top"][data-align="end"] { transform-origin: bottom right; }
+}
+
+.hk-select-popout-enter-active {
+  transition:
+    opacity var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-opacity-ease, cubic-bezier(0.16, 1, 0.3, 1)),
+    transform var(--hk-pop-in-duration, 0.2s)
+      var(--hk-pop-in-transform-ease, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+
+.hk-select-popout-leave-active {
+  transition:
+    opacity var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1)),
+    transform var(--hk-pop-out-duration, 0.15s)
+      var(--hk-pop-out-ease, cubic-bezier(0.4, 0, 1, 1));
+}
+
+.hk-select-popout-enter-from,
+.hk-select-popout-leave-to {
+  opacity: 0;
+}
+
+.hk-select-popout-host[data-side="bottom"] {
+  &.hk-select-popout-enter-from {
+    transform: translateY(calc(-1 * var(--hk-pop-offset, 4px)))
+      scale(var(--hk-pop-scale, 0.97));
+  }
+  &.hk-select-popout-leave-to {
+    transform: translateY(var(--hk-pop-offset, 4px))
+      scale(var(--hk-pop-scale, 0.97));
+  }
+}
+
+.hk-select-popout-host[data-side="top"] {
+  &.hk-select-popout-enter-from {
+    transform: translateY(var(--hk-pop-offset, 4px))
+      scale(var(--hk-pop-scale, 0.97));
+  }
+  &.hk-select-popout-leave-to {
+    transform: translateY(calc(-1 * var(--hk-pop-offset, 4px)))
+      scale(var(--hk-pop-scale, 0.97));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-select-popout-enter-active,
+  .hk-select-popout-leave-active {
+    transition: none;
+  }
 }
 
 .hk-select-popout {

--- a/packages/vue/src/components/HkSelectPanel.test.tsx
+++ b/packages/vue/src/components/HkSelectPanel.test.tsx
@@ -608,3 +608,59 @@ describe("HkSelectPanel mobile-sheet duplicate-title filter", () => {
     expect(label.classList.contains("hk-sheet-dup-title")).toBe(false);
   });
 });
+
+describe("HkSelectPanel desktop popout motion", () => {
+  it("grows the popout out of the resolved anchor side (auto-flip reflected in data-side)", async () => {
+    // mountPanel defaults to placement="top-start"; in the test layout
+    // the anchor sits at the very top, so the panel flips to the bottom
+    // side — the flip must be visible in data-side (it drives the pop
+    // transition's transform-origin).
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+
+    const host = document.body.querySelector<HTMLElement>(".hk-select-popout-host")!;
+    expect(host).toBeTruthy();
+    expect(host.dataset.side).toBe("bottom"); // flipped from top-start
+    expect(host.dataset.align).toBe("start");
+  });
+
+  it("keeps the desktop popout mounted through its close so the pop leave runs", async () => {
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+
+    expect(document.body.querySelector(".hk-select-popout-host")).toBeTruthy();
+
+    open.value = false;
+    await nextTick();
+    // happy-dom never finishes leave transitions, so the host lingers —
+    // exactly what a running pop-out leave looks like. A synchronous
+    // unmount (the pre-transition regression) removes it instantly.
+    expect(document.body.querySelector(".hk-select-popout-host")).toBeTruthy();
+  });
+
+  it("reopens with a fresh popout after a close", async () => {
+    const { open } = mountPanel();
+    await nextTick();
+    open.value = true;
+    await nextTick();
+    open.value = false;
+    await nextTick();
+    open.value = true;
+    await nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+
+    const hosts = Array.from(
+      document.body.querySelectorAll<HTMLElement>(".hk-select-popout-host"),
+    );
+    expect(hosts.length).toBeGreaterThanOrEqual(1);
+    // The newest host (last in DOM order) carries live content.
+    expect(hosts.at(-1)!.textContent).toContain("a");
+  });
+});

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -15,6 +15,7 @@ import { useOverlay } from "../runtime/useOverlay";
 import { useBreakpoint } from "../runtime/useBreakpoint";
 import { createBackGuard } from "../runtime/backStack";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 import "./HkSelect.scss";
 
 /**
@@ -85,7 +86,16 @@ export default defineComponent({
   setup(props, { emit, slots, expose }) {
     const manager = usePopupManager();
     const handle = ref<PopupHandle | null>(null);
-    const popoutZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
+    /** z of the last live registration — the leave transition keeps
+     *  painting at this z after the registry entry is dropped, so a
+     *  closing popout never sinks under the page it covered. A popup
+     *  opened DURING the leave window (≤150ms popout, ≤250ms sheet) can
+     *  reclaim the freed band slot and tie on the exact paint z; the tie
+     *  resolves by teleport DOM order, where the newcomer (mounted
+     *  later) paints above the dying panel — accepted, matching how
+     *  equal-z stacking already behaves. */
+    const lastZ = ref(0);
+    const popoutZ = computed(() => ((handle.value?.zIndex ?? lastZ.value) || 0) + 1);
 
     // Overlay registry entry so closeAll()/isOverlayOpen() see the open
     // panel; the onCloseRequested hook makes a global close flip the open
@@ -97,6 +107,13 @@ export default defineComponent({
 
     const { isMobile } = useBreakpoint();
     const sheetMode = computed(() => props.sheetOnMobile && isMobile.value);
+
+    // Open/close motion reports into the unified animation context
+    // (animationBus) for both surface shapes: the desktop popout and the
+    // mobile bottom sheet — scrim and panel on separate tracks.
+    const popoutAnim = useSurfaceTransition(250);
+    const sheetScrimAnim = useSurfaceTransition(320);
+    const sheetPanelAnim = useSurfaceTransition(320);
 
     // Window-first back priority (HkModal convention): while this panel is
     // the topmost window, the back gesture closes it instead of navigating
@@ -338,6 +355,11 @@ export default defineComponent({
           stopDupTitleSync();
           backGuard.release();
           if (handle.value) {
+            // Unregister immediately (stacking/breadcrumb must forget the
+            // dying panel at once) but remember its z — the leave
+            // transition below keeps rendering at that band for its
+            // short lifetime instead of sinking under the page.
+            lastZ.value = handle.value.zIndex;
             manager.unregister(handle.value.id);
             handle.value = null;
           }
@@ -368,6 +390,14 @@ export default defineComponent({
     // height fallback so top placements land sensibly before measure) and
     // again after the DOM settles, when the panel's real box is known and
     // flip/clamp decisions can use actual numbers.
+    /** Resolved popout orientation — drives the pop transition's
+     *  transform-origin (grow from the anchor edge, data-side/align on
+     *  the host). Updated by positionPanel on every reposition. */
+    const resolved = ref<{ side: "top" | "bottom"; align: "start" | "end" }>({
+      side: "bottom",
+      align: "start",
+    });
+
     function positionPanel(): void {
       const anchor = props.anchorRef;
       if (!anchor) return;
@@ -388,6 +418,10 @@ export default defineComponent({
         side = "bottom";
         top = r.bottom + props.offset;
       }
+      resolved.value = {
+        side,
+        align: props.placement.endsWith("-end") ? "end" : "start",
+      };
       // One flip never re-checks: taller menu panels (the viewport-relative
       // CSS cap) made this band reachable — a mid-viewport anchor flips
       // bottom→top into a negative top that was applied verbatim. Clamp so
@@ -451,7 +485,7 @@ export default defineComponent({
       if (sheetMode.value) {
         return (
           <Teleport to="body">
-            <Transition name="hk-select-sheet" appear>
+            <Transition name="hk-select-sheet" appear {...sheetScrimAnim.hooks("scrim")}>
               {props.open ? (
                 <div
                   class="hk-select-sheet-scrim"
@@ -460,7 +494,7 @@ export default defineComponent({
                 />
               ) : null}
             </Transition>
-            <Transition name="hk-select-sheet" appear>
+            <Transition name="hk-select-sheet" appear {...sheetPanelAnim.hooks("panel")}>
               {props.open ? (
                 <div
                   ref={panelRef}
@@ -490,23 +524,36 @@ export default defineComponent({
         );
       }
 
-      // Desktop popout: no enter/leave transition on master either —
-      // mount on open, unmount on close. The fixed host carries the
-      // inline coords + popup-manager z-index and anchors the overlay
-      // scrollbar tracks; the popout inside keeps every visual rule.
-      if (!props.open) return null;
+      // Desktop popout — same contract as the sheet branch: the Teleport
+      // stays mounted across the close so the pop leave transition runs
+      // (the panel scales/fades back into its anchor instead of
+      // vanishing). The fixed host carries the inline coords +
+      // popup-manager z-index and anchors the overlay scrollbar tracks;
+      // data-side/align feed the transition's transform-origin so the
+      // pop grows out of the edge the panel actually sits on (including
+      // after an auto-flip).
       return (
         <Teleport to="body">
-          <div ref={popoutHostRef} class="hk-select-popout-host" style={{ ...coords.value, zIndex: popoutZ.value }}>
-            <div
-              ref={panelRef}
-              class="hk-select-popout"
-              aria-label={props.title || undefined}
-              onKeydown={forwardKeydown}
-            >
-              {slots.default?.()}
-            </div>
-          </div>
+          <Transition name="hk-select-popout" appear {...popoutAnim.hooks()}>
+            {props.open ? (
+              <div
+                ref={popoutHostRef}
+                class="hk-select-popout-host"
+                data-side={resolved.value.side}
+                data-align={resolved.value.align}
+                style={{ ...coords.value, zIndex: popoutZ.value }}
+              >
+                <div
+                  ref={panelRef}
+                  class="hk-select-popout"
+                  aria-label={props.title || undefined}
+                  onKeydown={forwardKeydown}
+                >
+                  {slots.default?.()}
+                </div>
+              </div>
+            ) : null}
+          </Transition>
         </Teleport>
       );
     };

--- a/packages/vue/src/components/HkToast.tsx
+++ b/packages/vue/src/components/HkToast.tsx
@@ -8,6 +8,7 @@ import { useClipboard } from "../runtime/useClipboard";
 import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useI18n } from "../i18n/context";
 import { clearLeaveGeometry, pinLeaveGeometry } from "../utils/dom";
+import { useSurfaceTransition } from "../composables/useSurfaceTransition";
 import "./HkToast.scss";
 
 const LONG_THRESHOLD = 50;
@@ -161,6 +162,14 @@ export default defineComponent({
     // it holds the topmost z band (POPUP_Z_BANDS.toast): toasts stay
     // above every modal/drawer sheet no matter which opened first.
     const manager = usePopupManager();
+    // Toast enter/leave motion reported into the unified animation
+    // context. The TransitionGroup hooks fire per item onto ONE shared
+    // track: interleaved enters/leaves re-arm/cancel it, so the bus may
+    // briefly under- or over-report while several toasts swap — the
+    // duration cron in useReportedTransition self-heals within one
+    // window; this is cadence reporting, not exact per-item tracking.
+    const surf = useSurfaceTransition(320);
+    const itemHooks = surf.hooks();
     let popupHandle: PopupHandle | null = null;
     const containerZ = ref<number | null>(null);
 
@@ -188,8 +197,17 @@ export default defineComponent({
           <TransitionGroup
             tag="div"
             name="hk-toast"
-            onBeforeLeave={pinLeaveGeometry}
-            onLeaveCancelled={clearLeaveGeometry}
+            onBeforeEnter={itemHooks.onBeforeEnter}
+            onAfterEnter={itemHooks.onAfterEnter}
+            onBeforeLeave={(el: Element) => {
+              itemHooks.onBeforeLeave();
+              pinLeaveGeometry(el);
+            }}
+            onAfterLeave={itemHooks.onAfterLeave}
+            onLeaveCancelled={(el: Element) => {
+              itemHooks.onLeaveCancelled();
+              clearLeaveGeometry(el);
+            }}
           >
             {toasts.map((item) => (
               <HkToastItem

--- a/packages/vue/src/components/HkTooltip.scss
+++ b/packages/vue/src/components/HkTooltip.scss
@@ -22,7 +22,13 @@
   word-break: break-word;
   pointer-events: none;
   opacity: 0;
-  transition: opacity var(--duration-short) ease;
+  /* Fade-only on purpose: the popup positions itself with an INLINE
+   * transform (per-placement translate), which would override any SCSS
+   * scale and make a transform transition glide on the first show.
+   * Timing/easing join the pop motion family (--hk-pop-* in
+   * theme.scss) so hover hints keep the family cadence. */
+  transition: opacity var(--hk-pop-in-duration, 0.2s)
+    var(--hk-pop-in-opacity-ease, cubic-bezier(0.16, 1, 0.3, 1));
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
   background: #ffffff;
   color: #000000;
@@ -30,6 +36,12 @@
 
 .hk-tooltip-popup.hk-tooltip-visible {
   opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-tooltip-popup {
+    transition: none;
+  }
 }
 
 .hk-tooltip-content {

--- a/packages/vue/src/composables/useSurfaceTransition.test.ts
+++ b/packages/vue/src/composables/useSurfaceTransition.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { defineComponent } from "vue";
+
+import { useSurfaceTransition } from "./useSurfaceTransition";
+import type { AnimationHandle } from "../runtime/animationBus";
+import type { CronHandle } from "../runtime/cronBus";
+
+// The composable's whole job is delegation: surface hooks arm/cancel a
+// reported transition (animationBus) per named track, with the cron
+// timer as the safety release. Mock both buses and observe the wiring.
+const armed: string[] = [];
+const cancelled: string[] = [];
+
+vi.mock("../runtime/animationBus", () => ({
+  reportTransition: vi.fn((): AnimationHandle => {
+    const id = `anim-${armed.length + 1}`;
+    armed.push(id);
+    return {
+      disconnect() { cancelled.push(id); },
+    };
+  }),
+}));
+
+vi.mock("../runtime/cronBus", () => ({
+  scheduleCronAfter: vi.fn((_cb: () => void, _ms: number): CronHandle => ({
+    disconnect() { /* timer-side cancel; the handle cancel is what matters */ },
+  })),
+}));
+
+const Host = defineComponent({
+  setup(_, { expose }) {
+    const surf = useSurfaceTransition(300);
+    expose({ surf });
+    return () => null;
+  },
+});
+
+beforeEach(() => {
+  armed.length = 0;
+  cancelled.length = 0;
+});
+
+describe("useSurfaceTransition", () => {
+  it("arms on before-enter/leave and cancels on after-enter/leave", () => {
+    const surf = useSurfaceTransition(300);
+    const hooks = surf.hooks();
+
+    hooks.onBeforeEnter();
+    expect(armed).toHaveLength(1);
+    expect(cancelled).toHaveLength(0);
+
+    hooks.onAfterEnter();
+    expect(cancelled).toHaveLength(1);
+
+    hooks.onBeforeLeave();
+    expect(armed).toHaveLength(2);
+    hooks.onAfterLeave();
+    expect(cancelled).toHaveLength(2);
+  });
+
+  it("releases the report when a transition is cancelled mid-flight", () => {
+    const surf = useSurfaceTransition(300);
+    const hooks = surf.hooks();
+
+    hooks.onBeforeEnter();
+    hooks.onEnterCancelled();
+    expect(cancelled).toHaveLength(1);
+
+    hooks.onBeforeLeave();
+    hooks.onLeaveCancelled();
+    expect(cancelled).toHaveLength(2);
+  });
+
+  it("keeps named tracks independent — arming one never cancels the other", () => {
+    const surf = useSurfaceTransition(300);
+    const scrim = surf.hooks("scrim");
+    const panel = surf.hooks("panel");
+
+    scrim.onBeforeEnter();
+    panel.onBeforeEnter();
+    // Cancelling the scrim's report must not touch the panel's.
+    scrim.onAfterEnter();
+    expect(cancelled).toHaveLength(1);
+
+    panel.onAfterLeave();
+    expect(cancelled).toHaveLength(2);
+  });
+
+  it("runs inside a component setup without touching the DOM", () => {
+    const surf = useSurfaceTransition(300);
+    const hooks = surf.hooks();
+    hooks.onBeforeEnter();
+    hooks.onAfterEnter();
+    expect(Host).toBeTruthy();
+  });
+});

--- a/packages/vue/src/composables/useSurfaceTransition.ts
+++ b/packages/vue/src/composables/useSurfaceTransition.ts
@@ -1,0 +1,71 @@
+import { useReportedTransition, type ReportedTransitionTrack } from "./useReportedTransition";
+
+/**
+ * Standard wiring between an overlay surface's CSS enter/leave
+ * transitions and the unified animation context.
+ *
+ * Every popup/modal surface in hikari animates open/close through CSS
+ * transitions on a Vue `<Transition>`. The animation context
+ * (`runtime/animationBus.ts`) only knows about those transitions when
+ * somebody REPORTS them — otherwise the bus considers itself idle while
+ * a pure-CSS transition is still running, and coordination (reduced
+ * motion, performance suspension, JS-driven choreography that must
+ * outlive the CSS fade) breaks.
+ *
+ * This composable turns the HkPopover bookkeeping pattern into one
+ * reusable shape so every surface reports identically:
+ *
+ * ```tsx
+ * const surf = useSurfaceTransition(300);
+ * <Transition name="hk-…" appear {...surf.hooks()}>
+ * ```
+ *
+ * Multi-layer surfaces (scrim + panel, overlay + content) report on
+ * separate named tracks so each layer's report is armed/cancelled
+ * independently: `surf.hooks("scrim")`, `surf.hooks("panel")`.
+ */
+
+export interface SurfaceTransitionHooks {
+  onBeforeEnter(): void;
+  onAfterEnter(): void;
+  onBeforeLeave(): void;
+  onAfterLeave(): void;
+  /** A cancelled transition must release its report like a finished
+   *  one — otherwise the track stays armed until the duration cron
+   *  self-heals (advisory over-reporting, ≤ duration window). */
+  onEnterCancelled(): void;
+  onLeaveCancelled(): void;
+}
+
+export interface SurfaceTransition {
+  /**
+   * A Vue `<Transition>` hook set bound to one named track. Spread it
+   * onto the Transition (or merge the individual hooks with your own
+   * after-enter/after-leave logic — call the hook's method first so
+   * the report is cancelled even if your logic throws).
+   */
+  hooks(key?: string): SurfaceTransitionHooks;
+  /** Raw reported-transition track for custom arming. */
+  track(key?: string): ReportedTransitionTrack;
+}
+
+export function useSurfaceTransition(durationMs: number): SurfaceTransition {
+  const reported = useReportedTransition(durationMs);
+
+  return {
+    track(key?: string): ReportedTransitionTrack {
+      return reported.track(key ?? "");
+    },
+    hooks(key?: string): SurfaceTransitionHooks {
+      const t = () => reported.track(key ?? "");
+      return {
+        onBeforeEnter: () => { t().run(); },
+        onAfterEnter: () => { t().cancel(); },
+        onBeforeLeave: () => { t().run(); },
+        onAfterLeave: () => { t().cancel(); },
+        onEnterCancelled: () => { t().cancel(); },
+        onLeaveCancelled: () => { t().cancel(); },
+      };
+    },
+  };
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -210,6 +210,11 @@ export type { PasswordValidationResult, PasswordLevel } from "./utils/password";
 
 export { FOCUSABLE_SELECTOR, getFocusableElements, focusFirst, trapFocus, scrollToElement } from "./utils/dom";
 export { useDeferredTransition } from "./composables/useDeferredTransition";
+export { useSurfaceTransition } from "./composables/useSurfaceTransition";
+export type {
+  SurfaceTransition,
+  SurfaceTransitionHooks,
+} from "./composables/useSurfaceTransition";
 
 export { useZoomPan } from "./composables/useZoomPan";
 export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";

--- a/packages/vue/src/theme/theme.scss
+++ b/packages/vue/src/theme/theme.scss
@@ -23,6 +23,22 @@
   // stacks stay dozens of levels below the strip) but below tooltips
   // (3000) and toasts (4000).
   --hk-breadcrumb-z: 2500;
+
+  // ── Pop motion family ─────────────────────────────────────────────
+  // Every anchored popout surface (HkPopover, the HkSelectPanel desktop
+  // popout behind HkSelect/HkMenu, HkTooltip) grows out of its anchor
+  // and retracts into it with the SAME curve — dropdowns, menus and
+  // popovers read as one surface family instead of a mix of animated
+  // and bare surfaces. Durations are in/Out pair; the enter transform
+  // uses a slight overshoot, opacity does not. Components' SCSS carries
+  // identical fallback values at every use site.
+  --hk-pop-in-duration: 0.2s;
+  --hk-pop-out-duration: 0.15s;
+  --hk-pop-in-opacity-ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --hk-pop-in-transform-ease: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --hk-pop-out-ease: cubic-bezier(0.4, 0, 1, 1);
+  --hk-pop-scale: 0.97;
+  --hk-pop-offset: 4px;
 }
 
 [data-mode="dark"] body {


### PR DESCRIPTION
## Summary

用户直报：部分弹层（左上角各种菜单、电脑版下拉框菜单）直接弹出/消失没有动画。本 PR 在上游 hikari 统一全部 modal 族弹面的弹出/收回动画，并全部接入统一动画上下文（animationBus）。

**Root cause**: `HkSelectPanel` 桌面 popout 分支明确无过渡（mount on open / unmount on close），而 HkMenu（左上角菜单）、HkSelect（下拉框）、HkLocalePickerPopup 全部经它渲染；`HkMenu` 在关闭时直接卸载整棵面板树，即使面板自身有离场动画也会被杀；此外仅 HkPopover 一家向 animationBus 报告动画。

## Changes

- **HkSelectPanel 桌面 popout**：新增 `hk-select-popout` 进入/离开过渡（从锚点侧长出/收回，`data-side`/`data-align` 驱动 transform-origin，含自动翻转）；关闭时经 `lastZ` 快照保持 z 直到离场结束。
- **HkMenu linger**：关闭后面板树保留 ~320ms 让每层播完离场；子层关闭延迟清扫（desktop `closedFrom` / mobile `StackEntry.closing`）；重开重置级联。
- **新 composable `useSurfaceTransition`**：标准化六钩子（含 onEnter/LeaveCancelled）按命名轨道报告；**HkModal / HkDrawer / HkToast / HkBlockingToast / HkPopover / HkLocalePicker** 全部接入（HkLocalePicker 此前完全无动画）。
- **`--hk-pop-*` 动作族 tokens**（theme.scss）：HkPopover、select popout、HkLocalePicker 共用一条曲线；HkTooltip 加入家族节奏（纯 fade——内联定位 transform 禁止 scale）；全部带 prefers-reduced-motion 守卫。
- 版本 0.22.0 → 0.23.0。

## Verification（3 轮循环）

- R1 发现 HkDrawer 焦点丢失（BLOCKER）与 HkTooltip 死 CSS/首帧滑移（MAJOR），已修复后 R2/R3 连续 SHIP。
- `vue-tsc --noEmit` 0 错误；vitest 633+ 通过；唯一失败 `HkDatePicker > marks the selected day…` 已在干净 master 对照复现为**存量**（测试硬编码 2026-08，当前 09 月）。全量并行跑偶发 useTheme/useSolarTime/HkMenu 计时 flake 均在隔离复跑通过（NFS 负载性，R2/R3 已对照证明）。
- 本地验证绿即合并（§7 CI 策略）；若 hosted/self-hosted 出现环境性失败按 §6.2 记录豁免。

## Follow-ups（非本 PR）

- `--hi-duration-fast/normal`、`--hi-ease-out/in` 被 30+ 处消费但从未在 hikari 定义（chest/erp 主题桥已各自定义）——统一全局定义需与主题桥契约协调，另行处理。
- HkPickerPane 的 `--hi-duration-normal` fallback 0.18s 与别处 0.3s 不一致（存量）。
- 下游 chest 三个自建弹层（DataTableWidget 关系选择器、MindMapView 移动 sheet 关闭、PhysicalPreview 详情关闭）随后续 PR 修复；其余 webui（noa/e.cw/erp.cw 均源码 link）自动继承。easy-hydro vendored fork（0.12.0）实际使用的弹出面均已动画化，无需改动。
<!-- retrigger: 2026-09-02 edited event for check pickup after synchronize-trigger removal -->