### PR TITLE
🐛 Stop rendering an empty methods block on methods-less sign-in cards.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkSignInCard.test.ts
+++ b/packages/vue/src/components/HkSignInCard.test.ts
@@ -151,4 +151,19 @@ describe("HkSignInCard", () => {
     const c = mount(h(HkSignInCard, { title: "T" }));
     expect(usernameField(c).getAttribute("placeholder")).toBeTruthy();
   });
+
+  it("renders no methods block when the consumer passes no methods slot", () => {
+    const c = mount(h(HkSignInCard, { title: "T" }));
+    // The wrapper would otherwise render HkAuthCard's padded, top-margined
+    // `.s-auth-methods` wrapper as empty dead space under the form.
+    expect(c.querySelector(".s-auth-methods")).toBeNull();
+  });
+
+  it("forwards the methods slot content when the consumer provides one", () => {
+    const c = mount(
+      h(HkSignInCard, { title: "T" }, { methods: () => h("div", { class: "methods-probe" }) }),
+    );
+    expect(c.querySelector(".s-auth-methods")).toBeTruthy();
+    expect(c.querySelector(".methods-probe")).toBeTruthy();
+  });
 });

--- a/packages/vue/src/components/HkSignInCard.tsx
+++ b/packages/vue/src/components/HkSignInCard.tsx
@@ -152,7 +152,12 @@ export const HkSignInCard = defineComponent({
             </>
           ),
           footer: () => slots.footer?.(),
-          methods: () => slots.methods?.(),
+          /* Forward the methods slot ONLY when the consumer passed one: an
+             unconditional lambda would make HkAuthCard see a slot that
+             always exists and render its (padded, top-margined)
+             `.s-auth-methods` wrapper as empty dead space under the form
+             on every methods-less sign-in card. */
+          ...(slots.methods ? { methods: () => slots.methods?.() } : {}),
         }}
       </HkAuthCard>
     );


### PR DESCRIPTION
Review follow-up to #355 (自查发现): HkSignInCard forwarded the methods slot lambda unconditionally, so HkAuthCard always rendered the padded `.s-auth-methods` wrapper (16px top margin) as empty dead space under the form on every methods-less sign-in card (chest MFA/offline channels, erp user binding, any future consumer). Now forwarded only when the consumer provides one; two regression tests cover both directions. Version 0.30.2 → 0.30.3. vue-tsc 0 errors; HkSignInCard suite 12/12.