### PR TITLE
♻️ Inject theme variables through one managed root style block instead of inline attributes.

### DIFF
--- a/packages/vue/src/theme/tokenGroups.test.ts
+++ b/packages/vue/src/theme/tokenGroups.test.ts
@@ -343,14 +343,19 @@ describe("late registration", () => {
     setMode("dark");
     initTheme();
     const el = document.documentElement;
+    // Theme vars live in the managed :root block (lean injection), so the
+    // html inline style stays clean until the late group lands.
+    const block = () => document.head.querySelector("style[data-hikari-theme-vars]")?.textContent ?? "";
     expect(el.style.getPropertyValue("--late-wires-a")).toBe("");
+    expect(block()).not.toContain("--late-wires-a");
 
     registerTokenGroup(LATE_GROUP);
     await flushMicrotasks();
 
     // The injected hook re-applied the current dark theme, so the late
-    // group's registry defaults are already on the document element.
-    expect(el.style.getPropertyValue("--late-wires-a")).toBe("1 2 3");
+    // group's registry defaults are already in the managed block.
+    expect(block()).toContain("--late-wires-a:1 2 3");
+    expect(el.style.getPropertyValue("--late-wires-a")).toBe("");
   });
 
   it("coalesces same-tick registrations into a single re-apply", async () => {

--- a/packages/vue/src/theme/useTheme.test.ts
+++ b/packages/vue/src/theme/useTheme.test.ts
@@ -70,3 +70,70 @@ describe("useTheme theme clock", () => {
     expect(theme.useTheme().geo.value).toEqual({ lat: 1, lng: 2 });
   });
 });
+
+describe("useTheme lean cssvar injection", () => {
+  let theme: ThemeModule;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    document.documentElement.style.cssText = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-mode");
+    document.head.querySelectorAll("style[data-hikari-theme-vars]").forEach((el) => el.remove());
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("offline");
+    }));
+    theme = await import("./useTheme");
+  });
+
+  afterEach(() => {
+    theme.stopThemeClock();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("pickThemeVarDeltas keeps only values differing from the static cascade", () => {
+    const vars = {
+      "--a": "1 2 3",
+      "--b": "4 5 6",
+      "--c": "7 8 9",
+      "--d": " 10 11 12 ",
+    };
+    const baseline = {
+      "--a": "1 2 3",
+      "--b": "4  5 6",
+      "--c": "",
+      "--d": "10 11 12",
+    };
+    // Whitespace-only differences collapse (normalization), so only the
+    // genuinely absent/divergent values are injected.
+    expect(theme.pickThemeVarDeltas(vars, baseline)).toEqual({
+      "--c": "7 8 9",
+    });
+  });
+
+  it("writes theme vars into a managed :root style block, never inline", () => {
+    theme.initTheme();
+    const styleEl = document.head.querySelector("style[data-hikari-theme-vars]");
+    expect(styleEl).not.toBeNull();
+    // Real browsers compute the static defaults, so the block holds only the
+    // true deltas; either way it is a :root block, not an inline attribute.
+    expect(styleEl!.textContent).toMatch(/^:root\{/);
+    expect(styleEl!.textContent).toContain("--color-primary");
+    // The html inline style attribute stays clean — no token vars on it.
+    expect(document.documentElement.style.getPropertyValue("--color-primary")).toBe("");
+    // The epoch attributes that consumers watch are still written.
+    expect(document.documentElement.getAttribute("data-theme")).toBeTruthy();
+    expect(document.documentElement.getAttribute("data-mode")).toBeTruthy();
+    // Swapping theme keeps ONE managed block (no duplicates per apply) and
+    // actually re-applies: the block content changes with the preset.
+    const before = document.head.querySelector("style[data-hikari-theme-vars]")!.textContent;
+    theme.useTheme().setTheme("nord");
+    const blocks = document.head.querySelectorAll("style[data-hikari-theme-vars]");
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].textContent).toMatch(/^:root\{/);
+    expect(blocks[0].textContent).not.toBe(before);
+  });
+});

--- a/packages/vue/src/theme/useTheme.ts
+++ b/packages/vue/src/theme/useTheme.ts
@@ -148,6 +148,76 @@ function resolveEffectiveMode(mode: ThemeMode): "dark" | "light" {
 const THEME_TRANSITION_DURATION = 300;
 let transitionTimer: CronHandle | null = null;
 
+/**
+ * Theme vars live in ONE managed stylesheet block (`:root` overrides)
+ * instead of a hundred inline declarations on `<html style="...">`.
+ *  - Inline style attributes bloat the DOM, show up as giant devtools
+ *    noise on the root element, defeat caching of the token set and make
+ *    every style recalc parse the whole attribute again.
+ *  - A stylesheet block is a single atomic replacement (one recalc for
+ *    the whole theme apply) and inspectable/serializable.
+ *  - Only the DELTAS are written: hikari's static stylesheet already
+ *    seeds :root with the full default token set (including pure
+ *    derivations like `--hi-color-primary: rgb(var(--color-primary))`),
+ *    so a token whose value already resolves identically needs no
+ *    override at all — a default-ish theme injects a handful of vars
+ *    instead of ~80.
+ */
+const THEME_VARS_STYLE_ATTR = "data-hikari-theme-vars";
+
+function normalizeVarValue(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+/** Keep only the vars whose value differs from the static cascade. */
+export function pickThemeVarDeltas(
+  vars: Record<string, string>,
+  baseline: Record<string, string>,
+): Record<string, string> {
+  const deltas: Record<string, string> = {};
+  for (const [key, value] of Object.entries(vars)) {
+    const normalized = normalizeVarValue(value);
+    if (normalizeVarValue(baseline[key] ?? "") !== normalized) {
+      deltas[key] = normalized;
+    }
+  }
+  return deltas;
+}
+
+function themeVarsStyleElement(): HTMLStyleElement {
+  let styleEl = document.head.querySelector<HTMLStyleElement>(
+    `style[${THEME_VARS_STYLE_ATTR}]`,
+  );
+  if (!styleEl) {
+    styleEl = document.createElement("style");
+    styleEl.setAttribute(THEME_VARS_STYLE_ATTR, "");
+    document.head.appendChild(styleEl);
+  }
+  return styleEl;
+}
+
+function injectThemeVars(el: HTMLElement, vars: Record<string, string>): void {
+  const styleEl = themeVarsStyleElement();
+  // Measure the cascade WITHOUT our own previous overrides: disable the
+  // managed block, read every candidate, re-enable. One recalc serves
+  // all reads, and applyTheme is a rare switch-time action.
+  const baseline: Record<string, string> = {};
+  try {
+    styleEl.disabled = true;
+    const computed = getComputedStyle(el);
+    for (const key of Object.keys(vars)) {
+      baseline[key] = computed.getPropertyValue(key);
+    }
+  } finally {
+    styleEl.disabled = false;
+  }
+
+  const deltas = pickThemeVarDeltas(vars, baseline);
+  styleEl.textContent = Object.keys(deltas).length > 0
+    ? `:root{${Object.entries(deltas).map(([key, value]) => `${key}:${value}`).join(";")}}`
+    : "";
+}
+
 function applyTheme() {
   const el = document.documentElement;
   const all = getAllThemePresets();
@@ -168,9 +238,7 @@ function applyTheme() {
 
   invalidateLuminanceCache();
 
-  for (const [key, value] of Object.entries(vars)) {
-    el.style.setProperty(key, value);
-  }
+  injectThemeVars(el, vars);
 
   el.setAttribute("data-theme", currentTheme.value);
   el.setAttribute("data-mode", effectiveMode);


### PR DESCRIPTION
User observation: the `<html>` element carries too many CSS variables (hikari's `useTheme` injects ~80 tokens — 26 `--color-*` + 16 `--hi-*` aliases + extension-group slots like the 40 `--scada-*` — as **inline styles** on `documentElement` on every theme apply).

## What changed
- **One managed block**: theme tokens now land in a single `style[data-hikari-theme-vars]` in `<head>`, swapped atomically per apply (`:root{…}` textContent replace) — one style recalc, no inline-attribute churn, inspectable token set.
- **Deltas only**: `pickThemeVarDeltas` writes only vars whose value differs from the static cascade (baseline measured with the managed block temporarily `disabled`, so the measurement can never see our own previous overrides — repeated applies are idempotent by construction). Static `:root` seeds (tokens.scss) already declare the derivations (`--hi-color-primary: rgb(var(--color-primary))` etc.), so those duplicates are no longer re-injected.
- **Unchanged contract**: `data-theme`/`data-mode` epoch attributes still written per apply (chest's scada token resolver + 3D theme observer key off them); late token-group registrations re-apply into the same block; `--wallpaper-*`/`--font-*`/`--float-*` inline mechanisms (separate modules) untouched.

## Verification
- `vue-tsc --noEmit`: 0 errors.
- `vitest run` (74 files / 658 tests): only pre-existing `HkDatePicker is-today` date-boundary failure — reproduced identically on clean master (d98841b); all theme suites 59/59 incl. new lean-injection cases.
- Consumer audit: chest `tokenResolver.ts` / `useRenderer.ts` re-sync on `data-theme`/`data-mode` (still written); `tokenHygiene.test.ts` is a static `node:fs` scanner (unaffected); key spaces disjoint.
- 2-round cross-verify: R1 MERGE-OK (WARNs: try/finally hardening + non-vacuous swap test) → fixes applied → R2 both PASS, MERGE-OK.