### PR TITLE
✨ Add theme-configurable on-solid text and icon content colors.

### DIFF
--- a/packages/components/src/styles/components/icon-button-vars.scss
+++ b/packages/components/src/styles/components/icon-button-vars.scss
@@ -120,8 +120,12 @@
 // ------
 
 .hk-icon-button-primary {
-  --hi-icon-button-icon-color: var(--hi-color-text-on-primary);
-  --hi-icon-button-icon-color-active: var(--hi-color-text-on-primary);
+  // Icon on a solid brand fill follows the theme-configurable icon color
+  // (default white), mirroring packages/vue HkIconButtonVars.scss — both
+  // sheets ship in app bundles and must not diverge (identical-specifier
+  // cascade picks whichever loads last).
+  --hi-icon-button-icon-color: var(--hi-color-icon-on-solid, #fff);
+  --hi-icon-button-icon-color-active: var(--hi-color-icon-on-solid, #fff);
 
   --hi-icon-button-bg: var(--hi-color-primary);
   --hi-icon-button-bg-active: var(--hi-color-primary-dark);

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -40,7 +40,7 @@
 .hk-checkbox-box[data-checked] {
   background: var(--hi-color-primary, #ff6b9d);
   border-color: var(--hi-color-primary, #ff6b9d);
-  color: var(--hi-color-text-on-primary, #fff);
+  color: rgb(var(--color-on-solid-text, 255 255 255));
 }
 
 .hk-checkbox-box[data-indeterminate] {
@@ -69,7 +69,7 @@
 .hk-checkbox-icon {
   position: relative;
   z-index: var(--hi-z-above, 1);
-  color: var(--hi-color-text-on-primary, #fff);
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
   width: 14px;
   height: 14px;
 }
@@ -78,7 +78,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--hi-color-text-on-primary, #fff);
+  background: rgb(var(--color-on-solid-icon, 255 255 255));
   z-index: var(--hi-z-above, 1);
 }
 
@@ -86,7 +86,7 @@
   width: 8px;
   height: 2px;
   border-radius: 1px;
-  background: var(--hi-color-text-on-primary, #fff);
+  background: rgb(var(--color-on-solid-icon, 255 255 255));
   z-index: var(--hi-z-above, 1);
 }
 

--- a/packages/vue/src/components/HkColorSchemeEditor.test.ts
+++ b/packages/vue/src/components/HkColorSchemeEditor.test.ts
@@ -59,6 +59,27 @@ const SECTIONED_GROUP: TokenGroupDefinition = {
   ],
 };
 
+// Legacy prefill shape: a saved custom theme predating the optional
+// on-solid content slots (ThemeSchemeTokens keeps them optional for these).
+const legacyDark: HCustomTheme["dark"] = {
+  primary: { r: 12, g: 34, b: 56 },
+  secondary: { r: 21, g: 43, b: 65 },
+  accent: { r: 90, g: 80, b: 70 },
+  text: { r: 228, g: 228, b: 231 },
+  muted: { r: 180, g: 180, b: 180 },
+  border: { r: 255, g: 255, b: 255 },
+  focusedBorder: { r: 12, g: 34, b: 56 },
+  background: { r: 14, g: 14, b: 30 },
+  surface: { r: 24, g: 24, b: 42 },
+  selectedBackground: { r: 70, g: 70, b: 85 },
+  selectedText: { r: 240, g: 240, b: 240 },
+  statusBarBackground: { r: 24, g: 24, b: 42 },
+  success: { r: 114, g: 241, b: 184 },
+  error: { r: 255, g: 107, b: 107 },
+  warning: { r: 253, g: 235, b: 139 },
+  info: { r: 110, g: 231, b: 239 },
+};
+
 interface EditorExpose {
   reset: () => void;
   getDraft: () => HCustomTheme;
@@ -107,6 +128,21 @@ async function setPrimaryHex(hex: string): Promise<void> {
   await nextTick();
 }
 
+/** Set an arbitrary picker slot (by swatch index) of the active mode to a hex color. */
+async function setSwatchHex(swatchIndex: number, hex: string): Promise<void> {
+  const swatches = document.body.querySelectorAll(
+    ".s-scheme-colors .hk-color-picker-swatch-btn",
+  );
+  (swatches[swatchIndex] as HTMLButtonElement).click();
+  await settle();
+  const input = document.body.querySelector(
+    ".hk-color-picker-hex-row input.hk-input-element",
+  ) as HTMLInputElement | null;
+  input!.value = hex;
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+}
+
 beforeEach(() => {
   // Pin the effective mode so edits deterministically target the dark side.
   useTheme().setMode("dark");
@@ -120,12 +156,12 @@ afterEach(() => {
 });
 
 describe("HkColorSchemeEditor", () => {
-  it("renders the seven accent pickers on initial render", async () => {
+  it("renders the seven accent pickers plus the two on-solid content pickers", async () => {
     const { container } = mountEditor();
     await nextTick();
 
     const pickers = container.querySelectorAll(".s-scheme-colors .hk-color-picker");
-    expect(pickers).toHaveLength(7);
+    expect(pickers).toHaveLength(9); // 7 accents + onSolidText + onSolidIcon
     // No groups registered in this file yet: the extension section is absent.
     expect(container.querySelector(".s-scheme-groups")).toBeNull();
   });
@@ -137,6 +173,29 @@ describe("HkColorSchemeEditor", () => {
     await setPrimaryHex("ff0000");
     const draft = ref.value!.getDraft();
     expect(draft.dark.primary).toEqual({ r: 255, g: 0, b: 0 });
+  });
+
+  it("editing an on-solid content color updates getDraft()", async () => {
+    const { ref } = mountEditor();
+    await nextTick();
+
+    // 9th picker in the grid = onSolidIcon (7 accents, then text, then icon).
+    const swatches = document.body.querySelectorAll(
+      ".s-scheme-colors .hk-color-picker-swatch-btn",
+    );
+    (swatches[8] as HTMLButtonElement).click();
+    await settle();
+    const input = document.body.querySelector(
+      ".hk-color-picker-hex-row input.hk-input-element",
+    ) as HTMLInputElement | null;
+    input!.value = "00ff00";
+    input!.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+
+    const draft = ref.value!.getDraft();
+    expect(draft.dark.onSolidIcon).toEqual({ r: 0, g: 255, b: 0 });
+    // The untouched sibling slot keeps its default white.
+    expect(draft.dark.onSolidText).toEqual({ r: 255, g: 255, b: 255 });
   });
 
   it("getDraft() includes clamped group values", async () => {
@@ -172,5 +231,40 @@ describe("HkColorSchemeEditor", () => {
     ref.value!.reset();
     await nextTick();
     expect(ref.value!.getDraft().dark.primary).toEqual({ r: 255, g: 107, b: 157 });
+  });
+
+  it("reset() re-seeds on-solid slots to white when the prefill omits them", async () => {
+    const { ref } = mountEditor({ initialDark: legacyDark });
+    await nextTick();
+
+    // 8th picker in the grid = onSolidText (7 accents, then text, then icon).
+    await setSwatchHex(7, "00ff00");
+    expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 0, g: 255, b: 0 });
+
+    ref.value!.reset();
+    await nextTick();
+    // Regression: Object.assign alone cannot clear a slot the prefill omits,
+    // so reset() must re-seed the optional slots explicitly.
+    expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 255, g: 255, b: 255 });
+    expect(ref.value!.getDraft().dark.onSolidIcon).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("reset() restores prefill on-solid slot values after edits", async () => {
+    const { ref } = mountEditor({
+      initialDark: {
+        ...legacyDark,
+        onSolidText: { r: 255, g: 200, b: 0 },
+        onSolidIcon: { r: 0, g: 200, b: 255 },
+      },
+    });
+    await nextTick();
+
+    await setSwatchHex(7, "00ff00");
+    expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 0, g: 255, b: 0 });
+
+    ref.value!.reset();
+    await nextTick();
+    expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 255, g: 200, b: 0 });
+    expect(ref.value!.getDraft().dark.onSolidIcon).toEqual({ r: 0, g: 200, b: 255 });
   });
 });

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -14,6 +14,7 @@ import {
   resolveLocalizedText,
   tokenGroupsVersion,
   type ThemeSchemeTokens,
+  type ThemeTokenRGB,
   type ThemeTokenGroupModes,
   type ThemeTokenGroupValues,
   type TokenGroupDefinition,
@@ -41,6 +42,8 @@ const defaultDark: ThemeSchemeTokens = {
   error: { r: 255, g: 107, b: 107 },
   warning: { r: 253, g: 235, b: 139 },
   info: { r: 110, g: 231, b: 239 },
+  onSolidText: { r: 255, g: 255, b: 255 },
+  onSolidIcon: { r: 255, g: 255, b: 255 },
 };
 
 const defaultLight: ThemeSchemeTokens = {
@@ -60,12 +63,19 @@ const defaultLight: ThemeSchemeTokens = {
   error: { r: 239, g: 68, b: 68 },
   warning: { r: 245, g: 158, b: 11 },
   info: { r: 6, g: 182, b: 212 },
+  onSolidText: { r: 255, g: 255, b: 255 },
+  onSolidIcon: { r: 255, g: 255, b: 255 },
 };
 
 type ColorTokenKey = keyof ThemeSchemeTokens;
+/** Required (always-present) token slots — excludes the optional on-solid content colors. */
+type RequiredTokenKey = Exclude<ColorTokenKey, "onSolidText" | "onSolidIcon">;
 
-const editableTokens: ColorTokenKey[] = ["primary", "secondary", "accent", "success", "error", "warning", "info"];
-const derivedTokens: ColorTokenKey[] = ["background", "surface", "text", "muted", "border", "focusedBorder", "selectedBackground", "selectedText", "statusBarBackground"];
+const editableTokens: RequiredTokenKey[] = ["primary", "secondary", "accent", "success", "error", "warning", "info"];
+const derivedTokens: RequiredTokenKey[] = ["background", "surface", "text", "muted", "border", "focusedBorder", "selectedBackground", "selectedText", "statusBarBackground"];
+/** Content colors ON solid brand fills: user-choosable, never derived. */
+const contentTokens: Array<"onSolidText" | "onSolidIcon"> = ["onSolidText", "onSolidIcon"];
+const WHITE: ThemeTokenRGB = { r: 255, g: 255, b: 255 };
 
 function clamp(v: number): number {
   return Math.max(0, Math.min(255, v));
@@ -113,7 +123,9 @@ export interface HCustomTheme {
  * their own surface (tabs, drawers, panels) instead of the built-in modal.
  *
  * Edits the seven accent tokens (primary/secondary/accent/success/error/
- * warning/info) per mode (dark/light); surface tokens are derived. When
+ * warning/info) plus the on-solid content colors (onSolidText — text on
+ * brand fills, onSolidIcon — icons/shapes such as the switch thumb) per
+ * mode (dark/light); the remaining surface tokens are derived. When
  * extension token groups are registered (`registerTokenGroup` /
  * `registerTokenGroupConfig`), the "Extended colors" section renders one
  * Material expansion panel per group — sub-sectioned groups get one panel
@@ -187,6 +199,12 @@ export const HkColorSchemeEditor = defineComponent({
       themeName.value = t("hikari::theme.customThemeName");
       Object.assign(dark, props.initialDark ?? defaultDark);
       Object.assign(light, props.initialLight ?? defaultLight);
+      // Optional slots: a legacy prefill omitting them must reset to white
+      // (Object.assign alone leaves stale in-editor values in place).
+      for (const k of contentTokens) {
+        dark[k] = props.initialDark?.[k] ?? WHITE;
+        light[k] = props.initialLight?.[k] ?? WHITE;
+      }
       seedGroups(groupDark, "dark", props.initialGroups?.dark);
       seedGroups(groupLight, "light", props.initialGroups?.light);
       rederiveSurface();
@@ -361,6 +379,20 @@ export const HkColorSchemeEditor = defineComponent({
               onChange={(rgb: { r: number; g: number; b: number }) => updateToken(key, rgb)}
             />
           ))}
+          {contentTokens.map((key) => {
+            // Optional slots: an older prefilled custom theme may omit them.
+            const rgb = currentTokens.value[key] ?? WHITE;
+            return (
+              <HColorPicker
+                key={key}
+                r={rgb.r}
+                g={rgb.g}
+                b={rgb.b}
+                label={t(`hikari::theme.tokens.${key}`)}
+                onChange={(next: { r: number; g: number; b: number }) => updateToken(key, next)}
+              />
+            );
+          })}
         </div>
         {registeredGroups.value.length > 0 && (
           <div class="s-scheme-groups">

--- a/packages/vue/src/components/HkFab.scss
+++ b/packages/vue/src/components/HkFab.scss
@@ -94,7 +94,10 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
 }
 
 .hk-fab[data-variant="primary"] .hk-fab-button {
-  color: var(--hi-color-on-primary, #fff);
+  // Icon-only glyph on a solid brand fill: theme icon color (default
+  // white), not the luminance-computed on-primary that goes near-black
+  // on bright primaries.
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
   background: var(--hi-color-primary, #7aa2f7);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.22);
 

--- a/packages/vue/src/components/HkIconButtonVars.scss
+++ b/packages/vue/src/components/HkIconButtonVars.scss
@@ -120,8 +120,12 @@
 // ------
 
 .hk-icon-button-primary {
-  --hi-icon-button-icon-color: var(--hi-color-text-on-primary);
-  --hi-icon-button-icon-color-active: var(--hi-color-text-on-primary);
+  /* An icon on a solid brand fill follows the theme-configurable icon
+     color, like the switch thumb / checkbox tick (NOT the luminance-
+     computed --hi-color-text-on-primary, which flips near-black on
+     bright primaries). */
+  --hi-icon-button-icon-color: var(--hi-color-icon-on-solid, #fff);
+  --hi-icon-button-icon-color-active: var(--hi-color-icon-on-solid, #fff);
 
   --hi-icon-button-bg: var(--hi-color-primary);
   --hi-icon-button-bg-active: var(--hi-color-primary-dark);

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -38,7 +38,7 @@
 
 .s-log-tab[data-active] {
   background: rgb(var(--color-primary));
-  color: rgb(var(--color-on-primary));
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   font-weight: 600;
 }
 
@@ -68,7 +68,9 @@
 .s-log-btn[data-active] {
   background: rgb(var(--color-primary));
   border-color: rgb(var(--color-primary));
-  color: rgb(var(--color-on-primary));
+  /* Control chrome (icon buttons on the solid fill) follows the
+     theme-configurable icon color, not the computed on-primary. */
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
 }
 
 .s-log-btn:disabled {

--- a/packages/vue/src/components/HkRadio.scss
+++ b/packages/vue/src/components/HkRadio.scss
@@ -89,7 +89,7 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--hi-color-text-on-primary, #fff);
+  background: rgb(var(--color-on-solid-icon, 255 255 255));
   z-index: 1;
 
   [data-size="lg"] & {

--- a/packages/vue/src/components/HkSwitch.scss
+++ b/packages/vue/src/components/HkSwitch.scss
@@ -75,7 +75,10 @@
 .hk-switch-thumb {
   position: absolute;
   border-radius: 50%;
-  background: var(--hi-color-text-on-primary, #fff);
+  /* A shape on a solid brand fill: theme icon color (default white), not
+     the luminance-computed on-primary that went near-black on bright
+     primaries (synthwave pink) while HkButton labels stayed white. */
+  background: rgb(var(--color-on-solid-icon, 255 255 255));
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
   transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   z-index: 1;
@@ -137,6 +140,6 @@
 
   &-on {
     left: 4px;
-    color: var(--hi-color-text-on-primary, #fff);
+    color: rgb(var(--color-on-solid-text, 255 255 255));
   }
 }

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -200,7 +200,7 @@
 .hk-table-checkbox-icon {
   width: 12px;
   height: 12px;
-  color: var(--hi-color-text-on-primary, #ffffff);
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
 }
 
 /* SR-only utility */

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "خطأ",
     "hikari::theme.tokens.warning": "تحذير",
     "hikari::theme.tokens.info": "معلومات",
+    "hikari::theme.tokens.onSolidText": "نص على لون العلامة",
+    "hikari::theme.tokens.onSolidIcon": "أيقونات على لون العلامة",
     "hikari::theme.groupCount": "{count} ألوان",
     "hikari::theme.extendedColors": "ألوان موسعة",
     "hikari::secret.title": "سر",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Fehler",
     "hikari::theme.tokens.warning": "Warnung",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.tokens.onSolidText": "Text auf Markenfarbe",
+    "hikari::theme.tokens.onSolidIcon": "Symbole auf Markenfarbe",
     "hikari::theme.groupCount": "{count} Farben",
     "hikari::theme.extendedColors": "Erweiterte Farben",
     "hikari::secret.title": "Geheimnis",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Error",
     "hikari::theme.tokens.warning": "Warning",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.tokens.onSolidText": "Text on brand fill",
+    "hikari::theme.tokens.onSolidIcon": "Icons on brand fill",
     "hikari::theme.groupCount": "{count} colors",
     "hikari::theme.extendedColors": "Extended colors",
     "hikari::secret.title": "Secret",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Error",
     "hikari::theme.tokens.warning": "Advertencia",
     "hikari::theme.tokens.info": "Información",
+    "hikari::theme.tokens.onSolidText": "Texto sobre color de marca",
+    "hikari::theme.tokens.onSolidIcon": "Iconos sobre color de marca",
     "hikari::theme.groupCount": "{count} colores",
     "hikari::theme.extendedColors": "Colores extendidos",
     "hikari::secret.title": "Secreto",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Erreur",
     "hikari::theme.tokens.warning": "Avertissement",
     "hikari::theme.tokens.info": "Info",
+    "hikari::theme.tokens.onSolidText": "Texte sur la couleur de marque",
+    "hikari::theme.tokens.onSolidIcon": "Icônes sur la couleur de marque",
     "hikari::theme.groupCount": "{count} couleurs",
     "hikari::theme.extendedColors": "Couleurs étendues",
     "hikari::secret.title": "Secret",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "エラー",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "情報",
+    "hikari::theme.tokens.onSolidText": "ブランド色上の文字",
+    "hikari::theme.tokens.onSolidIcon": "ブランド色上のアイコン",
     "hikari::theme.groupCount": "{count} 色",
     "hikari::theme.extendedColors": "拡張カラー",
     "hikari::secret.title": "シークレット",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "오류",
     "hikari::theme.tokens.warning": "경고",
     "hikari::theme.tokens.info": "정보",
+    "hikari::theme.tokens.onSolidText": "브랜드 색 위의 텍스트",
+    "hikari::theme.tokens.onSolidIcon": "브랜드 색 위의 아이콘",
     "hikari::theme.groupCount": "색상 {count}개",
     "hikari::theme.extendedColors": "확장 색상",
     "hikari::secret.title": "비밀",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Erro",
     "hikari::theme.tokens.warning": "Aviso",
     "hikari::theme.tokens.info": "Informação",
+    "hikari::theme.tokens.onSolidText": "Texto sobre a cor da marca",
+    "hikari::theme.tokens.onSolidIcon": "Ícones sobre a cor da marca",
     "hikari::theme.groupCount": "{count} cores",
     "hikari::theme.extendedColors": "Cores estendidas",
     "hikari::secret.title": "Segredo",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "Ошибка",
     "hikari::theme.tokens.warning": "Предупреждение",
     "hikari::theme.tokens.info": "Информация",
+    "hikari::theme.tokens.onSolidText": "Текст на фирменном цвете",
+    "hikari::theme.tokens.onSolidIcon": "Значки на фирменном цвете",
     "hikari::theme.groupCount": "Цветов: {count}",
     "hikari::theme.extendedColors": "Расширенные цвета",
     "hikari::secret.title": "Секрет",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "错误",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "信息",
+    "hikari::theme.tokens.onSolidText": "品牌色上的文字",
+    "hikari::theme.tokens.onSolidIcon": "品牌色上的图标",
     "hikari::theme.groupCount": "{count} 种颜色",
     "hikari::theme.extendedColors": "扩展配色",
     "hikari::secret.title": "密钥",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -35,6 +35,8 @@
     "hikari::theme.tokens.error": "錯誤",
     "hikari::theme.tokens.warning": "警告",
     "hikari::theme.tokens.info": "資訊",
+    "hikari::theme.tokens.onSolidText": "品牌色上的文字",
+    "hikari::theme.tokens.onSolidIcon": "品牌色上的圖示",
     "hikari::theme.groupCount": "{count} 種顏色",
     "hikari::theme.extendedColors": "擴充配色",
     "hikari::secret.title": "金鑰",

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -60,6 +60,10 @@
   --hi-color-text-primary: rgb(var(--color-text, 0 0 0));
   --hi-color-text-on-primary: rgb(var(--color-on-primary, 255 255 255));
   --color-on-solid: 255 255 255;
+  --color-on-solid-text: 255 255 255;
+  --color-on-solid-icon: 255 255 255;
+  --hi-color-text-on-solid: rgb(var(--color-on-solid-text, 255 255 255));
+  --hi-color-icon-on-solid: rgb(var(--color-on-solid-icon, 255 255 255));
   --hi-color-text-secondary: color-mix(in srgb, rgb(var(--color-text, 0 0 0)) 60%, transparent);
   --hi-color-muted: rgb(var(--color-muted, 100 100 100));
   --hi-color-background: rgb(var(--color-background, 246 246 246));

--- a/packages/vue/src/theme/presets.ts
+++ b/packages/vue/src/theme/presets.ts
@@ -21,6 +21,18 @@ export interface ThemeSchemeTokens {
   error: ThemeTokenRGB;
   warning: ThemeTokenRGB;
   info: ThemeTokenRGB;
+  /**
+   * Text color rendered ON solid brand fills (primary buttons, badges).
+   * Optional for backward compatibility with saved custom themes that
+   * predate the slot; defaults to white when absent.
+   */
+  onSolidText?: ThemeTokenRGB;
+  /**
+   * Icon/shape color rendered ON solid brand fills (switch thumb, checkbox
+   * tick, radio dot). Optional for backward compatibility with saved custom
+   * themes that predate the slot; defaults to white when absent.
+   */
+  onSolidIcon?: ThemeTokenRGB;
 }
 
 /**
@@ -109,6 +121,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(255, 107, 107),
       warning: rgb(253, 235, 139),
       info: rgb(110, 231, 239),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
     light: {
       primary: rgb(214, 51, 132),
@@ -127,6 +141,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(239, 68, 68),
       warning: rgb(245, 158, 11),
       info: rgb(6, 182, 212),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
   },
   nord: {
@@ -149,6 +165,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(191, 97, 106),
       warning: rgb(208, 135, 112),
       info: rgb(136, 192, 208),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
     light: {
       primary: rgb(94, 129, 172),
@@ -167,6 +185,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(191, 97, 106),
       warning: rgb(208, 135, 112),
       info: rgb(136, 192, 208),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
   },
   gruvbox: {
@@ -189,6 +209,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(251, 118, 118),
       warning: rgb(251, 189, 84),
       info: rgb(131, 191, 152),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
     light: {
       primary: rgb(204, 128, 49),
@@ -207,6 +229,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(204, 69, 57),
       warning: rgb(204, 128, 49),
       info: rgb(70, 120, 104),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
   },
   tokyonight: {
@@ -229,6 +253,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(247, 118, 142),
       warning: rgb(255, 183, 87),
       info: rgb(125, 207, 255),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
     light: {
       primary: rgb(52, 96, 189),
@@ -247,6 +273,8 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(225, 72, 96),
       warning: rgb(206, 145, 60),
       info: rgb(56, 157, 192),
+      onSolidText: rgb(255, 255, 255),
+      onSolidIcon: rgb(255, 255, 255),
     },
   },
 };
@@ -288,10 +316,19 @@ export function tokensToCSSVars(
   const onPrimary = contrastColor(tokens.primary);
   const textSecondary = mixToken(tokens.text, tokens.muted, 0.25);
   const textTertiary = mixToken(tokens.text, tokens.muted, 0.5);
+  // Content colors for solid brand fills default to white (the historical
+  // hardcoded value); saved custom themes that predate the slots stay white.
+  const onSolidText = tokens.onSolidText ?? { r: 255, g: 255, b: 255 };
+  const onSolidIcon = tokens.onSolidIcon ?? { r: 255, g: 255, b: 255 };
   return {
     "--color-primary": `${tokens.primary.r} ${tokens.primary.g} ${tokens.primary.b}`,
     "--color-on-primary": `${onPrimary.r} ${onPrimary.g} ${onPrimary.b}`,
-    "--color-on-solid": "255 255 255",
+    "--color-on-solid-text": `${onSolidText.r} ${onSolidText.g} ${onSolidText.b}`,
+    "--color-on-solid-icon": `${onSolidIcon.r} ${onSolidIcon.g} ${onSolidIcon.b}`,
+    // Legacy name kept as an alias of the text slot: existing consumers
+    // (HkButton, --hi-color-text-on-secondary/danger/success) keep working
+    // and now follow the theme-configurable text choice.
+    "--color-on-solid": `${onSolidText.r} ${onSolidText.g} ${onSolidText.b}`,
     "--color-secondary": `${tokens.secondary.r} ${tokens.secondary.g} ${tokens.secondary.b}`,
     "--color-accent": `${tokens.accent.r} ${tokens.accent.g} ${tokens.accent.b}`,
     "--color-text": `${tokens.text.r} ${tokens.text.g} ${tokens.text.b}`,
@@ -319,6 +356,8 @@ export function tokensToCSSVars(
     "--hi-color-muted": "rgb(var(--color-muted))",
     "--hi-color-on-primary": "rgb(var(--color-on-primary))",
     "--hi-color-text-on-primary": "rgb(var(--color-on-primary))",
+    "--hi-color-text-on-solid": "rgb(var(--color-on-solid-text, 255 255 255))",
+    "--hi-color-icon-on-solid": "rgb(var(--color-on-solid-icon, 255 255 255))",
     "--hi-color-success": "rgb(var(--color-success))",
     "--hi-color-error": "rgb(var(--color-error))",
     "--hi-color-warning": "rgb(var(--color-warning))",

--- a/packages/vue/src/theme/tokenGroups.test.ts
+++ b/packages/vue/src/theme/tokenGroups.test.ts
@@ -7,6 +7,7 @@ import {
   themePresets,
   tokensToCSSVars,
   type CustomThemePreset,
+  type ThemeSchemeTokens,
 } from "./presets";
 import {
   allGroupSlots,
@@ -223,6 +224,39 @@ describe("group cssvars", () => {
     const vars = tokensToCSSVars(themePresets.nord.dark);
     expect(vars["--test-wires-power-l1"]).toBeUndefined();
     expect(Object.keys(vars).every((k) => k.startsWith("--color-") || k.startsWith("--hi-"))).toBe(true);
+  });
+});
+
+describe("on-solid content color tokens", () => {
+  it("emits theme-configurable text/icon triplets plus aliases", () => {
+    const vars = tokensToCSSVars(themePresets.nord.dark);
+    expect(vars["--color-on-solid-text"]).toBe("255 255 255");
+    expect(vars["--color-on-solid-icon"]).toBe("255 255 255");
+    // The legacy hardcoded-white name now aliases the text slot.
+    expect(vars["--color-on-solid"]).toBe("255 255 255");
+    expect(vars["--hi-color-text-on-solid"]).toBe("rgb(var(--color-on-solid-text, 255 255 255))");
+    expect(vars["--hi-color-icon-on-solid"]).toBe("rgb(var(--color-on-solid-icon, 255 255 255))");
+  });
+
+  it("scheme objects predating the slots fall back to white (saved custom themes)", () => {
+    const legacy: ThemeSchemeTokens = { ...themePresets.nord.dark };
+    delete legacy.onSolidText;
+    delete legacy.onSolidIcon;
+    const vars = tokensToCSSVars(legacy);
+    expect(vars["--color-on-solid-text"]).toBe("255 255 255");
+    expect(vars["--color-on-solid-icon"]).toBe("255 255 255");
+    expect(vars["--color-on-solid"]).toBe("255 255 255");
+  });
+
+  it("custom slot values flow through to the triplets", () => {
+    const vars = tokensToCSSVars({
+      ...themePresets.nord.dark,
+      onSolidText: { r: 10, g: 20, b: 30 },
+      onSolidIcon: { r: 40, g: 50, b: 60 },
+    });
+    expect(vars["--color-on-solid-text"]).toBe("10 20 30");
+    expect(vars["--color-on-solid-icon"]).toBe("40 50 60");
+    expect(vars["--color-on-solid"]).toBe("10 20 30");
   });
 });
 

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -57,6 +57,8 @@
   --color-primary: 122 162 247;
   --color-on-primary: 255 255 255;
   --color-on-solid: 255 255 255;
+  --color-on-solid-text: 255 255 255;
+  --color-on-solid-icon: 255 255 255;
   --color-secondary: 81 154 115;
   --color-accent: 247 181 0;
   --color-text: 30 30 30;
@@ -82,6 +84,8 @@
   --hi-color-muted: rgb(var(--color-muted));
   --hi-color-on-primary: rgb(var(--color-on-primary));
   --hi-color-text-on-primary: rgb(var(--color-on-primary));
+  --hi-color-text-on-solid: rgb(var(--color-on-solid-text, 255 255 255));
+  --hi-color-icon-on-solid: rgb(var(--color-on-solid-icon, 255 255 255));
   --hi-color-success: rgb(var(--color-success));
   --hi-color-error: rgb(var(--color-error));
   --hi-color-warning: rgb(var(--color-warning));


### PR DESCRIPTION
## Root cause

The switch thumb rendered near-black on bright theme primaries (user screenshot: Synthwave '84 dark, primary rgb(255,107,157), relative-luminance 0.5572) because the system had two divergent sources of truth for "content on a solid brand fill":

- `HkSwitch` thumb / `HkCheckbox` tick / `HkRadio` dot read `--hi-color-text-on-primary`, which `tokensToCSSVars()` computes via a luminance threshold (`> 0.55 -> black`) — 0.5572 lands a hair over the line, so the thumb went black.
- `HkButton` primary labels read `--color-on-solid`, hardcoded `255 255 255` — always white.

## Change

- `ThemeSchemeTokens` gains optional **`onSolidText`** / **`onSolidIcon`** slots (default white; optional so saved custom themes predating the slots keep working). All 8 preset scheme blocks ship them.
- `tokensToCSSVars()` emits `--color-on-solid-text` / `--color-on-solid-icon` triplets plus `--hi-color-text-on-solid` / `--hi-color-icon-on-solid` aliases; the legacy `--color-on-solid` name now aliases the text slot (existing consumers follow the theme-configurable choice; default rendering unchanged).
- Shape/mark consumers migrated off the luminance token: HkSwitch thumb + on-content, HkCheckbox box/tick/dot/dash, HkRadio dot, HkTable select-all tick, HkIconButton primary (**vue copy and the legacy `packages/components` copy kept byte-identical** — both ship in app bundles and previously diverged would cascade by import order), HkLogWindow active tab (text) + control button (icon), HkFab primary glyph.
- `HkColorSchemeEditor` renders the two new pickers (9 total), never derives them, and `reset()` re-seeds the optional slots so legacy prefills cannot preserve stale edits.
- Static white fallbacks in `tokens.scss` / `admin-tokens.scss`; 11-locale labels for the new pickers; `packages/vue` 0.22.0 -> 0.23.0.

## Verification (3-round cycle, fresh cycle after an R2 fail was fixed)

- `vue-tsc --noEmit`: 0 errors.
- `vitest`: 636 passed / 1 failed — the single failure is `HkDatePicker > marks the selected day and today in the grid`, which fails identically on master (calendar-dependent, untouched by this diff).
- Compiled the `./styles` entry with sass: emitted `.hk-icon-button-primary` carries the new value; triple-layered white fallback guarantees (inline bridge > static :root > point-of-use) verified.
- Two independent adversarial review rounds + final round (subagents): cascade-order audit of every touched selector+property, legacy-copy divergence sweep, chest `tokenHygiene` contract check, editor UX trace; the round-2 finding (reset() stale slots) fixed with regression tests proven to fail without the fix.

## Recorded follow-ups (out of scope here)

- `packages/components/src/theme/css.rs` bridge does not yet emit `--hi-color-icon-on-solid` (point-of-use `#fff` fallback covers Rust-bridge-only contexts).
- Legacy `button-vars.scss` primary icon-color still on the luminance token (legacy-markup consumers only).
- Legacy `switch/checkbox/radio` sheets + Dioxus `switch.rs` set the same properties via their own legacy tokens — pre-existing order-dependent overlap, default-invisible.
- Per-preset dark `onSolidText/Icon` tuning (e.g. gruvbox-dark yellow primary would prefer near-black content).
- shittim-chest `tokenHygiene` INJECTED_NAMES copy can pick up the 4 new names in its next touch.