### PR TITLE
✨ Expose component and theme style subpaths for registry installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,30 +150,35 @@ fn App() -> VNode {
 
 ### Vue 3
 
-The Vue port ships as `@celestia-island/hikari` (0.4.x, `packages/vue`). It is not yet published to the npm registry; consumers wire it up via a local link — this is what arona and shittim-chest use:
+The Vue port ships as `@celestia-island/hikari` (`packages/vue`), published to the npm registry as a **source distribution**: the package contains the TypeScript and SCSS sources, and consumer build pipelines (Vite + vue-tsc + sass) compile them like first-party code — no build step happens on publish. Depend on it from the registry:
 
 ```json
 // package.json
 {
   "dependencies": {
-    "@celestia-island/hikari": "link:../hikari/packages/vue"
+    "@celestia-island/hikari": "^*"
   }
 }
 ```
 
-or, with pnpm workspaces, list the local package in `pnpm-workspace.yaml` and depend on it with `workspace:*`:
+The package exposes these subpaths:
 
-```yaml
-packages:
-  - 'packages/*'
-  - '../hikari/packages/vue'
-```
+| Specifier | Resolves to |
+| --- | --- |
+| `@celestia-island/hikari` | `src/index.ts` — all `Hk*` components, composables, `initTheme` |
+| `@celestia-island/hikari/runtime` | `src/runtime/index.ts` |
+| `@celestia-island/hikari/styles` | `src/styles/index.scss` — full SCSS aggregate (monorepo/dev use) |
+| `@celestia-island/hikari/styles/*` | `src/styles/*` — e.g. `styles/admin-tokens.scss`, `styles/theme/base.scss` |
+| `@celestia-island/hikari/components/*` | `src/components/*` — e.g. `components/HkSelectionGrid` |
+| `@celestia-island/hikari/plugins` | `src/plugins/index.ts` |
 
-Once published to npm, installation will simply be `pnpm add @celestia-island/hikari`. Import the styles once in your app entry point, then use the `Hk*` components (HkButton, HkCard, HkInput, HkModal, ...) in your templates:
+Import the styles once in your app entry point (or the granular `styles/*` subpaths if you assemble your own bundle), then use the `Hk*` components (HkButton, HkCard, HkInput, HkModal, ...) in your templates:
 
 ```ts
 import "@celestia-island/hikari/styles";
 ```
+
+For local development against an upstream working copy, use `celestia-devtools link-npm-siblings` — it overlays `node_modules` with symlinks to sibling checkouts (tracked in `node_modules/.celestia-linked-siblings.json`, revert with `--remove`). No `link:` dependencies, no workspace-member manifests, and CI/production always resolve the pure registry package.
 
 ### Theme initialization
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
@@ -31,6 +31,8 @@
     "./styles": {
       "import": "./src/styles/index.scss"
     },
+    "./styles/*": "./src/styles/*",
+    "./components/*": "./src/components/*",
     "./plugins": {
       "import": "./src/plugins/index.ts",
       "types": "./src/plugins/index.ts"

--- a/packages/vue/src/styles/index.scss
+++ b/packages/vue/src/styles/index.scss
@@ -1,8 +1,9 @@
 // Re-export shared hikari theme and component styles.
 // NOTE: The `../../../theme/...` and `../../../components/...` imports below
-// resolve relative to the monorepo root and work locally. When published to
-// npm, consumers who need the full hikari SCSS stack should import this file
-// from a monorepo checkout or bring their own SCSS load-path resolution.
+// resolve relative to the monorepo root and work locally, but escape the npm
+// package — registry installs should import the granular subpaths instead
+// (`@celestia-island/hikari/styles/theme/*.scss`, `.../styles/admin-tokens.scss`),
+// which are vendored/exposed inside this package.
 @use "../../../theme/styles/variables.scss";
 @use "../../../theme/styles/mixins.scss";
 @use "../../../theme/styles/foundation.scss";

--- a/packages/vue/src/styles/theme/_glass.scss
+++ b/packages/vue/src/styles/theme/_glass.scss
@@ -1,0 +1,33 @@
+// Vendored byte-identical from packages/theme/styles/_glass.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// _glass.scss — Glass-morphism utility classes adopted from shittim-chest.
+// These provide the frosted-glass aesthetic that makes panels feel layered
+// without heavy borders.
+
+.hk-glass {
+  background: rgb(30 30 30 / var(--hi-opacity-half, 0.92));
+  backdrop-filter: blur(var(--hi-blur-md, 16px));
+  -webkit-backdrop-filter: blur(var(--hi-blur-md, 16px));
+}
+
+.hk-glass-header {
+  background: rgb(30 30 30 / var(--hi-opacity-more, 0.96));
+  backdrop-filter: blur(var(--hi-blur-sm, 8px));
+  -webkit-backdrop-filter: blur(var(--hi-blur-sm, 8px));
+}
+
+.hk-glass-panel {
+  background: rgb(30 30 30 / var(--hi-opacity-half, 0.92));
+  backdrop-filter: blur(var(--hi-blur-lg, 24px));
+  -webkit-backdrop-filter: blur(var(--hi-blur-lg, 24px));
+  border: 1px solid rgb(255 255 255 / 8%);
+  border-radius: var(--hi-radius-lg, 12px);
+  box-shadow: var(--hi-shadow-panel);
+}
+
+.hk-glass-float {
+  background: rgb(30 30 30 / var(--hi-opacity-more, 0.96));
+  backdrop-filter: blur(var(--hi-blur-md, 16px));
+  -webkit-backdrop-filter: blur(var(--hi-blur-md, 16px));
+  border: 1px solid rgb(255 255 255 / 6%);
+  box-shadow: var(--hi-shadow-elevated);
+}

--- a/packages/vue/src/styles/theme/_layout.scss
+++ b/packages/vue/src/styles/theme/_layout.scss
@@ -1,0 +1,123 @@
+// Vendored byte-identical from packages/theme/styles/_layout.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// _layout.scss — Shared unprefixed design tokens for hikari + plana components.
+// Originally sourced from shittim-chest's theme system; extracted here so
+// any project importing @celestia-island/hikari/styles gets them automatically.
+//
+// Prefixed --hi-* equivalents exist in _tokens.scss and foundation.scss;
+// these unprefixed tokens are what hikari Hk* components and plana Plana*
+// components reference at call sites (with var(--token, fallback) pattern).
+
+:root {
+  // ── Typography scale (HkTabs, HkButton, and plana components depend on these) ─
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  // ── Font families (body text, mono for version/numbers) ─
+  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+
+  // ── Spacing scale (0—96, named by px value for self-documenting call sites) ─
+  --space-1: 0.0625rem;
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+  --space-48: 3rem;
+  --space-64: 4rem;
+  --space-80: 5rem;
+  --space-96: 6rem;
+
+  // ── Border radius scale ─
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  // ── Blur scale (glass/backdrop effects) ─
+  --blur-xs: 4px;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+
+  // ── Opacity tiers ─
+  --opacity-faded: 0.45;
+  --opacity-less: 0.85;
+  --opacity-half: 0.92;
+  --opacity-more: 0.96;
+
+  // ── Z-index hierarchy (group bands) ─
+  // One registered context: every layer family owns a band. Members inside
+  // a band stack by DOM order (browser default) — only the band boundaries
+  // are managed. Overlay-class components (modal/drawer/popover/select
+  // popout/menu sheet/locale picker) MUST register with usePopupManager,
+  // which allocates from the popup band (1000 + 2n, reset when the stack
+  // empties); fixed layers above the stack (toast/tooltip/fatal/titlebar)
+  // never register.
+  //   0–9      local — intra-component stacking (self-contained contexts)
+  //   10–99    content float — sticky columns, in-page lifts, minimaps
+  //   100–199  app chrome — header, footer, header popups
+  //   200–899  app overlay — reserved for app-level decorations
+  //   900–999  app sheet — drawer sidebars, bottom sheets
+  //   1000–1999 popup stack — manager-allocated (modal/drawer/popover/…)
+  //   9999     toast   10000 tooltip   10001 fatal
+  //   100001   native titlebar (Tauri caption)   100002 modal breadcrumb
+  --z-base: 0;
+  --z-above: 1;
+  --z-overlay: 2;
+  --z-top: 3;
+  --z-content: 10;
+  --z-floating: 50;
+  --z-header: 100;
+  --z-footer: 110;
+  --z-header-popup: 150;
+  --z-sheet: 900;
+  --z-sidebar: 900;
+  --z-modal: 1000;
+  --z-modal-base: 1000;
+  --z-modal-step: 2;
+  --z-toast: 9999;
+  --z-tooltip: 10000;
+
+  // ── Layout dimensions ─
+  --s-header-height: 3rem;
+  --s-footer-height: 3rem;
+
+  // ── Semantic border tokens ─
+  --border-faint: rgb(var(--color-border) / 10%);
+  --border-subtle: rgb(var(--color-border) / 12%);
+
+  // ── Duration / easing ─
+  --duration-fast: 0.15s;
+  --duration-short: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in-expo: cubic-bezier(0.7, 0, 0.84, 0);
+
+  // ── Semantic accent colors (used by plana components) ─
+  --c-primary: rgb(var(--color-primary));
+  --c-primary-light: rgb(var(--color-primary) / 15%);
+  --c-primary-subtle: rgb(var(--color-primary) / 8%);
+  --c-primary-overlay: rgb(var(--color-primary) / 15%);
+
+  // ── Shadow scale ─
+  --shadow-modal: 0 12px 40px rgb(0 0 0 / 20%), 0 0 0 1px rgb(255 255 255 / 4%);
+}

--- a/packages/vue/src/styles/theme/_scrollbar.scss
+++ b/packages/vue/src/styles/theme/_scrollbar.scss
@@ -1,0 +1,73 @@
+// Vendored byte-identical from packages/theme/styles/_scrollbar.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// _scrollbar.scss — the shared overlay scrollbar chrome.
+//
+// ONE scrollbar system for the whole library: the `.hk-scrollbar-track` /
+// `.hk-scrollbar-thumb` DOM is created imperatively by
+// packages/vue/src/composables/useOverlayScrollbar.ts
+// (attachOverlayScrollbars) and styled here. HkScrollContainer keeps its
+// container-specific rules in HkScrollContainer.scss; every other scroll
+// region in the library attaches the same overlay and hides its native
+// bar with the standard two-liner:
+//
+//   scrollbar-width: none;
+//   &::-webkit-scrollbar { display: none; }
+
+.hk-scrollbar-track {
+  position: absolute;
+  z-index: 10;
+  background: transparent;
+  /* Click-through while faded: an invisible rail must never steal
+     clicks from the content beneath it (the track hugs the region's
+     edge, exactly where end-of-line links/buttons live). The rail
+     becomes interactive only while it is visible — the flash window
+     after a scroll (and while hovered/dragged within that window). */
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+
+  &[data-axis="horizontal"] {
+    left: 4px;
+    right: 4px;
+    bottom: 2px;
+    height: 6px;
+  }
+
+  &:not([data-axis="horizontal"]) {
+    top: 4px;
+    bottom: 4px;
+    right: 2px;
+    width: 6px;
+  }
+
+  &.is-scrolling,
+  &.is-hovering {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.hk-scrollbar-thumb {
+  position: absolute;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--hi-color-muted) 35%, transparent);
+  transition: background var(--hi-duration-fast, 0.15s) ease;
+
+  .is-hovering &,
+  &.is-dragging {
+    background: color-mix(in srgb, var(--hi-color-muted) 55%, transparent);
+  }
+}
+
+.hk-scrollbar-track[data-axis="horizontal"] .hk-scrollbar-thumb {
+  top: 0;
+  left: 0;
+  height: 100%;
+  min-width: 20px;
+}
+
+.hk-scrollbar-track:not([data-axis="horizontal"]) .hk-scrollbar-thumb {
+  top: 0;
+  left: 0;
+  width: 100%;
+  min-height: 20px;
+}

--- a/packages/vue/src/styles/theme/_tokens.scss
+++ b/packages/vue/src/styles/theme/_tokens.scss
@@ -1,0 +1,69 @@
+// Vendored byte-identical from packages/theme/styles/_tokens.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// _tokens.scss — Design tokens adopted from shittim-chest's theme system.
+// These supplement hikari's existing foundation.scss tokens with the
+// detail-oriented tokens that make shittim-chest's UI feel polished:
+// z-index hierarchy, blur/opacity tiers, shittim-chest easings, and
+// scrollbar geometry.
+
+:root {
+  // ── Z-Index Hierarchy (from shittim-chest) ──────────────────────
+  --hi-z-base: 0;
+  --hi-z-above: 1;
+  --hi-z-content: 10;
+  --hi-z-header: 30;
+  --hi-z-sidebar: 40;
+  --hi-z-floating: 50;
+  --hi-z-header-popup: 150;
+  --hi-z-modal: 1000;
+  --hi-z-modal-step: 2;
+  --hi-z-toast: 9999;
+  --hi-z-tooltip: 10000;
+
+  // ── Blur Scale ──────────────────────────────────────────────────
+  --hi-blur-xs: 4px;
+  --hi-blur-sm: 8px;
+  --hi-blur-md: 16px;
+  --hi-blur-lg: 24px;
+
+  // ── Opacity Tiers ───────────────────────────────────────────────
+  --hi-opacity-faded: 0.45;
+  --hi-opacity-less: 0.85;
+  --hi-opacity-half: 0.92;
+  --hi-opacity-more: 0.96;
+
+  // ── Extended Easing (shittim-chest style) ───────────────────────
+  --hi-ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --hi-ease-in-expo: cubic-bezier(0.7, 0, 0.84, 0);
+  --hi-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  // ── Extended Duration ───────────────────────────────────────────
+  --hi-duration-instant: 0.1s;
+  --hi-duration-short: 0.15s;
+  --hi-duration-fade: 0.15s;
+
+  // ── Motion Tokens ───────────────────────────────────────────────
+  --hi-motion-popup-scale: 0.98;
+  --hi-motion-popup-offset: 4px;
+  --hi-motion-drawer-offset: 0.5rem;
+
+  // ── Extended Shadow Ladder (shittim-chest style) ────────────────
+  --hi-shadow-panel: 0 4px 32px rgb(0 0 0 / 20%), 0 0 0 1px rgb(255 255 255 / 4%);
+  --hi-shadow-elevated: 0 8px 32px rgb(0 0 0 / 15%);
+  --hi-shadow-modal: 0 20px 60px rgb(0 0 0 / 25%), 0 0 0 1px rgb(255 255 255 / 5%);
+  --hi-shadow-dropdown: 0 4px 24px rgb(0 0 0 / 12%), 0 0 0 1px rgb(255 255 255 / 4%);
+  --hi-shadow-tooltip: 0 2px 8px rgb(0 0 0 / 20%);
+  --hi-shadow-focus: 0 0 0 3px rgb(255 107 157 / 12%);
+  --hi-shadow-focus-ring: 0 0 0 2px rgb(240 244 248), 0 0 0 4px rgb(238 162 164);
+  --hi-shadow-focus-ring-error: 0 0 0 2px rgb(240 244 248), 0 0 0 4px rgb(255 76 0);
+  --hi-shadow-button: 0 4px 14px rgb(238 162 164 / 35%);
+  --hi-shadow-button-danger: 0 4px 14px rgb(255 76 0 / 35%);
+
+  // ── Scrollbar Geometry (overlay scrollbar system) ───────────────
+  --hi-scroll-inset: 4px;
+  --hi-scroll-size: 8px;
+  --hi-scroll-size-hover: 14px;
+  --hi-scroll-thumb: 4px;
+  --hi-scroll-thumb-hover: 6px;
+  --hi-scroll-thumb-min: 20px;
+  --hi-scroll-edge: 1px;
+}

--- a/packages/vue/src/styles/theme/base.scss
+++ b/packages/vue/src/styles/theme/base.scss
@@ -1,0 +1,617 @@
+// Vendored byte-identical from packages/theme/styles/base.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// hikari-theme/styles/base.scss
+// 基础样式（使用 hikari-palette）
+
+// Layer1 - Foundation Layer
+@use './foundation.scss' as *;
+
+@use './variables.scss' as *;
+@use './mixins.scss' as *;
+
+// ------
+// CSS 自定义属性（Hikari Light Theme）
+// ------
+
+// ------
+// 默认变量（被 ThemeProvider 覆盖）
+// ------
+
+:root {
+
+    // 默认浅色主题（作为 fallback）
+    --hi-color-background: #D6ECF0;  // 月白
+    --hi-color-surface: #F0F4F8;  // 更亮的白色
+    --hi-color-border: #C4D8DA;
+
+    // 文字颜色
+    --hi-color-text-primary: rgba(0, 0, 0, 0.9);
+    --hi-color-text-secondary: rgba(0, 0, 0, 0.6);
+
+    // 主题色（与调色板一致）
+    --hi-color-primary: #EEA2A4;  // 牡丹粉红 (brightness 0.725 → 黑色文字)
+    --hi-color-secondary: #519A73;  // 苍翠 (brightness 0.501 → 黑色文字)
+    --hi-color-accent: #F7B500;  // 姜黄
+    --hi-color-success: #0EB840;  // 葱倩 (brightness 0.469 → 白色文字)
+    --hi-color-warning: #EED677;  // 鹅黄 (brightness 0.825 → 黑色文字)
+    --hi-color-danger: #FF4C00;  // 朱红 (brightness 0.474 → 白色文字)
+    --hi-color-info: #6ABED6;  // 魁卵青
+
+    // 黑色透明度变体
+    --hi-color-black-100: rgba(0, 0, 0, 1.0);
+    --hi-color-black-95: rgba(0, 0, 0, 0.95);
+    --hi-color-black-50: rgba(0, 0, 0, 0.5);
+    --hi-color-black-30: rgba(0, 0, 0, 0.3);
+    --hi-color-black-20: rgba(0, 0, 0, 0.2);
+    --hi-color-black-10: rgba(0, 0, 0, 0.1);
+    --hi-color-black-5: rgba(0, 0, 0, 0.05);
+
+    // ------
+    // 2. 透明度变体（用于叠加、发光、阴影）
+    // ------
+
+    // 白色透明度（用于暗黑模式发光）
+    --hi-color-white-100: rgba(255, 255, 255, 1.0);
+    --hi-color-white-95: rgba(255, 255, 255, 0.95);
+    --hi-color-white-90: rgba(255, 255, 255, 0.9);
+    --hi-color-white-70: rgba(255, 255, 255, 0.7);
+    --hi-color-white-50: rgba(255, 255, 255, 0.5);
+    --hi-color-white-30: rgba(255, 255, 255, 0.3);
+    --hi-color-white-20: rgba(255, 255, 255, 0.2);
+    --hi-color-white-15: rgba(255, 255, 255, 0.15);
+    --hi-color-white-10: rgba(255, 255, 255, 0.1);
+    --hi-color-white-8: rgba(255, 255, 255, 0.08);
+    --hi-color-white-5: rgba(255, 255, 255, 0.05);
+
+    // 黑色透明度（用于阴影、发光）
+    --hi-color-black-100: rgba(0, 0, 0, 1.0);
+    --hi-color-black-95: rgba(0, 0, 0, 0.95);
+    --hi-color-black-50: rgba(0, 0, 0, 0.5);
+    --hi-color-black-30: rgba(0, 0, 0, 0.3);
+    --hi-color-black-20: rgba(0, 0, 0, 0.2);
+    --hi-color-black-10: rgba(0, 0, 0, 0.1);
+    --hi-color-black-5: rgba(0, 0, 0, 0.05);
+
+    // 灰色透明度（用于滚动条、边框）
+    --hi-color-gray-100: rgba(128, 128, 128, 1.0);
+    --hi-color-gray-50: rgba(128, 128, 128, 0.5);
+    --hi-color-gray-40: rgba(128, 128, 128, 0.4);
+    --hi-color-gray-30: rgba(128, 128, 128, 0.3);
+    --hi-color-gray-20: rgba(128, 128, 128, 0.2);
+    --hi-color-gray-15: rgba(128, 128, 128, 0.15);
+
+    // 紫色透明度（用于发光特效，基于中国传统色"紫色" RGB: 141, 75, 187）
+    --hi-color-purple-60: rgba(141, 75, 187, 0.6);
+    --hi-color-purple-50: rgba(141, 75, 187, 0.5);
+    --hi-color-purple-40: rgba(141, 75, 187, 0.4);
+
+    // 简化变量名（向后兼容）
+    --hi-white-100: var(--hi-color-white-100);
+    --hi-white-50: var(--hi-color-white-50);
+    --hi-white-30: var(--hi-color-white-30);
+    --hi-white-20: var(--hi-color-white-20);
+    --hi-white-15: var(--hi-color-white-15);
+    --hi-white-10: var(--hi-color-white-10);
+    --hi-white-8: var(--hi-color-white-8);
+    --hi-white-5: var(--hi-color-white-5);
+
+    // 边框发光（白色半透明）
+    --hi-border-light: rgba(255, 255, 255, 0.2);
+
+    // ------
+    // 3. 文字颜色（基于基础色计算）
+    // ------
+
+    // 通用文字颜色
+    --hi-color-text-primary: rgba(0, 0, 0, 0.9);
+    --hi-color-text-secondary: rgba(0, 0, 0, 0.6);
+
+    // 主题色上的文字颜色（根据亮度动态计算，反色原则）
+    // primary: 牡丹粉红 (0.725) → 黑色
+    // secondary: 苍翠 (0.501) → 黑色
+    // success: 葱倩 (0.469) → 白色
+    // warning: 鹅黄 (0.825) → 黑色
+    // danger: 朱红 (0.474) → 白色
+    --hi-color-text-on-primary: rgba(0, 0, 0, 0.9);
+    --hi-color-text-on-secondary: rgba(0, 0, 0, 0.9);
+    --hi-color-text-on-success: var(--hi-color-white-100);
+    --hi-color-text-on-warning: rgba(0, 0, 0, 0.9);
+    --hi-color-text-on-danger: var(--hi-color-white-100);
+    --hi-color-text-on-info: rgba(0, 0, 0, 0.9);
+
+    // ------
+    // 4. 按钮颜色（基于基础色）
+    // ------
+
+    // Primary 按钮渐变（基于 --hi-color-primary 牡丹粉红）
+    --hi-button-primary: var(--hi-color-primary);
+    --hi-button-primary-hover: rgba(238, 162, 164, 0.8);
+    --hi-button-primary-light: #F4C4C5;
+    --hi-button-primary-dark: #D88B8E;
+
+    // Secondary 按钮渐变（基于 --hi-color-secondary 苍翠）
+    --hi-button-secondary: var(--hi-color-secondary);
+    --hi-button-secondary-hover: rgba(81, 154, 115, 0.8);
+    --hi-button-secondary-light: #6BB38C;
+    --hi-button-secondary-dark: #3D7657;
+
+    // Success 按钮渐变（基于 --hi-color-success 葱倩）
+    --hi-button-success: var(--hi-color-success);
+    --hi-button-success-hover: rgba(14, 184, 64, 0.8);
+    --hi-button-success-light: #3DC86E;
+    --hi-button-success-dark: #0A8F33;
+
+    // Danger 按钮渐变（基于 --hi-color-danger 朱红）
+    --hi-button-danger: var(--hi-color-danger);
+    --hi-button-danger-hover: rgba(255, 76, 0, 0.8);
+    --hi-button-danger-light: #FF7A33;
+    --hi-button-danger-dark: #CC3D00;
+
+    // Warning 按钮渐变（基于 --hi-color-warning）
+    --hi-button-warning: var(--hi-color-warning);
+    --hi-button-warning-hover: rgba(238, 214, 119, 0.8);
+    --hi-button-warning-light: rgba(238, 214, 119, 0.6);
+    --hi-button-warning-dark: rgba(189, 169, 83, 0.8);
+
+    // Info 按钮渐变（基于 --hi-color-info）
+    --hi-button-info: var(--hi-color-info);
+    --hi-button-info-hover: rgba(106, 190, 214, 0.8);
+    --hi-button-info-light: rgba(106, 190, 214, 0.6);
+    --hi-button-info-dark: rgba(75, 133, 150, 0.8);
+
+    // ------
+    // 简化变量名（向后兼容）
+    // ------
+
+    // 基础主题色
+    --hi-primary: var(--hi-color-primary);
+    --hi-primary-light: var(--hi-color-white-30);
+
+    --hi-secondary: var(--hi-color-secondary);
+    --hi-secondary-light: var(--hi-color-white-30);
+
+    --hi-success: var(--hi-color-success);
+    --hi-success-light: var(--hi-color-white-30);
+
+    --hi-danger: var(--hi-color-danger);
+    --hi-danger-light: var(--hi-color-white-30);
+
+    --hi-warning: var(--hi-color-warning);
+    --hi-warning-light: var(--hi-color-white-30);
+
+    --hi-info: var(--hi-color-info);
+    --hi-info-light: var(--hi-color-white-30);
+
+    // 背景色
+    --hi-surface: var(--hi-color-surface);
+    --hi-card-bg: var(--hi-button-secondary);
+    --hi-card-bg-light: rgba(255, 255, 255, 0.95);
+
+    // Overlay遮罩色（反色）- 使用调色板变量，95%透明度
+    --hi-overlay-color: var(--hi-color-black-95);
+
+    // 滚动条颜色
+    --hi-scrollbar-thumb-hover: var(--hi-glow-color);
+
+    // 文字颜色
+    --hi-color-text-inverted: #ffffff;
+
+    // ------
+    // 5. Ghost 按钮颜色（基于文字色）
+    // ------
+
+    // Ghost 文字和边框（白天模式使用灰色）
+    --hi-ghost-text: var(--hi-color-text-primary);
+    --hi-ghost-border: var(--hi-color-gray-30);
+    --hi-ghost-glow: var(--hi-glow-gray-50);
+
+    // Ghost 按钮在暗黑模式使用纯白色
+    --hi-ghost-text-dark: var(--hi-color-white-100);
+    --hi-ghost-border-dark: var(--hi-color-white-50);
+    --hi-ghost-glow-dark: var(--hi-glow-white-50);
+
+    // ------
+    // 6. 发光特效颜色（Glow 系统由 JS 注入）
+    // ------
+
+    // 基础黑白灰 glow（由 JS 选择使用）
+    --hi-glow-white-90: rgba(255, 255, 255, 0.9);
+    --hi-glow-white-70: rgba(255, 255, 255, 0.7);
+    --hi-glow-white-50: rgba(255, 255, 255, 0.5);
+    --hi-glow-white-30: rgba(255, 255, 255, 0.3);
+    --hi-glow-white-20: rgba(255, 255, 255, 0.2);
+    --hi-glow-black-90: rgba(0, 0, 0, 0.9);
+    --hi-glow-black-70: rgba(0, 0, 0, 0.7);
+    --hi-glow-black-50: rgba(0, 0, 0, 0.5);
+    --hi-glow-black-30: rgba(0, 0, 0, 0.3);
+    --hi-glow-black-20: rgba(0, 0, 0, 0.2);
+    --hi-glow-black-10: rgba(0, 0, 0, 0.1);
+    --hi-glow-gray-70: rgba(128, 128, 128, 0.7);
+    --hi-glow-gray-50: rgba(128, 128, 128, 0.5);
+    --hi-glow-gray-30: rgba(128, 128, 128, 0.3);
+    --hi-glow-gray-20: rgba(128, 128, 128, 0.2);
+
+    // 默认 glow 颜色（由 JS 注入实际值）
+    --hi-glow-color: var(--hi-glow-white-50);
+
+    // Glow 按钮颜色（基于主题色，用于按钮 glow 效果）
+    --hi-glow-button-primary: rgba(255, 179, 167, 0.6);
+    --hi-glow-button-secondary: rgba(6, 82, 121, 0.6);
+    --hi-glow-button-success: rgba(92, 191, 145, 0.6);
+    --hi-glow-button-danger: rgba(232, 90, 79, 0.6);
+    --hi-glow-button-warning: rgba(238, 214, 119, 0.6);
+    --hi-glow-button-info: rgba(106, 190, 214, 0.6);
+
+    // Glow 尺寸预设
+    --hi-glow-sm: 0 0 8px var(--hi-glow-color);
+    --hi-glow-md: 0 0 16px var(--hi-glow-color);
+    --hi-glow-lg: 0 0 24px var(--hi-glow-color);
+    --hi-glow-focus: 0 0 20px var(--hi-glow-color);
+
+    // 边框发光
+    --hi-border-glow: rgba(141, 75, 187, 0.6);
+    --hi-border-glow-width: 1px;
+
+    // ------
+    // 7. 阴影效果（使用黑色透明度）
+    // ------
+
+    --hi-shadow-sm: 0 1px 2px 0 var(--hi-color-black-5);
+    --hi-shadow-md: 0 4px 6px -1px var(--hi-color-black-10);
+    --hi-shadow-lg: 0 10px 15px -3px var(--hi-color-black-10);
+    --hi-shadow-xl: 0 20px 25px -5px var(--hi-color-black-10);
+
+}
+
+html {
+    font-size: 16px;
+    scroll-behavior: smooth;
+
+    // Hide native scrollbar (using custom scrollbar component)
+    &::-webkit-scrollbar {
+        display: none;
+    }
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+body {
+    font-family: $hikari-font-family-sans;
+    font-size: $hikari-font-size-base;
+    line-height: 1.5;
+    color: var(--hi-color-text-primary);
+    background-color: var(--hi-color-background);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+// ------
+// 排版样式 - 使用主题变量
+// ------
+
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 600;
+    line-height: 1.25;
+    margin-bottom: $hikari-spacing-md;
+    color: var(--hi-color-text-primary);
+}
+
+h1 {
+    font-size: $hikari-font-size-3xl;
+}
+
+h2 {
+    font-size: $hikari-font-size-2xl;
+}
+
+h3 {
+    font-size: $hikari-font-size-xl;
+}
+
+h4 {
+    font-size: $hikari-font-size-lg;
+}
+
+h5 {
+    font-size: $hikari-font-size-base;
+}
+
+h6 {
+    font-size: $hikari-font-size-sm;
+}
+
+/* NOTE: no element-level color reset here. body already sets
+   --hi-color-text-primary and inheritance flows down; resetting the
+   color on every p/span/div/label broke components that set a color on
+   a parent expecting children to inherit it (e.g. toast variants with
+   white text on colored backgrounds rendered dark-on-green). */
+
+a {
+    color: var(--hi-color-text-primary);
+    text-decoration: none;
+    transition: color $hikari-transition-fast;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+code {
+    font-family: $hikari-font-family-mono;
+    font-size: 0.9em;
+    padding: 0.2em 0.4em;
+    background-color: var(--hi-color-border);
+    border-radius: $hikari-radius-sm;
+}
+
+pre {
+    font-family: $hikari-font-family-mono;
+    font-size: $hikari-font-size-sm;
+    padding: $hikari-spacing-md;
+    background-color: var(--hi-color-background);
+    border: 1px solid var(--hi-color-border);
+    border-radius: $hikari-radius-md;
+    overflow-x: auto;
+
+    @include scrollbar-hidden;
+}
+
+// ------
+// 列表样式
+// ------
+
+ul, ol {
+    list-style: none;
+}
+
+li {
+    // No global margin - components control their own spacing
+}
+
+// ------
+// 表单元素
+// ------
+
+// Element-level baseline for BARE app inputs only. Hikari components render
+// their own <input>/<textarea>/<select> inside a styled shell (.hk-input-box
+// etc.) and must not inherit this border/focus ring: the bare-element
+// `input:focus-visible` (0,1,1) outranks the component's `.hk-input-element`
+// (0,1,0) `border: none`, so a focused field showed BOTH the shell's
+// focus-within border AND an inner 2px ring — the "double border" on the
+// add-view wizard's title/purpose fields (same disease class as the element
+// color reset #215 removed). Excluding any element carrying an `hk-` class
+// keeps the baseline for genuinely bare app markup while leaving every hikari
+// component interior untouched.
+//
+// 2026-08-19: the guards now sit inside :where(...) so they contribute ZERO
+// specificity. The plain :not() form measured (0,1,1) and outranked every
+// single-class button/label/select style in consuming apps (chest's
+// .s-workspace-btn grew a 16px/500 font overnight — hikari #233 fallout);
+// :where() keeps the hk- exclusion at (0,0,1), the exact cascade position
+// the element baseline had before the guards existed (#232/#233).
+input:where(:not([class^="hk-"]):not([class*=" hk-"])),
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"])),
+select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+    @include input-base;
+}
+
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+    min-height: 80px;
+    resize: vertical;
+}
+
+:where(*),
+
+:where(*::before),
+:where(*::after) {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+// ------
+// 暗黑模式特殊处理
+// ------
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        // 暗黑模式背景色
+        --hi-color-background: #0F172A;
+        --hi-color-surface: #1E293B;
+
+        // 暗黑模式文字色
+        --hi-color-text-primary: rgba(255, 255, 255, 0.9);
+        --hi-color-text-secondary: rgba(255, 255, 255, 0.6);
+
+        // 暗黑模式 Ghost 按钮使用纯白色
+        --hi-ghost-text: var(--hi-color-white-100);
+        --hi-ghost-border: var(--hi-color-white-50);
+        --hi-ghost-glow: var(--hi-glow-white-50);
+
+        // 暗黑模式按钮 glow 颜色（更高的不透明度以在深色背景上显示）
+        --hi-glow-button-primary: rgba(255, 179, 167, 0.8);
+        --hi-glow-button-secondary: rgba(6, 82, 121, 0.8);
+        --hi-glow-button-success: rgba(92, 191, 145, 0.8);
+        --hi-glow-button-danger: rgba(232, 90, 79, 0.8);
+        --hi-glow-button-warning: rgba(238, 214, 119, 0.8);
+        --hi-glow-button-info: rgba(106, 190, 214, 0.8);
+
+        // 暗黑模式Overlay遮罩色（淡白色）- 使用调色板变量，95%透明度
+        --hi-overlay-color: var(--hi-color-white-95);
+
+        // 暗黑模式Card背景色（黑色半透明）
+        --hi-card-bg-light: rgba(0, 0, 0, 0.95);
+    }
+}
+
+// Same hk- exclusion as the input/textarea/select baseline above: hikari
+// components render bare <select>/<label>/<button> interiors that own their
+// chrome, and the element-level :focus-visible ring (0,1,1) would outrank
+// their plain-class styles exactly like the double-border input bug (#232).
+select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+    appearance: none;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%239CA3AF" d="M2 4l4 4 4-4"/></svg>');
+    background-repeat: no-repeat;
+    background-position: right 1rem center;
+    padding-right: 2.5rem;
+}
+
+label:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+    display: block;
+    margin-bottom: $hikari-spacing-xs;
+    font-weight: 500;
+    color: var(--hi-color-text-secondary);
+}
+
+// ------
+// 按钮样式
+// ------
+
+button:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+    @include button-base;
+}
+
+// ------
+// 图片样式
+// ------
+
+img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+}
+
+// ------
+// 表格样式
+// ------
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: $hikari-spacing-md;
+}
+
+th,
+td {
+    padding: $hikari-spacing-sm $hikari-spacing-md;
+    text-align: left;
+    border-bottom: 1px solid var(--hi-color-border);
+}
+
+th {
+    font-weight: 600;
+    color: var(--hi-color-text-secondary);
+}
+
+// ------
+// 分隔线样式
+// ------
+
+hr {
+    border: none;
+    height: 1px;
+    background-color: var(--hi-color-border);
+    margin: $hikari-spacing-lg 0;
+}
+
+// ------
+// 容器样式
+// ------
+
+.hk-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 $hikari-spacing-md;
+}
+
+.hk-container-fluid {
+    width: 100%;
+    padding: 0 $hikari-spacing-md;
+}
+
+.hk-row {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 (-$hikari-spacing-sm);
+
+    > * {
+        margin: 0 $hikari-spacing-sm;
+    }
+}
+
+.hk-col {
+    flex: 1 1 0%;
+}
+
+// ------
+// 工具类
+// ------
+
+.hk-text-center {
+    text-align: center;
+}
+
+.hk-text-left {
+    text-align: left;
+}
+
+.hk-text-right {
+    text-align: right;
+}
+
+.hk-text-muted {
+    color: var(--hi-color-text-secondary);
+}
+
+.hk-text-primary {
+    color: var(--hi-color-primary);
+}
+
+.hk-text-success {
+    color: var(--hi-color-success);
+}
+
+.hk-text-warning {
+    color: var(--hi-color-warning);
+}
+
+.hk-text-danger {
+    color: var(--hi-color-danger);
+}
+
+// SVG 图标默认颜色继承
+// Note: 不强制设置 fill/stroke，避免覆盖 stroke-only 图标（如 Lucide/Feather）
+// 各组件/图标应自行声明 fill 或 stroke
+svg {
+    color: inherit;
+}
+
+.hk-mt-1 { margin-top: $hikari-spacing-xs; }
+.hk-mt-2 { margin-top: $hikari-spacing-sm; }
+.hk-mt-3 { margin-top: $hikari-spacing-md; }
+.hk-mt-4 { margin-top: $hikari-spacing-lg; }
+.hk-mt-5 { margin-top: $hikari-spacing-xl; }
+
+.hk-mb-1 { margin-bottom: $hikari-spacing-xs; }
+.hk-mb-2 { margin-bottom: $hikari-spacing-sm; }
+.hk-mb-3 { margin-bottom: $hikari-spacing-md; }
+.hk-mb-4 { margin-bottom: $hikari-spacing-lg; }
+.hk-mb-5 { margin-bottom: $hikari-spacing-xl; }
+
+.hk-p-1 { padding: $hikari-spacing-xs; }
+.hk-p-2 { padding: $hikari-spacing-sm; }
+.hk-p-3 { padding: $hikari-spacing-md; }
+.hk-p-4 { padding: $hikari-spacing-lg; }
+.hk-p-5 { padding: $hikari-spacing-xl; }
+
+.hk-hidden {
+    display: none;
+}
+
+.hk-visible {
+    visibility: visible;
+}
+
+.hk-invisible {
+    visibility: hidden;
+}

--- a/packages/vue/src/styles/theme/foundation.scss
+++ b/packages/vue/src/styles/theme/foundation.scss
@@ -1,0 +1,219 @@
+// Vendored byte-identical from packages/theme/styles/foundation.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// hikari-theme/styles/foundation.scss
+// Layer1 - Foundation Layer: Global CSS Variables
+//
+// This file defines the base layer of the design system.
+// All variables here can be overridden at Layer2 (component level) or Custom (runtime).
+
+// Import supplementary tokens adopted from shittim-chest's design system.
+@use 'tokens';
+@use 'layout';
+@use 'glass';
+@use 'scrollbar';
+
+// ------
+// 1. Color System
+// ------
+
+// Text Colors
+:root {
+  --hi-color-text-primary: #ffffff;
+  --hi-color-text-secondary: rgba(255, 255, 255, 0.7);
+  --hi-color-text-disabled: rgba(255, 255, 255, 0.3);
+  --hi-color-text-on-primary: #ffffff;
+  --hi-color-text-on-secondary: #ffffff;
+
+  // Icon Colors
+  --hi-icon-color: var(--hi-color-text-primary);
+  --hi-icon-color-secondary: var(--hi-color-text-secondary);
+  --hi-icon-color-disabled: var(--hi-color-text-disabled);
+
+  // Background Colors
+  --hi-bg-surface: rgba(30, 30, 30, 0.8);
+  --hi-bg-surface-dark: rgba(20, 20, 20, 0.9);
+  --hi-bg-overlay: rgba(0, 0, 0, 0.6);
+  --hi-bg-transparent: transparent;
+
+  // Border Colors
+  --hi-border-color: rgba(255, 255, 255, 0.1);
+  --hi-border-color-focus: var(--hi-color-primary);
+  --hi-border-color-disabled: rgba(255, 255, 255, 0.05);
+
+  // Shadow Colors
+  --hi-shadow-color: rgba(0, 0, 0, 0.1);
+  --hi-glow-color: rgba(255, 79, 0, 0.5);
+  --hi-color-primary-dark: #d97f83;
+  --hi-color-secondary-dark: #3f7a5b;
+
+  // ------
+  // 2. Border Radius System
+  // ------
+
+  // Base Radius
+  --hi-radius-none: 0;
+  --hi-radius-sm: 4px;
+  --hi-radius-md: 8px;
+  --hi-radius-lg: 12px;
+  --hi-radius-xl: 16px;
+  --hi-radius-full: 9999px;
+
+  // Component Radius
+  --hi-button-radius: var(--hi-radius-md);
+  --hi-input-radius: var(--hi-radius-md);
+  --hi-card-radius: var(--hi-radius-lg);
+  --hi-modal-radius: var(--hi-radius-xl);
+
+  // Internal Element Radius
+  --hi-icon-radius: var(--hi-radius-sm);
+  --hi-badge-radius: var(--hi-radius-full);
+
+  // ------
+  // 3. Animation System
+  // ------
+
+  // Duration
+  --hi-duration-instant: 0ms;
+  --hi-duration-fast: 150ms;
+  --hi-duration-normal: 300ms;
+  --hi-duration-slow: 500ms;
+
+  // Easing Functions
+  --hi-ease-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --hi-ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --hi-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --hi-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --hi-ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  --hi-ease-elastic: cubic-bezier(0.5, 1.5, 0.5, 1);
+
+  // Animation Delay
+  --hi-delay-none: 0ms;
+  --hi-delay-short: 100ms;
+  --hi-delay-medium: 200ms;
+  --hi-delay-long: 300ms;
+
+  // ------
+  // 4. Background System
+  // ------
+
+  // Solid Background
+  --hi-bg-solid-primary: var(--hi-color-primary);
+  --hi-bg-solid-secondary: var(--hi-color-secondary);
+  --hi-bg-solid-surface: var(--hi-color-surface);
+
+  // Gradient Background
+  --hi-bg-gradient-primary: linear-gradient(135deg, var(--hi-color-primary), var(--hi-color-primary-dark));
+  --hi-bg-gradient-secondary: linear-gradient(135deg, var(--hi-color-secondary), var(--hi-color-secondary-dark));
+
+  // Blur Background
+  --hi-bg-blur-sm: blur(10px);
+  --hi-bg-blur-md: blur(20px);
+  --hi-bg-blur-lg: blur(30px);
+
+  // ------
+  // 5. SVG System
+  // ------
+
+  // Fill
+  --hi-icon-fill: currentColor;
+  --hi-icon-fill-opacity: 1;
+
+  // Stroke
+  --hi-icon-stroke: none;
+  --hi-icon-stroke-width: 1;
+  --hi-icon-stroke-opacity: 1;
+
+  // Size
+  --hi-icon-size-xs: 12px;
+  --hi-icon-size-sm: 14px;
+  --hi-icon-size-md: 16px;
+  --hi-icon-size-lg: 20px;
+  --hi-icon-size-xl: 24px;
+
+  // ------
+  // 6. Spacing System
+  // ------
+
+  --hi-spacing-xs: 0.25rem;
+  --hi-spacing-sm: 0.5rem;
+  --hi-spacing-md: 1rem;
+  --hi-spacing-lg: 1.5rem;
+  --hi-spacing-xl: 2rem;
+  --hi-spacing-2xl: 3rem;
+
+  // ------
+  // 7. Shadow System
+  // ------
+
+  --hi-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.1);
+  --hi-shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --hi-shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --hi-shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
+
+  // ------
+  // 8. Border System
+  // ------
+
+  --hi-border-width: 1px;
+  --hi-border-width-focus: 2px;
+  --hi-border-style: solid;
+  --hi-border-style-dashed: dashed;
+
+  // ------
+  // 9. Z-Index System
+  // ------
+
+  --hi-z-index-dropdown: 1000;
+  --hi-z-index-sticky: 1020;
+  --hi-z-index-fixed: 1030;
+  --hi-z-index-modal-backdrop: 1040;
+  --hi-z-index-modal: 1050;
+  --hi-z-index-popover: 1060;
+  --hi-z-index-tooltip: 1070;
+}
+
+// ------
+// Dark Theme Overrides
+// ------
+
+[data-theme="dark"] {
+  --hi-color-text-primary: #ffffff;
+  --hi-color-text-secondary: rgba(255, 255, 255, 0.7);
+  --hi-color-text-disabled: rgba(255, 255, 255, 0.3);
+
+  --hi-bg-surface: rgba(30, 30, 30, 0.8);
+  --hi-bg-surface-dark: rgba(20, 20, 20, 0.9);
+
+  --hi-border-color: rgba(255, 255, 255, 0.1);
+  --hi-border-color-disabled: rgba(255, 255, 255, 0.05);
+}
+
+// ------
+// Light Theme Overrides
+// ------
+
+[data-theme="light"] {
+  --hi-color-text-primary: #1a1a1a;
+  --hi-color-text-secondary: rgba(0, 0, 0, 0.7);
+  --hi-color-text-disabled: rgba(0, 0, 0, 0.3);
+
+  --hi-bg-surface: rgba(255, 255, 255, 0.9);
+  --hi-bg-surface-dark: rgba(245, 245, 245, 0.95);
+
+  --hi-border-color: rgba(0, 0, 0, 0.1);
+  --hi-border-color-disabled: rgba(0, 0, 0, 0.05);
+}
+
+// ------
+// 4. Touch & Tap Reset (2026-08-30, mobile web parity)
+// ------
+// Clear the browser's default tap highlight — the translucent blue/gray
+// overlay Android/WebKit paints over tappable elements on touch. It sits
+// ON TOP of hikari's own :active/:hover states and reads as a stale
+// "blue hover mask" on phones. The property is inherited, so declaring it
+// once on the root covers every element (components may still override).
+// Zoom policy (the other half of the mobile contract) is a JS concern:
+// hikari exports applyViewportPolicy() from the runtime for app bootstrap.
+html {
+  -webkit-tap-highlight-color: transparent;
+  tap-highlight-color: transparent;
+}

--- a/packages/vue/src/styles/theme/mixins.scss
+++ b/packages/vue/src/styles/theme/mixins.scss
@@ -1,0 +1,793 @@
+// Vendored byte-identical from packages/theme/styles/mixins.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// hikari-theme/styles/mixins.scss
+// Mixins（使用 hikari-palette）
+
+@use './variables.scss' as *;
+
+// ------
+// 响应式 Mixins
+// ------
+
+@mixin mobile {
+    @media (max-width: 640px) {
+        @content;
+    }
+}
+
+@mixin tablet {
+    @media (min-width: 641px) and (max-width: 1024px) {
+        @content;
+    }
+}
+
+@mixin desktop {
+    @media (min-width: 1025px) {
+        @content;
+    }
+}
+
+// ------
+// Flexbox Mixins
+// ------
+
+@mixin flex-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@mixin flex-between {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+@mixin flex-start {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+@mixin flex-end {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+@mixin flex-column {
+    display: flex;
+    flex-direction: column;
+}
+
+// ------
+// 文本 Mixins
+// ------
+
+@mixin text-ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@mixin line-clamp($lines: 2) {
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+// ------
+// 交互 Mixins
+// ------
+
+@mixin hover-effect {
+    transition: all $hikari-transition-base;
+
+    &:hover {
+        opacity: 0.8;
+        cursor: pointer;
+    }
+}
+
+@mixin focus-ring {
+    outline: none;
+
+    &:focus-visible {
+        box-shadow: 0 0 0 2px var(--hi-color-primary);
+    }
+}
+
+@mixin disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+// ------
+// 按钮样式 Mixins
+// ------
+
+@mixin button-base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: $hikari-spacing-sm $hikari-spacing-md;
+    border-radius: $hikari-radius-md;
+    font-weight: 500;
+    font-size: $hikari-font-size-base;
+    transition: all $hikari-transition-base;
+    border: 1px solid transparent;
+    cursor: pointer;
+
+    @include focus-ring;
+}
+
+@mixin button-primary {
+    @include button-base;
+    background-color: var(--hi-color-primary);
+    color: var(--hi-color-text-primary);
+
+    &:hover:not(:disabled) {
+        filter: brightness(1.1);
+    }
+}
+
+@mixin button-secondary {
+    @include button-base;
+    background-color: transparent;
+    color: var(--hi-color-primary);
+    border-color: var(--hi-color-primary);
+
+    &:hover:not(:disabled) {
+        background-color: var(--hi-color-surface);
+    }
+}
+
+@mixin button-ghost {
+    @include button-base;
+    background-color: transparent;
+    color: var(--hi-color-text-primary);
+
+    &:hover:not(:disabled) {
+        background-color: var(--hi-color-surface);
+    }
+}
+
+// ------
+// 输入框样式 Mixins
+// ------
+
+@mixin input-base {
+    width: 100%;
+    padding: $hikari-spacing-sm $hikari-spacing-md;
+    border: 1px solid var(--hi-color-border);
+    border-radius: $hikari-radius-md;
+    background-color: var(--hi-color-background);
+    color: var(--hi-color-text-primary);
+    font-size: $hikari-font-size-base;
+    font-family: $hikari-font-family-sans;
+    transition: all $hikari-transition-base;
+
+    @include focus-ring;
+
+    &::placeholder {
+        color: var(--hi-color-text-secondary);
+    }
+
+    &:disabled {
+        @include disabled;
+    }
+}
+
+// ------
+// 卡片样式 Mixins
+// ------
+
+@mixin card-base {
+    background-color: var(--hi-color-surface);
+    border: 1px solid var(--hi-color-border);
+    border-radius: $hikari-radius-lg;
+    padding: $hikari-spacing-lg;
+    box-shadow: $hikari-shadow-md;
+    transition: all $hikari-transition-base;
+}
+
+@mixin card-hover {
+    &:hover {
+        box-shadow: $hikari-shadow-lg;
+        transform: translateY(-2px);
+    }
+}
+
+// ------
+// Arknights 平面设计 Mixins
+// ------
+
+@mixin arknights-border {
+    border: 1px solid var(--hi-color-white-10);
+}
+
+@mixin arknights-glow {
+    box-shadow: 0 0 20px var(--hi-color-secondary);
+}
+
+// ------
+// FUI 科幻感 Mixins
+// ------
+
+@mixin fui-glow {
+    box-shadow: 0 0 10px var(--hi-color-purple-50);
+}
+
+@mixin fui-pulse {
+    animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.7;
+    }
+}
+
+@mixin fui-hexagon {
+    clip-path: polygon(50% 0%, 100% 25%, 100% 75%, 50% 100%, 0% 75%, 0% 25%);
+}
+
+// ------
+// 滚动条 Mixins
+// ------
+
+@mixin scrollbar-hidden {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+// ------
+// FUI 亚克力背景系统
+// ------
+
+/// 亚克力材质效果（类似 Windows 10 Acrylic）
+@mixin acrylic-material {
+    background-color: rgba(var(--hi-color-surface-rgb, 29, 29, 29), $hikari-acrylic-opacity);
+    backdrop-filter: blur($hikari-acrylic-blur);
+    -webkit-backdrop-filter: blur($hikari-acrylic-blur);
+    position: relative;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><filter id="noise"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(%23noise)" opacity="0.05"/></svg>');
+        opacity: $hikari-acrylic-noise;
+        pointer-events: none;
+        z-index: -1;
+    }
+}
+
+/// 亚克力聚焦效果（Win10 风格的局部高亮）
+@mixin acrylic-focus {
+    @include acrylic-material;
+    transition: all $hikari-duration-normal $hikari-ease-smooth;
+
+    &:hover,
+    &:focus-within {
+        background-color: rgba(var(--hi-color-surface-rgb, 29, 29, 29), 0.95);
+        box-shadow: $hikari-glow-md, inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+        transform: translateY(-1px);
+    }
+
+    &:focus-within {
+        box-shadow: $hikari-glow-focus, inset 0 0 0 1px $hikari-border-glow-color;
+    }
+}
+
+// ------
+// FUI 发光边框系统
+// ------
+
+/// 基础发光边框
+@mixin glowing-border($color: $hikari-border-glow-color, $width: $hikari-border-glow-width) {
+    border: $width solid $color;
+    box-shadow: $hikari-glow-sm;
+    transition: all $hikari-duration-normal $hikari-ease-smooth;
+
+    &:hover {
+        box-shadow: $hikari-glow-md;
+        border-color: lighten($color, 10%);
+    }
+
+    &:focus,
+    &:focus-within {
+        box-shadow: $hikari-glow-focus;
+        border-color: lighten($color, 20%);
+    }
+}
+
+/// 多色发光边框（适用于不同状态）
+@mixin glowing-border-variant($color) {
+    $glow-color: rgba($color, 0.6);
+    @include glowing-border($glow-color);
+}
+
+// ------
+// FUI 强调色条系统
+// ------
+
+/// 左侧强调色条（最常用）
+@mixin accent-bar-left($width: $hikari-accent-bar-width, $color: var(--hi-color-primary)) {
+    position: relative;
+    border-left: $width solid $color;
+
+    &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: $width;
+        background: linear-gradient(180deg, $color 0%, transparent 100%);
+        opacity: 0;
+        transition: opacity $hikari-duration-normal $hikari-ease-smooth;
+    }
+
+    &:hover::before {
+        opacity: 1;
+    }
+}
+
+/// 右侧强调色条
+@mixin accent-bar-right($width: $hikari-accent-bar-width, $color: var(--hi-color-primary)) {
+    position: relative;
+    border-right: $width solid $color;
+
+    &::before {
+        content: '';
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        width: $width;
+        background: linear-gradient(180deg, transparent 0%, $color 100%);
+        opacity: 0;
+        transition: opacity $hikari-duration-normal $hikari-ease-smooth;
+    }
+
+    &:hover::before {
+        opacity: 1;
+    }
+}
+
+/// 顶部强调色条
+@mixin accent-bar-top($width: $hikari-accent-bar-width, $color: var(--hi-color-primary)) {
+    position: relative;
+    border-top: $width solid $color;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        height: $width;
+        background: linear-gradient(90deg, transparent 0%, $color 50%, transparent 100%);
+        opacity: 0;
+        transition: opacity $hikari-duration-normal $hikari-ease-smooth;
+    }
+
+    &:hover::before {
+        opacity: 1;
+    }
+}
+
+/// 底部强调色条
+@mixin accent-bar-bottom($width: $hikari-accent-bar-width, $color: var(--hi-color-primary)) {
+    position: relative;
+    border-bottom: $width solid $color;
+
+    &::before {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: $width;
+        background: linear-gradient(90deg, transparent 0%, $color 50%, transparent 100%);
+        opacity: 0;
+        transition: opacity $hikari-duration-normal $hikari-ease-smooth;
+    }
+
+    &:hover::before {
+        opacity: 1;
+    }
+}
+
+// ------
+// FUI 微动背景系统
+// ------
+
+/// 微动背景（ambient animation）
+@mixin ambient-background {
+    position: relative;
+    overflow: hidden;
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: -50%;
+        left: -50%;
+        width: 200%;
+        height: 200%;
+        background: radial-gradient(
+            circle at 50% 50%,
+            rgba(var(--hi-color-primary-rgb, 139, 92, 246), 0.03) 0%,
+            transparent 50%
+        );
+        animation: ambient-move $hikari-ambient-duration $hikari-ambient-easing infinite;
+        pointer-events: none;
+        z-index: 0;
+    }
+
+    & > * {
+        position: relative;
+        z-index: 1;
+    }
+}
+
+@keyframes ambient-move {
+    0%, 100% {
+        transform: translate(0, 0) scale(1);
+    }
+    25% {
+        transform: translate(5%, 5%) scale(1.05);
+    }
+    50% {
+        transform: translate(0, 10%) scale(1.1);
+    }
+    75% {
+        transform: translate(-5%, 5%) scale(1.05);
+    }
+}
+
+/// 脉冲光晕效果
+@mixin pulse-glow($color: var(--hi-color-primary)) {
+    position: relative;
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 100%;
+        height: 100%;
+        background: radial-gradient(circle, $color 0%, transparent 70%);
+        transform: translate(-50%, -50%);
+        opacity: 0;
+        animation: pulse-glow-animation 2s ease-in-out infinite;
+        pointer-events: none;
+    }
+}
+
+@keyframes pulse-glow-animation {
+    0%, 100% {
+        opacity: 0;
+        transform: translate(-50%, -50%) scale(0.8);
+    }
+    50% {
+        opacity: 0.3;
+        transform: translate(-50%, -50%) scale(1.2);
+    }
+}
+
+// ------
+// FUI 动画预设系统（GSAP 风格）
+// ------
+
+/// 从中间向左右展开（进入动画）
+@mixin animate-expand-horizontal($duration: $hikari-duration-normal) {
+    animation: expand-horizontal $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes expand-horizontal {
+    from {
+        opacity: 0;
+        transform: scaleX(0);
+        transform-origin: center;
+    }
+    to {
+        opacity: 1;
+        transform: scaleX(1);
+        transform-origin: center;
+    }
+}
+
+/// 从上下往中间收缩（进入动画）
+@mixin animate-collapse-vertical($duration: $hikari-duration-normal) {
+    animation: collapse-vertical $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes collapse-vertical {
+    from {
+        opacity: 0;
+        transform: scaleY(0);
+        transform-origin: center;
+    }
+    to {
+        opacity: 1;
+        transform: scaleY(1);
+        transform-origin: center;
+    }
+}
+
+/// 从左滑入
+@mixin animate-slide-in-left($duration: $hikari-duration-normal, $distance: 20px) {
+    animation: slide-in-left $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes slide-in-left {
+    from {
+        opacity: 0;
+        transform: translateX(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/// 从右滑入
+@mixin animate-slide-in-right($duration: $hikari-duration-normal, $distance: 20px) {
+    animation: slide-in-right $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes slide-in-right {
+    from {
+        opacity: 0;
+        transform: translateX(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}
+
+/// 从上滑入
+@mixin animate-slide-in-top($duration: $hikari-duration-normal, $distance: 20px) {
+    animation: slide-in-top $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes slide-in-top {
+    from {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/// 从下滑入
+@mixin animate-slide-in-bottom($duration: $hikari-duration-normal, $distance: 20px) {
+    animation: slide-in-bottom $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes slide-in-bottom {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/// 淡入 + 缩放
+@mixin animate-fade-in-scale($duration: $hikari-duration-normal) {
+    animation: fade-in-scale $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes fade-in-scale {
+    from {
+        opacity: 0;
+        transform: scale(0.9);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+/// 淡出 + 缩放（退出动画）
+@mixin animate-fade-out-scale($duration: $hikari-duration-normal) {
+    animation: fade-out-scale $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes fade-out-scale {
+    from {
+        opacity: 1;
+        transform: scale(1);
+    }
+    to {
+        opacity: 0;
+        transform: scale(0.9);
+    }
+}
+
+/// 模糊淡入
+@mixin animate-blur-in($duration: $hikari-duration-normal) {
+    animation: blur-in $duration $hikari-ease-smooth forwards;
+}
+
+@keyframes blur-in {
+    from {
+        opacity: 0;
+        filter: blur(10px);
+    }
+    to {
+        opacity: 1;
+        filter: blur(0);
+    }
+}
+
+/// 弹性进入
+@mixin animate-bounce-in($duration: $hikari-duration-slow) {
+    animation: bounce-in $duration $hikari-ease-bounce forwards;
+}
+
+@keyframes bounce-in {
+    0% {
+        opacity: 0;
+        transform: scale(0.3);
+    }
+    50% {
+        transform: scale(1.05);
+    }
+    70% {
+        transform: scale(0.9);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+// ------
+// FUI 交互状态 Mixins
+// ------
+
+/// 悬浮提升效果
+@mixin hover-lift($amount: 2px) {
+    transition: transform $hikari-duration-fast $hikari-ease-smooth,
+                box-shadow $hikari-duration-fast $hikari-ease-smooth;
+
+    &:hover {
+        transform: translateY(-$amount);
+        box-shadow: $hikari-glow-md;
+    }
+}
+
+/// 悬浮发光
+@mixin hover-glow($color: var(--hi-color-primary)) {
+    transition: all $hikari-duration-fast $hikari-ease-smooth;
+
+    &:hover {
+        box-shadow: 0 0 20px rgba($color, 0.5);
+    }
+}
+
+/// 点击按压效果
+@mixin active-press($scale: 0.98) {
+    &:active {
+        transform: scale($scale);
+        transition: transform $hikari-duration-instant ease-out;
+    }
+}
+
+// ------
+// FUI 组件基础样式
+// ------
+
+/// FUI 卡片基础
+@mixin fui-card-base {
+    @include acrylic-material;
+    @include hover-lift(2px);
+    border-radius: $hikari-radius-fui-md;
+    padding: $hikari-spacing-lg;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/// FUI 按钮基础
+@mixin fui-button-base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: $hikari-spacing-sm $hikari-spacing-md;
+    border-radius: $hikari-radius-fui-sm;
+    font-weight: 500;
+    font-size: $hikari-font-size-sm;
+    transition: all $hikari-duration-fast $hikari-ease-smooth;
+    border: 1px solid transparent;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+
+    @include active-press(0.98);
+
+    &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -100%;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(
+            90deg,
+            transparent,
+            rgba(255, 255, 255, 0.2),
+            transparent
+        );
+        transition: left $hikari-duration-slow $hikari-ease-smooth;
+    }
+
+    &:hover::before {
+        left: 100%;
+    }
+}
+
+/// FUI 输入框基础
+@mixin fui-input-base {
+    @include acrylic-focus;
+    border-radius: $hikari-radius-fui-sm;
+    padding: $hikari-spacing-sm $hikari-spacing-md;
+    font-size: $hikari-font-size-sm;
+    color: var(--hi-color-text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    outline: none;
+
+    &::placeholder {
+        color: var(--hi-color-text-secondary);
+        opacity: 0.7;
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+// ------
+// Pagination Mixins
+// ------
+
+/// Pagination compact variant
+@mixin pagination-compact {
+    .hk-pagination-size-selector,
+    .hk-pagination-total,
+    .hk-pagination-jumper {
+        display: none;
+    }
+
+    .hk-pagination-item {
+        min-width: 1.75rem;
+        height: 1.75rem;
+        padding: 0 0.5rem;
+        font-size: 0.8125rem;
+        margin: 0.0625rem;
+
+        svg {
+            width: 0.875rem;
+            height: 0.875rem;
+        }
+    }
+}

--- a/packages/vue/src/styles/theme/themes.scss
+++ b/packages/vue/src/styles/theme/themes.scss
@@ -1,0 +1,25 @@
+// Vendored byte-identical from packages/theme/styles/themes.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// hikari-theme/styles/themes.scss
+// 主题变体（使用 hikari-palette）
+
+@use './variables.scss' as *;
+
+// ------
+// 响应式主题切换
+// ------
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="fresh"]) {
+        --hi-color-background: #0F172A;
+        --hi-color-surface: #1E293B;
+        --hi-color-text-primary: rgba(255, 255, 255, 0.9);
+        --hi-color-text-secondary: rgba(255, 255, 255, 0.6);
+        --hi-color-text-on-primary: rgba(0, 0, 0, 0.9);
+        --hi-color-text-on-secondary: var(--hi-color-white-100);
+        --hi-color-text-on-ghost: rgba(255, 255, 255, 0.9);
+        --hi-color-text-on-danger: var(--hi-color-white-100);
+        --hi-color-text-on-success: rgba(0, 0, 0, 0.9);
+        --hi-color-text-on-warning: rgba(0, 0, 0, 0.9);
+        --hi-color-text-on-info: rgba(0, 0, 0, 0.9);
+    }
+}

--- a/packages/vue/src/styles/theme/variables.scss
+++ b/packages/vue/src/styles/theme/variables.scss
@@ -1,0 +1,125 @@
+// Vendored byte-identical from packages/theme/styles/variables.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+// hikari-theme/styles/variables.scss
+// CSS 变量（使用 hikari-palette）
+
+// ------
+// 1. Color System
+// ------
+// Colors are defined via CSS variables in the index.scss
+// and by the hikari-palette crate
+
+// ------
+// 2. Typography Variables
+// ------
+
+/* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+$hikari-font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+$hikari-font-family-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
+
+$hikari-font-size-xs: 0.75rem;
+$hikari-font-size-sm: 0.875rem;
+$hikari-font-size-base: 1rem;
+$hikari-font-size-lg: 1.125rem;
+$hikari-font-size-xl: 1.25rem;
+$hikari-font-size-2xl: 1.5rem;
+$hikari-font-size-3xl: 1.875rem;
+
+// ------
+// 间距变量
+// ------
+
+$hikari-spacing-xs: 0.25rem;
+$hikari-spacing-sm: 0.5rem;
+$hikari-spacing-md: 1rem;
+$hikari-spacing-lg: 1.5rem;
+$hikari-spacing-xl: 2rem;
+$hikari-spacing-2xl: 3rem;
+
+// ------
+// 圆角变量
+// ------
+
+$hikari-radius-sm: 0.25rem;
+$hikari-radius-md: 0.5rem;
+$hikari-radius-lg: 0.75rem;
+$hikari-radius-xl: 1rem;
+$hikari-radius-full: 9999px;
+
+// ------
+// 阴影变量
+// ------
+
+$hikari-shadow-sm: var(--hi-shadow-sm);
+$hikari-shadow-md: var(--hi-shadow-md);
+$hikari-shadow-lg: var(--hi-shadow-lg);
+$hikari-shadow-xl: var(--hi-shadow-xl);
+
+// ------
+// 过渡变量
+// ------
+
+$hikari-transition-fast: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+$hikari-transition-base: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+$hikari-transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
+
+// ------
+// FUI 设计系统变量
+// ------
+
+// 亚克力效果参数
+$hikari-acrylic-blur: 20px;
+$hikari-acrylic-noise: 0.5;
+$hikari-acrylic-opacity: 0.85;
+
+// 发光效果参数
+$hikari-glow-sm: var(--hi-glow-sm);
+$hikari-glow-md: var(--hi-glow-md);
+$hikari-glow-lg: var(--hi-glow-lg);
+$hikari-glow-focus: var(--hi-glow-focus);
+
+// 强调色条参数
+$hikari-accent-bar-width: 3px;
+$hikari-accent-bar-position: left; // left, right, top, bottom
+
+// 细微圆角（FUI 风格）
+$hikari-radius-fui-sm: 4px;
+$hikari-radius-fui-md: 6px;
+$hikari-radius-fui-lg: 8px;
+
+// 边框发光
+$hikari-border-glow-color: var(--hi-border-glow);
+$hikari-border-glow-width: var(--hi-border-glow-width);
+
+// 动画缓动函数（GSAP 风格）
+$hikari-ease-smooth: cubic-bezier(0.25, 0.1, 0.25, 1);
+$hikari-ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+$hikari-ease-elastic: cubic-bezier(0.5, 1.5, 0.5, 1);
+
+// 动画时长
+$hikari-duration-instant: 100ms;
+$hikari-duration-fast: 200ms;
+$hikari-duration-normal: 300ms;
+$hikari-duration-slow: 500ms;
+
+// 背景微动参数
+$hikari-ambient-duration: 8s;
+$hikari-ambient-easing: ease-in-out;
+
+// ------
+// Icon Button 尺寸变量
+// ------
+
+$hikari-icon-button-size-16: 16px;
+$hikari-icon-button-size-24: 24px;
+$hikari-icon-button-size-32: 32px;
+$hikari-icon-button-size-36: 36px;
+
+// ------
+// 常用图标尺寸变量
+// ------
+
+$hikari-icon-size-xs: 12px;
+$hikari-icon-size-sm: 14px;
+$hikari-icon-size-md: 16px;
+$hikari-icon-size-lg: 20px;
+$hikari-icon-size-xl: 24px;

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -12,7 +12,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@celestia-island/hikari': resolve(__dirname, 'src'),
-      '@celestia-island/plana-ui': resolve(__dirname, '../../../plana/packages/ui/src'),
       'vue': 'vue/dist/vue.esm-bundler.js',
     },
   },


### PR DESCRIPTION
## What

Makes the npm-published `@celestia-island/hikari` package self-sufficient so registry installs fully replace the `../hikari/packages/vue` sibling-checkout wiring for all current consumers (part of the family-wide registry-first sweep, PLAN.md).

- **Exports additions** (`packages/vue/package.json`): `./components/*` → `src/components/*` and `./styles/*` → `src/styles/*`, alongside the existing `. / ./runtime / ./styles / ./plugins` entries (source-distribution model kept). The exact `./styles` key still wins over the wildcard, so the aggregate `import "@celestia-island/hikari/styles"` keeps resolving to `src/styles/index.scss`.
- **Theme styles vendored**: chest + erp assemble their admin-chrome bundle from five `packages/theme/styles/*.scss` files (`variables / mixins / foundation / themes / base`) plus `admin-tokens.scss`. `packages/theme` is a Rust crate directory that an npm install can never contain, so all nine theme SCSS files (those five plus their internal `@use` deps `_tokens / _layout / _glass / _scrollbar`) are copied **byte-identical** into `packages/vue/src/styles/theme/` (verified with diff; only a one-line provenance header is prepended: *edit upstream, then re-copy*). They are reachable via the `./styles/*` wildcard — e.g. `@celestia-island/hikari/styles/theme/base.scss`. All internal `@use`s are same-directory relative, so the copies are self-contained. Nothing under `packages/theme` itself was touched.
- **Dead alias removed** (`packages/vue/vite.config.ts`): `@celestia-island/plana-ui → ../../../plana/packages/ui/src` (target retired in plana #264; zero imports repo-wide — only historical prose comments remain).
- **README rewrite**: the stale Vue section ("not yet published", `link:../hikari/packages/vue`, pnpm-workspace member wiring) now documents the registry model: depend with `^\*`, a subpath exports table, and `celestia-devtools link-npm-siblings` for local development (node_modules symlink overlay — no sibling checkout required, no manifest changes, revert with `--remove`).
- **Version** 0.29.0 → 0.30.0 (new exports surface = minor). No collision: open PRs #349 (0.26.0) and #337 (0.22.0) are stale bumps off older masters, neither claims 0.30.0.

## Consumer-facing specifiers that now resolve from a registry install

| Specifier | Target |
| --- | --- |
| `@celestia-island/hikari` | `src/index.ts` |
| `@celestia-island/hikari/runtime` | `src/runtime/index.ts` |
| `@celestia-island/hikari/plugins` | `src/plugins/index.ts` |
| `@celestia-island/hikari/styles` | `src/styles/index.scss` (aggregate — monorepo-relative `@use`s, dev use) |
| `@celestia-island/hikari/styles/index.scss` | `src/styles/index.scss` |
| `@celestia-island/hikari/styles/admin-tokens.scss` | `src/styles/admin-tokens.scss` |
| `@celestia-island/hikari/styles/theme/variables.scss` | `src/styles/theme/variables.scss` |
| `@celestia-island/hikari/styles/theme/mixins.scss` | `src/styles/theme/mixins.scss` |
| `@celestia-island/hikari/styles/theme/foundation.scss` | `src/styles/theme/foundation.scss` |
| `@celestia-island/hikari/styles/theme/themes.scss` | `src/styles/theme/themes.scss` |
| `@celestia-island/hikari/styles/theme/base.scss` | `src/styles/theme/base.scss` |
| `@celestia-island/hikari/styles/theme/_tokens.scss` | `src/styles/theme/_tokens.scss` |
| `@celestia-island/hikari/styles/theme/_layout.scss` | `src/styles/theme/_layout.scss` |
| `@celestia-island/hikari/styles/theme/_glass.scss` | `src/styles/theme/_glass.scss` |
| `@celestia-island/hikari/styles/theme/_scrollbar.scss` | `src/styles/theme/_scrollbar.scss` |
| `@celestia-island/hikari/components/<Name>` | `src/components/<Name>` (components are `.tsx`; extensionless type-imports resolve, e.g. `components/HkSelectionGrid`) |
| `@celestia-island/hikari/components/<Name>.tsx / .scss` | direct file |

Chest's `hikari-chrome.scss` / erp's `tokens.scss` can switch their six hikari `@use`s to `styles/theme/{variables,mixins,foundation,themes,base}.scss` + `styles/admin-tokens.scss` once this publishes; erp's `import type { SelectionGridCols } from "@celestia-island/hikari/components/HkSelectionGrid"` resolves via `./components/*`.

## Why

The npm package (0.4.5 published) predates the current exports surface; consumers still depend on a sibling checkout because deep component imports and the theme foundation files could not resolve from a registry install. This unblocks the consumer wave switching to `"@celestia-island/hikari": "^*"`.

## Verification

- `vue-tsc --noEmit` from `packages/vue` (worktree, shared node_modules symlink): **0 errors** (no build run, per the build freeze — targeted typecheck only).
- Exports-map resolution simulated for all 17 consumer specifiers above: every one maps to an existing file (extension resolution for `.tsx`).
- Vendored files verified byte-identical to `packages/theme/styles/*` (diff after stripping the provenance header); independent sass compiles of `theme/base.scss`, `theme/themes.scss`, `theme/mixins.scss`, `theme/foundation.scss`, `admin-tokens.scss` all succeed — the copies are self-contained.
- Independent subagent cross-verification: PASS 9/9 (diff scope, no `packages/theme` or crate changes, valid JSON, exact `./styles` key not shadowed, no absolute paths, no stray files).

---
Rebased onto master (8d6349e, #354): version conflict resolved keeping 0.30.0; head is now 942a610.