### PR TITLE
♻️ Shift overflowing placeholders to CSS motion and rework localized language rows.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/animation/registerAnimations.ts
+++ b/packages/vue/src/animation/registerAnimations.ts
@@ -98,3 +98,6 @@ registerCssAnimation("hk-flip-in");
 // components/HkVoiceInputPopup.scss — voice waveform bounce (loops
 // forever while listening; upstreamed from chest's plana-legacy).
 registerCssAnimation("s-voice-wave-bounce", { infinite: true });
+// components/HkPlaceholderMarquee.scss — overflowing placeholder sweep
+// (loops forever; pure CSS, loop geometry on inline custom properties).
+registerCssAnimation("hk-placeholder-marquee-scroll", { infinite: true });

--- a/packages/vue/src/components/HkInput.tsx
+++ b/packages/vue/src/components/HkInput.tsx
@@ -52,10 +52,12 @@ export default defineComponent({
     /**
      * Overflow strategy for a placeholder longer than the input line:
      * `marquee` (default) scrolls it like a storefront sign — the text is
-     * rendered three times inside a clipping window and the strip is
-     * translated through the hikari animation bus; `truncate` hard-cuts it
-     * with an ellipsis. The marquee parks while the input is focused or
-     * holds a value, and under reduced-motion the strip stays parked.
+     * rendered three times inside a clipping window and the strip travels
+     * through a registered pure-CSS keyframes animation (loop geometry on
+     * inline custom properties, no per-frame JS — see
+     * HkPlaceholderMarquee); `truncate` hard-cuts it with an ellipsis.
+     * The marquee parks while the input is focused or holds a value, and
+     * under reduced-motion the strip stays parked.
      */
     placeholderVariant: {
       type: String as () => "marquee" | "truncate",

--- a/packages/vue/src/components/HkListTransition.scss
+++ b/packages/vue/src/components/HkListTransition.scss
@@ -109,6 +109,9 @@
 .hk-list-reveal-leave-active {
   interpolate-size: allow-keywords;
   overflow: hidden;
+  /* A leaving row must not keep taking clicks during its squeeze-out —
+   * activating the body of a just-erased row would resurrect it. */
+  pointer-events: none;
   transition:
     height var(--hi-duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
     opacity var(--hi-duration-fast, 0.15s) ease-in;
@@ -128,4 +131,27 @@
 .hk-list-none-leave-active,
 .hk-list-none-move {
   transition: none;
+}
+
+/* Reduced motion: no list choreography. The global animation switch
+ * (`html[data-css-animations="0"]`) disables transitions too; the media
+ * block covers hosts that never wired the switch. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-list-pop-enter-active,
+  .hk-list-pop-leave-active,
+  .hk-list-slide-enter-active,
+  .hk-list-slide-leave-active,
+  .hk-list-fade-enter-active,
+  .hk-list-fade-leave-active,
+  .hk-list-grow-enter-active,
+  .hk-list-grow-leave-active,
+  .hk-list-reveal-enter-active,
+  .hk-list-reveal-leave-active,
+  .hk-list-pop-move,
+  .hk-list-slide-move,
+  .hk-list-fade-move,
+  .hk-list-grow-move,
+  .hk-list-reveal-move {
+    transition: none !important;
+  }
 }

--- a/packages/vue/src/components/HkListTransition.tsx
+++ b/packages/vue/src/components/HkListTransition.tsx
@@ -1,25 +1,82 @@
 import { defineComponent, TransitionGroup, type PropType } from "vue";
 
+import { useReportedTransition } from "../composables/useReportedTransition";
+
 import "./HkListTransition.scss";
 
 type ListAnimVariant = "pop" | "slide" | "fade" | "grow" | "reveal";
 
+/** Enter/leave report window: the slowest variant (pop/slide/fade) runs
+ *  --hi-duration-normal, the fast ones (grow/reveal) run their own 150ms
+ *  plus a 150ms stagger delay — both finish inside this budget. */
+const REPORT_MS = 320;
+
+/**
+ * HkListTransition — keyed list enter/enter/exit choreography.
+ *
+ * The library-level primitive for "items squeeze in / squeeze out": a
+ * `TransitionGroup` that fades + scales rows in and collapses the space
+ * on remove, then FLIPs the siblings into their new places (`move`).
+ * Variants:
+ *   - `pop`/`slide`/`fade` — standard enter/leave fades (leave elements
+ *     go absolute so the space contracts instantly);
+ *   - `grow` — scale-in with a one-beat stagger; leave collapses in
+ *     place, siblings close the gap after it;
+ *   - `reveal` — height-aware squeeze: entering rows expand from 80% of
+ *     their natural height (interpolate-size + calc-size), leaving rows
+ *     shrink back — the container height itself animates, so wrapping
+ *     groups and stacked cards both get a real space transition.
+ *
+ * Animation-context participation: every enter/leave batch is REPORTED to
+ * the runtime animation bus (`reportTransition`), so JS choreography that
+ * must outlive the CSS work (e.g. a sheet repositioning after a row is
+ * removed) is not cut short; `appear` animates the initial children on
+ * mount (open surfaces get the same gentle entrance as later updates);
+ * reduced motion / the global animation switch (`html[data-css-animations
+ * ="0"]`) disable the motion in scss.
+ */
 export default defineComponent({
   name: "HkListTransition",
   props: {
     tag: { type: String, default: "div" },
     variant: { type: String as PropType<ListAnimVariant>, default: "pop" },
     move: { type: Boolean, default: false },
+    /** Animate the children present at mount time (their enter
+     *  transitions run once). Defaults to false — bulk-rendered lists
+     *  usually want their rows to appear silently. */
+    appear: { type: Boolean, default: false },
     disabled: { type: Boolean, default: false },
   },
   setup(props, { slots }) {
+    const report = useReportedTransition(REPORT_MS);
+    // TransitionGroup forwards the enter/leave hooks to EVERY child, so
+    // a batch of N rows arms N reports on the shared track. Refcount
+    // them: each child's settle cancels only its own claim, and the
+    // track stays armed until the last child of the batch finishes.
+    let pending = 0;
+    const arm = () => {
+      pending++;
+      report.run();
+    };
+    const settle = () => {
+      pending = Math.max(0, pending - 1);
+      if (pending === 0) report.cancel();
+    };
+
     return () => {
       const name = props.disabled ? "hk-list-none" : `hk-list-${props.variant}`;
       return (
         <TransitionGroup
           tag={props.tag}
           name={name}
+          appear={props.appear}
           moveClass={props.move ? undefined : "hk-list-move-disabled"}
+          onBeforeEnter={arm}
+          onAfterEnter={settle}
+          onEnterCancelled={settle}
+          onBeforeLeave={arm}
+          onAfterLeave={settle}
+          onLeaveCancelled={settle}
         >
           {slots.default?.()}
         </TransitionGroup>

--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -5,6 +5,14 @@
   width: 100%;
 }
 
+/* Leading Languages glyph: balances the field's left cushion against the
+ * wrapped language chip on the right edge, so the centered text line stays
+ * on the box axis (HkInput reserves affix clearance symmetrically). */
+.hk-localized-input-lead {
+  color: rgb(var(--color-muted));
+  opacity: 0.75;
+}
+
 /* The wrapped language chip riding the input's right edge. A button so
  * it is focusable/AT-reachable, but it must never steal the field's
  * click-to-edit: pointer events stop at the chip boundary (handled in
@@ -65,32 +73,54 @@
     margin-inline-start: 0;
   }
 
+  .hk-input-affix.hk-input-prefix {
+    position: absolute;
+    top: 6px;
+    left: var(--space-8, 8px);
+    margin-inline-end: 0;
+  }
+
   .hk-input-element.hk-input-textarea {
     padding-right: calc(var(--space-12, 12px) + var(--hk-input-affix-end-w, 0px));
+    padding-left: calc(var(--space-12, 12px) + var(--hk-input-affix-start-w, 0px));
   }
 }
 
-/* ── translation tag cloud (menu header) ────────────────────────────
- * One pill per already-translated language: click the body to switch
- * the field to that language, click the trailing × to erase the
- * translation outright. The cloud lives inside the HkMenu popout/sheet
- * surface, above the "Add language" cascade row. */
+/* ── language list (menu header) ────────────────────────────────────
+ * One row per language currently present — including the one being
+ * edited. LEFT = the already-edited translation text (empty glyph while
+ * it holds nothing), RIGHT = the same language chip as the closed field.
+ * Clicking the chip ARMS the delete: the row turns danger-red and an ×
+ * button widens into the chip's slot (desktop: hovering the row swaps
+ * the × in without arming); clicking the × erases the translation. The
+ * list squashes/expands around adds and removals via HkListTransition. */
 .hk-localized-input-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  min-width: 15rem;
-  max-width: 20rem;
-  padding: 10px 10px 8px;
+  padding: 10px 0 8px;
   border-bottom: 1px solid var(--border-faint);
 }
 
+/* Rows live inside the HkListTransition container (keyed by language). */
+.hk-localized-input-tag-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 15rem;
+  max-width: 20rem;
+}
+
 .hk-localized-input-tag {
-  display: inline-flex;
-  align-items: stretch;
-  max-width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 2.375rem;
+  /* 16px leading padding puts the row's text exactly on the shared text
+   * edge: the mobile sheet's title inset (2×--space-16 over the list's
+   * own 1×--space-16) and the desktop popout's option text edge
+   * (8px panel + 16px row). */
+  padding: 5px var(--space-16);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-full, 999px);
+  border-radius: var(--radius-md);
   background: rgb(var(--color-surface) / var(--opacity-half, 50%));
   overflow: hidden;
   transition: border-color 0.12s ease, background 0.12s ease;
@@ -104,19 +134,28 @@
     border-color: rgb(var(--color-primary) / 45%);
     background: rgb(var(--color-primary) / 12%);
   }
+
+  /* Armed delete: the whole row reads as the danger zone — the chip is
+   * about to be replaced by its confirm ×. */
+  &[data-armed] {
+    border-color: rgb(var(--color-danger, 240 70 80) / 55%);
+    background: rgb(var(--color-danger, 240 70 80) / 12%);
+  }
 }
 
 .hk-localized-input-tag-body {
+  flex: 1;
+  min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  min-width: 0;
-  padding: 3px 4px 3px 10px;
+  gap: 6px;
+  padding: 0;
   border: 0;
   background: transparent;
   color: rgb(var(--color-text));
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   line-height: 1.4;
+  text-align: left;
   cursor: pointer;
   appearance: none;
 }
@@ -127,14 +166,54 @@
   line-height: 1;
 }
 
-.hk-localized-input-tag-label {
+.hk-localized-input-tag-text {
+  flex: 1;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  /* No translation yet (usually the language being edited): the glyph
+   * stays muted so the row reads as "nothing stored here". */
+  &[data-empty] {
+    color: rgb(var(--color-muted));
+    opacity: 0.75;
+  }
 }
 
-.hk-localized-input-tag[data-active] .hk-localized-input-tag-label {
+.hk-localized-input-tag[data-active] .hk-localized-input-tag-text {
   font-weight: 600;
+}
+
+/* The language chip — same grammar as the closed field's chip. */
+.hk-localized-input-tag-locale {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border: 0;
+  border-radius: 999px;
+  background: rgb(var(--color-primary) / 14%);
+  color: rgb(var(--color-text));
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  cursor: pointer;
+  appearance: none;
+  transition: color 0.12s ease, background 0.12s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(var(--color-primary) / 22%);
+  }
+}
+
+.hk-localized-input-tag-label {
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 9rem;
 }
 
 .hk-localized-input-tag-code {
@@ -152,20 +231,47 @@
   background: rgb(var(--color-primary));
 }
 
+/* The confirm × occupies the chip's slot: while hidden its width
+ * collapses to 0 (so the chip sits at the row edge), and on arm/hover it
+ * widens in — pushing the chip label a step leftward, exactly where the
+ * × now sits. Width transitions animate the reflow smoothly. */
 .hk-localized-input-tag-x {
+  flex: none;
   display: inline-flex;
   align-items: center;
-  padding: 3px 6px;
+  justify-content: center;
+  width: 1.5rem;
+  max-width: 0;
+  padding: 0;
+  overflow: hidden;
   border: 0;
   background: transparent;
-  color: rgb(var(--color-muted));
+  color: rgb(var(--color-danger, 240 70 80));
   cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
   appearance: none;
-  transition: color 0.12s ease, background 0.12s ease;
+  transition: max-width 0.15s ease, opacity 0.12s ease;
 
   &:hover,
   &:focus-visible {
     color: rgb(var(--color-danger, 240 70 80));
-    background: rgb(var(--color-danger, 240 70 80) / 12%);
+  }
+}
+
+.hk-localized-input-tag[data-armed] .hk-localized-input-tag-x,
+.hk-localized-input-tag:hover .hk-localized-input-tag-x,
+.hk-localized-input-tag-x:focus-visible {
+  max-width: 1.5rem;
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-localized-input-tag,
+  .hk-localized-input-tag-locale,
+  .hk-localized-input-tag-x,
+  .hk-localized-input-chip {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -54,10 +54,10 @@ function mountInput(opts: MountOptions = {}) {
 
 /**
  * Reactive harness — a REAL v-model parent: `update:translations` /
- * `update:modelValue` flow back into the props, so the tag cloud (which
- * renders from `props.translations`) updates live while the menu stays
- * open, exactly as in an application. One-way `mountInput` cannot show
- * that (its props never change). */
+ * `update:modelValue` flow back into the props, so the language list
+ * (which renders from `props.translations`) updates live while the menu
+ * stays open, exactly as in an application. One-way `mountInput` cannot
+ * show that (its props never change). */
 function mountReactive(opts: MountOptions = {}) {
   const events = {
     modelValue: [] as string[],
@@ -119,7 +119,7 @@ function menuRows(): HTMLElement[] {
   return [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-row")];
 }
 
-/** Translation tag pills inside the opened menu's header cloud. */
+/** Language rows inside the opened menu's header list. */
 function menuTags(): HTMLElement[] {
   return [...document.querySelectorAll<HTMLElement>(".hk-localized-input-tag")];
 }
@@ -130,22 +130,44 @@ function tagLabels(): string[] {
   );
 }
 
-/** The tag pill body (switch target) for the language whose label is `label`. */
-function tagBody(label: string): HTMLButtonElement | undefined {
-  return (
-    menuTags()
-      .find((t) => (t.querySelector(".hk-localized-input-tag-label")?.textContent ?? "") === label)
-      ?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-body") ?? undefined
+/** The language row whose chip label is `label`. */
+function tag(label: string): HTMLElement | undefined {
+  return menuTags().find(
+    (t) => (t.querySelector(".hk-localized-input-tag-label")?.textContent ?? "") === label,
   );
 }
 
-/** The erase × button on the tag for `label`. */
+/** The row body (text zone — switch target) of the language row. */
+function tagBody(label: string): HTMLButtonElement | undefined {
+  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-body") ?? undefined;
+}
+
+/** The language chip (arm-delete target) of the row. */
+function tagLocale(label: string): HTMLButtonElement | undefined {
+  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-locale") ?? undefined;
+}
+
+/** The confirm × on the row. */
 function tagX(label: string): HTMLButtonElement | undefined {
-  return (
-    menuTags()
-      .find((t) => (t.querySelector(".hk-localized-input-tag-label")?.textContent ?? "") === label)
-      ?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-x") ?? undefined
-  );
+  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-x") ?? undefined;
+}
+
+/** Full two-step erase: arm via the chip, then confirm on the ×. The
+ *  TransitionGroup keeps the leaving row mounted through its leave window
+ *  (jsdom has no CSS engine, so the ghost clears on the next-frame
+ *  fallback) — poll until the row is really gone. */
+async function eraseViaArm(container: HTMLElement, label: string) {
+  tagLocale(label)!.click();
+  await nextTick();
+  expect(tag(label)?.hasAttribute("data-armed"), "row is armed before the confirm ×").toBe(true);
+  tagX(label)!.click();
+  await nextTick();
+  await nextTick();
+  const deadline = Date.now() + 800;
+  while (tag(label) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await nextTick();
+  }
 }
 
 /** Wait for the menu's leave-transition window to finish — rows linger
@@ -174,7 +196,7 @@ describe("HkLocalizedInput", () => {
     expect(queryField(container).value).toBe("Plant overview");
   });
 
-  it("carries the locale code only inside the opened menu tags", async () => {
+  it("carries the locale code only inside the opened menu rows", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
@@ -182,11 +204,11 @@ describe("HkLocalizedInput", () => {
     // The chip stays code-free while the menu is closed.
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
     await openMenu(container);
-    // Tags show the bare label plus a small code suffix — no parens form.
-    const tag = menuTags().find((t) => (t.textContent ?? "").includes("简体中文"));
-    expect(tag, "tag for the filled translation renders").toBeTruthy();
-    expect(tag!.querySelector(".hk-localized-input-tag-code")?.textContent).toBe("zh-Hans");
-    expect(tag!.textContent).not.toContain("(zh-Hans)");
+    // Rows show the bare label plus a small code suffix — no parens form.
+    const row = tag("简体中文");
+    expect(row, "row for the filled translation renders").toBeTruthy();
+    expect(row!.querySelector(".hk-localized-input-tag-code")?.textContent).toBe("zh-Hans");
+    expect(row!.textContent).not.toContain("(zh-Hans)");
     // "Add language" cascade children still carry the parenthesized code.
     const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
     addRow!.click();
@@ -219,34 +241,49 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)?.en).toBeUndefined();
   });
 
-  it("renders a tag for every filled language, including the one being edited", async () => {
+  it("renders a row for every language, including the one being edited — text left, chip right", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
     await openMenu(container);
-    // Every filled language is a tag — the edited one included, marked active.
+    // Every language in the map is a row — the edited one included, marked active.
     expect(tagLabels()).toEqual(expect.arrayContaining(["English", "简体中文"]));
     const activeTag = menuTags().find((t) => t.hasAttribute("data-active"));
     expect(activeTag?.querySelector(".hk-localized-input-tag-label")?.textContent).toBe("English");
-    // The dedicated delete cascade is gone — tags carry their own ×.
+    // LEFT = the translation text, RIGHT = the language chip.
+    const zhRow = tag("简体中文")!;
+    const text = zhRow.querySelector(".hk-localized-input-tag-text")!;
+    expect(text.textContent).toBe("工厂总览");
+    expect(text.hasAttribute("data-empty")).toBe(false);
+    const enRow = tag("English")!;
+    expect(
+      enRow.querySelector(".hk-localized-input-tag-text")?.textContent,
+    ).toBe("Plant overview");
+    // The dedicated delete cascade is gone — rows carry their own arm/× pair.
     const allRows = menuRows().map((r) => r.textContent ?? "");
     expect(allRows.some((l) => l.includes("Delete language"))).toBe(false);
     expect(allRows.some((l) => l.includes("Add language"))).toBe(true);
-    // One × per tag.
-    for (const tag of menuTags()) {
-      expect(tag.querySelector(".hk-localized-input-tag-x"), "erase × on every tag").toBeTruthy();
+    // One chip + one × per row.
+    for (const row of menuTags()) {
+      expect(row.querySelector(".hk-localized-input-tag-locale"), "chip on every row").toBeTruthy();
+      expect(row.querySelector(".hk-localized-input-tag-x"), "confirm × on every row").toBeTruthy();
     }
   });
 
-  it("renders no tags when no translation is filled", async () => {
-    const { container } = mountInput({ modelValue: "" });
+  it("lists the edited language even while it holds no translation (empty glyph)", async () => {
+    const { container } = mountInput({ modelValue: "Plant overview" });
     await openMenu(container);
-    expect(menuTags().length).toBe(0);
-    expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
+    // The field edits English with nothing stored yet — still listed.
+    expect(tagLabels()).toEqual(["English"]);
+    const row = tag("English")!;
+    const text = row.querySelector(".hk-localized-input-tag-text")!;
+    expect(text.textContent).toBe("—");
+    expect(text.hasAttribute("data-empty")).toBe(true);
+    expect(row.hasAttribute("data-active")).toBe(true);
   });
 
-  it("switches to an existing language via its tag: commits text, loads its value, closes the menu", async () => {
+  it("switches to an existing language via its row body: commits text, loads its value, closes the menu", async () => {
     const { events, container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
@@ -330,7 +367,7 @@ describe("HkLocalizedInput", () => {
     mounts.push({ app, container });
     expect(queryChip(container).disabled).toBe(false);
     await openMenu(container);
-    // Only the erase-own-language tag remains in the cloud.
+    // Only the current language's row remains in the list.
     expect(tagLabels()).toEqual(["English"]);
   });
 
@@ -414,8 +451,8 @@ describe("HkLocalizedInput", () => {
     app.mount(container);
     mounts.push({ app, container });
     await openMenu(container);
-    const tag = menuTags().find((t) => (t.textContent ?? "").includes("简体中文"));
-    expect(tag?.querySelector(".hk-localized-input-tag-flag")?.textContent).toBe("🇨🇳");
+    const row = tag("简体中文");
+    expect(row?.querySelector(".hk-localized-input-tag-flag")?.textContent).toBe("🇨🇳");
   });
 
   it("follows a sourceLang change without stealing focus", async () => {
@@ -455,24 +492,99 @@ describe("HkLocalizedInput", () => {
     expect(document.activeElement).not.toBe(queryField(container));
   });
 
-  it("erases a non-current translation via the tag × and keeps the menu open", async () => {
+  it("arms only the tapped row and disarms it on a second tap", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(true);
+    expect(tag("English")?.hasAttribute("data-armed")).toBe(false);
+    // Tapping the same chip again disarms.
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(false);
+    // Arming a sibling disarms the previous row.
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    tagLocale("English")!.click();
+    await nextTick();
+    expect(tag("English")?.hasAttribute("data-armed")).toBe(true);
+    expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(false);
+  });
+
+  it("keeps the confirm × out of the tab order until the row is armed", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const x = tagX("简体中文")!;
+    // Disarmed: not tabbable, hidden from AT — the arm step is the guard.
+    expect(x.tabIndex).toBe(-1);
+    expect(x.getAttribute("aria-hidden")).toBe("true");
+    // Arm: the × becomes the next tab stop and announces itself.
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(x.tabIndex).toBe(0);
+    expect(x.hasAttribute("aria-hidden")).toBe(false);
+  });
+
+  it("names the row body by its action and the arm/confirm controls by their step", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    expect(tagBody("简体中文")?.getAttribute("aria-label")).toBe("Switch to 简体中文 (zh-Hans)");
+    // The chip labels the ARM step (Remove translation), the × the
+    // confirm step (Confirm delete).
+    expect(tagLocale("简体中文")?.getAttribute("aria-label")).toBe(
+      "Remove translation — 简体中文 (zh-Hans)",
+    );
+    expect(tagX("简体中文")?.getAttribute("aria-label")).toBe(
+      "Confirm delete — 简体中文 (zh-Hans)",
+    );
+  });
+
+  it("disarms every row when the menu closes", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(true);
+    // Close the menu, then reopen it: the armed state must not survive —
+    // a stale armed row would turn the next open into an armed delete
+    // waiting to fire.
+    queryChip(container).click();
+    await nextTick();
+    await nextTick();
+    queryChip(container).click();
+    await nextTick();
+    await nextTick();
+    expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(false);
+    expect(tag("English")?.hasAttribute("data-armed")).toBe(false);
+  });
+
+  it("erases a non-current translation via arm → confirm × and keeps the menu open", async () => {
     const { events, container } = mountReactive({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
     await openMenu(container);
-    const x = tagX("简体中文");
-    expect(x, "erase × renders on the tag").toBeTruthy();
-    x!.click();
-    await nextTick();
-    await nextTick();
+    await eraseViaArm(container, "简体中文");
     // The map loses only the erased language; no edit-state events fire.
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(events.modelValue).toEqual([]);
     expect(events.languagechange).toEqual([]);
     expect(queryField(container).value).toBe("Plant overview");
     expect(queryChip(container).textContent).toContain("English");
-    // The menu STAYS open and the cloud updates live.
+    // The menu STAYS open and the list updates live.
     expect(tagLabels()).toEqual(["English"]);
     expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
   });
@@ -483,12 +595,8 @@ describe("HkLocalizedInput", () => {
       translations: { en: "Plant overview", "zh-Hans": "工厂总览", ja: "プラント概覧" },
     });
     await openMenu(container);
-    tagX("简体中文")!.click();
-    await nextTick();
-    await nextTick();
-    tagX("日本語")!.click();
-    await nextTick();
-    await nextTick();
+    await eraseViaArm(container, "简体中文");
+    await eraseViaArm(container, "日本語");
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(tagLabels()).toEqual(["English"]);
   });
@@ -508,9 +616,7 @@ describe("HkLocalizedInput", () => {
     expect(queryChip(container).textContent).toContain("简体中文");
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
     await openMenu(container);
-    tagX("简体中文")!.click();
-    await nextTick();
-    await nextTick();
+    await eraseViaArm(container, "简体中文");
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(events.modelValue.at(-1)).toBe("Plant overview");
     expect(events.languagechange.at(-1)).toBe("en");
@@ -527,9 +633,7 @@ describe("HkLocalizedInput", () => {
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
     await openMenu(container);
-    tagX("English")!.click();
-    await nextTick();
-    await nextTick();
+    await eraseViaArm(container, "English");
     expect(events.translations.at(-1)).toEqual({ "zh-Hans": "工厂总览" });
     expect(events.modelValue.at(-1)).toBe("工厂总览");
     expect(events.languagechange.at(-1)).toBe("zh-Hans");
@@ -543,17 +647,16 @@ describe("HkLocalizedInput", () => {
       translations: { en: "Plant overview" },
     });
     await openMenu(container);
-    tagX("English")!.click();
-    await nextTick();
-    await nextTick();
+    await eraseViaArm(container, "English");
     expect(events.translations.at(-1)).toEqual({});
     expect(events.modelValue.at(-1)).toBe("");
-    // The cloud collapses once nothing is filled; the menu stays open.
-    expect(menuTags().length).toBe(0);
+    // The edited language row stays (empty glyph); the menu stays open.
+    expect(tagLabels()).toEqual(["English"]);
+    expect(tag("English")?.querySelector(".hk-localized-input-tag-text")?.textContent).toBe("—");
     expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
   });
 
-  it("dismisses the menu when the active tag's body is clicked", async () => {
+  it("dismisses the menu when the active row's body is clicked", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -49,11 +49,12 @@ const EMPTY_GLYPH = "—";
  *       · LEFT side of a row = the already-edited translation text;
  *       · RIGHT side = the same language chip as the closed field —
  *         click it to ARM deletion: the row turns danger-red, the chip
- *         label shifts and an × button appears in the chip's slot
- *         (desktop: hovering the chip swaps in the × right away);
- *       · clicking the × erases the translation for real — the two-step
- *         (arm → confirm) is the whole guard, on touch and desktop
- *         alike. The menu stays open so several translations can be
+ *         label shifts and an × button appears in the chip's slot;
+ *       · clicking the × erases the translation for real. On TOUCH the
+ *         arm is the guard (tap the chip, then tap the × that appears);
+ *         on DESKTOP hovering the row swaps in the × and a single click
+ *         on it erases — the hover IS the preview, the click the
+ *         confirm. The menu stays open so several translations can be
  *         wiped in one pass; the list updates live with squeeze-in /
  *         squeeze-out list transitions (HkListTransition, which reports
  *         to the animation context and honors reduced motion). Deleting

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -1,11 +1,12 @@
 import { computed, defineComponent, nextTick, ref, watch, type PropType } from "vue";
 
-import { ChevronDown, X } from "lucide-vue-next";
+import { ChevronDown, Languages, X } from "lucide-vue-next";
 
 import { useI18n } from "../i18n/context";
 
 import HkBadge from "./HkBadge";
 import HkInput from "./HkInput";
+import HkListTransition from "./HkListTransition";
 import HkMenu, { type HkMenuItem } from "./HkMenu";
 import "./HkLocalizedInput.scss";
 
@@ -26,27 +27,39 @@ export interface HkLocaleOption {
 /** Marker key for the "Add language" cascade root (never a real locale). */
 const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
 
+/** Placeholder glyph for a language that holds no translation yet. */
+const EMPTY_GLYPH = "—";
+
 /**
  * HkLocalizedInput — single-field multilingual text editor.
  *
  * One input that edits ONE language at a time. The text is centered (the
- * base `HkInput` element style) and a small badge-like language chip sits
- * wrapped on the RIGHT edge of the field:
+ * base `HkInput` element style), a leading `Languages` glyph balances the
+ * field's left cushion against the wrapped language chip on the RIGHT
+ * edge (both affixes are measured, so the centered line stays on the box
+ * axis), and a small badge-like language chip rides the right edge:
  *
  *   - Click the field itself → normal text editing for the chip's language.
  *   - Click the chip → the language menu (`HkMenu`, so desktop gets an
  *     anchored popout and mobile a bottom-up sheet — identical behavior
- *     to the app-level language switcher). The menu body is a TAG CLOUD:
- *       · one pill tag per language that already holds a translation —
- *         INCLUDING the one being edited (marked active). Clicking the
- *         tag body switches the field to that language and keeps editing;
- *       · an × on each tag's right edge ERASES that translation straight
- *         away — no separate "delete language" cascade anymore. The menu
- *         stays open so several translations can be wiped in one pass;
- *         the cloud updates live. Deleting the language being edited
- *         moves the field to `sourceLang` if that still holds a
- *         translation, else to the first remaining translation (or
- *         `sourceLang` itself once the map is empty);
+ *     to the app-level language switcher). The menu body is a LANGUAGE
+ *     LIST — one row per language currently present, INCLUDING the one
+ *     being edited (its row carries the active tint and shows the empty
+ *     glyph while it holds no text):
+ *       · LEFT side of a row = the already-edited translation text;
+ *       · RIGHT side = the same language chip as the closed field —
+ *         click it to ARM deletion: the row turns danger-red, the chip
+ *         label shifts and an × button appears in the chip's slot
+ *         (desktop: hovering the chip swaps in the × right away);
+ *       · clicking the × erases the translation for real — the two-step
+ *         (arm → confirm) is the whole guard, on touch and desktop
+ *         alike. The menu stays open so several translations can be
+ *         wiped in one pass; the list updates live with squeeze-in /
+ *         squeeze-out list transitions (HkListTransition, which reports
+ *         to the animation context and honors reduced motion). Deleting
+ *         the language being edited moves the field to `sourceLang` if
+ *         that still holds a translation, else to the first remaining
+ *         translation (or `sourceLang` itself once the map is empty);
  *       · an "Add language" cascade into the full locale catalog; picking
  *         one closes the menu and drops the field straight into edit
  *         state for the freshly added language.
@@ -70,11 +83,11 @@ const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
  *   - switching languages commits the current text, swaps `modelValue`
  *     to the target language's stored text ("" when none), and refocuses
  *     the field.
- *   - erasing a language via a tag × emits `update:translations` without
- *     that key; erasing the language being edited additionally swaps
- *     `modelValue` and emits `languagechange` for the fallback language
- *     (sourceLang first, then the first remaining translation, else
- *     sourceLang).
+ *   - erasing a language via the armed × emits `update:translations`
+ *     without that key; erasing the language being edited additionally
+ *     swaps `modelValue` and emits `languagechange` for the fallback
+ *     language (sourceLang first, then the first remaining translation,
+ *     else sourceLang).
  */
 export const HkLocalizedInput = defineComponent({
   name: "HkLocalizedInput",
@@ -118,6 +131,15 @@ export const HkLocalizedInput = defineComponent({
     const menuOpen = ref(false);
     const chipRef = ref<HTMLElement | null>(null);
     const rootRef = ref<HTMLElement | null>(null);
+    /** Code of the tag whose delete is ARMED (chip tapped but the × not
+     *  confirmed yet). At most one row is armed at a time. */
+    const armedCode = ref<string | null>(null);
+
+    // Closing the menu disarms any armed row — the next open starts
+    // calm instead of showing a red delete waiting to fire.
+    watch(menuOpen, (open) => {
+      if (!open) armedCode.value = null;
+    });
 
     // Follow the app locale: whenever the parent's sourceLang changes
     // (the app-level language switch moved), commit the current text
@@ -157,7 +179,7 @@ export const HkLocalizedInput = defineComponent({
     );
 
     /** The menu's action rows: only the "Add language" cascade remains —
-     *  existing translations live in the tag cloud above it. */
+     *  existing translations live in the tag list above it. */
     const menuItems = computed<HkMenuItem[]>(() =>
       addableOptions.value.length > 0
         ? [
@@ -174,16 +196,46 @@ export const HkLocalizedInput = defineComponent({
         : [],
     );
 
+    /** Rows of the language list: EVERY language that holds a translation
+     *  — the currently edited one included, even while it is still empty.
+     *  Filled entries keep their insertion order; the edited language is
+     *  appended when it has no text yet (or moves with the order it was
+     *  filled in otherwise). */
+    const langRows = computed(() => {
+      const codes = [...filledCodes.value];
+      if (!codes.includes(editLang.value)) codes.push(editLang.value);
+      return codes;
+    });
+
     /** The chip is useful while ANY interaction remains: at least one
-     *  translation to switch to / erase, or one language left to add. */
+     *  row to switch to / erase, or one language left to add. */
     const chipDisabled = computed(
-      () => props.disabled || (filledCodes.value.length === 0 && menuItems.value.length === 0),
+      () =>
+        props.disabled ||
+        (filledCodes.value.length === 0 &&
+          addableOptions.value.length === 0 &&
+          langRows.value.length <= 1),
     );
 
-    /** Accessible label of a tag's erase button, e.g.
-     *  "Remove translation — English (en)". */
-    function eraseLabel(code: string): string {
+    /** Accessible label of a row's language chip: arming the delete for
+     *  this language (the × that then appears confirms it). */
+    function armLabel(code: string): string {
       return `${t("hikari::localizedInput.removeTranslation", "Remove translation")} — ${localeLabel(code)} (${code})`;
+    }
+
+    /** Accessible label of the confirm ×: erases the translation for
+     *  real after the arm step. */
+    function confirmLabel(code: string): string {
+      return `${t("hikari::localizedInput.confirmDelete", "Confirm delete")} — ${localeLabel(code)} (${code})`;
+    }
+
+    /** Accessible name of a row body: the control switches the field to
+     *  that language — the raw translation text is visible content (and
+     *  the empty glyph reads as punctuation), so the name must identify
+     *  the ACTION (title is ignored by the accname algorithm once the
+     *  element has text content). */
+    function switchLabel(code: string): string {
+      return `${t("hikari::localizedInput.switchLanguage", "Switch to")} ${localeLabel(code)} (${code})`;
     }
 
     function commitTranslations(code: string, value: string) {
@@ -214,13 +266,13 @@ export const HkLocalizedInput = defineComponent({
       });
     }
 
-    /** Switch the edited language (tag body or freshly added one):
+    /** Switch the edited language (row body or freshly added one):
      *  commit the current text, swap the field to the target language,
      *  close the menu, and resume editing focused. */
     function switchLanguage(code: string, opts: { viaWatch?: boolean } = {}) {
       if (!code || code === ADD_LANGUAGE_KEY) return;
       if (code === editLang.value) {
-        // Already editing it (tag body click on the active tag): just
+        // Already editing it (row body click on the active row): just
         // dismiss the menu and hand focus back to the field.
         if (!opts.viaWatch) {
           menuOpen.value = false;
@@ -230,6 +282,7 @@ export const HkLocalizedInput = defineComponent({
       }
       commitTranslations(editLang.value, props.modelValue);
       editLang.value = code;
+      armedCode.value = null;
       emit("update:modelValue", (props.translations[code] ?? "").trim());
       if (!opts.viaWatch) {
         menuOpen.value = false;
@@ -238,16 +291,29 @@ export const HkLocalizedInput = defineComponent({
       emit("languagechange", code);
     }
 
-    /** Erase a language's translation via its tag's ×: drop the key
+    /** Arm (or disarm) a row's delete: the chip click turns the row red
+     *  and swaps the chip slot for the confirm ×. One armed row at a
+     *  time — arming a sibling disarms the previous one. */
+    function toggleArm(code: string) {
+      armedCode.value = armedCode.value === code ? null : code;
+    }
+
+    /** Erase a language's translation via its armed row's ×: drop the key
      *  from `translations`, and when the erased language is the one
      *  being edited move the field to a fallback — the source language
      *  if it still holds a translation, else the first remaining
      *  translation, else the source language itself. Erasing another
      *  language never disturbs the edit state. The menu STAYS open so
-     *  the cloud updates live and further tags can be erased. */
+     *  the list updates live (with the squeeze-out transition) and
+     *  further rows can be erased. */
     function eraseLanguage(code: string) {
+      // A ghost row (mid-leave after an earlier erase, or a stale × from
+      // a parent re-render) can still be clicked — erasing an already
+      // absent key must not re-emit or disturb the edit state.
+      if (!(code in props.translations)) return;
       const next = { ...props.translations };
       delete next[code];
+      armedCode.value = null;
       emit("update:translations", next);
       if (code === editLang.value) {
         const remaining = Object.keys(next).filter(
@@ -267,66 +333,70 @@ export const HkLocalizedInput = defineComponent({
       switchLanguage(key);
     }
 
-    return () => (
-      <div class="hk-localized-input" ref={rootRef} data-multiline={props.multiline || undefined}>
-        <HkInput
-          modelValue={props.modelValue}
-          onUpdate:modelValue={onInput}
-          placeholder={props.placeholder}
-          placeholderVariant={props.multiline ? "truncate" : "marquee"}
-          disabled={props.disabled}
-          size={props.size}
-          label={props.label}
-          type={props.multiline ? "textarea" : "text"}
-          rows={props.rows}
-          autoGrow={props.autoGrow}
-        >
-          {{
-            suffix: () => (
-              <button
-                ref={(el: unknown) => {
-                  chipRef.value = (el as HTMLElement) ?? null;
-                }}
-                type="button"
-                class="hk-localized-input-chip"
-                disabled={chipDisabled.value}
-                data-empty={filledCodes.value.length === 0 || undefined}
-                aria-haspopup="menu"
-                aria-expanded={menuOpen.value}
-                aria-label={t(
-                  "hikari::localizedInput.chooseLanguage",
-                  "Choose editing language",
-                )}
-                onClick={(e: MouseEvent) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  menuOpen.value = !menuOpen.value;
-                }}
-                onMousedown={(e: MouseEvent) => e.preventDefault()}
-              >
-                <HkBadge variant="primary" size="sm" class="hk-localized-input-chip-badge">
-                  {chipLabel.value}
-                </HkBadge>
-                <ChevronDown size={12} class="hk-localized-input-chip-caret" />
-              </button>
-            ),
-          }}
-        </HkInput>
-        <HkMenu
-          variant="popup"
-          items={menuItems.value}
-          open={menuOpen.value}
-          onUpdate:open={(v: boolean) => {
-            menuOpen.value = v;
-          }}
-          onSelect={onMenuSelect}
-          anchorRef={chipRef.value}
-          placement="bottom-end"
-          title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
-        >
-          {{
-            header: () =>
-              filledCodes.value.length > 0 ? (
+    return () => {
+      const rows = langRows.value;
+      return (
+        <div class="hk-localized-input" ref={rootRef} data-multiline={props.multiline || undefined}>
+          <HkInput
+            modelValue={props.modelValue}
+            onUpdate:modelValue={onInput}
+            placeholder={props.placeholder}
+            placeholderVariant={props.multiline ? "truncate" : "marquee"}
+            disabled={props.disabled}
+            size={props.size}
+            label={props.label}
+            type={props.multiline ? "textarea" : "text"}
+            rows={props.rows}
+            autoGrow={props.autoGrow}
+          >
+            {{
+              prefixIcon: () => (
+                <Languages size={15} class="hk-localized-input-lead" aria-hidden="true" />
+              ),
+              suffix: () => (
+                <button
+                  ref={(el: unknown) => {
+                    chipRef.value = (el as HTMLElement) ?? null;
+                  }}
+                  type="button"
+                  class="hk-localized-input-chip"
+                  disabled={chipDisabled.value}
+                  data-empty={filledCodes.value.length === 0 || undefined}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen.value}
+                  aria-label={t(
+                    "hikari::localizedInput.chooseLanguage",
+                    "Choose editing language",
+                  )}
+                  onClick={(e: MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    menuOpen.value = !menuOpen.value;
+                  }}
+                  onMousedown={(e: MouseEvent) => e.preventDefault()}
+                >
+                  <HkBadge variant="primary" size="sm" class="hk-localized-input-chip-badge">
+                    {chipLabel.value}
+                  </HkBadge>
+                  <ChevronDown size={12} class="hk-localized-input-chip-caret" />
+                </button>
+              ),
+            }}
+          </HkInput>
+          <HkMenu
+            variant="popup"
+            items={menuItems.value}
+            open={menuOpen.value}
+            onUpdate:open={(v: boolean) => {
+              menuOpen.value = v;
+            }}
+            onSelect={onMenuSelect}
+            anchorRef={chipRef.value}
+            placement="bottom-end"
+            title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
+          >
+            {{
+              header: () => (
                 <div
                   class="hk-localized-input-tags"
                   role="group"
@@ -335,33 +405,71 @@ export const HkLocalizedInput = defineComponent({
                     "Existing translations",
                   )}
                 >
-                  {filledCodes.value.map((code) => {
+                  <HkListTransition
+                    tag="div"
+                    variant="reveal"
+                    move
+                    appear
+                    class="hk-localized-input-tag-list"
+                  >
+                    {rows.map((code) => {
                     const active = code === editLang.value;
                     const option = props.localeOptions.find((o) => o.code === code);
+                    const value = (props.translations[code] ?? "").trim();
                     return (
-                      <span
+                      <div
                         key={code}
                         class="hk-localized-input-tag"
                         data-active={active || undefined}
+                        data-armed={armedCode.value === code || undefined}
                       >
                         <button
                           type="button"
                           class="hk-localized-input-tag-body"
                           title={`${localeLabel(code)} (${code})`}
+                          aria-label={switchLabel(code)}
                           onClick={() => switchLanguage(code)}
                         >
                           {option?.flag && (
                             <span class="hk-localized-input-tag-flag">{option.flag}</span>
                           )}
+                          <span
+                            class="hk-localized-input-tag-text"
+                            data-empty={!value || undefined}
+                          >
+                            {value || EMPTY_GLYPH}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          class="hk-localized-input-tag-locale"
+                          aria-label={armLabel(code)}
+                          title={armLabel(code)}
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation();
+                            toggleArm(code);
+                          }}
+                          onMousedown={(e: MouseEvent) => e.preventDefault()}
+                        >
                           <span class="hk-localized-input-tag-label">{localeLabel(code)}</span>
                           <span class="hk-localized-input-tag-code">{code}</span>
-                          {active && <span class="hk-localized-input-tag-dot" aria-hidden="true" />}
+                          {active && (
+                            <span class="hk-localized-input-tag-dot" aria-hidden="true" />
+                          )}
                         </button>
                         <button
                           type="button"
                           class="hk-localized-input-tag-x"
-                          aria-label={eraseLabel(code)}
-                          title={eraseLabel(code)}
+                          aria-label={confirmLabel(code)}
+                          title={confirmLabel(code)}
+                          // Hidden via CSS until armed/hovered; keep it out
+                          // of the tab order while it is invisible, so
+                          // keyboard users cannot fire the delete on an
+                          // unseen control — the chip arms first, then the
+                          // × becomes the next tab stop (focus-visible
+                          // reveals it, see scss).
+                          tabindex={armedCode.value === code ? 0 : -1}
+                          aria-hidden={armedCode.value === code ? undefined : true}
                           onClick={(e: MouseEvent) => {
                             e.stopPropagation();
                             eraseLanguage(code);
@@ -369,15 +477,17 @@ export const HkLocalizedInput = defineComponent({
                         >
                           <X size={11} />
                         </button>
-                      </span>
+                      </div>
                     );
                   })}
+                  </HkListTransition>
                 </div>
-              ) : null,
-          }}
-        </HkMenu>
-      </div>
-    );
+              ),
+            }}
+          </HkMenu>
+        </div>
+      );
+    };
   },
 });
 

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -61,6 +61,18 @@
   transform: translate(-50%, -50%);
   interpolate-size: allow-keywords;
   width: 100%;
+  // Size changes animate instead of snapping: `height: auto` growth
+  // cannot fire a CSS transition (verified in Chromium — neither auto
+  // nor calc-size(auto, size) changes its computed value on content
+  // growth, even under interpolate-size), so HkModal's useSizeMorph
+  // measures the frame's natural (capped) height and pins it as px on
+  // every content change — the transition below animates old→new px.
+  // `interpolate-size: allow-keywords` stays for the enter/leave height
+  // choreography's calc-size() keywords. The enter/leave classes below
+  // override this transition during open/close, as they always have.
+  transition:
+    height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1)),
+    max-height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
   background: var(--hk-modal-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
   backdrop-filter: var(--hk-modal-blur, blur(12px));
   border: 1px solid var(--hk-modal-border-color, var(--hi-color-border, rgba(0, 0, 0, 0.08)));
@@ -409,5 +421,15 @@
       padding: var(--space-8) var(--space-16);
       font-size: var(--text-base);
     }
+  }
+}
+
+/* Reduced motion: no size morphing — the frame swaps instantly (the
+ * open/close choreography above is flattened by the same media query in
+ * the transition classes). The global animation switch
+ * (`html[data-css-animations="0"]`) disables transitions wholesale. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-modal-content {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -21,6 +21,7 @@ import { createBackGuard } from "../runtime/backStack";
 import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import { useSizeMorph } from "../composables/useSizeMorph";
 import HButton from "./HkButton";
 import HFab from "./HkFab";
 import HSpinner from "./HkSpinner";
@@ -84,6 +85,14 @@ export default defineComponent({
     const handle = ref<{ id: string; zIndex: number } | null>(null);
     const bodyRef = ref<HTMLElement>();
     const contentRef = ref<HTMLElement>();
+    /** Natural-height probe inside the scroll container: the body's
+     *  content wrapper, whose height is the content's intrinsic height
+     *  regardless of scroll — the size morph measures this (see
+     *  useSizeMorph). */
+    const innerRef = ref<HTMLElement>();
+    // Content-driven size morphing: the frame follows content growth with
+    // the height transition instead of snapping (see useSizeMorph).
+    const morph = useSizeMorph(contentRef, innerRef);
     const shouldRender = ref(false);
     let previouslyFocused: HTMLElement | null = null;
     let unmounted = false;
@@ -589,8 +598,15 @@ export default defineComponent({
               onAfterEnter={() => {
                 contentHooks.onAfterEnter();
                 onAfterEnter();
+                // Size morphs arm once the open choreography finished —
+                // pinning during enter would override its height reveal.
+                morph.start();
               }}
-              onBeforeLeave={contentHooks.onBeforeLeave}
+              onBeforeLeave={() => {
+                contentHooks.onBeforeLeave();
+                // Release the pinned height so the leave owns the frame.
+                morph.stop();
+              }}
               onAfterLeave={() => {
                 contentHooks.onAfterLeave();
                 onAfterLeave();
@@ -648,7 +664,7 @@ export default defineComponent({
                       class="hk-modal-body-scroll"
                       onScroll={onBodyScroll}
                     >
-                      <div class="hk-modal-body-inner">
+                      <div ref={innerRef} class="hk-modal-body-inner">
                         {props.windowed
                           ? renderWindowedBody()
                           : slots.default?.()}

--- a/packages/vue/src/components/HkPlaceholderMarquee.scss
+++ b/packages/vue/src/components/HkPlaceholderMarquee.scss
@@ -8,6 +8,15 @@
  * through it, so the sign scrolls seamlessly. While the text fits, the whole
  * layer is merely a hidden measuring probe — the host input shows its native
  * placeholder instead (the component reports the flip via `overflowChange`).
+ *
+ * The strip motion is a registered CSS keyframes animation (see
+ * `animation/registerAnimations.ts`): the keyframes travel from 0 to
+ * `var(--hk-marquee-shift)` (one copy width, published inline by the
+ * component after measuring) over `var(--hk-marquee-duration)` — pure
+ * compositor work with zero per-frame JS. The animation-context switch
+ * (`html[data-css-animations="0"]`, driven by setReducedMotion / perf
+ * suspension) and the local `data-parked` attribute (host focus) park the
+ * strip via `animation-play-state`.
  */
 .hk-placeholder-marquee {
   position: absolute;
@@ -25,13 +34,27 @@
   // Match the native placeholder's centered posture (HkInput's element is
   // text-align: center) so the two modes do not shift horizontally.
   text-align: center;
-  // The strip is wider than the window; the JS offset drives translateX.
-  will-change: transform;
 
   &__strip {
     display: inline-flex;
     align-items: center;
     flex-shrink: 0;
+    // CSS-driven scrolling strip (overflowing only). `will-change` lifts it
+    // to the compositor so the transform never re-rasterizes text on the
+    // main thread — the whole point of the CSS takeover. Direction comes
+    // from --hk-marquee-direction (reverse for a negative speed).
+    &--scroll {
+      animation: hk-placeholder-marquee-scroll var(--hk-marquee-duration, 12s)
+        linear infinite;
+      animation-direction: var(--hk-marquee-direction, normal);
+      will-change: transform;
+    }
+  }
+
+  // Parked while the host input is focused: the loop freezes (play-state),
+  // text stays readable, and blur resumes the sweep from the same spot.
+  &[data-parked] &__strip--scroll {
+    animation-play-state: paused;
   }
 
   &__copy {
@@ -39,7 +62,7 @@
   }
 
   // Hidden probe mode (text fits): visibility keeps the element laid out —
-  // clientWidth and the copy's bounding rect still measure reality for the
+  // clientWidth and the copy's laid-out width still measure reality for the
   // ResizeObserver loop — while the native placeholder of the host input
   // does the actual showing.
   &--hidden {
@@ -56,10 +79,31 @@
   }
 }
 
-// Reduced motion: the bus is parked by setReducedMotion(true); park the
-// strip at its natural position too so no transform jumps remain.
+// Loop geometry is data-driven: the strip travels exactly one copy width
+// (three identical copies are laid out, so the wrap is seamless wherever
+// the loop restarts).
+@keyframes hk-placeholder-marquee-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(var(--hk-marquee-shift, -100%));
+  }
+}
+
+// Reduced motion: park the strip at its natural position — no transform
+// jumps, no sweep. The media query covers hosts without useReducedMotion
+// wired; `html[data-css-animations="0"]` covers the runtime switch (and
+// must stop the animation outright, not merely pause it mid-loop, so the
+// first copy — the natural reading position — shows).
 @media (prefers-reduced-motion: reduce) {
   .hk-placeholder-marquee__strip {
+    animation: none !important;
     transform: none !important;
   }
+}
+
+html[data-css-animations="0"] .hk-placeholder-marquee__strip {
+  animation: none !important;
+  transform: none !important;
 }

--- a/packages/vue/src/components/HkPlaceholderMarquee.test.ts
+++ b/packages/vue/src/components/HkPlaceholderMarquee.test.ts
@@ -71,7 +71,7 @@ async function forceGeometry(
   const copy = container.querySelector(".hk-placeholder-marquee__copy") as HTMLElement;
   expect(host && copy).toBeTruthy();
   Object.defineProperty(host, "clientWidth", { configurable: true, get: () => hostWidth });
-  Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => copyWidth });
+  vi.spyOn(copy, "getBoundingClientRect").mockReturnValue({ width: copyWidth } as DOMRect);
   marqueeExposed(container)?.measure?.();
   await nextTick();
 }
@@ -175,14 +175,14 @@ describe("HkPlaceholderMarquee", () => {
     const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
     const copy = container.querySelector(".hk-placeholder-marquee__copy") as HTMLElement;
     Object.defineProperty(host, "clientWidth", { configurable: true, get: () => 200 });
-    Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => 500 });
+    vi.spyOn(copy, "getBoundingClientRect").mockReturnValue({ width: 500 } as DOMRect);
     marqueeExposed(container)?.measure?.();
     await nextTick();
     // Swap the text AND the laid-out width while still overflowing — the
     // vars must republish (this used to freeze on the stale measurement).
     textRef.value = "a much longer second placeholder";
     await nextTick();
-    Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => 700 });
+    vi.spyOn(copy, "getBoundingClientRect").mockReturnValue({ width: 700 } as DOMRect);
     marqueeExposed(container)?.measure?.();
     await nextTick();
     const strip = container.querySelector(".hk-placeholder-marquee__strip") as HTMLElement;
@@ -190,6 +190,21 @@ describe("HkPlaceholderMarquee", () => {
     expect(strip.style.getPropertyValue("--hk-marquee-shift")).toBe("-700px");
     // 700px at 24px/s → 29.167s per loop.
     expect(strip.style.getPropertyValue("--hk-marquee-duration")).toBe("29.167s");
+  });
+
+  it("parks the strip for a zero speed and reverses for a negative one", async () => {
+    const { container } = mountMarquee({ text: "parking and reversing", speed: 0 });
+    await forceGeometry(container, 500, 200);
+    const strip = container.querySelector(".hk-placeholder-marquee__strip") as HTMLElement;
+    // speed 0 → no sweep at all (matches the old JS behavior: offset
+    // never advanced) — the strip shows the text statically.
+    expect(strip.classList.contains("hk-placeholder-marquee__strip--scroll")).toBe(false);
+    const { container: c2 } = mountMarquee({ text: "parking and reversing", speed: -24 });
+    await forceGeometry(c2, 500, 200);
+    const strip2 = c2.querySelector(".hk-placeholder-marquee__strip") as HTMLElement;
+    expect(strip2.classList.contains("hk-placeholder-marquee__strip--scroll")).toBe(true);
+    expect(strip2.style.getPropertyValue("--hk-marquee-direction")).toBe("reverse");
+    expect(strip2.style.getPropertyValue("--hk-marquee-duration")).toBe("20.833s");
   });
 
   it("re-renders the copy when the text prop changes", async () => {

--- a/packages/vue/src/components/HkPlaceholderMarquee.test.ts
+++ b/packages/vue/src/components/HkPlaceholderMarquee.test.ts
@@ -71,7 +71,7 @@ async function forceGeometry(
   const copy = container.querySelector(".hk-placeholder-marquee__copy") as HTMLElement;
   expect(host && copy).toBeTruthy();
   Object.defineProperty(host, "clientWidth", { configurable: true, get: () => hostWidth });
-  vi.spyOn(copy, "getBoundingClientRect").mockReturnValue({ width: copyWidth } as DOMRect);
+  Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => copyWidth });
   marqueeExposed(container)?.measure?.();
   await nextTick();
 }
@@ -94,6 +94,8 @@ describe("HkPlaceholderMarquee", () => {
     expect(copies).toHaveLength(1);
     expect(copies[0].textContent).toBe("用户名");
     expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(true);
+    // The strip carries no animation while the text fits.
+    expect(container.querySelector(".hk-placeholder-marquee__strip--scroll")).toBeNull();
   });
 
   it("renders three identical copies for the seamless wrap once the text overflows", async () => {
@@ -110,6 +112,19 @@ describe("HkPlaceholderMarquee", () => {
     expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(false);
   });
 
+  it("drives the sweep with CSS custom properties instead of per-frame JS", async () => {
+    const { container } = mountMarquee({ text: "advent calendar of placeholders" });
+    await forceGeometry(container, 500, 200);
+    const strip = container.querySelector(".hk-placeholder-marquee__strip") as HTMLElement;
+    // The animation class rides the strip; the loop geometry is published
+    // as custom properties (never recomputed per frame by JS).
+    expect(strip.classList.contains("hk-placeholder-marquee__strip--scroll")).toBe(true);
+    expect(strip.style.getPropertyValue("--hk-marquee-shift")).toBe("-500px");
+    // 500px at the default 24px/s → 20.833s per loop.
+    expect(strip.style.getPropertyValue("--hk-marquee-duration")).toBe("20.833s");
+    expect(strip.getAttribute("style")).not.toContain("transform");
+  });
+
   it("collapses back to a hidden probe when the window grows past the text", async () => {
     const { container } = mountMarquee({ text: "shrinking story" });
     await forceGeometry(container, 500, 200);
@@ -118,6 +133,7 @@ describe("HkPlaceholderMarquee", () => {
     const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
     expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(1);
     expect(host.classList.contains("hk-placeholder-marquee--hidden")).toBe(true);
+    expect(container.querySelector(".hk-placeholder-marquee__strip--scroll")).toBeNull();
   });
 
   it("renders a single ellipsis copy in truncate variant", () => {
@@ -131,14 +147,49 @@ describe("HkPlaceholderMarquee", () => {
     expect(container.querySelector(".hk-placeholder-marquee")).toBeNull();
   });
 
-  it("exposes setActive without throwing in both directions", async () => {
+  it("exposes setActive: focus parks the sweep via data-parked, blur resumes", async () => {
     const { container } = mountMarquee({ text: "scrolls" });
+    await forceGeometry(container, 500, 200);
     await nextTick();
     const exposed = marqueeExposed(container);
     expect(exposed).toBeTruthy();
-    expect(typeof exposed!.setActive).toBe("function");
-    expect(() => exposed!.setActive!(true)).not.toThrow();
-    expect(() => exposed!.setActive!(false)).not.toThrow();
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    exposed!.setActive!(true);
+    await nextTick();
+    expect(host.hasAttribute("data-parked")).toBe(true);
+    exposed!.setActive!(false);
+    await nextTick();
+    expect(host.hasAttribute("data-parked")).toBe(false);
+  });
+
+  it("republishes the loop geometry when the text changes while the overflow persists", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const textRef = ref("first placeholder");
+    const app = createApp({
+      render: () => h(HkPlaceholderMarquee, { text: textRef.value }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    // Overflow with copy width 500.
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    const copy = container.querySelector(".hk-placeholder-marquee__copy") as HTMLElement;
+    Object.defineProperty(host, "clientWidth", { configurable: true, get: () => 200 });
+    Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => 500 });
+    marqueeExposed(container)?.measure?.();
+    await nextTick();
+    // Swap the text AND the laid-out width while still overflowing — the
+    // vars must republish (this used to freeze on the stale measurement).
+    textRef.value = "a much longer second placeholder";
+    await nextTick();
+    Object.defineProperty(copy, "offsetWidth", { configurable: true, get: () => 700 });
+    marqueeExposed(container)?.measure?.();
+    await nextTick();
+    const strip = container.querySelector(".hk-placeholder-marquee__strip") as HTMLElement;
+    expect(strip.classList.contains("hk-placeholder-marquee__strip--scroll")).toBe(true);
+    expect(strip.style.getPropertyValue("--hk-marquee-shift")).toBe("-700px");
+    // 700px at 24px/s → 29.167s per loop.
+    expect(strip.style.getPropertyValue("--hk-marquee-duration")).toBe("29.167s");
   });
 
   it("re-renders the copy when the text prop changes", async () => {
@@ -204,6 +255,21 @@ describe("HkInput placeholder-variant", () => {
     await forceGeometry(container, 500, 200);
     expect(input.getAttribute("placeholder")).toBe("");
     expect(container.querySelectorAll(".hk-placeholder-marquee__copy")).toHaveLength(3);
+  });
+
+  it("parks the sweep when the host input is focused", async () => {
+    const { container } = mountInput({
+      placeholder: "focus parks the sweeping placeholder sign",
+    });
+    await forceGeometry(container, 500, 200);
+    const host = container.querySelector(".hk-placeholder-marquee") as HTMLElement;
+    const input = container.querySelector("input") as HTMLInputElement;
+    input.dispatchEvent(new Event("focus"));
+    await nextTick();
+    expect(host.hasAttribute("data-parked")).toBe(true);
+    input.dispatchEvent(new Event("blur"));
+    await nextTick();
+    expect(host.hasAttribute("data-parked")).toBe(false);
   });
 
   it("drops the overlay once the input holds a value", async () => {

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -1,5 +1,4 @@
 import { defineComponent, ref, computed, onMounted, onBeforeUnmount, watch, type PropType } from "vue";
-import { onFrame } from "../runtime/animationBus";
 
 /**
  * Overflow strategy for a placeholder that does not fit its input.
@@ -11,10 +10,20 @@ import { onFrame } from "../runtime/animationBus";
  *   times side by side inside a clipping window, and translates the strip
  *   leftward in a loop — the classic scrolling storefront sign. The strip
  *   content is identical in all three copies so the wrap-around is seamless.
- *   Animation runs through the hikari animation bus, so it participates in
- *   the unified frame scheduling, pauses under reduced-motion, and parks the
- *   strip at the natural position when the host input is focused. The
- *   `overflowChange` event tells the host when to swap its native
+ *
+ *   The motion is PURE CSS: one registered infinite keyframes animation
+ *   (`hk-placeholder-marquee-scroll`, see animation/registerAnimations.ts)
+ *   whose loop distance and duration live on inline custom properties
+ *   (`--hk-marquee-shift` / `--hk-marquee-duration`), measured once per
+ *   geometry change — never per frame. There is no JS/rAF animation and no
+ *   reactive per-frame transform write, so scrolling the page (or a mobile
+ *   bottom sheet) never competes with the strip for the main thread; the
+ *   animation runs on the compositor. The animation-context switch
+ *   (`setReducedMotion` / performance suspension via
+ *   `html[data-css-animations="0"]`) parks the strip, and the strip also
+ *   parks while the host input is focused (`data-parked`).
+ *
+ *   The `overflowChange` event tells the host when to swap its native
  *   placeholder for the scrolling overlay.
  * - `truncate`: hard-cut the text at the container edge with an ellipsis.
  */
@@ -31,8 +40,6 @@ export const HkPlaceholderMarquee = defineComponent({
     variant: { type: String as PropType<PlaceholderVariant>, default: "marquee" },
     /** Pixels per second of strip travel. Negative scrolls rightward. */
     speed: { type: Number, default: 24 },
-    /** Park delay (ms) while focused — small hold before scrolling resumes. */
-    focusHoldMs: { type: Number, default: 600 },
   },
   emits: {
     overflowChange: (_overflowing: boolean) => true,
@@ -40,13 +47,14 @@ export const HkPlaceholderMarquee = defineComponent({
   setup(props, { emit, expose }) {
     const hostEl = ref<HTMLElement | null>(null);
     const firstCopyEl = ref<HTMLElement | null>(null);
-    const offset = ref(0);
     const overflowing = ref(false);
-    const focused = ref(false);
+    const parked = ref(false);
+    /** One copy's laid-out width (incl. trailing spacing) — reactive so
+     *  the loop geometry republishes when it changes even if the
+     *  overflow state does not (zoom, font swap, text edit mid-overflow). */
+    const loopWidth = ref(0);
 
-    let handle: { disconnect(): void } | null = null;
-    let holdUntil = 0;
-    let copyWidth = 0;
+    let ro: ResizeObserver | null = null;
 
     const measure = () => {
       const host = hostEl.value;
@@ -57,53 +65,55 @@ export const HkPlaceholderMarquee = defineComponent({
       // instead of stripWidth / 3 — stays correct in the fitting case,
       // where the strip holds a single copy, and through overflow flips,
       // where the copy count changes under the same strip.
-      copyWidth = copy.getBoundingClientRect().width;
+      const copyWidth = copy.offsetWidth;
+      loopWidth.value = copyWidth;
       overflowing.value = copyWidth - COPY_SPACING > host.clientWidth;
-      if (!overflowing.value) offset.value = 0;
       emit("overflowChange", overflowing.value);
-    };
-
-    const frame = (ctx: { now: number; delta: number }) => {
-      if (!overflowing.value || focused.value || copyWidth <= 0) return;
-      if (ctx.now < holdUntil) return;
-      // delta is in seconds, matching the animation bus FrameContext —
-      // nominal speed holds regardless of the bus's normal-priority frame
-      // budget (33ms) or the display's refresh rate.
-      offset.value = (offset.value - props.speed * ctx.delta) % copyWidth;
     };
 
     onMounted(() => {
       measure();
-      handle = onFrame(frame, "normal");
       if (typeof ResizeObserver !== "undefined" && hostEl.value) {
         ro = new ResizeObserver(() => measure());
         ro.observe(hostEl.value);
       }
     });
 
-    let ro: ResizeObserver | null = null;
     watch(() => props.text, () => {
       // Re-measure after the DOM paints the new strip.
       requestAnimationFrame(() => measure());
     });
 
     onBeforeUnmount(() => {
-      handle?.disconnect();
       ro?.disconnect();
     });
 
     expose({
       /** Called by the host input: focus parks the strip, blur resumes. */
       setActive(active: boolean) {
-        focused.value = active;
-        if (active) holdUntil = performance.now() + props.focusHoldMs;
+        parked.value = active;
       },
       measure,
     });
 
-    const stripStyle = computed(() => ({
-      transform: `translateX(${offset.value}px)`,
-    }));
+    /** Loop geometry, published as custom properties + a direction flag
+     *  on the strip: the keyframes animate
+     *  `translateX(0 → var(--hk-marquee-shift))` over
+     *  `var(--hk-marquee-duration)` — both measured, never recomputed per
+     *  frame. Duration = one copy width at the configured px/s speed;
+     *  the sign of the speed flips the direction (reverse plays the
+     *  keyframes backwards, which wraps seamlessly on the three copies).
+     *  The duration is clamped away from 0/negative so a 0 or negative
+     *  speed can never invalidate the animation shorthand. */
+    const stripVars = computed(() => {
+      if (!overflowing.value || loopWidth.value <= 0) return undefined;
+      const speed = Number.isFinite(props.speed) ? Math.abs(props.speed) : 24;
+      return {
+        "--hk-marquee-shift": `${-loopWidth.value}px`,
+        "--hk-marquee-duration": `${(loopWidth.value / Math.max(speed, 0.1)).toFixed(3)}s`,
+        "--hk-marquee-direction": (props.speed ?? 24) < 0 ? "reverse" : "normal",
+      } as Record<string, string>;
+    });
 
     return () => {
       if (!props.text) return null;
@@ -124,9 +134,16 @@ export const HkPlaceholderMarquee = defineComponent({
             // placeholder does the showing.
             overflowing.value ? "" : "hk-placeholder-marquee--hidden",
           ].filter(Boolean).join(" ")}
+          data-parked={parked.value || undefined}
           aria-hidden="true"
         >
-          <span class="hk-placeholder-marquee__strip" style={stripStyle.value}>
+          <span
+            class={[
+              "hk-placeholder-marquee__strip",
+              overflowing.value ? "hk-placeholder-marquee__strip--scroll" : "",
+            ].filter(Boolean).join(" ")}
+            style={stripVars.value}
+          >
             <span ref={firstCopyEl} class="hk-placeholder-marquee__copy">{props.text}</span>
             {overflowing.value && (
               <>

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -64,8 +64,12 @@ export const HkPlaceholderMarquee = defineComponent({
       // copy spacing as trailing padding). Reading the first copy element —
       // instead of stripWidth / 3 — stays correct in the fitting case,
       // where the strip holds a single copy, and through overflow flips,
-      // where the copy count changes under the same strip.
-      const copyWidth = copy.offsetWidth;
+      // where the copy count changes under the same strip. The fractional
+      // bounding-rect width keeps the CSS loop shift bit-exact with the
+      // laid-out advance — an integer-rounded width would show a ≤0.5px
+      // seam at every wrap (the copy rides the animated strip, so the
+      // width itself is never affected by the strip's transform).
+      const copyWidth = copy.getBoundingClientRect().width;
       loopWidth.value = copyWidth;
       overflowing.value = copyWidth - COPY_SPACING > host.clientWidth;
       emit("overflowChange", overflowing.value);
@@ -103,14 +107,16 @@ export const HkPlaceholderMarquee = defineComponent({
      *  frame. Duration = one copy width at the configured px/s speed;
      *  the sign of the speed flips the direction (reverse plays the
      *  keyframes backwards, which wraps seamlessly on the three copies).
-     *  The duration is clamped away from 0/negative so a 0 or negative
-     *  speed can never invalidate the animation shorthand. */
+     *  A non-finite or zero speed parks the strip (no scroll class) —
+     *  matching the pre-CSS behavior, where the JS loop simply never
+     *  advanced. */
     const stripVars = computed(() => {
       if (!overflowing.value || loopWidth.value <= 0) return undefined;
       const speed = Number.isFinite(props.speed) ? Math.abs(props.speed) : 24;
+      if (speed === 0) return undefined;
       return {
         "--hk-marquee-shift": `${-loopWidth.value}px`,
-        "--hk-marquee-duration": `${(loopWidth.value / Math.max(speed, 0.1)).toFixed(3)}s`,
+        "--hk-marquee-duration": `${(loopWidth.value / speed).toFixed(3)}s`,
         "--hk-marquee-direction": (props.speed ?? 24) < 0 ? "reverse" : "normal",
       } as Record<string, string>;
     });
@@ -140,7 +146,10 @@ export const HkPlaceholderMarquee = defineComponent({
           <span
             class={[
               "hk-placeholder-marquee__strip",
-              overflowing.value ? "hk-placeholder-marquee__strip--scroll" : "",
+              // The sweep only starts once the loop geometry is known —
+              // overflowing text with a parked speed (0/non-finite) stays
+              // a static strip, matching the old JS behavior.
+              overflowing.value && stripVars.value ? "hk-placeholder-marquee__strip--scroll" : "",
             ].filter(Boolean).join(" ")}
             style={stripVars.value}
           >

--- a/packages/vue/src/components/HkPlaceholderMarquee.tsx
+++ b/packages/vue/src/components/HkPlaceholderMarquee.tsx
@@ -107,9 +107,9 @@ export const HkPlaceholderMarquee = defineComponent({
      *  frame. Duration = one copy width at the configured px/s speed;
      *  the sign of the speed flips the direction (reverse plays the
      *  keyframes backwards, which wraps seamlessly on the three copies).
-     *  A non-finite or zero speed parks the strip (no scroll class) —
-     *  matching the pre-CSS behavior, where the JS loop simply never
-     *  advanced. */
+     *  A zero speed parks the strip (no scroll class) — matching the
+     *  pre-CSS behavior, where the JS loop simply never advanced
+     *  (non-finite speeds fall back to the default rate). */
     const stripVars = computed(() => {
       if (!overflowing.value || loopWidth.value <= 0) return undefined;
       const speed = Number.isFinite(props.speed) ? Math.abs(props.speed) : 24;

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -261,6 +261,17 @@
   bottom: var(--hk-sheet-bottom-gap, 0.375rem);
   display: flex;
   flex-direction: column;
+  /* The panel height hugs its content (up to the cap below); the sheet
+   * morphs smoothly when content grows/shrinks — a language list gaining
+   * or losing rows, a select whose options filter. `height: auto` growth
+   * cannot fire a CSS transition, so HkSelectPanel's useSizeMorph pins
+   * the measured natural height as px (see useSizeMorph) and the
+   * transition below animates old→new px; `interpolate-size: allow-keywords`
+   * stays harmless for the enter/leave slide. */
+  interpolate-size: allow-keywords;
+  transition:
+    height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1)),
+    max-height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
   max-height: min(
     72vh,
     calc(
@@ -376,7 +387,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .hk-select-sheet-enter-active,
-  .hk-select-sheet-leave-active {
+  .hk-select-sheet-leave-active,
+  .hk-select-sheet-panel {
     transition: none;
   }
 }

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -16,6 +16,7 @@ import { useBreakpoint } from "../runtime/useBreakpoint";
 import { createBackGuard } from "../runtime/backStack";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import { useSizeMorph } from "../composables/useSizeMorph";
 import "./HkSelect.scss";
 
 /**
@@ -114,6 +115,33 @@ export default defineComponent({
     const popoutAnim = useSurfaceTransition(250);
     const sheetScrimAnim = useSurfaceTransition(320);
     const sheetPanelAnim = useSurfaceTransition(320);
+    const panelRef = ref<HTMLElement>();
+    const sheetListRef = ref<HTMLElement>();
+    /** Natural-height probe inside the sheet list: the content wrapper
+     *  (slot children), whose height is the content's intrinsic height
+     *  regardless of scroll — the sheet size morph measures this (see
+     *  useSizeMorph). */
+    const sheetContentRef = ref<HTMLElement>();
+    // Content-driven size morphing on the mobile sheet: the panel follows
+    // content growth (a language list gaining rows, filtered options)
+    // with the height transition instead of snapping.
+    const morph = useSizeMorph(panelRef, sheetContentRef);
+    // Sheet panel transition hooks: the surface transition's own set plus
+    // the size-morph lifecycle (arm after enter — pinning during the
+    // slide-up would fight it — and release before the leave). The inner
+    // hooks("panel") call shares the same reported track, so merging is
+    // safe.
+    const sheetPanelHooks = {
+      ...sheetPanelAnim.hooks("panel"),
+      onAfterEnter: () => {
+        sheetPanelAnim.hooks("panel").onAfterEnter();
+        morph.start();
+      },
+      onBeforeLeave: () => {
+        sheetPanelAnim.hooks("panel").onBeforeLeave();
+        morph.stop();
+      },
+    };
 
     // Window-first back priority (HkModal convention): while this panel is
     // the topmost window, the back gesture closes it instead of navigating
@@ -156,8 +184,6 @@ export default defineComponent({
       if (handle.value) manager.setBlocking(handle.value.id, mode);
     });
 
-    const panelRef = ref<HTMLElement>();
-    const sheetListRef = ref<HTMLElement>();
     // Fixed positioning wrapper around the desktop popout — the overlay
     // scrollbar's track host (the popout itself teleports to body, whose
     // box is no positioning context for the tracks).
@@ -222,6 +248,10 @@ export default defineComponent({
       for (const el of list.querySelectorAll<HTMLElement>(
         "h1,h2,h3,h4,h5,h6,p,div,span,strong",
       )) {
+        // The sheet's own content wrapper (a plain div whose textContent
+        // picks up the heading's text) is never the candidate — the scan
+        // must descend to the actual heading it wraps.
+        if (el.classList.contains("hk-select-sheet-content")) continue;
         if ((el.textContent ?? "").trim() !== title) continue;
         if (el.matches(DUP_TITLE_CONTENT)) continue;
         if (el.closest(DUP_TITLE_CONTENT)) continue;
@@ -494,7 +524,7 @@ export default defineComponent({
                 />
               ) : null}
             </Transition>
-            <Transition name="hk-select-sheet" appear {...sheetPanelAnim.hooks("panel")}>
+            <Transition name="hk-select-sheet" appear {...sheetPanelHooks}>
               {props.open ? (
                 <div
                   ref={panelRef}
@@ -515,7 +545,11 @@ export default defineComponent({
                     <div class="hk-select-sheet-title">{props.title}</div>
                   ) : null}
                   <div class="hk-select-sheet-body" ref={sheetBodyRef}>
-                    <div class="hk-select-sheet-list" ref={sheetListRef}>{slots.default?.()}</div>
+                    <div class="hk-select-sheet-list" ref={sheetListRef}>
+                      <div class="hk-select-sheet-content" ref={sheetContentRef}>
+                        {slots.default?.()}
+                      </div>
+                    </div>
                   </div>
                 </div>
               ) : null}

--- a/packages/vue/src/composables/useSizeMorph.test.ts
+++ b/packages/vue/src/composables/useSizeMorph.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+
+import { useSizeMorph } from "./useSizeMorph";
+
+/** Injectable ResizeObserver: captures the callback so tests can fire
+ *  content changes deterministically (happy-dom's own RO never fires —
+ *  there is no layout engine). */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  callback: () => void;
+  observed: Element[] = [];
+  disconnected = false;
+
+  constructor(callback: () => void) {
+    this.callback = callback;
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(el: Element): void {
+    this.observed.push(el);
+  }
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+const originalRO = globalThis.ResizeObserver;
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+interface Harness {
+  frame: HTMLElement;
+  content: HTMLElement;
+  setNatural(height: number): void;
+  start(): void;
+  stop(): void;
+  remeasure(): void;
+}
+
+function mountHarness(initialHeight: number): Harness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let frameEl: HTMLElement | null = null;
+  let contentEl: HTMLElement | null = null;
+  let natural = initialHeight;
+  let morph: ReturnType<typeof useSizeMorph> | null = null;
+  const app = createApp({
+    setup() {
+      const frame = ref<HTMLElement | null>(null);
+      const content = ref<HTMLElement | null>(null);
+      morph = useSizeMorph(frame, content);
+      return () =>
+        h("div", [
+          h("div", {
+            ref: (el: unknown) => {
+              frame.value = (el as HTMLElement | null) ?? null;
+              frameEl = frame.value;
+              if (frameEl) {
+                Object.defineProperty(frameEl, "offsetHeight", {
+                  configurable: true,
+                  get: () => natural,
+                });
+              }
+            },
+            class: "frame",
+          }, [
+            h("div", {
+              ref: (el: unknown) => {
+                content.value = (el as HTMLElement | null) ?? null;
+                contentEl = content.value;
+              },
+              class: "content",
+            }, "content"),
+          ]),
+        ]);
+    },
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return {
+    frame: frameEl!,
+    content: contentEl!,
+    setNatural: (h: number) => {
+      natural = h;
+    },
+    start: () => morph!.start(),
+    stop: () => morph!.stop(),
+    remeasure: () => morph!.remeasure(),
+  };
+}
+
+beforeEach(() => {
+  FakeResizeObserver.instances = [];
+  globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalRO;
+  vi.useRealTimers();
+  for (const m of mounts.splice(0)) {
+    m.app.unmount();
+    m.container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+/** Wait past the 150ms settle debounce + the rAF hop. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 220));
+  await nextTick();
+}
+
+describe("useSizeMorph", () => {
+  it("pins the frame to its natural height on start", () => {
+    const h = mountHarness(120);
+    h.start();
+    expect(h.frame.style.height).toBe("120px");
+  });
+
+  it("re-pins through a content change and keeps the live transition restored", async () => {
+    const h = mountHarness(120);
+    h.start();
+    h.setNatural(160);
+    FakeResizeObserver.instances[0]!.callback();
+    await settle();
+    expect(h.frame.style.height).toBe("160px");
+    // The dance restored whatever inline transition the CSS had (none
+    // set here — the inline attribute must be gone, not "none").
+    expect(h.frame.style.transition).toBe("");
+    // The observer watches the content element.
+    expect(FakeResizeObserver.instances[0]!.observed).toEqual([h.content]);
+  });
+
+  it("keeps the last pin when a measurement returns no layout (bail path)", () => {
+    const h = mountHarness(120);
+    h.start();
+    h.setNatural(0);
+    h.remeasure();
+    expect(h.frame.style.height).toBe("120px");
+    expect(h.frame.style.transition).toBe("");
+  });
+
+  it("release returns the frame to auto on stop", () => {
+    const h = mountHarness(120);
+    h.start();
+    h.stop();
+    expect(h.frame.style.height).toBe("");
+    expect(FakeResizeObserver.instances[0]!.disconnected).toBe(true);
+  });
+
+  it("does nothing while disarmed", () => {
+    const h = mountHarness(120);
+    h.remeasure();
+    expect(h.frame.style.height).toBe("");
+  });
+});

--- a/packages/vue/src/composables/useSizeMorph.ts
+++ b/packages/vue/src/composables/useSizeMorph.ts
@@ -1,0 +1,149 @@
+import { onBeforeUnmount, type Ref } from "vue";
+
+export interface SizeMorph {
+  /** Arm the morph: observe the content and pin the frame's natural
+   *  height on every change. Call once the surface finished its open
+   *  enter transition — pinning during enter would override the
+   *  choreography's own height animation. */
+  start(): void;
+  /** Disarm the morph and release the frame to `height: auto` — call
+   *  before a surface's leave/close so the exit animation owns the
+   *  height again. */
+  stop(): void;
+  /** Re-measure and pin now (resize events, open flows). */
+  remeasure(): void;
+}
+
+/**
+ * useSizeMorph — smooth size morphing for content-hugging surfaces.
+ *
+ * Modals and bottom sheets size themselves from their content
+ * (`height: auto`), and CSS cannot fire a height transition for an
+ * auto→auto growth — even under `interpolate-size: allow-keywords`
+ * neither `auto` nor `calc-size(auto, size)` changes its computed value
+ * when the content grows (verified in Chromium), so the frame simply
+ * snaps. This composable closes the gap: a ResizeObserver on the content
+ * reports every change, the frame's natural (capped) height is measured,
+ * and it is pinned as an explicit px value so the frame's CSS height
+ * transition animates old→new.
+ *
+ * Measurement uses a transition-disabled dance so the browser's
+ * before/after style bookkeeping stays clean: transitions are switched
+ * off while the pin is released/measured/restored (no animation, no
+ * repaint inside the task — the intermediate frames are never painted),
+ * the OLD pin is re-established first, and only then does the new pin
+ * flip under the LIVE transition — a real computed-value change from the
+ * old height, so the animation plays instead of snapping.
+ *
+ * The observer does no per-frame work at rest: it fires only on actual
+ * content changes (bursts collapse into one rAF), and during a morph the
+ * pin chases the target with the CSS transition — bounded, one-shot
+ * choreography, not an infinite per-frame animation.
+ *
+ * Reduced motion / the global animation switch stay honored: the frame's
+ * transition-duration collapses to one frame under
+ * `html[data-css-animations="0"]`, so the pin updates snap.
+ */
+export function useSizeMorph(
+  frame: Ref<HTMLElement | null | undefined>,
+  content: Ref<HTMLElement | null | undefined>,
+): SizeMorph {
+  let ro: ResizeObserver | null = null;
+  let raf = 0;
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  let armed = false;
+  /** Last pinned height (px) — the transition's "from" value. */
+  let pinned = 0;
+
+  function release(): void {
+    const f = frame.value;
+    if (f) f.style.height = "";
+    pinned = 0;
+  }
+
+  function remeasure(): void {
+    if (!armed) return;
+    const f = frame.value;
+    const c = content.value;
+    if (!f || !c) return;
+    // 1. Disable transitions, release the pin and measure the frame's
+    //    natural (CSS-capped) height in one layout flush.
+    // 2. Re-establish the OLD pin (still transition-disabled) and flush
+    //    it, so the style history is exactly "old height" when the live
+    //    CSS transition returns.
+    // 3. Flip to the NEW pin under the live transition — the computed
+    //    value changes old→new, so the height transition animates.
+    // No paint happens between the steps: they run in one task and the
+    // layout flushes are invisible to the screen.
+    const inlineTransition = f.style.transition;
+    f.style.transition = "none";
+    f.style.height = "";
+    const natural = f.offsetHeight;
+    if (natural <= 0) {
+      // Keep pre-transition state intact and bail.
+      if (pinned > 0) f.style.height = `${pinned}px`;
+      f.style.transition = inlineTransition;
+      return;
+    }
+    if (pinned > 0) f.style.height = `${pinned}px`;
+    // Flush the old-pin state before re-enabling the transition.
+    void f.offsetHeight;
+    f.style.transition = inlineTransition;
+    f.style.height = `${Math.round(natural)}px`;
+    pinned = Math.round(natural);
+  }
+
+  function onResize(): void {
+    // Debounce the choreography: content can change in a burst (a list
+    // transition shrinking rows over several frames, a textarea growing
+    // per keystroke). Dancing to every intermediate would restart the
+    // frame's transition mid-flight and cause backwards flicks; instead
+    // measure once the content settled (~150ms quiet) and morph after.
+    // A keystroke while the debounce runs just pushes the update later.
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => {
+      settleTimer = null;
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        remeasure();
+      });
+    }, 150);
+  }
+
+  function start(): void {
+    if (armed) return;
+    armed = true;
+    if (typeof ResizeObserver === "undefined" || !content.value) {
+      remeasure();
+      return;
+    }
+    ro = new ResizeObserver(onResize);
+    ro.observe(content.value);
+    remeasure();
+  }
+
+  function stop(): void {
+    if (!armed) return;
+    armed = false;
+    ro?.disconnect();
+    ro = null;
+    if (settleTimer) {
+      clearTimeout(settleTimer);
+      settleTimer = null;
+    }
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+    release();
+  }
+
+  onBeforeUnmount(() => {
+    ro?.disconnect();
+    if (settleTimer) clearTimeout(settleTimer);
+    if (raf) cancelAnimationFrame(raf);
+  });
+
+  return { start, stop, remeasure };
+}

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "المسؤولون",
     "hikari::localizedInput.addLanguage": "إضافة لغة",
     "hikari::localizedInput.removeTranslation": "إزالة الترجمة",
+    "hikari::localizedInput.switchLanguage": "التبديل إلى",
+    "hikari::localizedInput.confirmDelete": "تأكيد الحذف",
     "hikari::localizedInput.translations": "الترجمات الحالية",
     "hikari::localizedInput.chooseLanguage": "اختر لغة التحرير",
     "hikari::statusBar.panel": "اللوحة",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administratoren",
     "hikari::localizedInput.addLanguage": "Sprache hinzufügen",
     "hikari::localizedInput.removeTranslation": "Übersetzung entfernen",
+    "hikari::localizedInput.switchLanguage": "Wechseln zu",
+    "hikari::localizedInput.confirmDelete": "Löschen bestätigen",
     "hikari::localizedInput.translations": "Vorhandene Übersetzungen",
     "hikari::localizedInput.chooseLanguage": "Bearbeitungssprache wählen",
     "hikari::statusBar.panel": "Panel",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administrators",
     "hikari::localizedInput.addLanguage": "Add language",
     "hikari::localizedInput.removeTranslation": "Remove translation",
+    "hikari::localizedInput.switchLanguage": "Switch to",
+    "hikari::localizedInput.confirmDelete": "Confirm delete",
     "hikari::localizedInput.translations": "Existing translations",
     "hikari::localizedInput.chooseLanguage": "Choose editing language",
     "hikari::statusBar.panel": "Panel",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Añadir idioma",
     "hikari::localizedInput.removeTranslation": "Eliminar traducción",
+    "hikari::localizedInput.switchLanguage": "Cambiar a",
+    "hikari::localizedInput.confirmDelete": "Confirmar eliminación",
     "hikari::localizedInput.translations": "Traducciones existentes",
     "hikari::localizedInput.chooseLanguage": "Elegir idioma de edición",
     "hikari::statusBar.panel": "Panel",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administrateurs",
     "hikari::localizedInput.addLanguage": "Ajouter une langue",
     "hikari::localizedInput.removeTranslation": "Supprimer la traduction",
+    "hikari::localizedInput.switchLanguage": "Basculer vers",
+    "hikari::localizedInput.confirmDelete": "Confirmer la suppression",
     "hikari::localizedInput.translations": "Traductions existantes",
     "hikari::localizedInput.chooseLanguage": "Choisir la langue d’édition",
     "hikari::statusBar.panel": "Panneau",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理者",
     "hikari::localizedInput.addLanguage": "言語を追加",
     "hikari::localizedInput.removeTranslation": "翻訳を削除",
+    "hikari::localizedInput.switchLanguage": "切り替え先",
+    "hikari::localizedInput.confirmDelete": "削除を確認",
     "hikari::localizedInput.translations": "既存の翻訳",
     "hikari::localizedInput.chooseLanguage": "編集言語を選択",
     "hikari::statusBar.panel": "パネル",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "관리자",
     "hikari::localizedInput.addLanguage": "언어 추가",
     "hikari::localizedInput.removeTranslation": "번역 삭제",
+    "hikari::localizedInput.switchLanguage": "전환 대상",
+    "hikari::localizedInput.confirmDelete": "삭제 확인",
     "hikari::localizedInput.translations": "기존 번역",
     "hikari::localizedInput.chooseLanguage": "편집 언어 선택",
     "hikari::statusBar.panel": "패널",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Adicionar idioma",
     "hikari::localizedInput.removeTranslation": "Remover tradução",
+    "hikari::localizedInput.switchLanguage": "Alternar para",
+    "hikari::localizedInput.confirmDelete": "Confirmar exclusão",
     "hikari::localizedInput.translations": "Traduções existentes",
     "hikari::localizedInput.chooseLanguage": "Escolher idioma de edição",
     "hikari::statusBar.panel": "Painel",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Администраторы",
     "hikari::localizedInput.addLanguage": "Добавить язык",
     "hikari::localizedInput.removeTranslation": "Удалить перевод",
+    "hikari::localizedInput.switchLanguage": "Переключиться на",
+    "hikari::localizedInput.confirmDelete": "Подтвердить удаление",
     "hikari::localizedInput.translations": "Существующие переводы",
     "hikari::localizedInput.chooseLanguage": "Выбрать язык редактирования",
     "hikari::statusBar.panel": "Панель",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理员",
     "hikari::localizedInput.addLanguage": "添加新语言",
     "hikari::localizedInput.removeTranslation": "删除该翻译",
+    "hikari::localizedInput.switchLanguage": "切换至",
+    "hikari::localizedInput.confirmDelete": "确认删除",
     "hikari::localizedInput.translations": "已有翻译",
     "hikari::localizedInput.chooseLanguage": "选择编辑语言",
     "hikari::statusBar.panel": "面板",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理員",
     "hikari::localizedInput.addLanguage": "新增語言",
     "hikari::localizedInput.removeTranslation": "刪除該翻譯",
+    "hikari::localizedInput.switchLanguage": "切換至",
+    "hikari::localizedInput.confirmDelete": "確認刪除",
     "hikari::localizedInput.translations": "已有翻譯",
     "hikari::localizedInput.chooseLanguage": "選擇編輯語言",
     "hikari::statusBar.panel": "面板",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -215,6 +215,8 @@ export type {
   SurfaceTransition,
   SurfaceTransitionHooks,
 } from "./composables/useSurfaceTransition";
+export { useSizeMorph } from "./composables/useSizeMorph";
+export type { SizeMorph } from "./composables/useSizeMorph";
 
 export { useZoomPan } from "./composables/useZoomPan";
 export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";

--- a/packages/vue/src/theme/theme.scss
+++ b/packages/vue/src/theme/theme.scss
@@ -57,10 +57,17 @@
 // not display:none — keeps layouts stable and is cheap. The rules are
 // attribute-scoped so they compose with the per-component
 // `prefers-reduced-motion` blocks instead of fighting them.
+//
+// Transitions participate in the same switch: duration collapses to one
+// frame, so surface/list choreography (popup fades, list squeeze-ins,
+// modal/sheet size morphing) snaps to its end state during suspension
+// instead of running motion the context asked to stop.
 html[data-css-animations="0"] *,
 html[data-css-animations="0"] *::before,
 html[data-css-animations="0"] *::after {
   animation-play-state: paused !important;
+  transition-duration: 0.01ms !important;
+  transition-delay: 0 !important;
 }
 
 // Smooth scrolling is the keyframes' most expensive friend — it drives


### PR DESCRIPTION
## What & why

Mobile Web UI round for the localized (i18n) input and the animation context (user-reported):

1. **Placeholder sweep no longer janks on mobile.** `HkPlaceholderMarquee` was driving the marquee through a per-frame JS callback that wrote a reactive transform every animation frame (Vue patch per frame, competing with page/sheet scroll on the main thread). The sweep is now ONE registered CSS keyframes animation (`hk-placeholder-marquee-scroll`) whose loop distance/duration ride inline custom properties — measured once per geometry change, never per frame; the transform runs on the compositor. Animation-context participation: registered in `registerAnimations.ts` (so `setReducedMotion` / perf suspension parks the strip at its natural reading position), focus parks via `data-parked` (play-state), and the strip keeps the exact 3-copy seamless wrap.
2. **Language list redesign (arm → confirm delete).** Rows replace the pill cloud: every language present — the one being edited included, with an empty glyph while it holds no text — is a row with the translation text LEFT and the same language chip as the closed field RIGHT (text edge aligned with the sheet title inset / popout option text edge). Chip click arms the delete (row turns danger-red, a confirm × widens into the chip slot, pushing the label a step leftward); the × click erases for real. Desktop: hovering the row swaps the × in, one click confirms. The menu stays open for multi-erase passes; arming a sibling disarms the previous row; closing the menu disarms. Rows animate in/out with space squeeze via `HkListTransition` (new `appear` + move + animation-bus reporting). A leading `Languages` glyph balances the field against the right chip; a11y: body/chip/× carry step-accurate labels, and the × leaves the tab order until armed.
3. **Modal + bottom-sheet size morphs.** `auto`-height growth cannot fire a CSS transition (verified in Chromium), so a new exported `useSizeMorph` composable watches a surface's content and pins the measured natural height as px — the frame's height transition then animates old→new. Wired into `HkModal` (after the open enter; released before leave) and the mobile `HkSelectPanel` sheet. `HkListTransition` additionally reports its batches to the animation context (refcounted per child), and the global animation switch (`html[data-css-animations="0"]`) now collapses transition durations too — reduced motion / perf suspension snaps keyframes and transitions alike.

## Verification

- vue-tsc: 0 errors.
- vitest full suite: 680 tests, 679 pass. The single failure is the pre-existing date-dependent `HkDatePicker` "marks the selected day and today in the grid" (confirmed failing identically on clean master at the branch point; the not-yet-2027 hardcoded year), plus a known run-order-timing flaky HkMenu cascade test that passes in isolation. All targeted suites (localized input, marquee, useSizeMorph, select panel, modal, menu, affix, registrar) green; 13 net new passing tests over master.
- Real-Chromium checks (page samples): strip transform advances ~24px/s exclusively via CSS; `data-parked` freezes it; `html[data-css-animations="0"]` parks it at the natural position; the size-morph pin+height-transition recipe animates old→new smoothly.
- Adversarial review: 3 rounds (2 independent reviewers) — R1 found 7 issues (keyboard × bypass, a11y names, label swap, speed clamp, leave-clickability, report refcount, test gaps), all fixed and re-verified; R2 SHIP; R3 final gate PASS with only the documented pre-existing flakes.

## Notes

- `HkPlaceholderMarquee.focusHoldMs` prop removed (was only meaningful for the old JS park delay; the CSS park is immediate). `HkPlaceholderMarquee` is internally used in this repo; consumers pass no such prop.
- `HkListTransition` gains `appear` (default false), `useSizeMorph` is exported — both additive.
- Version: packages/vue `0.27.0 → 0.28.0`.
