### PR TITLE
♻️ Migrate remaining on-primary consumers and legacy duplicates to the on-solid slots.

### DIFF
--- a/packages/components/src/basic/switch.rs
+++ b/packages/components/src/basic/switch.rs
@@ -235,7 +235,9 @@ impl StyledComponent for SwitchComponent {
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: var(--hi-component-selection-surface);
+    /* On-solid icon expression matching the vue HkSwitch thumb: immune to
+       stylesheet order when both copies land in the same bundle. */
+    background-color: rgb(var(--color-on-solid-icon, 255 255 255));
     border-radius: 50%;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     transition: transform 0.2s ease, background 0.2s ease;

--- a/packages/components/src/display/calendar.rs
+++ b/packages/components/src/display/calendar.rs
@@ -329,7 +329,7 @@ impl StyledComponent for CalendarComponent {
 
 .hk-calendar-nav-button:hover:not(:disabled) {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-icon-on-solid, #ffffff);
     border-color: var(--hi-color-primary);
     box-shadow: 0 0 8px var(--hi-color-primary-glow);
 }
@@ -394,7 +394,7 @@ impl StyledComponent for CalendarComponent {
 
 .hk-calendar-day.hk-calendar-day-selected {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
     box-shadow: 0 0 12px var(--hi-color-primary-glow);
 }
 

--- a/packages/components/src/display/user_guide.rs
+++ b/packages/components/src/display/user_guide.rs
@@ -385,7 +385,7 @@ impl StyledComponent for UserGuideComponent {
 .hk-user-guide-primary-button {
     background-color: var(--hi-color-primary);
     border-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
 }
 
 .hk-user-guide-primary-button:hover {

--- a/packages/components/src/display/zoom_controls.rs
+++ b/packages/components/src/display/zoom_controls.rs
@@ -161,7 +161,7 @@ impl StyledComponent for ZoomControlsComponent {
 
 .hk-zoom-controls-button:active:not(.hk-zoom-controls-button-disabled) {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-icon-on-solid, #ffffff);
 }
 
 .hk-zoom-controls-button-disabled {

--- a/packages/components/src/entry/auto_complete.rs
+++ b/packages/components/src/entry/auto_complete.rs
@@ -316,7 +316,7 @@ impl StyledComponent for AutoCompleteComponent {
 .hk-autocomplete-option:hover,
 .hk-autocomplete-option.hk-autocomplete-option-focused {
     background-color: var(--hi-color-primary);
-    color: var(--hi-color-text-on-primary, #ffffff);
+    color: var(--hi-color-text-on-solid, #ffffff);
 }
 "#
     }

--- a/packages/components/src/navigation/stepper.rs
+++ b/packages/components/src/navigation/stepper.rs
@@ -148,7 +148,7 @@ impl StyledComponent for StepperComponent {
 
 .hk-step-pending .hk-step-number {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
     box-shadow: 0 0 8px var(--hi-color-primary-glow);
 }
 

--- a/packages/components/src/navigation/steps.rs
+++ b/packages/components/src/navigation/steps.rs
@@ -307,7 +307,7 @@ impl StyledComponent for StepsComponent {
 
 .hk-step-process .hk-step-icon .hk-step-number-process {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
     box-shadow: 0 0 8px rgba(var(--hi-color-primary-rgb), 0.5);
 }
 

--- a/packages/components/src/production/code_highlight.rs
+++ b/packages/components/src/production/code_highlight.rs
@@ -366,7 +366,7 @@ impl StyledComponent for CodeHighlightComponent {
 
 .hk-code-highlight-copy:hover {
     background-color: var(--hi-color-primary, #3b82f6);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
     border-color: var(--hi-color-primary, #3b82f6);
     box-shadow: 0 0 8px var(--hi-color-primary-glow, rgba(59, 130, 246, 0.35));
 }
@@ -374,7 +374,7 @@ impl StyledComponent for CodeHighlightComponent {
 .hk-code-highlight-copy.hk-code-highlight-copy-copied,
 .hk-code-highlight-copy.copied {
     background-color: var(--hi-color-primary, #3b82f6);
-    color: white;
+    color: var(--hi-color-text-on-solid, #ffffff);
     box-shadow: 0 0 12px var(--hi-color-primary-glow, rgba(59, 130, 246, 0.35));
     opacity: 1;
 }

--- a/packages/components/src/production/markdown_editor.rs
+++ b/packages/components/src/production/markdown_editor.rs
@@ -487,7 +487,7 @@ impl StyledComponent for MarkdownEditorComponent {
 
 .hk-markdown-editor-toolbar-button-active {
     background-color: var(--hi-color-primary);
-    color: white;
+    color: var(--hi-color-icon-on-solid, #ffffff);
 }
 
 .hk-markdown-editor-toolbar-divider {

--- a/packages/components/src/styles/checkbox.scss
+++ b/packages/components/src/styles/checkbox.scss
@@ -79,7 +79,9 @@
 // ------
 
 .hk-checkbox-icon {
-    color: var(--hi-component-selection-icon);
+    /* On-solid icon expression matching the vue HkCheckbox tick: immune to
+       stylesheet order when both copies land in the same bundle. */
+    color: rgb(var(--color-on-solid-icon, 255 255 255));
     width: 70%;
     height: 70%;
     opacity: 1;

--- a/packages/components/src/styles/components/anchor.scss
+++ b/packages/components/src/styles/components/anchor.scss
@@ -60,7 +60,7 @@
 
 .hk-anchor-active {
   background: var(--hi-color-primary, #00a0e9);
-  color: white;
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   font-weight: 500;
 
   &:hover {

--- a/packages/components/src/styles/components/badge.scss
+++ b/packages/components/src/styles/components/badge.scss
@@ -43,7 +43,7 @@
   box-shadow:
     0 0 8px var(--hi-glow-button-primary),
     inset 0 0 4px var(--hi-color-white-10);
-  color: var(--hi-color-text-on-primary);
+  color: rgb(var(--color-on-solid-text, 255 255 255));
 }
 
 // Secondary (苍翠)

--- a/packages/components/src/styles/components/button-vars.scss
+++ b/packages/components/src/styles/components/button-vars.scss
@@ -114,11 +114,14 @@
 // ------
 
 .hk-button-primary {
-  --hi-button-text-color: var(--hi-color-text-on-primary);
-  --hi-button-text-color-active: var(--hi-color-text-on-primary);
+  // Content on the solid primary fill follows the theme-configurable
+  // on-solid slots (text vs icon), not the luminance-computed on-primary
+  // token — mirrors packages/vue HkButton/HkIconButton behavior.
+  --hi-button-text-color: rgb(var(--color-on-solid-text, 255 255 255));
+  --hi-button-text-color-active: rgb(var(--color-on-solid-text, 255 255 255));
 
-  --hi-button-icon-color: var(--hi-color-text-on-primary);
-  --hi-button-icon-color-active: var(--hi-color-text-on-primary);
+  --hi-button-icon-color: rgb(var(--color-on-solid-icon, 255 255 255));
+  --hi-button-icon-color-active: rgb(var(--color-on-solid-icon, 255 255 255));
 
   --hi-button-bg: var(--hi-color-primary);
   --hi-button-bg-active: var(--hi-color-primary-dark);

--- a/packages/components/src/styles/components/checkbox.scss
+++ b/packages/components/src/styles/components/checkbox.scss
@@ -82,7 +82,9 @@
 // ------
 
 .hk-checkbox-icon {
-    color: var(--hi-component-selection-icon);
+    /* On-solid icon expression matching the vue HkCheckbox tick: immune to
+       stylesheet order when both copies land in the same bundle. */
+    color: rgb(var(--color-on-solid-icon, 255 255 255));
     width: 70%;
     height: 70%;
     opacity: 1;

--- a/packages/components/src/styles/components/filter.scss
+++ b/packages/components/src/styles/components/filter.scss
@@ -55,7 +55,7 @@
   padding: 0 5px;
   border-radius: 9px;
   background: var(--hi-color-primary, #00a0e9);
-  color: white;
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   font-size: 11px;
   font-weight: 500;
 }

--- a/packages/components/src/styles/components/icon-button-vars.scss
+++ b/packages/components/src/styles/components/icon-button-vars.scss
@@ -124,8 +124,8 @@
   // (default white), mirroring packages/vue HkIconButtonVars.scss — both
   // sheets ship in app bundles and must not diverge (identical-specifier
   // cascade picks whichever loads last).
-  --hi-icon-button-icon-color: var(--hi-color-icon-on-solid, #fff);
-  --hi-icon-button-icon-color-active: var(--hi-color-icon-on-solid, #fff);
+  --hi-icon-button-icon-color: rgb(var(--color-on-solid-icon, 255 255 255));
+  --hi-icon-button-icon-color-active: rgb(var(--color-on-solid-icon, 255 255 255));
 
   --hi-icon-button-bg: var(--hi-color-primary);
   --hi-icon-button-bg-active: var(--hi-color-primary-dark);

--- a/packages/components/src/styles/components/radio.scss
+++ b/packages/components/src/styles/components/radio.scss
@@ -87,7 +87,9 @@
   left: 50%;
   width: 8px;
   height: 8px;
-  background: var(--hi-component-selection-bg);
+  /* On-solid icon expression matching the vue HkRadio dot: immune to
+     stylesheet order when both copies land in the same bundle. */
+  background: rgb(var(--color-on-solid-icon, 255 255 255));
   border-radius: 50%;
   transform: translate(-50%, -50%) scale(0);
   transition: transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1);

--- a/packages/components/src/styles/components/stepper.scss
+++ b/packages/components/src/styles/components/stepper.scss
@@ -166,7 +166,7 @@
 
   .hk-step-connector,
   .hk-step-connector-vertical {
-    background-color: rgba(255, 255, 0.24);
+    background-color: rgba(255, 255, 255, 0.24);
   }
 
   .hk-step-active .hk-step-number {

--- a/packages/components/src/styles/components/switch.scss
+++ b/packages/components/src/styles/components/switch.scss
@@ -75,7 +75,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: #fff;
+    /* Same expression as the vue HkSwitch thumb: both sheets may ship in
+       one bundle, so identical values keep the cascade order irrelevant. */
+    background-color: rgb(var(--color-on-solid-icon, 255 255 255));
     border-radius: 2px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     transition: transform var(--hikari-duration-fast, 0.2s) var(--hikari-ease-smooth, ease),

--- a/packages/components/src/styles/components/tree.scss
+++ b/packages/components/src/styles/components/tree.scss
@@ -463,7 +463,7 @@
       left: 50%;
       width: 0.375rem;
       height: 0.625rem;
-      border: solid white;
+      border: solid rgb(var(--color-on-solid-icon, 255 255 255));
       border-width: 0 2px 2px 0;
       transform: translate(-50%, -60%) rotate(45deg);
     }
@@ -484,7 +484,7 @@
       left: 50%;
       width: 0.5rem;
       height: 2px;
-      background: white;
+      background: rgb(var(--color-on-solid-icon, 255 255 255));
       transform: translate(-50%, -50%);
     }
   }

--- a/packages/components/src/theme/css.rs
+++ b/packages/components/src/theme/css.rs
@@ -186,6 +186,11 @@ pub struct ThemePalette {
     pub text_color_on_success: String,
     pub text_color_on_ghost: String,
 
+    /// Theme-configurable content colors for solid brand fills (white by
+    /// default), mirroring the vue bridge's onSolidText/onSolidIcon slots.
+    pub text_color_on_solid: String,
+    pub icon_color_on_solid: String,
+
     pub border_light: String,
     pub border_ghost: String,
 
@@ -285,6 +290,9 @@ impl ThemePalette {
             text_color_on_danger: "#ffffff".to_string(),
             text_color_on_success: "#ffffff".to_string(),
             text_color_on_ghost: palette.primary.hex(),
+
+            text_color_on_solid: "#ffffff".to_string(),
+            icon_color_on_solid: "#ffffff".to_string(),
 
             border_light: "rgba(255,255,255, 0.2)".to_string(),
             border_ghost: palette.primary.hex(),
@@ -450,6 +458,8 @@ impl ThemePalette {
                 self.text_color_on_success
             ),
             format!("--hi-color-text-on-ghost: {};", self.text_color_on_ghost),
+            format!("--hi-color-text-on-solid: {};", self.text_color_on_solid),
+            format!("--hi-color-icon-on-solid: {};", self.icon_color_on_solid),
             format!("--hi-color-border-ghost: {};", self.border_ghost),
             format!("--hi-border-light: {};", self.border_light),
             format!("--hi-glow-button-primary: {};", self.glow_button_primary),

--- a/packages/extra-components/src/extra/code_highlighter.rs
+++ b/packages/extra-components/src/extra/code_highlighter.rs
@@ -390,7 +390,7 @@ impl CodeHighlighterComponent {
   padding: 0.25rem 0.75rem;
   border-radius: 4px;
   background-color: var(--hi-color-primary, #00A0E9);
-  color: white;
+  color: var(--hi-color-text-on-solid, #ffffff);
   transition: all 0.3s ease;
 }
 

--- a/packages/extra-components/src/styles/components/code_highlighter.scss
+++ b/packages/extra-components/src/styles/components/code_highlighter.scss
@@ -36,7 +36,7 @@
   padding: 0.25rem 0.75rem;
   border-radius: 4px;
   background-color: var(--hi-color-primary, #00A0E9);
-  color: white;
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   transition: all 0.3s ease;
 }
 

--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -22,7 +22,7 @@
   flex-shrink: 0;
   border-radius: var(--radius-lg, 12px);
   background: rgb(var(--color-primary));
-  color: rgb(var(--color-on-primary));
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   font-size: var(--text-lg, 1.125rem);
   font-weight: 700;
 }

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -61,6 +61,12 @@
 .hk-btn-primary {
   background: rgb(var(--color-primary));
   color: rgb(var(--color-on-solid));
+
+  /* Glyphs follow the icon slot so custom themes can split text/icon ink
+     (mirrors the legacy button-vars primary block). */
+  svg {
+    color: rgb(var(--color-on-solid-icon, 255 255 255));
+  }
 }
 
 .hk-btn-primary:hover:not(:disabled) {

--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -301,7 +301,7 @@
 
   &.is-selected {
     background: var(--hi-color-primary);
-    color: var(--hi-color-text-on-primary);
+    color: rgb(var(--color-on-solid-text, 255 255 255));
     font-weight: 600;
 
     &:hover {

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -167,7 +167,7 @@
 
   &.is-selected {
     background: var(--hi-color-primary);
-    color: var(--hi-color-text-on-primary);
+    color: rgb(var(--color-on-solid-text, 255 255 255));
     font-weight: 600;
     &:hover { background: var(--hi-color-primary); }
   }
@@ -342,7 +342,7 @@
 .hk-dtp-popup-confirm {
   appearance: none;
   background: var(--hi-color-primary);
-  color: var(--hi-color-text-on-primary);
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   border: 0;
   border-radius: var(--hi-radius-sm, 4px);
   padding: var(--hi-space-6, 6px) var(--hi-space-14, 14px);

--- a/packages/vue/src/components/HkIconButtonVars.scss
+++ b/packages/vue/src/components/HkIconButtonVars.scss
@@ -124,8 +124,8 @@
      color, like the switch thumb / checkbox tick (NOT the luminance-
      computed --hi-color-text-on-primary, which flips near-black on
      bright primaries). */
-  --hi-icon-button-icon-color: var(--hi-color-icon-on-solid, #fff);
-  --hi-icon-button-icon-color-active: var(--hi-color-icon-on-solid, #fff);
+  --hi-icon-button-icon-color: rgb(var(--color-on-solid-icon, 255 255 255));
+  --hi-icon-button-icon-color-active: rgb(var(--color-on-solid-icon, 255 255 255));
 
   --hi-icon-button-bg: var(--hi-color-primary);
   --hi-icon-button-bg-active: var(--hi-color-primary-dark);

--- a/packages/vue/src/components/HkLogo.scss
+++ b/packages/vue/src/components/HkLogo.scss
@@ -24,7 +24,7 @@ a.hk-logo {
   align-items: center;
   justify-content: center;
   background: var(--hi-color-primary);
-  color: #fff;
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   border-radius: var(--hi-radius-md, 8px);
 }
 

--- a/packages/vue/src/components/HkSecretRevealModal.scss
+++ b/packages/vue/src/components/HkSecretRevealModal.scss
@@ -40,7 +40,7 @@
   border: none;
   border-radius: var(--radius-sm, 6px);
   background: rgb(var(--color-primary));
-  color: rgb(var(--color-on-primary));
+  color: rgb(var(--color-on-solid-text, 255 255 255));
   font-size: var(--text-sm, 0.8125rem);
   font-weight: 600;
   cursor: pointer;
@@ -52,7 +52,7 @@
 
 .s-secret-modal-copy[data-copied] {
   background: rgb(var(--color-success));
-  color: rgb(var(--color-on-primary));
+  color: rgb(var(--color-on-solid-text, 255 255 255));
 }
 
 .s-secret-modal-copy:disabled {

--- a/packages/vue/src/components/HkSelectionGrid.scss
+++ b/packages/vue/src/components/HkSelectionGrid.scss
@@ -92,7 +92,7 @@
   align-items: center;
   justify-content: center;
   background: var(--hi-color-primary, #58a6ff);
-  color: #fff;
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
   font-size: 0.625rem;
   opacity: 0;
   transform: scale(0.5);

--- a/packages/vue/src/components/HkSelectionWaterfall.scss
+++ b/packages/vue/src/components/HkSelectionWaterfall.scss
@@ -56,7 +56,7 @@
   height: 0.875rem;
   border-radius: 50%;
   background: var(--hi-color-primary, #58a6ff);
-  color: #fff;
+  color: rgb(var(--color-on-solid-icon, 255 255 255));
 }
 
 .hk-selection-waterfall-name {

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -217,7 +217,7 @@
 .hk-timeline-step[data-status="completed"] {
   [data-el="indicator"] {
     background-color: var(--hi-color-primary);
-    color: #fff;
+    color: rgb(var(--color-on-solid-icon, 255 255 255));
   }
 
   [data-el="label"] {

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -58,7 +58,7 @@
   --hi-color-surface: rgb(var(--color-surface, 255 255 255));
   --hi-color-border: rgb(var(--color-border, 100 100 100) / 15%);
   --hi-color-text-primary: rgb(var(--color-text, 0 0 0));
-  --hi-color-text-on-primary: rgb(var(--color-on-primary, 255 255 255));
+  --hi-color-text-on-primary: rgb(var(--color-on-primary, 255 255 255)); /* deprecated in-tree: prefer the on-solid slots */
   --color-on-solid: 255 255 255;
   --color-on-solid-text: 255 255 255;
   --color-on-solid-icon: 255 255 255;

--- a/packages/vue/src/theme/presets.ts
+++ b/packages/vue/src/theme/presets.ts
@@ -165,8 +165,10 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(191, 97, 106),
       warning: rgb(208, 135, 112),
       info: rgb(136, 192, 208),
-      onSolidText: rgb(255, 255, 255),
-      onSolidIcon: rgb(255, 255, 255),
+      // Nord's dark primary is the pale Polar Water #88C0D0: the Nord
+      // design language puts dark ink on it (white is ~1.9:1).
+      onSolidText: rgb(46, 52, 64),
+      onSolidIcon: rgb(46, 52, 64),
     },
     light: {
       primary: rgb(94, 129, 172),
@@ -209,8 +211,10 @@ export const themePresets: Record<ThemeId, ThemePreset> = {
       error: rgb(251, 118, 118),
       warning: rgb(251, 189, 84),
       info: rgb(131, 191, 152),
-      onSolidText: rgb(255, 255, 255),
-      onSolidIcon: rgb(255, 255, 255),
+      // Gruvbox's dark primary is the warm yellow #FBBD54: gruvbox always
+      // inks dark fg on it (white is ~1.7:1).
+      onSolidText: rgb(40, 40, 40),
+      onSolidIcon: rgb(40, 40, 40),
     },
     light: {
       primary: rgb(204, 128, 49),

--- a/packages/vue/src/theme/tokenGroups.test.ts
+++ b/packages/vue/src/theme/tokenGroups.test.ts
@@ -229,13 +229,24 @@ describe("group cssvars", () => {
 
 describe("on-solid content color tokens", () => {
   it("emits theme-configurable text/icon triplets plus aliases", () => {
-    const vars = tokensToCSSVars(themePresets.nord.dark);
+    const vars = tokensToCSSVars(themePresets.synthwave84.dark);
     expect(vars["--color-on-solid-text"]).toBe("255 255 255");
     expect(vars["--color-on-solid-icon"]).toBe("255 255 255");
     // The legacy hardcoded-white name now aliases the text slot.
     expect(vars["--color-on-solid"]).toBe("255 255 255");
     expect(vars["--hi-color-text-on-solid"]).toBe("rgb(var(--color-on-solid-text, 255 255 255))");
     expect(vars["--hi-color-icon-on-solid"]).toBe("rgb(var(--color-on-solid-icon, 255 255 255))");
+  });
+
+  it("tunes the pale gruvbox/nord dark primaries to dark ink", () => {
+    // Their dark primaries are light enough that white content is illegible
+    // (~1.7:1 / ~1.9:1); the presets carry near-black slots instead.
+    const gruvbox = tokensToCSSVars(themePresets.gruvbox.dark);
+    expect(gruvbox["--color-on-solid-text"]).toBe("40 40 40");
+    expect(gruvbox["--color-on-solid-icon"]).toBe("40 40 40");
+    const nord = tokensToCSSVars(themePresets.nord.dark);
+    expect(nord["--color-on-solid-text"]).toBe("46 52 64");
+    expect(nord["--color-on-solid-icon"]).toBe("46 52 64");
   });
 
   it("scheme objects predating the slots fall back to white (saved custom themes)", () => {

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -83,6 +83,8 @@
   --hi-color-text-secondary: rgb(var(--color-text-secondary));
   --hi-color-muted: rgb(var(--color-muted));
   --hi-color-on-primary: rgb(var(--color-on-primary));
+  /* Deprecated in-tree: luminance-computed contrast, kept only for external
+     consumers. In-tree components use the on-solid slots instead. */
   --hi-color-text-on-primary: rgb(var(--color-on-primary));
   --hi-color-text-on-solid: rgb(var(--color-on-solid-text, 255 255 255));
   --hi-color-icon-on-solid: rgb(var(--color-on-solid-icon, 255 255 255));


### PR DESCRIPTION
Follow-up to #345, completing the retirement of the luminance-computed on-primary double track.

## What changed
- **Vue text positions** → `rgb(var(--color-on-solid-text, 255 255 255))`: HkAboutModal mark, HkSecretRevealModal copy buttons (default + copied state), HkDatePicker selected day, HkDateTimePicker selected day + confirm, HkLogo mark.
- **Vue indicator glyphs** → icon slot: HkSelectionGrid check, HkSelectionWaterfall badge, HkTimeline completed check.
- **HkButton.scss**: primary `svg` rule on the icon slot so custom themes can split text/icon ink (mirrors legacy button-vars).
- **Legacy components package**: hardcoded white swapped for the on-solid slots (calendar nav + selected day, user guide button, zoom controls, stepper, steps, code highlight copy states, markdown editor toolbar, autocomplete focused option, extra-components highlighter).
- **Order-independence**: legacy scss/Dioxus duplicates now use byte-identical on-solid expressions — button-vars primary vars, icon-button-vars (both copies), badge, switch thumb (scss + switch.rs), checkbox tick (both copies), radio dot, anchor active, filter counter, tree checkmark/indeterminate, code_highlighter.scss.
- **Bug fixes on the way**: tree.scss white glyph/dash on primary, stepper.scss malformed `rgba(255, 255, 0.24)` → `rgba(255, 255, 255, 0.24)` (rendered pure yellow).
- **css.rs bridge**: `ThemePalette` gains `text_color_on_solid` / `icon_color_on_solid` (white defaults) and emits `--hi-color-text-on-solid` / `--hi-color-icon-on-solid`.
- **Presets**: gruvbox/nord dark `onSolidText/onSolidIcon` tuned to near-black ink (their pale primaries give white ~1.7:1/~1.9:1); other six preset/mode combos stay white. Covered in tokenGroups tests.
- **Deprecation notes** on the in-tree on-primary aliases (kept emitted for external consumers).
- No version bump retained: master moved to 0.27.0 while this PR queued (#346/#350/#352 carried 0.24.0-0.27.0); this PR carries no package.json change.

## Verification
- 3-round subagent cycle (2 restarts: round 1 FAIL → 14 hardcoded-white sites fixed; round 1' FAIL → tree.scss + form normalization fixed; rounds 2'+3' PASS with independent cross-check).
- vue-tsc 0 errors; vitest 645/646 (sole failure = known master HkDatePicker fixed-grid case); sass entry compile carries all on-solid expressions; cargo check exit 0 for hikari-components and hikari-extra-components (dedicated CARGO_HOME/CARGO_TARGET_DIR).
- Exhaustive residual sweep: zero hardcoded content colors on solid brand fills remain (status fills / inverse surfaces / scrims intentionally keep white).
