### PR TITLE
🐛 Measure the auth label column with max-content so it can shrink.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAuthMethodList.tsx
+++ b/packages/vue/src/components/HkAuthMethodList.tsx
@@ -54,15 +54,20 @@ export default defineComponent({
     const listRef = ref<HTMLDivElement | null>(null);
 
     /** Measure the widest label text and publish it as the label-column
-     *  width custom property. `scrollWidth` reports the text width even
-     *  while the fixed column clips it, so this is correct both before
-     *  the variable is first set and after any label change. */
+     *  width custom property. Each span is momentarily set to
+     *  `max-content` while reading: a plain `scrollWidth` on the fixed
+     *  column would report `max(textWidth, columnWidth)` and the column
+     *  could never shrink below its fallback. All reads happen inside one
+     *  synchronous task, so no intermediate paint is observable. */
     function measure() {
       const root = listRef.value;
       if (!root) return;
       let widest = 0;
       for (const label of root.querySelectorAll<HTMLElement>(".s-auth-methods-label")) {
+        const previous = label.style.width;
+        label.style.width = "max-content";
         widest = Math.max(widest, label.scrollWidth);
+        label.style.width = previous;
       }
       if (widest > 0) root.style.setProperty("--auth-methods-label-width", `${widest}px`);
     }


### PR DESCRIPTION
## Summary
Follow-up to #364 (live browser verification caught it): reading `scrollWidth` on the fixed-width label span returns `max(textWidth, columnWidth)`, so the measured column could only ever GROW from its 8em fallback — exactly the dead space the user asked to remove. Each span is now momentarily set to `width: max-content` while reading (all reads inside one synchronous task — no observable intermediate paint), so the published `--auth-methods-label-width` is the true widest text width and the aligned block hugs the longest label.

Version 0.31.1 → 0.31.2 (0.31.1 tag was already cut with the grow-only variant; this supersedes it).

## Verification
vue-tsc 0 errors; HkAuthMethodList suite 4/4 (scrollWidth stubs unaffected — they intercept the max-content read).