### PR TITLE
🔥 Drop the minimap legacy zoom events in favor of zoomTo.

### DIFF
--- a/packages/vue/src/components/HkImageViewer.tsx
+++ b/packages/vue/src/components/HkImageViewer.tsx
@@ -340,9 +340,11 @@ export default defineComponent({
             zoomPercent={zoomPercent.value}
             canZoomIn={canZoomIn.value}
             canZoomOut={canZoomOut.value}
+            zoomStepPercent={5}
+            minZoomPercent={Math.max(1, Math.round(fit.value * 100))}
+            maxZoomPercent={Math.round(MAX_ZOOM * 100)}
             showReset
-            onZoomIn={() => setZoom(zoom.value * 1.2)}
-            onZoomOut={() => setZoom(zoom.value / 1.2)}
+            onZoomTo={(percent: number) => setZoom(percent / 100)}
             onReset={resetView}
             onPanDelta={onPanDelta}
           />

--- a/packages/vue/src/components/HkMinimap.tsx
+++ b/packages/vue/src/components/HkMinimap.tsx
@@ -31,9 +31,9 @@ export interface MinimapRect {
  * `transform-origin: 0 0` — the same model HImageViewer uses.
  *
  * The zoom bar is governed by default: ±5% fixed steps clamped to the
- * 50–200% range, with each press emitting `zoomTo` (clamped target
- * percent) alongside the legacy `zoomIn`/`zoomOut`. Consumers with a
- * wider native camera range override `minZoomPercent`/`maxZoomPercent`.
+ * 50–200% range, each press emitting `zoomTo` with the clamped target
+ * percent. Consumers with a wider native camera range override
+ * `minZoomPercent`/`maxZoomPercent`.
  */
 export default defineComponent({
   name: "HkMinimap",
@@ -66,17 +66,13 @@ export default defineComponent({
      *  when a reset handler was wired up). */
     showReset: { type: Boolean, default: false },
     /** Optional prop-callback surface (alternative to the emits). */
-    onZoomIn: { type: Function as PropType<() => void>, default: undefined },
-    onZoomOut: { type: Function as PropType<() => void>, default: undefined },
     onZoomTo: { type: Function as PropType<(percent: number) => void>, default: undefined },
     onReset: { type: Function as PropType<() => void>, default: undefined },
     onPanDelta: { type: Function as PropType<(dx: number, dy: number) => void>, default: undefined },
   },
   emits: {
-    zoomIn: () => true,
-    zoomOut: () => true,
     /** Fixed-step zoom request carrying the clamped target percent —
-     *  consumers that can animate their camera should prefer this. */
+     *  consumers animate their camera toward this target. */
     zoomTo: (_percent: number) => true,
     reset: () => true,
     panDelta: (_dx: number, _dy: number) => true,
@@ -132,14 +128,12 @@ export default defineComponent({
       props.canZoomOut && props.zoomPercent > props.minZoomPercent + 1e-9);
 
     /** Step the zoom bar by the fixed increment, clamped to [min, max];
-     *  emits the legacy zoomIn/zoomOut plus a `zoomTo` carrying the exact
-     *  clamped target percent. No-op (and stays disabled) at the bounds. */
+     *  emits `zoomTo` with the exact clamped target percent. No-op (and
+     *  stays disabled) at the bounds. */
     function stepZoom(dir: number) {
       const raw = props.zoomPercent + dir * props.zoomStepPercent;
       const next = Math.min(props.maxZoomPercent, Math.max(props.minZoomPercent, raw));
       if (Math.abs(next - props.zoomPercent) < 1e-9) return;
-      if (dir > 0) emit("zoomIn");
-      else emit("zoomOut");
       emit("zoomTo", next);
     }
 


### PR DESCRIPTION
## What

Removes `zoomIn`/`zoomOut` from `HkMinimap` (emits and the prop-callback surface): the governed zoom bar now emits only `zoomTo` with the exact clamped target percent. Full migration of every in-tree consumer:

- **HImageViewer** (this repo): bar presses now call `setZoom(percent/100)` (same center-anchored clamp as before); the minimap receives the viewer's true dynamic bounds (`fit..800%`) instead of inheriting the 50–200% defaults.
- chest consumers follow in the companion chest PR (SCADA + TopologyView + media pipeline), with their native ranges pinned.

`canZoomIn`/`canZoomOut` props stay: consumers can still gate stepping beyond the bounds.

## Verification
- vue-tsc 0 errors; vitest 712 passed / 2 failures identical to clean master baseline (`registerAnimations`, `HkDatePicker` — pre-existing).
- Typecheck proves migration completeness: with the events gone, any consumer still passing `onZoomIn`/`onZoomOut` fails the build.
- Version 0.30.2 → 0.31.0 (API removal).