### PR TITLE
🎨 Restyle tool code panes as flat editor surfaces.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkToolBlock.scss
+++ b/packages/vue/src/components/HkToolBlock.scss
@@ -65,7 +65,7 @@
 }
 
 .s-tool-body {
-  padding: 0 var(--space-10, 0.625rem) var(--space-8, 0.5rem);
+  padding: var(--space-4, 0.25rem) var(--space-10, 0.625rem) var(--space-8, 0.5rem);
   display: flex;
   flex-direction: column;
   gap: var(--space-6, 0.375rem);
@@ -141,10 +141,9 @@
 }
 
 .s-tool-code-block {
-  margin: var(--space-4, 0.25rem) 0;
-  background: rgb(var(--color-surface) / 0.85);
-  border-radius: var(--radius-sm, 4px);
-  border: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
+  margin: var(--space-8, 0.5rem) 0;
+  background: rgb(var(--color-muted) / 7%);
+  border-radius: var(--radius-md, 8px);
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-2xs, 0.625rem);
   line-height: 1.65;
@@ -153,6 +152,7 @@
   cursor: pointer;
   max-height: 240px;
   overflow: auto;
+  padding: var(--space-6, 0.375rem) 0;
 
   /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
      hidden, never styled. */
@@ -170,26 +170,27 @@
 .s-tool-code-table {
   border-collapse: collapse;
   width: 100%;
+  margin: 0;
 }
 
 .s-tool-code-table td {
   vertical-align: top;
   font-family: inherit;
+  border: none;
 }
 
 .s-tool-code-num {
   width: 1%;
-  min-width: 3.5em;
-  padding: 0 1.25em 0 0.75em;
+  min-width: 2.75em;
+  padding: 0 0.875em 0 1em;
   text-align: right;
   user-select: none;
   white-space: nowrap;
-  color: rgb(var(--color-muted) / 0.4);
-  border-right: 1px solid var(--border-faint, rgb(var(--color-border) / 10%));
+  color: rgb(var(--color-muted) / 0.45);
 }
 
 .s-tool-code-content {
-  padding: 0 var(--space-12, 0.75rem) 0 var(--space-16, 1rem);
+  padding: 0 var(--space-12, 0.75rem) 0 0;
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/packages/vue/src/components/HkToolBlock.tsx
+++ b/packages/vue/src/components/HkToolBlock.tsx
@@ -576,7 +576,7 @@ export const HkToolBlock = defineComponent({
               )
             )}
 
-            {props.callText && props.resultText && (
+            {props.variant !== "exec" && props.callText && props.resultText && (
               <HDivider variant="dashed" tone="faint" spacing="sm" />
             )}
 


### PR DESCRIPTION
## Problem

Chest webui's task log (`TodoLogModal` → hikari `HToolBlock`, exec variant) rendered the tool call code as an over-bordered table — user feedback: "怎么这表格线画的好像有点多".

Root causes:
1. `packages/theme/styles/base.scss` ships **global** `table { margin-bottom: 1rem }` and `th, td { border-bottom: 1px solid var(--hi-color-border) }` — the `td` rule leaked into HkToolBlock's `<table class="s-tool-code-table">`, drawing a horizontal line under **every** code line (specificity: global `td` never was overridden).
2. `.s-tool-code-num` added a vertical gutter `border-right` divider.
3. `.s-tool-code-block` wrapped the pane in a full `1px` border.
4. The pane had **zero vertical padding**, so the code sat flush against the header above and the result below.

## Change

Restyle the exec code pane as a modern flat editor surface (VS Code / GitHub code-block style):

- Kill the leaks at the component root: `.s-tool-code-table td { border: none }` and `.s-tool-code-table { margin: 0 }`.
- Drop the gutter divider and the outer border; keep the card frame from `.s-tool-block` only.
- Flat muted-background pane, `--radius-md` corners, `--space-6` vertical padding inside plus `--space-8` margins around, so the code no longer hugs the header/result.
- Keep click-to-copy affordance and overlay-scrollbar pane behavior.
- Remove the redundant dashed `HDivider` between code and result for the exec variant only (`default` / `write_to_var` keep it).

Verified in a live-style preview against real theme tokens (dark + leak simulation) — screenshot shows flat borderless pane with muted line numbers.

## Verification

- `vue-tsc --noEmit` clean.
- vitest: 72/73 files, 634/635 tests — the single failure is `HkDatePicker.test.ts` is-today date-boundary (fails identically on clean master, pre-existing; today's date at month boundary).
- SCSS standalone compile clean.
- Cross-review by independent subagent: SHIP.

hikari 0.22.1 → 0.24.0 (skips 0.23.0 — claimed by in-flight #342/#344/#345).

Deployment: chest consumes via workspace link; dev.celestia.world picks this up on the next chest webui deploy wave.

Rebased onto master (a58030f #345) — resolved version conflict by keeping 0.24.0 (0.23.0 now taken by merged #345).

Rebased again onto master @d98841b (#344 merged while queued); version stays 0.24.0. Lint check re-triggered.

Rebased onto master @41de31d (#342 merged).

(Re-trigger for pool drain; previous lint-commits run cancelled while queued >20min.)