### PR TITLE
🐛 Type the auth method icon prop as unknown for host store skew.

### DIFF
--- a/packages/vue/src/components/HkAuthMethodList.tsx
+++ b/packages/vue/src/components/HkAuthMethodList.tsx
@@ -1,4 +1,4 @@
-import { defineComponent, type PropType, type VNode } from "vue";
+import { defineComponent, type PropType } from "vue";
 import HkButton from "./HkButton";
 import "./HkAuthMethodList.scss";
 
@@ -30,9 +30,12 @@ export default defineComponent({
         key: string;
         label: string;
         /** Prebuilt icon vnode (brand SVG, <img>, …) — `null` renders an
-         *  empty fixed-width column so the labels still align. The column
-         *  is fixed-size, so any ~16-20px glyph aligns. */
-        icon?: VNode | null;
+         *  empty fixed-width column so the labels still align. Typed loose
+         *  on purpose (same as HkAltSignIn entries): hosts materialize
+         *  hikari against their own vue store, and a hard VNode type
+         *  breaks typecheck whenever the host's vue minor differs. The
+         *  value renders as-is inside the fixed-size column. */
+        icon?: unknown;
         disabled?: boolean;
       }>,
       required: true,


### PR DESCRIPTION
Follow-up to #355: `icon?: unknown` (same loose-typing precedent as `HkAltSignIn` entry icons) — hosts materialize hikari against their own vue store, and a hard `VNode` type fails host typechecks when vue minors differ (erp vue 3.5.42 vs chest-store 3.5.40). vue-tsc 0 errors; component tests 2/2.