### PR TITLE
✨ Add an embedded-field opt-out to the bare input baseline.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Hikari Contributors"]

--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hikari-e2e"
-version = "0.3.20"
+version.workspace = true
 description = "E2E testing framework for Hikari UI components"
 authors = ["Hikari Contributors"]
 license-file = "../../LICENSE"

--- a/packages/theme/styles/base.scss
+++ b/packages/theme/styles/base.scss
@@ -387,13 +387,25 @@ li {
 // .s-workspace-btn grew a 16px/500 font overnight — hikari #233 fallout);
 // :where() keeps the hk- exclusion at (0,0,1), the exact cascade position
 // the element baseline had before the guards existed (#232/#233).
-input:where(:not([class^="hk-"]):not([class*=" hk-"])),
-textarea:where(:not([class^="hk-"]):not([class*=" hk-"])),
-select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+//
+// 2026-09-02: sanctioned opt-out for shell-EMBEDDED app inputs. Apps that
+// hand-roll a styled field shell around a bare <input> (chest's prefixed
+// workspace-URL field) hit the same double-border disease as #232: the
+// baseline's :focus-visible ring (0,1,1) outranks the shell author's plain
+// class `outline: none` (0,1,0) and paints an inner frame inside the shell
+// while typing. Stamping `data-field-embedded` on the element opts it out
+// of the baseline entirely — the shell owns all field chrome. The guard
+// rides inside the same :where(...) so it adds zero specificity.
+input:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])),
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])),
+select:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     @include input-base;
 }
 
-textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+// Same opt-out contract as the baseline above: an embedded textarea must
+// not get a forced 80px min-height / vertical resize grip inside an app's
+// own shell.
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     min-height: 80px;
     resize: vertical;
 }
@@ -446,7 +458,9 @@ textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
 // components render bare <select>/<label>/<button> interiors that own their
 // chrome, and the element-level :focus-visible ring (0,1,1) would outrank
 // their plain-class styles exactly like the double-border input bug (#232).
-select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+// The embedded-field opt-out applies here too: a select inside an app's own
+// shell must not get the forced appearance reset + chevron + padding.
+select:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%239CA3AF" d="M2 4l4 4 4-4"/></svg>');
     background-repeat: no-repeat;

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/styles/theme/base.scss
+++ b/packages/vue/src/styles/theme/base.scss
@@ -388,13 +388,25 @@ li {
 // .s-workspace-btn grew a 16px/500 font overnight — hikari #233 fallout);
 // :where() keeps the hk- exclusion at (0,0,1), the exact cascade position
 // the element baseline had before the guards existed (#232/#233).
-input:where(:not([class^="hk-"]):not([class*=" hk-"])),
-textarea:where(:not([class^="hk-"]):not([class*=" hk-"])),
-select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+//
+// 2026-09-02: sanctioned opt-out for shell-EMBEDDED app inputs. Apps that
+// hand-roll a styled field shell around a bare <input> (chest's prefixed
+// workspace-URL field) hit the same double-border disease as #232: the
+// baseline's :focus-visible ring (0,1,1) outranks the shell author's plain
+// class `outline: none` (0,1,0) and paints an inner frame inside the shell
+// while typing. Stamping `data-field-embedded` on the element opts it out
+// of the baseline entirely — the shell owns all field chrome. The guard
+// rides inside the same :where(...) so it adds zero specificity.
+input:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])),
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])),
+select:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     @include input-base;
 }
 
-textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+// Same opt-out contract as the baseline above: an embedded textarea must
+// not get a forced 80px min-height / vertical resize grip inside an app's
+// own shell.
+textarea:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     min-height: 80px;
     resize: vertical;
 }
@@ -447,7 +459,9 @@ textarea:where(:not([class^="hk-"]):not([class*=" hk-"])) {
 // components render bare <select>/<label>/<button> interiors that own their
 // chrome, and the element-level :focus-visible ring (0,1,1) would outrank
 // their plain-class styles exactly like the double-border input bug (#232).
-select:where(:not([class^="hk-"]):not([class*=" hk-"])) {
+// The embedded-field opt-out applies here too: a select inside an app's own
+// shell must not get the forced appearance reset + chevron + padding.
+select:where(:not([class^="hk-"]):not([class*=" hk-"]):not([data-field-embedded])) {
     appearance: none;
     background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="%239CA3AF" d="M2 4l4 4 4-4"/></svg>');
     background-repeat: no-repeat;


### PR DESCRIPTION
## What

The global bare-input baseline (`input/textarea/select:where(:not([class^="hk-"]):not([class*=" hk-"]))`) gains a third zero-specificity guard inside the same `:where(...)`: `:not([data-field-embedded])`. All four guarded rule groups share the contract: the `input-base` chrome (border/background/focus ring), the textarea `min-height: 80px; resize: vertical` rule, and the select `appearance: none` + chevron + padding rule.

## Why

Apps that hand-roll a styled field shell around a bare `<input>` hit the same double-border disease class #232 fixed for `hk-` components: the baseline's element-level `:focus-visible` ring measures (0,1,1) and outranks the shell author's plain-class `outline: none` (0,1,0), painting an inner frame inside the shell while typing. Observed live on shittim-chest's prefixed workspace-URL field (仓库地址 in the create-workspace modal). The `hk-` class exclusion only helps hikari's own components; `data-field-embedded` is the sanctioned opt-out for app-embedded fields — the shell owns all field chrome.

The guard rides inside `:where()` so it adds zero specificity (the #233 lesson), and it only ever shrinks selector matching: elements without the attribute match exactly as before (compiled diff vs master is selector-text only, verified).

## Vendored copy

Per the #353 vendoring protocol, `packages/vue/src/styles/theme/base.scss` is re-copied byte-identical from the upstream file (header line preserved), so npm registry installs get the same opt-out.

## Bundle

- `packages/e2e/Cargo.toml`: `version = "0.3.20"` → `version.workspace = true` to clear the pre-existing `verify-versions` drift (CI gate is green with this; note cargo-level workspace membership of `packages/e2e` remains a pre-existing follow-up chore, unchanged behavior).
- Versions: npm 0.29.1 → **0.30.1** (on top of master's #353 0.30.0), cargo 0.3.21 → 0.3.22. Rebased onto master tip b5d141a (#353).

## Verification

- `celestia-devtools verify-versions`: green (cargo=0.3.22, npm=0.30.1).
- Single-file sass compile of both `base.scss` copies: clean; compiled diff vs master contains only the new `:not([data-field-embedded])` selector text (14/14 added lines carry the guard, zero property changes). Vendored copy verified byte-identical to upstream modulo the header.
- Two independent adversarial review rounds (R1/R2): SHIP, 0 MAJOR; R1's contract-completeness minor (textarea/select siblings unguarded) is fixed in this PR.
- Per §7.2 no full build was run; downstream compile behavior is covered by consumers' next malkuth build wave.