### PR TITLE
🐛 Refuse to interpolate undefined into captcha, probe, and attachment URLs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.20"
+version = "0.3.21"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Hikari Contributors"]

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAttachmentModal.tsx
+++ b/packages/vue/src/components/HkAttachmentModal.tsx
@@ -139,7 +139,16 @@ export const HkAttachmentModal = defineComponent({
       if (props.resolveUrl) {
         srcLoading.value = true;
         try {
-          resolvedSrc.value = await props.resolveUrl(att.name);
+          const resolved = await props.resolveUrl(att.name);
+          // A resolver that misses (map lookup, stale cache) may return
+          // undefined — store the empty string so every src binding stays
+          // a real string and the srcError path explains the empty preview.
+          if (typeof resolved !== "string" || !resolved) {
+            resolvedSrc.value = "";
+            srcError.value = `no URL resolved for "${att.name}"`;
+            return;
+          }
+          resolvedSrc.value = resolved;
         } catch (e) {
           resolvedSrc.value = "";
           srcError.value = e instanceof Error ? e.message : String(e);

--- a/packages/vue/src/components/HkCaptchaWidget.tsx
+++ b/packages/vue/src/components/HkCaptchaWidget.tsx
@@ -110,6 +110,16 @@ export const HkCaptchaWidget = defineComponent({
       loading.value = true;
       try {
         const src = props.scriptUrl || DEFAULT_SCRIPT_URLS[props.provider];
+        // An unknown provider string (config-driven value, typo) makes the
+        // lookup above return undefined — and `el.src = undefined` coerces
+        // to the literal "undefined", so the browser fetches
+        // `<origin>/undefined` and the widget reports a bogus load failure.
+        // Fail loudly with the provider name instead.
+        if (!src) {
+          throw new Error(
+            `no script URL for captcha provider "${props.provider}" (expected "${Object.keys(DEFAULT_SCRIPT_URLS).join('" | "')}")`,
+          );
+        }
         if (props.provider === "turnstile") {
           await loadScript(src);
           const api = getGlobal("turnstile") as TurnstileApi | undefined;

--- a/packages/vue/src/composables/useConnectionProbe.ts
+++ b/packages/vue/src/composables/useConnectionProbe.ts
@@ -34,8 +34,12 @@ export function setProbeEndpoint(endpoint: string | (() => string)): void {
 }
 
 function endpointUrl(): string {
-  const base = (typeof probeEndpoint === "function" ? probeEndpoint() : probeEndpoint)
-    .replace(/\/+$/, "");
+  // A consumer-registered endpoint function returning undefined/null must
+  // degrade to the same-origin default ("/api/health"), not crash the
+  // probe loop — the TypeError from .replace-on-undefined is swallowed by
+  // probeOnce's catch and permanently misreports the app as offline.
+  const raw = typeof probeEndpoint === "function" ? probeEndpoint() : probeEndpoint;
+  const base = (raw ?? "").replace(/\/+$/, "");
   return `${base}/api/health`;
 }
 

--- a/packages/vue/src/utils/powNonce.ts
+++ b/packages/vue/src/utils/powNonce.ts
@@ -6,6 +6,18 @@ export type ChallengeDescriptor =
   | null;
 
 /**
+ * Normalize the API base before it is interpolated into request URLs.
+ * Both exported functions are public API: a caller that passes an
+ * undefined/missed config value would otherwise fetch `undefined/health`
+ * — a relative URL resolving to `<origin>/undefined/health` — and fail
+ * with a 404 that looks like a backend problem. Same pattern as
+ * useEngineHealth's baseUrl guard.
+ */
+function normalizeBase(baseUrl: string): string {
+  return (baseUrl ?? "").replace(/\/+$/, "");
+}
+
+/**
  * Fetch the anti-bot challenge descriptor from a public `/health`-style
  * endpoint (upstreamed from shittim-chest's api/pow.ts).
  *
@@ -21,7 +33,7 @@ export async function fetchChallenge(
 ): Promise<ChallengeDescriptor | undefined> {
   let resp: Response;
   try {
-    resp = await fetchFn(`${baseUrl}/health`, { credentials: "same-origin" });
+    resp = await fetchFn(`${normalizeBase(baseUrl)}/health`, { credentials: "same-origin" });
   } catch {
     return undefined;
   }
@@ -66,7 +78,7 @@ export async function negotiateNonce(
       // challenge === null: the gate is disabled and the backend issues a
       // nonce without proof, so an empty body is the correct request.
     }
-    const resp = await fetchFn(`${baseUrl}/auth/nonce`, {
+    const resp = await fetchFn(`${normalizeBase(baseUrl)}/auth/nonce`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: body ? JSON.stringify(body) : undefined,


### PR DESCRIPTION
## Summary
Defensive sweep for the undefined-into-URL bug class field-observed in the chest demo (a poisoned route target made vue-router compute `origin + "undefined"` and full-page navigate to the invalid host). Four low-level guards so library consumers can never stringify undefined into a URL:

- **HkCaptchaWidget**: an unknown provider string (config-driven value) made `DEFAULT_SCRIPT_URLS[provider]` → undefined and `el.src = undefined` fetch `<origin>/undefined`; now fails loudly via the error emit with the provider name.
- **powNonce.ts**: `fetchChallenge`/`negotiateNonce` normalize the public `baseUrl` param (mirrors `useEngineHealth`), so an undefined config value degrades to same-origin instead of `fetch("undefined/health")`.
- **useConnectionProbe**: a registered endpoint resolver returning undefined no longer throws inside the probe loop (which the catch misreports as permanently offline).
- **HkAttachmentModal**: an attachment resolver returning undefined becomes a typed error state instead of a silently empty preview.

## Verification
- `vue-tsc --noEmit`: 0 errors
- full vitest run: failure set identical to the master baseline (HkDatePicker, HkMenu — pre-existing, verified via stash on pristine master)

## Versions
cargo 0.3.20 → 0.3.21; @celestia-island/hikari 0.29.0 → 0.29.1