### PR TITLE
🐛 Stop filling stroke icons inside icon buttons.

### DIFF
--- a/packages/vue/src/components/HkIconButton.scss
+++ b/packages/vue/src/components/HkIconButton.scss
@@ -150,7 +150,6 @@
       width: var(--hi-icon-button-icon-size);
       height: var(--hi-icon-button-icon-size);
       display: block;
-      fill: currentColor;
     }
   }
 


### PR DESCRIPTION
## Problem

Chest's panel-header refresh button renders as a filled "circle with a slash" blob instead of the refresh glyph.

## Root cause

`.hk-icon-button .hk-icon-button-icon svg { fill: currentColor; }` — CSS `fill` overrides the `fill="none"` presentation attribute carried by every lucide stroke icon, so any stroke icon inside an `HIconButton` is filled solid. `RefreshCw` (two arcs + two L-shaped arrowheads, all stroke-only) renders filled as a solid disc with a diagonal band — exactly the reported "circle with a slash".

## Fix

Remove the `fill: currentColor` declaration from the icon rule. Each icon's own attributes decide the fill again; the component's fallback circle SVG already carries `fill="none"`.

Version bumped to 0.24.0 (0.23.0 is already claimed by two in-flight PRs).

## Verification

- `HkIconButton.test.tsx`: 3/3 passed.
- Change is CSS-only; no component behavior touched.

## Notes

- Fixes the rendering for ALL lucide icons inside HIconButton app-wide (visible breakage was worst on RefreshCw, but e.g. close/fab icons were affected too).
- Local verification green per §7; awaiting lint-commits.