### PR TITLE
🎨 Swap the armed delete into an in-place × overlay and widen the empty-row hint.

### DIFF
--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -88,12 +88,13 @@
 
 /* ── language list (menu header) ────────────────────────────────────
  * One row per language currently present — including the one being
- * edited. LEFT = the already-edited translation text (empty glyph while
- * it holds nothing), RIGHT = the same language chip as the closed field.
- * Clicking the chip ARMS the delete: the row turns danger-red and an ×
- * button widens into the chip's slot (desktop: hovering the row swaps
- * the × in without arming); clicking the × erases the translation. The
- * list squashes/expands around adds and removals via HkListTransition. */
+ * edited. LEFT = the already-edited translation text (italic enter-text
+ * hint while it holds nothing), RIGHT = the same language chip as the
+ * closed field. Clicking the chip ARMS the delete: the row turns
+ * danger-red and the × overlays the chip in the same slot (desktop:
+ * hovering the row swaps the × in without arming); clicking the × erases
+ * the translation. The list squashes/expands around adds and removals
+ * via HkListTransition. */
 .hk-localized-input-tags {
   padding: 10px 0 8px;
   border-bottom: 1px solid var(--border-faint);
@@ -104,8 +105,13 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-width: 15rem;
-  max-width: 20rem;
+  /* Wider than the old two-line pill cloud: a full row carries the
+   * translation text AND the language chip, and desktop popouts should
+   * not crumple them into one tight box. `min(18rem, 100%)` keeps the
+   * floor from overflowing tiny (sub-320px) mobile viewports — the
+   * sheet list can never scroll horizontally because of it. */
+  min-width: min(18rem, 100%);
+  max-width: 24rem;
 }
 
 .hk-localized-input-tag {
@@ -173,11 +179,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  /* No translation yet (usually the language being edited): the glyph
-   * stays muted so the row reads as "nothing stored here". */
+  /* No translation yet (usually the language being edited): an italic
+   * "enter text" hint asks for input instead of a bare punctuation
+   * glyph — the row reads as an empty slot, not a dash. */
   &[data-empty] {
     color: rgb(var(--color-muted));
-    opacity: 0.75;
+    opacity: 0.8;
+    font-style: italic;
   }
 }
 
@@ -231,38 +239,44 @@
   background: rgb(var(--color-primary));
 }
 
-/* The confirm × occupies the chip's slot: while hidden its width
- * collapses to 0 (so the chip sits at the row edge), and on arm/hover it
- * widens in — pushing the chip label a step leftward, exactly where the
- * × now sits. Width transitions animate the reflow smoothly. */
-.hk-localized-input-tag-x {
+/* The chip's slot hosts BOTH the chip and the confirm ×: the × overlays
+ * the chip absolutely (inset:0), so arm/hover swaps the two in place —
+ * zero layout animation, zero reflow, nothing slides. The row never
+ * changes its geometry, which is exactly what makes the armed state feel
+ * instant (the previous width-transition version reflowed the row and
+ * was visibly laggy). */
+.hk-localized-input-tag-slot {
+  position: relative;
+  display: inline-flex;
   flex: none;
+}
+
+.hk-localized-input-tag-x {
+  position: absolute;
+  inset: 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
-  max-width: 0;
   padding: 0;
-  overflow: hidden;
   border: 0;
+  border-radius: 999px;
   background: transparent;
   color: rgb(var(--color-danger, 240 70 80));
   cursor: pointer;
   opacity: 0;
   pointer-events: none;
   appearance: none;
-  transition: max-width 0.15s ease, opacity 0.12s ease;
+  transition: opacity 0.1s ease;
 
   &:hover,
   &:focus-visible {
-    color: rgb(var(--color-danger, 240 70 80));
+    background: rgb(var(--color-danger, 240 70 80) / 12%);
   }
 }
 
 .hk-localized-input-tag[data-armed] .hk-localized-input-tag-x,
 .hk-localized-input-tag:hover .hk-localized-input-tag-x,
 .hk-localized-input-tag-x:focus-visible {
-  max-width: 1.5rem;
   opacity: 1;
   pointer-events: auto;
 }

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -271,15 +271,17 @@ describe("HkLocalizedInput", () => {
     }
   });
 
-  it("lists the edited language even while it holds no translation (empty glyph)", async () => {
+  it("lists the edited language even while it holds no translation (italic hint)", async () => {
     const { container } = mountInput({ modelValue: "Plant overview" });
     await openMenu(container);
     // The field edits English with nothing stored yet — still listed.
     expect(tagLabels()).toEqual(["English"]);
     const row = tag("English")!;
     const text = row.querySelector(".hk-localized-input-tag-text")!;
-    expect(text.textContent).toBe("—");
+    // No bare dash: an i18n "enter text" hint asks for input instead.
+    expect(text.textContent).toBe("Enter text in the field");
     expect(text.hasAttribute("data-empty")).toBe(true);
+    expect(text.classList.contains("hk-localized-input-tag-text")).toBe(true);
     expect(row.hasAttribute("data-active")).toBe(true);
   });
 
@@ -532,6 +534,28 @@ describe("HkLocalizedInput", () => {
     expect(x.hasAttribute("aria-hidden")).toBe(false);
   });
 
+  it("swaps the chip for the × in place — one slot, no layout shift", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
+    });
+    await openMenu(container);
+    const row = tag("简体中文")!;
+    const slot = row.querySelector(".hk-localized-input-tag-slot")!;
+    // Both controls share the chip's slot; the × overlays it (absolute
+    // in CSS), so arming never reflows the row or slides the label.
+    expect(slot.querySelector(".hk-localized-input-tag-locale")).toBeTruthy();
+    const x = slot.querySelector(".hk-localized-input-tag-x")!;
+    expect(x.getAttribute("aria-hidden")).toBe("true");
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(x.getAttribute("aria-hidden")).toBeNull();
+    expect(row.hasAttribute("data-armed")).toBe(true);
+    // The chip itself stays in the DOM (covered by the ×) — the swap is
+    // purely visual.
+    expect(slot.querySelector(".hk-localized-input-tag-locale")).toBeTruthy();
+  });
+
   it("names the row body by its action and the arm/confirm controls by their step", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
@@ -547,6 +571,15 @@ describe("HkLocalizedInput", () => {
     expect(tagX("简体中文")?.getAttribute("aria-label")).toBe(
       "Confirm delete — 简体中文 (zh-Hans)",
     );
+    // Arm: the chip relabels to its actual action (cancel), leaves the
+    // tab order, and the × takes the sole tab stop of the slot.
+    tagLocale("简体中文")!.click();
+    await nextTick();
+    expect(tagLocale("简体中文")?.getAttribute("aria-label")).toBe(
+      "Cancel delete — 简体中文 (zh-Hans)",
+    );
+    expect(tagLocale("简体中文")?.tabIndex).toBe(-1);
+    expect(tagX("简体中文")?.tabIndex).toBe(0);
   });
 
   it("disarms every row when the menu closes", async () => {
@@ -650,9 +683,11 @@ describe("HkLocalizedInput", () => {
     await eraseViaArm(container, "English");
     expect(events.translations.at(-1)).toEqual({});
     expect(events.modelValue.at(-1)).toBe("");
-    // The edited language row stays (empty glyph); the menu stays open.
+    // The edited language row stays (italic hint); the menu stays open.
     expect(tagLabels()).toEqual(["English"]);
-    expect(tag("English")?.querySelector(".hk-localized-input-tag-text")?.textContent).toBe("—");
+    expect(tag("English")?.querySelector(".hk-localized-input-tag-text")?.textContent).toBe(
+      "Enter text in the field",
+    );
     expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
   });
 

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -27,9 +27,6 @@ export interface HkLocaleOption {
 /** Marker key for the "Add language" cascade root (never a real locale). */
 const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
 
-/** Placeholder glyph for a language that holds no translation yet. */
-const EMPTY_GLYPH = "—";
-
 /**
  * HkLocalizedInput — single-field multilingual text editor.
  *
@@ -44,12 +41,13 @@ const EMPTY_GLYPH = "—";
  *     anchored popout and mobile a bottom-up sheet — identical behavior
  *     to the app-level language switcher). The menu body is a LANGUAGE
  *     LIST — one row per language currently present, INCLUDING the one
- *     being edited (its row carries the active tint and shows the empty
- *     glyph while it holds no text):
+ *     being edited (its row carries the active tint and shows an italic
+ *     "enter text" hint while it holds no text):
  *       · LEFT side of a row = the already-edited translation text;
  *       · RIGHT side = the same language chip as the closed field —
- *         click it to ARM deletion: the row turns danger-red, the chip
- *         label shifts and an × button appears in the chip's slot;
+ *         click it to ARM deletion: the row turns danger-red and an ×
+ *         button appears IN PLACE of the chip (no slide, no layout
+ *         shift — just an instant swap in the same slot);
  *       · clicking the × erases the translation for real. On TOUCH the
  *         arm is the guard (tap the chip, then tap the × that appears);
  *         on DESKTOP hovering the row swaps in the × and a single click
@@ -224,6 +222,13 @@ export const HkLocalizedInput = defineComponent({
       return `${t("hikari::localizedInput.removeTranslation", "Remove translation")} — ${localeLabel(code)} (${code})`;
     }
 
+    /** Accessible label of the SAME chip while the row is armed: clicking
+     *  it again cancels — the label must follow the actual action (the ×
+     *  on top of it owns the confirm). */
+    function cancelLabel(code: string): string {
+      return `${t("hikari::localizedInput.cancelDelete", "Cancel delete")} — ${localeLabel(code)} (${code})`;
+    }
+
     /** Accessible label of the confirm ×: erases the translation for
      *  real after the arm step. */
     function confirmLabel(code: string): string {
@@ -232,9 +237,9 @@ export const HkLocalizedInput = defineComponent({
 
     /** Accessible name of a row body: the control switches the field to
      *  that language — the raw translation text is visible content (and
-     *  the empty glyph reads as punctuation), so the name must identify
-     *  the ACTION (title is ignored by the accname algorithm once the
-     *  element has text content). */
+     *  the empty hint reads as a passive prompt, not the action), so the
+     *  name must identify the ACTION (title is ignored by the accname
+     *  algorithm once the element has text content). */
     function switchLabel(code: string): string {
       return `${t("hikari::localizedInput.switchLanguage", "Switch to")} ${localeLabel(code)} (${code})`;
     }
@@ -438,46 +443,59 @@ export const HkLocalizedInput = defineComponent({
                             class="hk-localized-input-tag-text"
                             data-empty={!value || undefined}
                           >
-                            {value || EMPTY_GLYPH}
+                            {value ||
+                              t(
+                                "hikari::localizedInput.emptyRow",
+                                "Enter text in the field",
+                              )}
                           </span>
                         </button>
-                        <button
-                          type="button"
-                          class="hk-localized-input-tag-locale"
-                          aria-label={armLabel(code)}
-                          title={armLabel(code)}
-                          onClick={(e: MouseEvent) => {
-                            e.stopPropagation();
-                            toggleArm(code);
-                          }}
-                          onMousedown={(e: MouseEvent) => e.preventDefault()}
-                        >
-                          <span class="hk-localized-input-tag-label">{localeLabel(code)}</span>
-                          <span class="hk-localized-input-tag-code">{code}</span>
-                          {active && (
-                            <span class="hk-localized-input-tag-dot" aria-hidden="true" />
-                          )}
-                        </button>
-                        <button
-                          type="button"
-                          class="hk-localized-input-tag-x"
-                          aria-label={confirmLabel(code)}
-                          title={confirmLabel(code)}
-                          // Hidden via CSS until armed/hovered; keep it out
-                          // of the tab order while it is invisible, so
-                          // keyboard users cannot fire the delete on an
-                          // unseen control — the chip arms first, then the
-                          // × becomes the next tab stop (focus-visible
-                          // reveals it, see scss).
-                          tabindex={armedCode.value === code ? 0 : -1}
-                          aria-hidden={armedCode.value === code ? undefined : true}
-                          onClick={(e: MouseEvent) => {
-                            e.stopPropagation();
-                            eraseLanguage(code);
-                          }}
-                        >
-                          <X size={11} />
-                        </button>
+                        <span class="hk-localized-input-tag-slot">
+                          <button
+                            type="button"
+                            class="hk-localized-input-tag-locale"
+                            aria-label={armedCode.value === code ? cancelLabel(code) : armLabel(code)}
+                            title={armedCode.value === code ? cancelLabel(code) : armLabel(code)}
+                            // While armed the confirm × covers this chip and
+                            // owns the confirmation; the chip becomes the
+                            // cancel control — and leaves the tab order (the
+                            // × takes its tab stop) so the armed row exposes
+                            // exactly one actionable control at a time.
+                            tabindex={armedCode.value === code ? -1 : 0}
+                            onClick={(e: MouseEvent) => {
+                              e.stopPropagation();
+                              toggleArm(code);
+                            }}
+                            onMousedown={(e: MouseEvent) => e.preventDefault()}
+                          >
+                            <span class="hk-localized-input-tag-label">{localeLabel(code)}</span>
+                            <span class="hk-localized-input-tag-code">{code}</span>
+                            {active && (
+                              <span class="hk-localized-input-tag-dot" aria-hidden="true" />
+                            )}
+                          </button>
+                          <button
+                            type="button"
+                            class="hk-localized-input-tag-x"
+                            aria-label={confirmLabel(code)}
+                            title={confirmLabel(code)}
+                            // Hidden via CSS until armed/hovered; keep it out
+                            // of the tab order while it is invisible, so
+                            // keyboard users cannot fire the delete on an
+                            // unseen control — the chip arms first, then the
+                            // × becomes the next tab stop (focus-visible
+                            // reveals it, see scss). It OVERLAYS the chip in
+                            // the same slot: the row never reflows.
+                            tabindex={armedCode.value === code ? 0 : -1}
+                            aria-hidden={armedCode.value === code ? undefined : true}
+                            onClick={(e: MouseEvent) => {
+                              e.stopPropagation();
+                              eraseLanguage(code);
+                            }}
+                          >
+                            <X size={11} />
+                          </button>
+                        </span>
                       </div>
                     );
                   })}

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "المسؤولون",
     "hikari::localizedInput.addLanguage": "إضافة لغة",
     "hikari::localizedInput.removeTranslation": "إزالة الترجمة",
+    "hikari::localizedInput.cancelDelete": "إلغاء الحذف",
+    "hikari::localizedInput.emptyRow": "أدخل نصًا في الحقل",
     "hikari::localizedInput.switchLanguage": "التبديل إلى",
     "hikari::localizedInput.confirmDelete": "تأكيد الحذف",
     "hikari::localizedInput.translations": "الترجمات الحالية",

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administratoren",
     "hikari::localizedInput.addLanguage": "Sprache hinzufügen",
     "hikari::localizedInput.removeTranslation": "Übersetzung entfernen",
+    "hikari::localizedInput.cancelDelete": "Löschen abbrechen",
+    "hikari::localizedInput.emptyRow": "Text im Feld eingeben",
     "hikari::localizedInput.switchLanguage": "Wechseln zu",
     "hikari::localizedInput.confirmDelete": "Löschen bestätigen",
     "hikari::localizedInput.translations": "Vorhandene Übersetzungen",

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administrators",
     "hikari::localizedInput.addLanguage": "Add language",
     "hikari::localizedInput.removeTranslation": "Remove translation",
+    "hikari::localizedInput.cancelDelete": "Cancel delete",
+    "hikari::localizedInput.emptyRow": "Enter text in the field",
     "hikari::localizedInput.switchLanguage": "Switch to",
     "hikari::localizedInput.confirmDelete": "Confirm delete",
     "hikari::localizedInput.translations": "Existing translations",

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Añadir idioma",
     "hikari::localizedInput.removeTranslation": "Eliminar traducción",
+    "hikari::localizedInput.cancelDelete": "Cancelar eliminación",
+    "hikari::localizedInput.emptyRow": "Introduce texto en el campo",
     "hikari::localizedInput.switchLanguage": "Cambiar a",
     "hikari::localizedInput.confirmDelete": "Confirmar eliminación",
     "hikari::localizedInput.translations": "Traducciones existentes",

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administrateurs",
     "hikari::localizedInput.addLanguage": "Ajouter une langue",
     "hikari::localizedInput.removeTranslation": "Supprimer la traduction",
+    "hikari::localizedInput.cancelDelete": "Annuler la suppression",
+    "hikari::localizedInput.emptyRow": "Saisissez un texte dans le champ",
     "hikari::localizedInput.switchLanguage": "Basculer vers",
     "hikari::localizedInput.confirmDelete": "Confirmer la suppression",
     "hikari::localizedInput.translations": "Traductions existantes",

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理者",
     "hikari::localizedInput.addLanguage": "言語を追加",
     "hikari::localizedInput.removeTranslation": "翻訳を削除",
+    "hikari::localizedInput.cancelDelete": "削除をキャンセル",
+    "hikari::localizedInput.emptyRow": "入力欄にテキストを入力してください",
     "hikari::localizedInput.switchLanguage": "切り替え先",
     "hikari::localizedInput.confirmDelete": "削除を確認",
     "hikari::localizedInput.translations": "既存の翻訳",

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "관리자",
     "hikari::localizedInput.addLanguage": "언어 추가",
     "hikari::localizedInput.removeTranslation": "번역 삭제",
+    "hikari::localizedInput.cancelDelete": "삭제 취소",
+    "hikari::localizedInput.emptyRow": "입력란에 텍스트를 입력하세요",
     "hikari::localizedInput.switchLanguage": "전환 대상",
     "hikari::localizedInput.confirmDelete": "삭제 확인",
     "hikari::localizedInput.translations": "기존 번역",

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Administradores",
     "hikari::localizedInput.addLanguage": "Adicionar idioma",
     "hikari::localizedInput.removeTranslation": "Remover tradução",
+    "hikari::localizedInput.cancelDelete": "Cancelar exclusão",
+    "hikari::localizedInput.emptyRow": "Digite um texto no campo",
     "hikari::localizedInput.switchLanguage": "Alternar para",
     "hikari::localizedInput.confirmDelete": "Confirmar exclusão",
     "hikari::localizedInput.translations": "Traduções existentes",

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "Администраторы",
     "hikari::localizedInput.addLanguage": "Добавить язык",
     "hikari::localizedInput.removeTranslation": "Удалить перевод",
+    "hikari::localizedInput.cancelDelete": "Отменить удаление",
+    "hikari::localizedInput.emptyRow": "Введите текст в поле",
     "hikari::localizedInput.switchLanguage": "Переключиться на",
     "hikari::localizedInput.confirmDelete": "Подтвердить удаление",
     "hikari::localizedInput.translations": "Существующие переводы",

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理员",
     "hikari::localizedInput.addLanguage": "添加新语言",
     "hikari::localizedInput.removeTranslation": "删除该翻译",
+    "hikari::localizedInput.cancelDelete": "取消删除",
+    "hikari::localizedInput.emptyRow": "请在编辑框输入文本",
     "hikari::localizedInput.switchLanguage": "切换至",
     "hikari::localizedInput.confirmDelete": "确认删除",
     "hikari::localizedInput.translations": "已有翻译",

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -114,6 +114,8 @@
     "hikari::adminHeader.adminGroup": "管理員",
     "hikari::localizedInput.addLanguage": "新增語言",
     "hikari::localizedInput.removeTranslation": "刪除該翻譯",
+    "hikari::localizedInput.cancelDelete": "取消刪除",
+    "hikari::localizedInput.emptyRow": "請在編輯框輸入文字",
     "hikari::localizedInput.switchLanguage": "切換至",
     "hikari::localizedInput.confirmDelete": "確認刪除",
     "hikari::localizedInput.translations": "已有翻譯",


### PR DESCRIPTION
## What & why

Follow-up on the shipped localized-input list (user feedback, desktop screenshot):

1. **Armed delete is now an in-place swap.** The previous armed state slid the chip label leftward while a separate × expanded into the slot via a max-width transition — that reflowing animation was visibly laggy on touch. The × now **overlays the chip** in the same slot (`position: absolute; inset: 0`; opacity swap only), so the row geometry never changes on arm. Clicking the chip shows the × right there; clicking the × erases. While armed the chip itself becomes the *cancel* control (its label swaps to a new `localizedInput.cancelDelete` string, e.g. "取消删除", and it leaves the tab order) — the confirm × owns the slot's single actionable stop, and keyboard users get exactly one tab target per slot.
2. **Empty rows get an italic i18n hint.** Instead of a bare "—" glyph, a row with no translation shows an italic prompt (`localizedInput.emptyRow`: "Enter text in the field" / "请在编辑框输入文本"), in all 11 catalogs.
3. **Desktop menu widened.** The language list grew from 15–20rem to 18–24rem so a full row (translation text + chip) does not crumple inside one tight popout; `min(18rem, 100%)` keeps sub-320px mobile viewports safe from horizontal scroll.

## Verification

- vue-tsc: 0 errors. Targeted suites 118/119 in one batch (the one failure is the known run-order timing flake in HkMenu's cascade anchor test — passes in isolation); full suite 683/686 with exactly the pre-existing failures (date-dependent HkDatePicker, the registerAnimations keyframes-parity break that #353 introduced on master — fails identically on clean master — plus that same HkMenu flake).
- Adversarial review: R1 SHIP (4 polish findings: stale doc, armed-chip a11y label/tab flow, min-width overflow on tiny viewports, double-tap consequence — the latter accepted by design per the user's tap-to-arm/tap-to-confirm spec); all fixed; R2 cross-verification SHIP with no new regressions.
- Version: 0.30.1 → 0.30.2 (previous master bump 0.30.0→0.30.1 landed while this branch was in flight).

- Head updated on 2026-09-02T08:04:36Z (rebase onto ca49c93).

- Head updated (merge ec89a45, master fe4ef2f).

- Head updated (1887e0d, rebase onto fe4ef2f).
