### PR TITLE
🐛 Fix theme sheet dead space and segmented merge width jumps.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -203,7 +203,8 @@
 
 /* === Merged cell (dynamic merged-option rendering) ===
  * The contiguous run of options listed in `mergeKeys` collapses into ONE
- * combined cell (the #merged slot) — a REAL flex child of the track,
+ * combined cell (the #merged slot) — a REAL in-flow child of the track
+ * (a grid item on slot-unit strips, see the distribution rules below),
  * not an absolute cover: it joins layout and the animation context
  * (hk-tabs-swap enter/leave + the sliding indicator measures it when
  * the active option is merged). Chrome follows the unselected-option
@@ -240,4 +241,43 @@
 
 .hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"] .hk-tabs-merged {
   flex: 1 0 auto;
+}
+
+/* === Slot-unit distribution (block strips carrying data-slots) ===
+ * A merged cell always spans its run's option count and TabItem.span
+ * may weight any trigger; the row is then divided into one equal 1fr
+ * track per unit, NOT by content. This is what makes dynamic merging
+ * width-stable: the theme toggle's altitude strip replaces the
+ * Light+Dark pair and occupies EXACTLY the two one-unit tracks those
+ * triggers owned, so toggling auto ↔ manual never re-measures any
+ * cell — the strip neither narrows (desktop content-size case) nor
+ * re-divides (mobile block case, thirds stay thirds).
+ *
+ * The division is a GRID because flex-basis math cannot give padded
+ * items exact equal units: a zero flex basis still leaves each item's
+ * own padding riding on its share (item = padding + share of the
+ * remainder), so a 12px-padded trigger consistently stole ~8-16px from
+ * its neighbors. Grid `1fr` tracks are exact regardless of item
+ * padding, borders or content, in both the definite-width and the
+ * `width: max-content; min-width: 100%` intrinsic contexts.
+ *
+ * `minmax(min-content, 1fr)` keeps the never-clip contract: when the
+ * row runs tight a track floors at its content and the max-content
+ * list scrolls instead; the cell's flex-era `min-width: 0` is reset to
+ * `auto` so its content keeps counting toward its track's floor. The
+ * sliding indicator (absolute, positioned from JS measurements) and
+ * the swap transition's absolute leaving items are untouched by the
+ * display switch. Keep this AFTER the rules it overrides
+ * (equal-or-higher specificity + source order). */
+.hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] {
+  display: grid;
+  grid-template-columns: repeat(var(--hk-tabs-units, 1), minmax(min-content, 1fr));
+}
+
+.hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] > .hk-tabs-trigger,
+.hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] > .hk-tabs-trigger,
+.hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] > .hk-tabs-merged,
+.hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] > .hk-tabs-merged {
+  grid-column: span var(--hk-tabs-span, 1) / span var(--hk-tabs-span, 1);
+  min-width: auto;
 }

--- a/packages/vue/src/components/HkTabs.test.ts
+++ b/packages/vue/src/components/HkTabs.test.ts
@@ -1,7 +1,12 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { createApp, defineComponent, h, nextTick, ref } from "vue";
 
 import HkTabs from "./HkTabs";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 const mounts: ReturnType<typeof createApp>[] = [];
 const containers: HTMLElement[] = [];
@@ -407,5 +412,106 @@ describe("HkTabs segmented variant", () => {
     mounts.push(app);
     app.mount(container);
     expect(container.querySelector(".hk-tabs-trigger-icon .glyph")).not.toBeNull();
+  });
+
+  it("flags block strips with a merged run for slot-unit distribution", async () => {
+    const { container } = mountLive(
+      { variant: "segmented", block: true, mergeKeys: ["b", "c"] },
+      { merged: () => h("span", { class: "strip" }, "m") },
+    );
+    await settle();
+    const list = container.querySelector<HTMLElement>(".hk-tabs-list")!;
+    expect(list.getAttribute("data-slots")).toBe("");
+    // The strip announces its total unit count (three options, two of
+    // which are replaced by the two-unit cell → still three units) and
+    // the surviving trigger carries its unit weight; the merged cell
+    // carries the run length — two one-unit slots become one two-unit
+    // cell, so the row's division is identical before and after merging.
+    expect(list.style.getPropertyValue("--hk-tabs-units")).toBe("3");
+    const trig = list.querySelector<HTMLElement>(".hk-tabs-trigger")!;
+    expect(trig.style.getPropertyValue("--hk-tabs-span")).toBe("1");
+    const cell = list.querySelector<HTMLElement>(".hk-tabs-merged")!;
+    expect(cell.style.getPropertyValue("--hk-tabs-span")).toBe("2");
+
+    // Slot units are a block-strip layout extra: an inline strip with
+    // the same merge stays content-sized and never gets the attribute.
+    const inline = mountLive(
+      { variant: "segmented", mergeKeys: ["b", "c"] },
+      { merged: () => h("span", "m") },
+    );
+    const inlineList = inline.container.querySelector<HTMLElement>(".hk-tabs-list")!;
+    expect(inlineList.hasAttribute("data-slots")).toBe(false);
+    expect(inlineList.style.getPropertyValue("--hk-tabs-units")).toBe("");
+  });
+
+  it("keeps plain block strips off slot units", () => {
+    // No merge, no spans → the content-sized block flex is untouched.
+    const { container } = mountLive({ variant: "segmented", block: true });
+    const list = container.querySelector<HTMLElement>(".hk-tabs-list")!;
+    expect(list.hasAttribute("data-slots")).toBe(false);
+    expect(list.style.getPropertyValue("--hk-tabs-units")).toBe("");
+  });
+
+  it("weights a TabItem span onto slot-unit distribution", () => {
+    const { container } = mountLive({
+      variant: "segmented",
+      block: true,
+      tabs: [
+        { key: "a", label: "Alpha" },
+        { key: "b", label: "Beta", span: 2 },
+      ],
+    });
+    const list = container.querySelector<HTMLElement>(".hk-tabs-list")!;
+    expect(list.getAttribute("data-slots")).toBe("");
+    expect(list.style.getPropertyValue("--hk-tabs-units")).toBe("3");
+    const trigs = list.querySelectorAll<HTMLElement>(".hk-tabs-trigger");
+    expect(trigs[0].style.getPropertyValue("--hk-tabs-span")).toBe("1");
+    expect(trigs[1].style.getPropertyValue("--hk-tabs-span")).toBe("2");
+  });
+
+  it("clamps bogus span values to sane slot units", () => {
+    const { container } = mountLive({
+      variant: "segmented",
+      block: true,
+      tabs: [
+        { key: "a", label: "Alpha", span: 0 },
+        { key: "b", label: "Beta", span: -3 },
+        { key: "c", label: "Gamma", span: 1.9 },
+      ],
+    });
+    const list = container.querySelector<HTMLElement>(".hk-tabs-list")!;
+    // Zero/negative degrade to single slots; 1.9 rounds to 2 — the strip
+    // stays a coherent slot grid (four units across three options).
+    expect(list.getAttribute("data-slots")).toBe("");
+    expect(list.style.getPropertyValue("--hk-tabs-units")).toBe("4");
+    const spans = [...list.querySelectorAll<HTMLElement>(".hk-tabs-trigger")].map(
+      (el) => el.style.getPropertyValue("--hk-tabs-span"),
+    );
+    expect(spans).toEqual(["1", "1", "2"]);
+  });
+
+  it("pins the slot-unit grid contract in the stylesheet source", () => {
+    // happy-dom performs no layout, so the geometry itself can't be
+    // asserted here; pin the declarations the layout depends on instead
+    // — deleting or gutting the slot-unit rules must turn this red.
+    const scss = readFileSync(join(here, "HkTabs.scss"), "utf-8");
+    const listRule = scss.match(
+      /\.hk-tabs-list\[data-variant="segmented"\]\[data-block="true"\]\[data-slots\]\s*\{([^}]*)\}/,
+    );
+    expect(listRule).toBeTruthy();
+    expect(listRule![1]).toContain("display: grid");
+    expect(listRule![1]).toContain(
+      "repeat(var(--hk-tabs-units, 1), minmax(min-content, 1fr))",
+    );
+    // The item rule must place items by span and must NOT reintroduce a
+    // flex distribution — flex-basis math skews the units by item padding.
+    const itemRule = scss.match(
+      /\[data-slots\] > \.hk-tabs-trigger[\s\S]*?\{([^}]*)\}/,
+    );
+    expect(itemRule).toBeTruthy();
+    expect(itemRule![1]).toContain(
+      "grid-column: span var(--hk-tabs-span, 1)",
+    );
+    expect(itemRule![1]).not.toMatch(/\bflex:/);
   });
 });

--- a/packages/vue/src/components/HkTabs.tsx
+++ b/packages/vue/src/components/HkTabs.tsx
@@ -18,6 +18,18 @@ export interface TabItem {
    *  slot wins when provided). */
   icon?: unknown;
   disabled?: boolean;
+  /**
+   * Slot-unit width for block (row-filling) strips: how many equal
+   * option slots this trigger occupies (default 1). Declaring ANY span
+   * (or using a merged cell, which always spans its run length) flips
+   * the strip onto slot-unit distribution — one `1fr` grid track per
+   * unit — so every option lands on an exact fraction of the row and
+   * the total width stays constant while options merge and unmerge
+   * (the theme toggle's altitude strip keeps the exact Light+Dark
+   * footprint it replaces). Fractional values round and values below 1
+   * clamp to 1. Ignored outside block strips.
+   */
+  span?: number;
 }
 
 /** A protruding icon button at one inline end of the strip (the former
@@ -66,11 +78,16 @@ interface ScrollerExpose {
  * - `mergeKeys` + the `#merged` slot: DYNAMIC MERGED-OPTION rendering —
  *   a contiguous run of options collapses into ONE combined cell (e.g.
  *   the theme toggle's solar-altitude strip replacing the manual halves
- *   while "auto" is active). The cell is a real flex child of the track
- *   (never an absolute cover), so it joins layout AND the animation
+ *   while "auto" is active). The cell is a real in-flow child of the
+ *   track (never an absolute cover), so it joins layout AND the animation
  *   context: options/cells fade-swap on merge changes, and the sliding
  *   indicator measures the cell when the active key is merged. Merged
  *   options are skipped by keyboard navigation;
+ * - slot-unit distribution (block strips): a merged cell always spans
+ *   its run's option count and `TabItem.span` may size any trigger —
+ *   the row is then divided into one equal `1fr` grid track per unit,
+ *   so merging Light+Dark into the altitude strip swaps TWO one-unit
+ *   slots for ONE two-unit cell and nothing else on the strip moves;
  * - full arrow-key navigation (arrows/Home/End, wrapping, disabled tabs
  *   skipped, selection follows focus) and roving tabindex.
  */
@@ -115,8 +132,8 @@ export default defineComponent({
      *  ONE merged cell rendered by the `#merged` slot (dynamic
      *  merged-option rendering). Merged triggers are not rendered and
      *  are skipped by keyboard navigation; the cell takes the first
-     *  merged option's place as a real flex child of the track, joining
-     *  layout AND the animation context (swap transitions + the sliding
+     *  merged option's place as a real in-flow child of the track,
+     *  joining layout AND the animation context (swap transitions + the sliding
      *  indicator measures it when the active key is merged). Pass
      *  undefined/empty to disable. A single-key run is allowed — note
      *  the cell is role=presentation, so that option leaves the radio/
@@ -171,6 +188,38 @@ export default defineComponent({
     function isMergedTab(tab: TabItem): boolean {
       return hasMergedCell.value && mergeSet.value.has(tab.key);
     }
+    /** Slot-unit weight of an option (TabItem.span): non-integers round
+     *  and the value is clamped into [1, 64], so a bogus or absurd value
+     *  degrades to sane track counts instead of poisoning the grid
+     *  (browsers cap repeat() counts; beyond that the declaration would
+     *  become invalid at computed-value time and drop the division). */
+    function slotSpan(tab: TabItem): number {
+      const s = tab.span;
+      if (typeof s !== "number" || s < 1) return 1;
+      return Math.min(64, Math.max(1, Math.round(s)));
+    }
+    /** Slot-unit distribution (block strips only): active when a merged
+     *  cell actually renders (it always spans its run length) or ANY
+     *  option declares a span. Plain strips — including a degraded merge
+     *  that fell back to plain triggers — never see the attribute and
+     *  keep the content-sized block flex exactly as before. */
+    const slotMode = computed(
+      () =>
+        hasMergedCell.value ||
+        props.tabs.some((tb) => slotSpan(tb) !== 1),
+    );
+    /** Total slot units the strip is divided into while in slot mode:
+     *  every rendered option contributes its clamped span, and the
+     *  merged cell contributes its run's option count (it replaces
+     *  those triggers). Matches the grid track count in HkTabs.scss. */
+    const slotUnits = computed(() => {
+      let units = 0;
+      for (const tb of props.tabs) {
+        if (isMergedTab(tb)) continue;
+        units += slotSpan(tb);
+      }
+      return units + (hasMergedCell.value ? mergedRun.value.length : 0);
+    });
     /** Navigable = rendered trigger: not disabled, not whole-strip
      *  disabled upstream, and not collapsed into the merged cell. */
     function isNavigable(tab: TabItem): boolean {
@@ -397,7 +446,7 @@ export default defineComponent({
       props.tabs.forEach((tab, idx) => {
         if (isMergedTab(tab)) {
           // The merged run renders as ONE combined cell at its first
-          // option's position — a real flex child of the track (joins
+          // option's position — a real in-flow child of the track (joins
           // layout and the swap/indicator animation context), never an
           // absolute cover. role=presentation: the radiogroup's a11y
           // surface is the remaining triggers; interactive slot content
@@ -411,6 +460,9 @@ export default defineComponent({
                 role="presentation"
                 data-keys={mergedRun.value.join(" ")}
                 data-disabled={props.disabled || undefined}
+                // The cell occupies as many slot units as the options it
+                // replaces (see HkTabs.scss slot-unit distribution).
+                style={{ "--hk-tabs-span": String(mergedRun.value.length) }}
               >
                 {slots.merged?.({ keys: mergedRun.value })}
               </div>,
@@ -433,6 +485,9 @@ export default defineComponent({
             class="hk-tabs-trigger"
             data-active={active || undefined}
             data-disabled={props.disabled || disabled || undefined}
+            // Slot-unit weight (1 unless the option declares a span);
+            // only consumed while the strip carries data-slots.
+            style={{ "--hk-tabs-span": String(slotSpan(tab)) }}
             // Roving tabindex: the active trigger joins the page tab
             // sequence, the others stay arrow-reachable.
             tabindex={active || idx === fallbackTabbableIdx.value ? undefined : -1}
@@ -452,6 +507,14 @@ export default defineComponent({
           ref={listRef}
           data-variant={props.variant}
           data-block={isBlock.value ? "true" : undefined}
+          // Block strips on slot units divide the row into one equal
+          // 1fr track per unit instead of by content — see HkTabs.scss.
+          data-slots={isBlock.value && slotMode.value ? "" : undefined}
+          style={
+            isBlock.value && slotMode.value
+              ? { "--hk-tabs-units": String(slotUnits.value) }
+              : undefined
+          }
           role={isSegmented.value ? "radiogroup" : "tablist"}
           onKeydown={onKeydown}
         >

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -115,21 +115,18 @@
 }
 
 /* ── Theme list rows ────────────────────────────────────────────────────
- * Every row shares identical geometry: [pill button][fixed trailing slot].
- * Non-custom themes get an invisible slot mirroring the delete button's
- * footprint, so every active highlight is exactly the same width.
+ * Every row is ONE full-width pill: the delete affordance for custom
+ * themes overlays the pill's trailing edge (the row is the positioning
+ * context), so built-in rows reserve no trailing column — the old
+ * invisible slot left a permanent dead strip right of every row in the
+ * mobile bottom sheet — and every pill and highlight still shares the
+ * exact same width.
  */
 
 .s-theme-item-row {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: var(--space-4, 0.25rem);
-}
-
-.s-theme-item-slot {
-  width: 1.5rem;
-  height: 1.5rem;
-  flex-shrink: 0;
 }
 
 /* Theme rows speak the SAME grammar as every dropdown option
@@ -165,6 +162,11 @@
   white-space: nowrap;
 }
 
+/* Custom rows keep the name clear of the overlaid delete button. */
+.s-theme-item-row[data-custom] .s-theme-item-name {
+  margin-right: 2rem;
+}
+
 .s-theme-item-check {
   flex-shrink: 0;
   color: rgb(var(--color-primary));
@@ -183,13 +185,19 @@
   font-weight: 600;
 }
 
+/* Delete affordance for custom themes — an overlay pinned inside the
+ * pill's trailing edge (the row is relative), not a reserved column:
+ * built-in rows show nothing there and the pill runs to the row edge. */
 .s-theme-item-delete {
+  position: absolute;
+  right: var(--space-8, 0.5rem);
+  top: 50%;
+  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 1.5rem;
   height: 1.5rem;
-  flex-shrink: 0;
   border: none;
   border-radius: var(--radius-sm, 6px);
   background: transparent;
@@ -205,9 +213,8 @@
 /* Touch-sized rows on phone widths — the same sheet bump the shared
  * surfaces apply (.hk-select-sheet-list .hk-select-option → 14px
  * vertical, .hk-select-sheet-panel .hk-menu-row → 44px min-height).
- * The trailing slot mirrors the delete button's bumped footprint so
- * the equal-highlight-width invariant across custom/non-custom rows
- * survives on mobile too. */
+ * The overlaid delete button grows with them and the name clearance
+ * follows so the two never collide on long custom scheme names. */
 @media (max-width: 767px) {
   .s-theme-item-btn {
     min-height: 44px;
@@ -219,8 +226,7 @@
     height: 2.25rem;
   }
 
-  .s-theme-item-slot {
-    width: 2.25rem;
-    height: 2.25rem;
+  .s-theme-item-row[data-custom] .s-theme-item-name {
+    margin-right: 2.75rem;
   }
 }

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -155,10 +155,14 @@ describe("HkThemeToggle color-mode group", () => {
     const strip = altitudeStrip();
     expect(strip).toBeTruthy();
     expect(strip!.textContent).toMatch(/[+-]?\d+(?:\.\d+)?°/);
-    const cell = strip!.closest(".hk-tabs-merged");
+    const cell = strip!.closest<HTMLElement>(".hk-tabs-merged");
     expect(cell).toBeTruthy();
     expect(cell!.getAttribute("data-keys")).toBe("light dark");
     expect(cell!.parentElement?.classList.contains("hk-tabs-list")).toBe(true);
+    // Slot-unit width: the cell spans the two options it replaces, so
+    // the group divides exactly as it did before the merge.
+    expect(cell!.style.getPropertyValue("--hk-tabs-span")).toBe("2");
+    expect(cell!.parentElement!.getAttribute("data-slots")).toBe("");
     expect(document.body.querySelector(".hk-tabs-overlay")).toBeNull();
     // The merged Light/Dark triggers leave the radio order entirely —
     // the strip is the single pointer surface while auto is active.
@@ -189,7 +193,7 @@ describe("HkThemeToggle color-mode group", () => {
     expect(modeSegments()).toHaveLength(3);
   });
 
-  it("keeps every theme row footprint uniform for list highlights", async () => {
+  it("keeps every theme row one full-width pill with deletes overlaid", async () => {
     useTheme().addCustomTheme(anyPresetTokens());
     const { container } = mountToggle(true);
     await settle();
@@ -202,21 +206,23 @@ describe("HkThemeToggle color-mode group", () => {
 
     let customRows = 0;
     for (const row of rows) {
-      // Every row is exactly [pill button][trailing slot] — delete button
-      // for custom themes, an equally sized invisible slot otherwise — so
-      // all highlight boxes share one width and left/right padding.
-      expect(row.children).toHaveLength(2);
+      // The pill is the first (and for built-ins the ONLY) in-flow child:
+      // no trailing slot element survives (it reserved a dead column
+      // right of every built-in row in the mobile sheet). Custom rows
+      // flag themselves and carry the delete button overlay as the one
+      // extra child.
       expect(row.children[0].classList.contains("s-theme-item-btn")).toBe(true);
-      const trailing = row.children[1];
-      const isDelete = trailing.classList.contains("s-theme-item-delete");
-      const isSlot = trailing.classList.contains("s-theme-item-slot");
-      expect(isDelete || isSlot).toBe(true);
-      if (isDelete) customRows += 1;
+      expect(row.querySelector(".s-theme-item-slot")).toBeNull();
+      const extra = [...row.children].slice(1);
+      if (row.hasAttribute("data-custom")) {
+        customRows += 1;
+        expect(extra).toHaveLength(1);
+        expect(extra[0].classList.contains("s-theme-item-delete")).toBe(true);
+      } else {
+        expect(extra).toHaveLength(0);
+      }
     }
     expect(customRows).toBe(1);
-
-    // Built-ins keep an explicit reserved slot element.
-    expect(rows[0].querySelector(".s-theme-item-slot")).toBeTruthy();
 
     // Active check glyph sits inside the pill, leading the name.
     const activeBtn = document.body.querySelector<HTMLButtonElement>(".s-theme-item-btn[data-active]");

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -228,7 +228,13 @@ export const HkThemeToggle = defineComponent({
 
             <div class="s-theme-menu-label">{t("hikari::theme.themes")}</div>
             {allThemeList.value.map((th) => (
-              <div key={th.id} class="s-theme-item-row">
+              // One full-width pill per row — the delete affordance for
+              // custom themes OVERLAYS the pill's trailing edge instead
+              // of reserving a trailing column, so built-in rows carry
+              // no dead space (a bottom sheet once showed a permanent
+              // ~40px empty strip right of every row) and every pill
+              // and highlight shares the exact same width.
+              <div key={th.id} class="s-theme-item-row" data-custom={th.isCustom || undefined}>
                 <button
                   type="button"
                   class="s-theme-item-btn"
@@ -238,7 +244,7 @@ export const HkThemeToggle = defineComponent({
                   {currentTheme.value === th.id && <Check size={14} class="s-theme-item-check" />}
                   <span class="s-theme-item-name">{th.name}</span>
                 </button>
-                {th.isCustom ? (
+                {th.isCustom && (
                   <button
                     type="button"
                     class="s-theme-item-delete"
@@ -247,8 +253,6 @@ export const HkThemeToggle = defineComponent({
                   >
                     <Trash2 size={12} />
                   </button>
-                ) : (
-                  <span class="s-theme-item-slot" aria-hidden="true" />
                 )}
               </div>
             ))}


### PR DESCRIPTION
## Summary

Two user-reported geometry bugs in the chest webui theme popover (mobile bottom sheet + desktop menu), both fixed in hikari so chest needs no code change. Rebased onto #351; version bump adjusted to 0.29.0 (master already consumed 0.28.0).

### Bug 1 — dead strip right of every theme row (mobile bottom sheet)
Every theme row reserved an invisible trailing column (`.s-theme-item-slot`, 36px + gap on mobile) so custom-theme delete buttons aligned, leaving a permanent dead strip right of every built-in row.

**Fix:** each row is ONE full-width pill; the delete button for custom themes overlays the pill's trailing edge (the row is the positioning context, `data-custom` rows reserve name clearance). Built-in rows render no trailing element at all.

### Bug 2 — theme mode strip re-measures on auto ↔ manual
Merging Light+Dark into the altitude strip changed every other cell's width (desktop: strip narrowed; mobile: thirds became halves). Root cause: legacy block flex divides by content (`flex: 1 0 auto`), so replacing two options with one merged cell redistributes everything.

**Fix:** slot-unit distribution for segmented block strips — a merged cell always spans its run's option count, `TabItem.span` may weight any trigger, and a strip carrying `data-slots` switches to a grid dividing the row into one `1fr` track per announced unit (`--hk-tabs-units`). The altitude strip now occupies exactly the two one-unit slots its triggers owned: measured subpixel-exact at 461px (auto trigger 143.65625px == manual trigger; merged cell 287.34375px == sum of the two replaced cells), in both the definite-width and `width: max-content; min-width: 100%` contexts.

Grid (not flex-basis) is required for exactness: flex basis math adds each item's own padding onto its share (`item = padding + share of remainder`), so a 12px-padded trigger consistently stole ~8–16px; grid `1fr` tracks are padding-immune. `minmax(min-content, 1fr)` keeps the never-clip contract (tight tracks floor at content; the max-content list scrolls instead).

## Verification
- `vitest` HkTabs + HkThemeToggle: 28/28 (new: data-slots/`--hk-tabs-units`/span vars, span clamping, row structure, merged-cell unit assertions, SCSS source contract test that goes red if the grid rules are deleted — sabotage-proven); incl. #351's HkInput suites: 41/41 across 4 files
- `vue-tsc --noEmit`: exit 0
- Full suite: 672 tests, only the known master-red DatePicker date-boundary failure (+ one HkMenu cascade flake under full-suite NFS load; 27/27 ×3 in isolation, file does not import HkTabs)
- Real-Chromium verification with a faithful full-sheet replica at 461×972 (numbers above) + screenshot of uniform full-width pills and the overlaid delete button
- 3-round verify cycle: round-1 adversarial review FAILED the first flex-based attempt (padding skew), reworked to grid; round-2 cross-verification PASS (cascade arithmetic, consumer enumeration across hikari + chest — no other HTabs consumer can enter slot mode, sabotage experiment, gates)
- Non-slot consumers (chest ThemeCustomizeDialog, ConnectionModal, UsageView, HkColorSchemeEditor) never get `data-slots` — legacy behavior byte-identical

Version bump: `@celestia-island/hikari` 0.28.0 → 0.29.0 (post-#351).