### PR TITLE
✨ Add the HkAuthMethodList provider button group and an HkAuthCard methods slot.

### DIFF
--- a/packages/vue/src/components/HkAuthCard.tsx
+++ b/packages/vue/src/components/HkAuthCard.tsx
@@ -6,6 +6,12 @@ import { defineComponent, type PropType } from "vue";
  * form body.
  *
  * Slot layout contract:
+ * - `methods` renders into a full-width block between the form and the
+ *   footer (typically `HkAuthMethodList`): alternative sign-in buttons
+ *   that must line up with the form inputs. Keeping them OUT of the
+ *   footer is what lets the footer's checkbox rows stay a centered,
+ *   fit-content group instead of being dragged full width with the
+ *   buttons.
  * - `footer` renders into `.s-auth-footer`, a flex column sized to its
  *   widest row and centered in the card: every slot child is its own row
  *   (remember-me, protocol consent, a sign-in link…) and the rows share
@@ -39,6 +45,11 @@ export const HkAuthCard = defineComponent({
         <div class="s-auth-form">
           {slots.default?.()}
         </div>
+        {slots.methods && (
+          <div class="s-auth-methods">
+            {slots.methods()}
+          </div>
+        )}
         {slots.footer && (
           <div class="s-auth-footer">
             {slots.footer()}

--- a/packages/vue/src/components/HkAuthMethodList.scss
+++ b/packages/vue/src/components/HkAuthMethodList.scss
@@ -1,0 +1,47 @@
+/* Full-width stacked alternative sign-in buttons (login card). The block
+   container `.s-auth-methods` and its spacing are owned by HkAuthCard's
+   slot styles (styles/admin-tokens.scss); this file only styles the
+   divider and the buttons the component renders into that slot. */
+
+/* "Other ways to sign in" divider row between rules. */
+.s-auth-methods-divider {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 0 var(--space-4, 0.25rem);
+  color: var(--hi-color-muted, #999);
+  font-size: var(--text-xs, 0.75rem);
+  text-align: center;
+}
+
+.s-auth-methods-divider::before,
+.s-auth-methods-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--hi-color-border, #ddd);
+}
+
+/* Fixed icon + label columns: the two spans keep the same width on every
+   row, so icons and labels align across buttons while each button stays a
+   centered hk-btn-block. HkButton has a fragment root, so inbound classes
+   don't fall through — scope everything off the `.s-auth-methods`
+   container instead of a button-level class. Apps with longer labels
+   widen the label column via `--auth-methods-label-width`. */
+.s-auth-methods > .hk-btn .s-auth-methods-icon {
+  width: 20px;
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.s-auth-methods > .hk-btn .s-auth-methods-label {
+  width: var(--auth-methods-label-width, 8em);
+  flex: none;
+  text-align: start;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/packages/vue/src/components/HkAuthMethodList.test.tsx
+++ b/packages/vue/src/components/HkAuthMethodList.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import HkAuthMethodList from "./HkAuthMethodList";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+const methods = [
+  { key: "github", label: "GitHub" },
+  { key: "linuxdo", label: "LinuxDo" },
+];
+
+describe("HkAuthMethodList", () => {
+  it("renders one fixed-column button per method and an optional divider", () => {
+    // The card's `methods` slot owns the `.s-auth-methods` container —
+    // reproduce that context here (the component itself is a fragment).
+    const c = mount(
+      h("div", { class: "s-auth-methods" }, h(HkAuthMethodList, { divider: "其他方式登录", methods })),
+    );
+    const divider = c.querySelector(".s-auth-methods-divider");
+    expect(divider?.textContent).toContain("其他方式登录");
+    const buttons = c.querySelectorAll<HTMLButtonElement>(".s-auth-methods > .hk-btn");
+    expect(buttons.length).toBe(2);
+    const labels = [...buttons].map(
+      (b) => b.querySelector<HTMLElement>(".s-auth-methods-label")?.textContent,
+    );
+    expect(labels).toEqual(["GitHub", "LinuxDo"]);
+    for (const b of buttons) {
+      expect(b.querySelector(".s-auth-methods-icon")).toBeTruthy();
+      expect(b.classList.contains("hk-btn-block")).toBe(true);
+    }
+  });
+
+  it("emits select with the method key on click", async () => {
+    let picked = "";
+    const c = mount(
+      h("div", { class: "s-auth-methods" }, h(HkAuthMethodList, {
+        methods,
+        onSelect: (key: string) => {
+          picked = key;
+        },
+      })),
+    );
+    const buttons = c.querySelectorAll<HTMLButtonElement>(".s-auth-methods > .hk-btn");
+    buttons[1]!.click();
+    await nextTick();
+    expect(picked).toBe("linuxdo");
+  });
+});

--- a/packages/vue/src/components/HkAuthMethodList.tsx
+++ b/packages/vue/src/components/HkAuthMethodList.tsx
@@ -1,0 +1,69 @@
+import { defineComponent, type PropType, type VNode } from "vue";
+import HkButton from "./HkButton";
+import "./HkAuthMethodList.scss";
+
+/**
+ * HkAuthMethodList — full-width stacked third-party sign-in buttons for
+ * auth cards (the ERP login's provider-button grammar, componentized).
+ *
+ * Every button renders [icon | label] with a FIXED icon column and a FIXED
+ * label column (CSS var `--auth-methods-label-width`, default 8em), so the
+ * icons and the label text start at the same x on every row regardless of
+ * label length; because every content block is then the same width, the
+ * row can stay centered like any HkButton without the columns drifting.
+ *
+ * Render it through HkAuthCard's `methods` slot: the card owns the
+ * full-width block layout and the vertical rhythm, and the footer's
+ * checkbox rows keep their centered-group behavior instead of being
+ * dragged full width with the buttons.
+ */
+export default defineComponent({
+  name: "HkAuthMethodList",
+  props: {
+    /** Optional divider text rendered above the buttons, e.g. "其他方式登录".
+     *  Consumer-localized on purpose: hikari ships no dictionary dependency
+     *  onto hosts here. */
+    divider: { type: String, default: "" },
+    /** Provider entries, in render order. */
+    methods: {
+      type: Array as unknown as () => Array<{
+        key: string;
+        label: string;
+        /** Prebuilt icon vnode (brand SVG, <img>, …) — `null` renders an
+         *  empty fixed-width column so the labels still align. The column
+         *  is fixed-size, so any ~16-20px glyph aligns. */
+        icon?: VNode | null;
+        disabled?: boolean;
+      }>,
+      required: true,
+    },
+  },
+  emits: {
+    /** A method button was clicked. */
+    select: (_key: string) => true,
+  },
+  setup(props, { emit }) {
+    return () => (
+      <>
+        {props.divider && (
+          <div class="s-auth-methods-divider">
+            <span>{props.divider}</span>
+          </div>
+        )}
+        {props.methods.map((method) => (
+          <HkButton
+            key={method.key}
+            variant="outline"
+            size="md"
+            block
+            disabled={method.disabled === true}
+            onClick={() => emit("select", method.key)}
+          >
+            <span class="s-auth-methods-icon">{method.icon}</span>
+            <span class="s-auth-methods-label">{method.label}</span>
+          </HkButton>
+        ))}
+      </>
+    );
+  },
+});

--- a/packages/vue/src/components/HkSignInCard.tsx
+++ b/packages/vue/src/components/HkSignInCard.tsx
@@ -30,6 +30,10 @@ import HkAuthSubmitButton from "./HkAuthSubmitButton";
  *   `hikari::signIn.usernamePlaceholder` locale when unset.
  * - `footer` slot — content below the submit button (remember-me,
  *   protocol links, …).
+ * - `methods` slot — forwarded to HkAuthCard's full-width methods block
+ *   between the form and the footer (typically `HkAuthMethodList`), so
+ *   alternative sign-in buttons line up with the inputs while the footer
+ *   rows keep their centered-group layout.
  *
  * ```tsx
  * <HSignInCard
@@ -148,6 +152,7 @@ export const HkSignInCard = defineComponent({
             </>
           ),
           footer: () => slots.footer?.(),
+          methods: () => slots.methods?.(),
         }}
       </HkAuthCard>
     );

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -260,6 +260,7 @@ export { HkAdminHeader as HAdminHeader } from "./components/HkAdminHeader";
 export { HkNavSidebar as HNavSidebar } from "./components/HkNavSidebar";
 export { HkThemeToggle as HThemeToggle } from "./components/HkThemeToggle";
 export { HkAuthCard as HAuthCard } from "./components/HkAuthCard";
+export { default as HAuthMethodList } from "./components/HkAuthMethodList";
 export { HkSignInCard as HSignInCard } from "./components/HkSignInCard";
 export { default as HAuthSubmitButton } from "./components/HkAuthSubmitButton";
 export { usePageTitle, useRouteTitle } from "./composables/usePageTitle";

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -655,6 +655,26 @@
   padding-bottom: var(--space-8, 0.5rem);
 }
 
+/* Full-width alternative sign-in methods block (HkAuthCard `methods`
+   slot, usually HkAuthMethodList). Same side padding as the form and the
+   footer so the buttons line up exactly with the inputs; the footer keeps
+   its fit-content centered-group behavior because the buttons live here,
+   not in the footer. */
+.s-auth-methods {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8, 0.5rem);
+  padding: 0 var(--space-32, 2rem);
+  margin-top: var(--space-16, 1rem);
+}
+
+/* Keep the vertical rhythm when the block sits between form and footer:
+   form → 24px → divider row (8px collapsed padding + 16px margin), and
+   buttons → 16px → footer rows (the footer's own margin-top). */
+.s-auth-form:has(+ .s-auth-methods) {
+  padding-bottom: var(--space-8, 0.5rem);
+}
+
 .s-auth-link {
   font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-text-secondary, #999);
@@ -686,6 +706,7 @@
   .s-auth-header { padding-left: var(--space-16, 1rem); padding-right: var(--space-16, 1rem); }
   .s-auth-form  { padding: var(--space-20, 1.25rem) var(--space-16, 1rem) var(--space-24, 1.5rem); }
   .s-auth-footer { padding-left: var(--space-16, 1rem); padding-right: var(--space-16, 1rem); }
+  .s-auth-methods { padding-left: var(--space-16, 1rem); padding-right: var(--space-16, 1rem); }
 }
 
 /* ── Arona app utility classes ── */


### PR DESCRIPTION
## Summary
Componentize the full-width stacked third-party sign-in buttons (the ERP login's provider-button grammar) so hosts stop hand-rolling them:

- **`HkAuthMethodList`**: renders one outline `HkButton` per provider with a fixed 20px icon column and a fixed label column (`--auth-methods-label-width`, default 8em, ellipsis on overflow). Because every content block is the same width, icons and labels align across rows regardless of label length while each button stays a centered `hk-btn-block`. Optional localized divider row ("其他方式登录").
- **`HkAuthCard` `methods` slot**: rendered full-width between the form and the footer (same side padding as the form, so buttons line up exactly with the inputs). Hosting alt-sign-in buttons there — instead of inside the footer — keeps the footer's checkbox rows a centered fit-content group (the shittim-chest login had regressed to left-stuck rows when the footer itself was widened).
- Vertical rhythm: form → 24px → divider/buttons → 16px → footer rows; ≤480px padding follows the card.

## Verification
- vue-tsc 0 errors; new `HkAuthMethodList.test.tsx` 2/2 (divider + fixed-column buttons render, select emit on click). Note HkButton has a fragment root so inbound classes don't fall through — styles scope off the `.s-auth-methods` container.