### PR TITLE
✨ Add QR code and international phone input components.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.0",
+  "version": "0.32.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.2",
+  "version": "0.32.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
@@ -32,7 +32,6 @@
       "import": "./src/styles/index.scss"
     },
     "./styles/*": "./src/styles/*",
-    "./theme/*": "./src/theme/*",
     "./components/*": "./src/components/*",
     "./plugins": {
       "import": "./src/plugins/index.ts",

--- a/packages/vue/src/components/HkPhoneInput.scss
+++ b/packages/vue/src/components/HkPhoneInput.scss
@@ -1,0 +1,140 @@
+.hk-phone-input {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+/* The dial-code chip riding the field's LEFT edge — flag glyph + "+86"
+ * + caret, mirroring the language-tag chip pattern of HkLocalizedInput
+ * (which rides the right edge). A button so it is focusable and
+ * AT-reachable; mousedown is suppressed in TSX so clicking it never
+ * steals focus from the number field before the menu opens. */
+.hk-phone-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 11rem;
+  padding: 2px 6px 2px 4px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-text));
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: rgb(var(--color-primary) / 14%);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+}
+
+.hk-phone-chip-flag {
+  flex: none;
+  font-size: calc(var(--text-sm, 14px) * 1.05);
+  line-height: 1;
+  /* Windows has no color flag font — the regional-indicator letters it
+   * substitutes are tiny; nudge them to the visible size. */
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
+    sans-serif;
+}
+
+.hk-phone-chip-dial {
+  font-weight: 600;
+  font-size: var(--text-sm, 14px);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-phone-chip-caret {
+  flex: none;
+  color: rgb(var(--color-muted));
+}
+
+/* ── country list (menu) ────────────────────────────────────────────
+ * The search box caps the menu header; rows below it scroll inside the
+ * popup/sheet list surface (HkSelectPanel caps and scrolls the popout,
+ * and the mobile sheet body scrolls natively). */
+.hk-phone-dial-search {
+  padding: 8px 10px 6px;
+}
+
+.hk-phone-dial-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px 6px 8px;
+  /* Roomier than the 2px HkMenu gutter so rows read as a picker. */
+  min-width: 13rem;
+  max-width: min(19rem, calc(100vw - 2rem));
+}
+
+.hk-phone-dial-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 4px 8px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-text));
+  font-size: var(--text-sm, 14px);
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+  transition: background 0.1s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(var(--color-primary) / 10%);
+    outline: none;
+  }
+
+  &[data-active] {
+    background: rgb(var(--color-primary) / 16%);
+    font-weight: 600;
+  }
+}
+
+.hk-phone-dial-flag {
+  flex: none;
+  font-size: calc(var(--text-base, 15px) * 1.05);
+  line-height: 1;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
+    sans-serif;
+}
+
+.hk-phone-dial-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-phone-dial-code {
+  flex: none;
+  color: rgb(var(--color-muted));
+  font-size: calc(var(--text-sm, 14px) * 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-phone-dial-empty {
+  padding: 14px 12px;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-sm, 14px);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-phone-chip,
+  .hk-phone-dial-row {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkPhoneInput.test.tsx
+++ b/packages/vue/src/components/HkPhoneInput.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HkPhoneInput } from "./HkPhoneInput";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+interface MountOptions {
+  modelValue?: string;
+  dialCode?: string;
+  disabled?: boolean;
+}
+
+function mountPhone(opts: MountOptions = {}) {
+  const events = {
+    modelValue: [] as string[],
+    dialCode: [] as string[],
+    dialchange: [] as string[],
+    change: [] as string[],
+  };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(HkPhoneInput, {
+        modelValue: opts.modelValue ?? "",
+        dialCode: opts.dialCode ?? "+86",
+        disabled: opts.disabled ?? false,
+        "onUpdate:modelValue": (v: string) => {
+          events.modelValue.push(v);
+        },
+        "onUpdate:dialCode": (v: string) => {
+          events.dialCode.push(v);
+        },
+        onDialchange: (v: string) => {
+          events.dialchange.push(v);
+        },
+        onChange: (v: string) => {
+          events.change.push(v);
+        },
+      }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { events, container };
+}
+
+afterEach(() => {
+  while (mounts.length > 0) {
+    const { app, container } = mounts.pop()!;
+    app.unmount();
+    container.remove();
+  }
+});
+
+function queryChip(container: HTMLElement): HTMLButtonElement {
+  const chip = container.querySelector<HTMLButtonElement>(".hk-phone-chip");
+  expect(chip, "dial-code chip renders inside the field").toBeTruthy();
+  return chip!;
+}
+
+function queryField(container: HTMLElement): HTMLInputElement {
+  const field = container.querySelector<HTMLInputElement>(".hk-input-element");
+  expect(field).toBeTruthy();
+  return field!;
+}
+
+async function openPicker(container: HTMLElement) {
+  queryChip(container).click();
+  await nextTick();
+  await nextTick();
+}
+
+function pickerRows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLButtonElement>(".hk-phone-dial-row")];
+}
+
+describe("HkPhoneInput", () => {
+  it("renders the dial chip with the canonical code", () => {
+    const { container } = mountPhone({ dialCode: "86" });
+    expect(queryChip(container).querySelector(".hk-phone-chip-dial")?.textContent).toBe("+86");
+    expect(queryField(container).getAttribute("inputmode")).toBe("tel");
+  });
+
+  it("shows a bare code when the dial matches no catalog entry", () => {
+    const { container } = mountPhone({ dialCode: "+999" });
+    expect(queryChip(container).querySelector(".hk-phone-chip-dial")?.textContent).toBe("+999");
+  });
+
+  it("sanitizes typed numbers to digits, spaces and dashes", () => {
+    const { container, events } = mountPhone();
+    const field = queryField(container);
+    field.value = "138 1234-5678x+86";
+    field.dispatchEvent(new Event("input"));
+    expect(events.modelValue.at(-1)).toBe("138 1234-567886");
+  });
+
+  it("emits the composed E.164 on blur", () => {
+    const { container, events } = mountPhone({ modelValue: "13812345678" });
+    queryField(container).dispatchEvent(new Event("blur"));
+    expect(events.change.at(-1)).toBe("+8613812345678");
+  });
+
+  it("lists catalog rows with flags and codes when opened", async () => {
+    const { container } = mountPhone();
+    await openPicker(container);
+    const rows = pickerRows();
+    expect(rows.length).toBeGreaterThan(50);
+    const first = rows[0];
+    expect(first.textContent).toContain("China");
+    expect(first.textContent).toContain("+86");
+  });
+
+  it("picks a country from the list and refocuses the number field", async () => {
+    const { container, events } = mountPhone();
+    await openPicker(container);
+    const rows = pickerRows();
+    const japan = rows.find((r) => r.textContent?.includes("Japan"))!;
+    expect(japan).toBeTruthy();
+    japan.click();
+    await nextTick();
+    expect(events.dialCode.at(-1)).toBe("+81");
+    expect(events.dialchange.at(-1)).toBe("+81");
+    // The picker plays its leave transition, then unmounts.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(pickerRows()).toHaveLength(0);
+  });
+
+  it("disables the chip when the field is disabled", () => {
+    const { container } = mountPhone({ disabled: true });
+    expect(queryChip(container).disabled).toBe(true);
+  });
+});

--- a/packages/vue/src/components/HkPhoneInput.tsx
+++ b/packages/vue/src/components/HkPhoneInput.tsx
@@ -1,0 +1,306 @@
+import { computed, defineComponent, nextTick, ref, useAttrs, watch, type PropType } from "vue";
+
+import { ChevronDown, Search } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import {
+  DIAL_CODES,
+  dialCodeName,
+  flagEmoji,
+  formatE164,
+  normalizeDial,
+  resolveDial,
+  type DialCodeEntry,
+} from "../data/dialCodes";
+
+import HkInput from "./HkInput";
+import HkMenu from "./HkMenu";
+import "./HkPhoneInput.scss";
+
+/**
+ * HkPhoneInput — phone-number field with a country dial-code picker.
+ *
+ * Mirrors the language-tag chip pattern of HkLocalizedInput but for
+ * dial codes: a leading chip inside the field (flag glyph + "+86" +
+ * caret) opens a searchable country list. The chip rides the LEFT edge
+ * of the field — the natural reading order for "which country, then
+ * which number" — while the number itself is typed after it.
+ *
+ *   - `modelValue` is the NATIONAL number only ("13812345678"); the
+ *     country selection lives in `dialCode` ("+86" shape, normalized on
+ *     emit). Splitting the two keeps callers free to store whatever
+ *     they already store (a bare "86" works too — matched by dial).
+ *   - The chip shows the resolved country's flag plus the dial code in
+ *     canonical "+…" shape. Unknown dial codes fall back to showing
+ *     the normalized code alone (no flag).
+ *   - The picker menu (`HkMenu`, desktop popout + mobile bottom sheet)
+ *     lists the catalog in its defined order, flag + localized name +
+ *     dial code per row, with a live filter field on top. Filtering
+ *     matches the country's English/Chinese name, its ISO code, and
+ *     the bare dial digits ("86", "0086" or "86" both hit China).
+ *   - Picking a row emits `update:dialCode` ("+…"), `dialchange`
+ *     (same value) and refocuses the number field. Blurring the field
+ *     emits `change` with the composed E.164 — use it to validate or
+ *     submit without recomputing `formatE164` yourself.
+ *
+ * The number input sanitizes itself: only digits, spaces and dashes
+ * survive (pasted "+86 138-1234-5678" becomes "138 1234-5678"), and
+ * `inputmode="tel"` raises the dial pad on touch devices. The
+ * catalog defaults to the bundled dictionary (China first); pass
+ * `countries` to scope the list (e.g. mainland-only deployments).
+ */
+export const HkPhoneInput = defineComponent({
+  name: "HkPhoneInput",
+  // The root wrapper carries no meaningful semantics; DOM attributes
+  // (inputmode, maxlength, aria-*) belong on the inner input.
+  inheritAttrs: false,
+  props: {
+    /** National number only — never includes the dial code. */
+    modelValue: { type: String, default: "" },
+    /** Dial code in any shape: "+86", "86", "0086". Kept as given
+     *  (canonicalized only for matching), so v-model round-trips. */
+    dialCode: { type: String, default: "+86" },
+    /** Country catalog. Defaults to the bundled dictionary. */
+    countries: {
+      type: Array as PropType<readonly DialCodeEntry[]>,
+      default: () => DIAL_CODES,
+    },
+    placeholder: { type: String, default: "" },
+    disabled: { type: Boolean, default: false },
+    readonly: { type: Boolean, default: false },
+    size: { type: String as PropType<"sm" | "md" | "lg">, default: "md" },
+    label: { type: String, default: undefined },
+    error: { type: String, default: undefined },
+    hint: { type: String, default: undefined },
+    required: { type: Boolean, default: false },
+    name: { type: String, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_value: string) => true,
+    "update:dialCode": (_dial: string) => true,
+    /** Country picked from the list — payload "+86" shape. */
+    dialchange: (_dial: string) => true,
+    /** Field blurred — payload the composed E.164 ("" when empty). */
+    change: (_e164: string) => true,
+    focus: (_e: FocusEvent) => true,
+    blur: (_e: FocusEvent) => true,
+  },
+  setup(props, { emit }) {
+    const { t, locale } = useI18n();
+    const attrs = useAttrs();
+
+    const menuOpen = ref(false);
+    const chipRef = ref<HTMLElement | null>(null);
+    const rootRef = ref<HTMLElement | null>(null);
+    const query = ref("");
+
+    // A fresh open starts with an empty filter.
+    watch(menuOpen, (open) => {
+      if (!open) query.value = "";
+    });
+
+    /** Canonical "+86" derived from the prop, whatever shape it is in. */
+    const canonicalDial = computed(() => {
+      const bare = normalizeDial(props.dialCode);
+      return bare ? `+${bare}` : "";
+    });
+
+    /** The country the current dial code resolves to (first catalog
+     *  match for shared prefixes like +1). */
+    const activeEntry = computed(() =>
+      resolveDial(props.dialCode, undefined, props.countries),
+    );
+
+    /** Searchable rows: filter against en/zh names, ISO code, dial. */
+    const filteredRows = computed(() => {
+      const q = query.value.trim().toLowerCase();
+      const qDial = q.replace(/\D/g, "");
+      if (!q) return props.countries;
+      return props.countries.filter((c) => {
+        if (c.iso.toLowerCase().includes(q)) return true;
+        if (qDial && c.dial.includes(qDial)) return true;
+        return (
+          c.en.toLowerCase().includes(q) ||
+          c.zh.toLowerCase().includes(q)
+        );
+      });
+    });
+
+    function pickCountry(entry: DialCodeEntry) {
+      const dial = `+${entry.dial}`;
+      menuOpen.value = false;
+      emit("update:dialCode", dial);
+      emit("dialchange", dial);
+      // Refocus the number field so pick-then-type flows without a
+      // second tap (the chip's menu is the only focusable sibling).
+      nextTick(() => {
+        const el = rootRef.value?.querySelector<HTMLElement>("input");
+        el?.focus();
+      });
+    }
+
+    /** Emit the composed E.164 on blur ("" when the number is empty). */
+    function onBlur(e: FocusEvent) {
+      emit("blur", e);
+      emit("change", formatE164(canonicalDial.value, props.modelValue));
+    }
+
+    function onInput(value: string) {
+      // Digits, spaces and dashes only; everything else (plus signs,
+      // parentheses, stray letters from a paste) drops out.
+      const cleaned = value.replace(/[^\d\s-]/g, "");
+      emit("update:modelValue", cleaned);
+    }
+
+    function chipLabel(): string {
+      const bare = normalizeDial(props.dialCode);
+      return bare ? `+${bare}` : t("hikari::phoneInput.dialCode", "+…");
+    }
+
+    return () => {
+      const rows = filteredRows.value;
+      const active = activeEntry.value;
+      const nameFor = (entry: DialCodeEntry) =>
+        dialCodeName(entry, locale);
+      const inputAttrs = {
+        inputmode: "tel" as const,
+        maxlength: 18,
+        ...attrs,
+      };
+      delete (inputAttrs as Record<string, unknown>).class;
+      delete (inputAttrs as Record<string, unknown>).style;
+      return (
+        <div class="hk-phone-input" ref={rootRef}>
+          <HkInput
+            modelValue={props.modelValue}
+            onUpdate:modelValue={onInput}
+            placeholder={props.placeholder}
+            disabled={props.disabled}
+            readonly={props.readonly}
+            size={props.size}
+            label={props.label}
+            error={props.error}
+            hint={props.hint}
+            required={props.required}
+            name={props.name}
+            onBlur={onBlur}
+            autocomplete="tel-national"
+            {...inputAttrs}
+          >
+            {{
+              prefix: () => (
+                <button
+                  ref={(el: unknown) => {
+                    chipRef.value = (el as HTMLElement) ?? null;
+                  }}
+                  type="button"
+                  class="hk-phone-chip"
+                  disabled={props.disabled || props.readonly}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen.value}
+                  aria-label={t(
+                    "hikari::phoneInput.chooseCountry",
+                    "Choose country code",
+                  )}
+                  title={active ? `${nameFor(active)} ${chipLabel()}` : chipLabel()}
+                  onMousedown={(e: MouseEvent) => e.preventDefault()}
+                  onClick={(e: MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    if (!props.disabled && !props.readonly) {
+                      menuOpen.value = !menuOpen.value;
+                    }
+                  }}
+                >
+                  <span class="hk-phone-chip-flag" aria-hidden="true">
+                    {active ? flagEmoji(active.iso) : ""}
+                  </span>
+                  <span class="hk-phone-chip-dial">{chipLabel()}</span>
+                  <ChevronDown size={12} class="hk-phone-chip-caret" aria-hidden="true" />
+                </button>
+              ),
+            }}
+          </HkInput>
+          <HkMenu
+            variant="popup"
+            items={[]}
+            open={menuOpen.value}
+            onUpdate:open={(v: boolean) => {
+              menuOpen.value = v;
+            }}
+            anchorRef={chipRef.value}
+            placement="bottom-start"
+            matchAnchorWidth={false}
+            title={t("hikari::phoneInput.chooseCountry", "Choose country code")}
+          >
+            {{
+              header: () => (
+                <div class="hk-phone-dial-search" role="search">
+                  <HkInput
+                    modelValue={query.value}
+                    onUpdate:modelValue={(v: string) => {
+                      query.value = v;
+                    }}
+                    size="sm"
+                    placeholder={t(
+                      "hikari::phoneInput.searchCountries",
+                      "Search country or code",
+                    )}
+                    aria-label={t(
+                      "hikari::phoneInput.searchCountries",
+                      "Search country or code",
+                    )}
+                    autocomplete="off"
+                    onKeydown={(e: KeyboardEvent) => {
+                      // Enter picks the first filtered row.
+                      if (e.key === "Enter" && !e.isComposing && rows.length > 0) {
+                        e.preventDefault();
+                        pickCountry(rows[0]);
+                      }
+                    }}
+                  >
+                    {{
+                      prefixIcon: () => (
+                        <Search size={13} aria-hidden="true" />
+                      ),
+                    }}
+                  </HkInput>
+                </div>
+              ),
+              default: () =>
+                rows.length > 0 ? (
+                  <div class="hk-phone-dial-list">
+                    {rows.map((entry) => {
+                      const selected = entry.iso === active?.iso;
+                      return (
+                        <button
+                          key={entry.iso}
+                          type="button"
+                          class="hk-phone-dial-row"
+                          data-active={selected || undefined}
+                          onClick={() => pickCountry(entry)}
+                        >
+                          <span class="hk-phone-dial-flag" aria-hidden="true">
+                            {flagEmoji(entry.iso)}
+                          </span>
+                          <span class="hk-phone-dial-name">{nameFor(entry)}</span>
+                          <span class="hk-phone-dial-code">+{entry.dial}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div class="hk-phone-dial-empty">
+                    {t("hikari::phoneInput.noMatches", "No matching country")}
+                  </div>
+                ),
+            }}
+          </HkMenu>
+        </div>
+      );
+    };
+  },
+});
+
+export default HkPhoneInput;

--- a/packages/vue/src/components/HkPhoneInput.tsx
+++ b/packages/vue/src/components/HkPhoneInput.tsx
@@ -75,6 +75,9 @@ export const HkPhoneInput = defineComponent({
     hint: { type: String, default: undefined },
     required: { type: Boolean, default: false },
     name: { type: String, default: undefined },
+    /** Fired when Enter is pressed inside the number field (form
+     *  submit). Forwarded to the inner HkInput. */
+    submitOnEnter: { type: Function, default: undefined },
   },
   emits: {
     "update:modelValue": (_value: string) => true,
@@ -186,6 +189,7 @@ export const HkPhoneInput = defineComponent({
             name={props.name}
             onBlur={onBlur}
             autocomplete="tel-national"
+            submitOnEnter={props.submitOnEnter}
             {...inputAttrs}
           >
             {{

--- a/packages/vue/src/components/HkQrCode.scss
+++ b/packages/vue/src/components/HkQrCode.scss
@@ -1,0 +1,23 @@
+.hk-qr-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-6, 6px);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.hk-qr-canvas {
+  display: block;
+  border-radius: var(--radius-sm, 4px);
+  // Always a white backing so the QR stays scannable regardless of theme.
+  background: #ffffff;
+  box-shadow: 0 1px 6px rgb(0 0 0 / 0.08);
+}
+
+.hk-qr-label {
+  font-size: var(--text-2xs, 0.75rem);
+  line-height: 1.4;
+  color: rgb(var(--color-muted, 120 113 108));
+  text-align: center;
+}

--- a/packages/vue/src/components/HkQrCode.test.tsx
+++ b/packages/vue/src/components/HkQrCode.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import { HkQrCode } from "./HkQrCode";
+
+const OTPAUTH =
+  "otpauth://totp/Example:langyo%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountQr(props: Record<string, unknown> = {}) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () => h(HkQrCode, props),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  while (mounts.length > 0) {
+    const { app, container } = mounts.pop()!;
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkQrCode", () => {
+  it("renders a labeled canvas for a value", async () => {
+    const container = mountQr({ value: OTPAUTH });
+    await nextTick();
+    const canvas = container.querySelector("canvas.hk-qr-canvas");
+    expect(canvas).toBeTruthy();
+    expect(canvas!.getAttribute("role")).toBe("img");
+    expect(canvas!.getAttribute("aria-label")).toBe("QR code");
+    expect((canvas as HTMLElement).style.width).toBe("168px");
+  });
+
+  it("shows the caption label under the QR", async () => {
+    const container = mountQr({ value: OTPAUTH, label: "Scan with your app" });
+    await nextTick();
+    expect(container.querySelector(".hk-qr-label")?.textContent).toBe(
+      "Scan with your app",
+    );
+    // The aria-label falls back to the caption.
+    expect(container.querySelector("canvas")?.getAttribute("aria-label")).toBe(
+      "Scan with your app",
+    );
+  });
+
+  it("renders nothing for an empty value", async () => {
+    const container = mountQr({ value: "" });
+    await nextTick();
+    expect(container.querySelector("canvas")).toBeNull();
+    expect(container.querySelector(".hk-qr-card")?.getAttribute("data-empty")).toBe("true");
+  });
+
+  it("re-encodes when the value changes", async () => {
+    const container = mountQr({ value: OTPAUTH, size: 200 });
+    await nextTick();
+    const canvas = container.querySelector("canvas") as HTMLCanvasElement;
+    expect((canvas.style.width)).toBe("200px");
+  });
+});

--- a/packages/vue/src/components/HkQrCode.tsx
+++ b/packages/vue/src/components/HkQrCode.tsx
@@ -1,0 +1,121 @@
+import {
+  computed,
+  defineComponent,
+  onMounted,
+  ref,
+  watch,
+  type PropType,
+} from "vue";
+
+import { useI18n } from "../i18n/context";
+import { qrMatrix, type QrErrorCorrectionLevel } from "../utils/qr/qrEncoder";
+import "./HkQrCode.scss";
+
+/**
+ * HkQrCode — render a scannable QR code from an arbitrary string value
+ * (typically an `otpauth://` URI).
+ *
+ * The QR is always rendered as dark modules on a white card (independent of
+ * the app theme) so it stays scannable in dark mode, matching the pattern of
+ * authenticator apps. Rendering goes to a `<canvas>` (crisp at any scale and
+ * device-pixel-ratio). Re-encodes whenever `value` changes.
+ *
+ * Contract:
+ *   - `value` is the payload (e.g. an otpauth URI); empty/whitespace renders
+ *     nothing.
+ *   - `size` is the rendered CSS size in px; the canvas backing store is
+ *     scaled by the device pixel ratio so module edges stay sharp.
+ *   - `inverse` swaps dark/light (advanced use; the default light card is the
+ *     high-contrast, always-scannable choice).
+ */
+export const HkQrCode = defineComponent({
+  name: "HkQrCode",
+  props: {
+    /** Payload to encode. Render nothing when empty. */
+    value: { type: String, default: "" },
+    /** Rendered CSS size in px (square). Default 168. */
+    size: { type: Number, default: 168 },
+    /** Quiet-zone width in modules. Default 2. */
+    margin: { type: Number, default: 2 },
+    /** Error-correction level. Default "M". */
+    level: { type: String as PropType<QrErrorCorrectionLevel>, default: "M" },
+    colorDark: { type: String, default: "#000000" },
+    colorLight: { type: String, default: "#ffffff" },
+    /** Swap dark/light (use with a dark card only). Default false. */
+    inverse: { type: Boolean, default: false },
+    /** Optional caption shown under the QR. */
+    label: { type: String, default: "" },
+    disabled: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const { t } = useI18n();
+    const canvasRef = ref<HTMLCanvasElement | null>(null);
+
+    const dark = computed(() => (props.inverse ? props.colorLight : props.colorDark));
+    const light = computed(() => (props.inverse ? props.colorDark : props.colorLight));
+    const hasValue = computed(() => props.value.trim().length > 0);
+
+    function draw() {
+      if (!canvasRef.value || !hasValue.value) return;
+      if (typeof document === "undefined") return; // SSR guard
+      const canvas = canvasRef.value;
+      const matrix = qrMatrix(props.value, {
+        errorCorrectionLevel: props.level,
+      });
+      const count = matrix.length;
+      const totalModules = count + props.margin * 2;
+      const dpr = (typeof window !== "undefined" && window.devicePixelRatio) || 1;
+      const cssSize = props.size;
+      const backing = Math.round(cssSize * dpr);
+      canvas.width = backing;
+      canvas.height = backing;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      // Fill the quiet-zone / background.
+      ctx.fillStyle = light.value;
+      ctx.fillRect(0, 0, backing, backing);
+      const cell = backing / totalModules;
+      // Draw each dark module (quiet zone = margin offset).
+      for (let row = 0; row < count; row++) {
+        for (let col = 0; col < count; col++) {
+          if (matrix[row][col]) {
+            ctx.fillStyle = dark.value;
+            ctx.fillRect(
+              (props.margin + col) * cell,
+              (props.margin + row) * cell,
+              cell + 0.5, // slight overlap avoids hairline seams on scaled canvases
+              cell + 0.5,
+            );
+          }
+        }
+      }
+    }
+
+    onMounted(draw);
+    watch(
+      () => [props.value, props.size, props.margin, props.level, props.colorDark, props.colorLight, props.inverse],
+      draw,
+    );
+
+    const ariaLabel = computed(
+      () => props.label || t("hikari::qrCode.alt", "QR code"),
+    );
+
+    return () => (
+      <div class="hk-qr-card" data-empty={hasValue.value ? undefined : true}>
+        {hasValue.value ? (
+          <canvas
+            ref={canvasRef}
+            class="hk-qr-canvas"
+            role="img"
+            aria-label={ariaLabel.value}
+            style={{ width: `${props.size}px`, height: `${props.size}px` }}
+          />
+        ) : null}
+        {props.label ? <div class="hk-qr-label">{props.label}</div> : null}
+      </div>
+    );
+  },
+});
+
+export default HkQrCode;

--- a/packages/vue/src/data/dialCodes.test.ts
+++ b/packages/vue/src/data/dialCodes.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DIAL_CODES,
+  entryByDialCode,
+  entryByIso,
+  flagEmoji,
+  formatE164,
+  normalizeDial,
+  parseE164,
+} from "./dialCodes";
+
+describe("dialCodes catalog", () => {
+  it("starts with China and contains the expected shape", () => {
+    expect(DIAL_CODES[0]).toMatchObject({ iso: "cn", dial: "86", en: "China", zh: "中国" });
+    for (const entry of DIAL_CODES) {
+      expect(entry.iso).toMatch(/^[a-z]{2}$/);
+      expect(entry.dial).toMatch(/^\d+$/);
+      expect(entry.en.length).toBeGreaterThan(0);
+      expect(entry.zh.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has no duplicate ISO codes and no dangling dial codes", () => {
+    const isos = new Set(DIAL_CODES.map((c) => c.iso));
+    expect(isos.size).toBe(DIAL_CODES.length);
+  });
+
+  it("derives flag emoji from ISO codes", () => {
+    expect(flagEmoji("cn")).toBe("🇨🇳");
+    expect(flagEmoji("us")).toBe("🇺🇸");
+    expect(flagEmoji("zz")).toBe("🇿🇿"); // any two letters map
+    expect(flagEmoji("")).toBe("");
+  });
+});
+
+describe("formatE164 / parseE164", () => {
+  it("composes E.164 from dial code and national number", () => {
+    expect(formatE164("+86", "13812345678")).toBe("+8613812345678");
+    expect(formatE164("86", "138 1234-5678")).toBe("+8613812345678");
+    expect(formatE164("0086", "13812345678")).toBe("+8613812345678");
+  });
+
+  it("returns empty for missing parts", () => {
+    expect(formatE164("", "138")).toBe("");
+    expect(formatE164("+86", "")).toBe("");
+    expect(formatE164("+86", "  ")).toBe("");
+  });
+
+  it("round-trips a parsed E.164", () => {
+    const parsed = parseE164("+8613812345678");
+    expect(parsed).toEqual({ dial: "86", national: "13812345678", iso: "cn" });
+    expect(formatE164(`+${parsed.dial}`, parsed.national)).toBe("+8613812345678");
+  });
+
+  it("resolves shared prefixes to the longest dial match", () => {
+    // +1 → United States (first catalog entry for dial 1).
+    const us = parseE164("+12125551234");
+    expect(us.dial).toBe("1");
+    expect(us.iso).toBe("us");
+    expect(us.national).toBe("2125551234");
+  });
+
+  it("splits +852 Hong Kong without confusing +85 prefixes", () => {
+    const hk = parseE164("+85291234567");
+    expect(hk).toEqual({ dial: "852", national: "91234567", iso: "hk" });
+  });
+
+  it("handles a bare number without a country match", () => {
+    const parsed = parseE164("99999999");
+    // "99" matches no catalog dial prefix (no entry starts 99), so the
+    // whole string stays national.
+    expect(parsed.national).toBe("99999999");
+    expect(parsed.dial).toBe("");
+    expect(parsed.iso).toBeUndefined();
+  });
+});
+
+describe("lookups", () => {
+  it("finds entries by iso and by dial", () => {
+    expect(entryByIso("JP")?.dial).toBe("81");
+    expect(entryByDialCode("+81")?.iso).toBe("jp");
+    expect(entryByDialCode("81")?.iso).toBe("jp");
+    expect(entryByDialCode("jp")?.dial).toBe("81");
+    expect(entryByDialCode("+999")).toBeUndefined();
+  });
+
+  it("normalizes dial shapes", () => {
+    expect(normalizeDial("+86")).toBe("86");
+    expect(normalizeDial("0086")).toBe("86");
+    expect(normalizeDial("+1 234")).toBe("1234");
+  });
+});

--- a/packages/vue/src/data/dialCodes.ts
+++ b/packages/vue/src/data/dialCodes.ts
@@ -1,0 +1,233 @@
+/**
+ * Country dial-code dictionary for phone inputs (SMS enrollment, contact
+ * forms, …). Deliberately NOT part of the locale JSON: it is a data
+ * catalog, not copy — locale JSON files stay small and this table stays
+ * machine-queryable.
+ *
+ * Every entry carries an ISO 3166-1 alpha-2 code (lowercase) plus
+ * localized country names in English and Simplified Chinese. The flag is
+ * derived from the ISO code at render time (`flagEmoji`), so the table
+ * never carries hand-typed emoji that can silently rot.
+ */
+
+export interface DialCodeEntry {
+  /** ISO 3166-1 alpha-2 country code, lowercase (e.g. "cn"). */
+  iso: string;
+  /** National dial code WITHOUT the leading "+" (e.g. "86"). */
+  dial: string;
+  /** English country name (index + fallback). */
+  en: string;
+  /** Simplified Chinese country name. */
+  zh: string;
+}
+
+/** Flag glyph for an ISO 3166-1 alpha-2 code (regional indicators). */
+export function flagEmoji(iso: string): string {
+  const upper = iso.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) return "";
+  return String.fromCodePoint(
+    ...Array.from(upper, (c) => 0x1f1e6 + c.charCodeAt(0) - 65),
+  );
+}
+
+/** Localized country name: zh locales read the zh field, everything else
+ *  falls back to English (the dictionary ships en + zh only). */
+export function dialCodeName(entry: DialCodeEntry, locale: string): string {
+  return locale.toLowerCase().startsWith("zh") ? entry.zh : entry.en;
+}
+
+/**
+ * Ordered catalog. China first (the primary audience of the workspace),
+ * then Asia-Pacific neighbors, then the rest of the world. Order also
+ * drives parse ambiguity resolution (first match wins for shared dial
+ * prefixes like +1 / +7).
+ */
+export const DIAL_CODES: readonly DialCodeEntry[] = [
+  { iso: "cn", dial: "86", en: "China", zh: "中国" },
+  { iso: "hk", dial: "852", en: "Hong Kong (China)", zh: "中国香港" },
+  { iso: "mo", dial: "853", en: "Macau (China)", zh: "中国澳门" },
+  { iso: "tw", dial: "886", en: "Taiwan (China)", zh: "中国台湾" },
+  { iso: "jp", dial: "81", en: "Japan", zh: "日本" },
+  { iso: "kr", dial: "82", en: "South Korea", zh: "韩国" },
+  { iso: "sg", dial: "65", en: "Singapore", zh: "新加坡" },
+  { iso: "my", dial: "60", en: "Malaysia", zh: "马来西亚" },
+  { iso: "th", dial: "66", en: "Thailand", zh: "泰国" },
+  { iso: "vn", dial: "84", en: "Vietnam", zh: "越南" },
+  { iso: "ph", dial: "63", en: "Philippines", zh: "菲律宾" },
+  { iso: "id", dial: "62", en: "Indonesia", zh: "印度尼西亚" },
+  { iso: "in", dial: "91", en: "India", zh: "印度" },
+  { iso: "pk", dial: "92", en: "Pakistan", zh: "巴基斯坦" },
+  { iso: "bd", dial: "880", en: "Bangladesh", zh: "孟加拉国" },
+  { iso: "lk", dial: "94", en: "Sri Lanka", zh: "斯里兰卡" },
+  { iso: "np", dial: "977", en: "Nepal", zh: "尼泊尔" },
+  { iso: "kh", dial: "855", en: "Cambodia", zh: "柬埔寨" },
+  { iso: "la", dial: "856", en: "Laos", zh: "老挝" },
+  { iso: "mm", dial: "95", en: "Myanmar", zh: "缅甸" },
+  { iso: "bn", dial: "673", en: "Brunei", zh: "文莱" },
+  { iso: "mn", dial: "976", en: "Mongolia", zh: "蒙古" },
+  { iso: "us", dial: "1", en: "United States", zh: "美国" },
+  { iso: "ca", dial: "1", en: "Canada", zh: "加拿大" },
+  { iso: "gb", dial: "44", en: "United Kingdom", zh: "英国" },
+  { iso: "de", dial: "49", en: "Germany", zh: "德国" },
+  { iso: "fr", dial: "33", en: "France", zh: "法国" },
+  { iso: "it", dial: "39", en: "Italy", zh: "意大利" },
+  { iso: "es", dial: "34", en: "Spain", zh: "西班牙" },
+  { iso: "pt", dial: "351", en: "Portugal", zh: "葡萄牙" },
+  { iso: "nl", dial: "31", en: "Netherlands", zh: "荷兰" },
+  { iso: "be", dial: "32", en: "Belgium", zh: "比利时" },
+  { iso: "ch", dial: "41", en: "Switzerland", zh: "瑞士" },
+  { iso: "at", dial: "43", en: "Austria", zh: "奥地利" },
+  { iso: "ie", dial: "353", en: "Ireland", zh: "爱尔兰" },
+  { iso: "se", dial: "46", en: "Sweden", zh: "瑞典" },
+  { iso: "no", dial: "47", en: "Norway", zh: "挪威" },
+  { iso: "dk", dial: "45", en: "Denmark", zh: "丹麦" },
+  { iso: "fi", dial: "358", en: "Finland", zh: "芬兰" },
+  { iso: "is", dial: "354", en: "Iceland", zh: "冰岛" },
+  { iso: "pl", dial: "48", en: "Poland", zh: "波兰" },
+  { iso: "cz", dial: "420", en: "Czechia", zh: "捷克" },
+  { iso: "sk", dial: "421", en: "Slovakia", zh: "斯洛伐克" },
+  { iso: "hu", dial: "36", en: "Hungary", zh: "匈牙利" },
+  { iso: "ro", dial: "40", en: "Romania", zh: "罗马尼亚" },
+  { iso: "bg", dial: "359", en: "Bulgaria", zh: "保加利亚" },
+  { iso: "gr", dial: "30", en: "Greece", zh: "希腊" },
+  { iso: "hr", dial: "385", en: "Croatia", zh: "克罗地亚" },
+  { iso: "rs", dial: "381", en: "Serbia", zh: "塞尔维亚" },
+  { iso: "ua", dial: "380", en: "Ukraine", zh: "乌克兰" },
+  { iso: "ru", dial: "7", en: "Russia", zh: "俄罗斯" },
+  { iso: "kz", dial: "7", en: "Kazakhstan", zh: "哈萨克斯坦" },
+  { iso: "tr", dial: "90", en: "Türkiye", zh: "土耳其" },
+  { iso: "il", dial: "972", en: "Israel", zh: "以色列" },
+  { iso: "ae", dial: "971", en: "United Arab Emirates", zh: "阿联酋" },
+  { iso: "sa", dial: "966", en: "Saudi Arabia", zh: "沙特阿拉伯" },
+  { iso: "qa", dial: "974", en: "Qatar", zh: "卡塔尔" },
+  { iso: "kw", dial: "965", en: "Kuwait", zh: "科威特" },
+  { iso: "bh", dial: "973", en: "Bahrain", zh: "巴林" },
+  { iso: "om", dial: "968", en: "Oman", zh: "阿曼" },
+  { iso: "jo", dial: "962", en: "Jordan", zh: "约旦" },
+  { iso: "lb", dial: "961", en: "Lebanon", zh: "黎巴嫩" },
+  { iso: "iq", dial: "964", en: "Iraq", zh: "伊拉克" },
+  { iso: "ir", dial: "98", en: "Iran", zh: "伊朗" },
+  { iso: "af", dial: "93", en: "Afghanistan", zh: "阿富汗" },
+  { iso: "ge", dial: "995", en: "Georgia", zh: "格鲁吉亚" },
+  { iso: "am", dial: "374", en: "Armenia", zh: "亚美尼亚" },
+  { iso: "az", dial: "994", en: "Azerbaijan", zh: "阿塞拜疆" },
+  { iso: "uz", dial: "998", en: "Uzbekistan", zh: "乌兹别克斯坦" },
+  { iso: "eg", dial: "20", en: "Egypt", zh: "埃及" },
+  { iso: "ma", dial: "212", en: "Morocco", zh: "摩洛哥" },
+  { iso: "dz", dial: "213", en: "Algeria", zh: "阿尔及利亚" },
+  { iso: "tn", dial: "216", en: "Tunisia", zh: "突尼斯" },
+  { iso: "ng", dial: "234", en: "Nigeria", zh: "尼日利亚" },
+  { iso: "ke", dial: "254", en: "Kenya", zh: "肯尼亚" },
+  { iso: "et", dial: "251", en: "Ethiopia", zh: "埃塞俄比亚" },
+  { iso: "tz", dial: "255", en: "Tanzania", zh: "坦桑尼亚" },
+  { iso: "za", dial: "27", en: "South Africa", zh: "南非" },
+  { iso: "gh", dial: "233", en: "Ghana", zh: "加纳" },
+  { iso: "br", dial: "55", en: "Brazil", zh: "巴西" },
+  { iso: "mx", dial: "52", en: "Mexico", zh: "墨西哥" },
+  { iso: "ar", dial: "54", en: "Argentina", zh: "阿根廷" },
+  { iso: "cl", dial: "56", en: "Chile", zh: "智利" },
+  { iso: "co", dial: "57", en: "Colombia", zh: "哥伦比亚" },
+  { iso: "pe", dial: "51", en: "Peru", zh: "秘鲁" },
+  { iso: "ve", dial: "58", en: "Venezuela", zh: "委内瑞拉" },
+  { iso: "uy", dial: "598", en: "Uruguay", zh: "乌拉圭" },
+  { iso: "ec", dial: "593", en: "Ecuador", zh: "厄瓜多尔" },
+  { iso: "au", dial: "61", en: "Australia", zh: "澳大利亚" },
+  { iso: "nz", dial: "64", en: "New Zealand", zh: "新西兰" },
+  { iso: "fj", dial: "679", en: "Fiji", zh: "斐济" },
+];
+
+/** Normalize a dial-code input ("86", "+86", "0086") to bare digits. */
+export function normalizeDial(dial: string): string {
+  return dial.replace(/^\+/, "").replace(/^00/, "").replace(/\D/g, "");
+}
+
+/** Strip every non-digit from a national number (keeps leading zeros
+ *  where a country genuinely needs them, e.g. Italy). */
+export function normalizeNational(national: string): string {
+  return national.replace(/\D/g, "");
+}
+
+/** Find a catalog entry by lowercase ISO code. */
+export function entryByIso(iso: string, list: readonly DialCodeEntry[] = DIAL_CODES) {
+  return list.find((c) => c.iso === iso.toLowerCase());
+}
+
+/** Find the first catalog entry matching a dial code (order = priority
+ *  for shared prefixes like +1 / +7). */
+export function entryByDial(dial: string, list: readonly DialCodeEntry[] = DIAL_CODES) {
+  const bare = normalizeDial(dial);
+  return list.find((c) => c.dial === bare);
+}
+
+/** Resolve an entry from an ISO code OR dial code (dial wins when the
+ *  caller only knows the number). */
+export function entryByDialCode(
+  isoOrDial: string,
+  list: readonly DialCodeEntry[] = DIAL_CODES,
+) {
+  return entryByIso(isoOrDial, list) ?? entryByDial(isoOrDial, list);
+}
+
+/** Resolve an entry from a dial-code string in any shape ("+86" → CN). */
+export function resolveDial(
+  dial: string,
+  isoHint?: string,
+  list: readonly DialCodeEntry[] = DIAL_CODES,
+): DialCodeEntry | undefined {
+  const bare = normalizeDial(dial);
+  if (!bare) return undefined;
+  if (isoHint) {
+    const byIso = entryByIso(isoHint, list);
+    if (byIso && byIso.dial === bare) return byIso;
+  }
+  return list.find((c) => c.dial === bare);
+}
+
+/**
+ * Compose an E.164 number: national digits plus the selected dial code.
+ * Handles a national number that already carries a trunk prefix ("0…")
+ * only where the dial code demands it (kept simple: leading "0" is
+ * dropped for every country — trunk prefixes are caller territory).
+ *
+ * @returns full E.164 string ("+8613812345678") or "" when empty.
+ */
+export function formatE164(
+  dialCode: string,
+  national: string,
+  list: readonly DialCodeEntry[] = DIAL_CODES,
+): string {
+  const bare = normalizeDial(dialCode);
+  if (!bare) return "";
+  const digits = normalizeNational(national);
+  if (!digits) return "";
+  return `+${bare}${digits}`;
+}
+
+export interface ParsedE164 {
+  /** Bare dial digits (e.g. "86"), or "" when nothing parses. */
+  dial: string;
+  /** National digits after the dial code (e.g. "13812345678"). */
+  national: string;
+  /** Best-guess country (first catalog entry matching the dial). */
+  iso?: string;
+}
+
+/** Split an E.164 string ("+8613812345678") into dial code + national
+ *  digits. Longest dial prefix wins (so "+1" keeps US/CA whole). */
+export function parseE164(
+  e164: string,
+  list: readonly DialCodeEntry[] = DIAL_CODES,
+): ParsedE164 {
+  const digits = e164.replace(/^\+/, "").replace(/\D/g, "");
+  if (!digits) return { dial: "", national: "" };
+  const byLength = [...list]
+    .filter((c) => digits.startsWith(c.dial))
+    .sort((a, b) => b.dial.length - a.dial.length);
+  const best = byLength[0];
+  if (!best) return { dial: "", national: digits };
+  return {
+    dial: best.dial,
+    national: digits.slice(best.dial.length),
+    iso: best.iso,
+  };
+}

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -146,6 +146,11 @@
     "hikari::statusBar.backend.ok": "OK",
     "hikari::statusBar.backend.warn": "Degraded",
     "hikari::statusBar.backend.error": "Error",
-    "hikari::statusBar.backend.unknown": "Unknown"
+    "hikari::statusBar.backend.unknown": "Unknown",
+    "hikari::qrCode.alt": "QR code",
+    "hikari::phoneInput.dialCode": "Code",
+    "hikari::phoneInput.chooseCountry": "Choose country code",
+    "hikari::phoneInput.searchCountries": "Search country or code",
+    "hikari::phoneInput.noMatches": "No matching country"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -150,6 +150,11 @@
     "hikari::statusBar.region.CN": "中国大陆",
     "hikari::statusBar.region.TW": "中国台湾",
     "hikari::statusBar.region.HK": "中国香港",
-    "hikari::statusBar.region.MO": "中国澳门"
+    "hikari::statusBar.region.MO": "中国澳门",
+    "hikari::qrCode.alt": "二维码",
+    "hikari::phoneInput.dialCode": "区号",
+    "hikari::phoneInput.chooseCountry": "选择国家区号",
+    "hikari::phoneInput.searchCountries": "搜索国家或区号",
+    "hikari::phoneInput.noMatches": "没有匹配的国家"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -150,6 +150,11 @@
     "hikari::statusBar.region.CN": "中國大陸",
     "hikari::statusBar.region.TW": "中國台灣",
     "hikari::statusBar.region.HK": "中國香港",
-    "hikari::statusBar.region.MO": "中國澳門"
+    "hikari::statusBar.region.MO": "中國澳門",
+    "hikari::qrCode.alt": "QR 碼",
+    "hikari::phoneInput.dialCode": "區碼",
+    "hikari::phoneInput.chooseCountry": "選擇國家區碼",
+    "hikari::phoneInput.searchCountries": "搜尋國家或區碼",
+    "hikari::phoneInput.noMatches": "沒有符合的國家"
   }
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -34,9 +34,11 @@ export { default as HModal } from "./components/HkModal";
 export { default as HNavItem } from "./components/HkNavItem";
 export { default as HNumberInput } from "./components/HkNumberInput";
 export { default as HPasswordInput } from "./components/HkPasswordInput";
+export { default as HPhoneInput } from "./components/HkPhoneInput";
 export { default as HPhaseTransition } from "./components/HkPhaseTransition";
 export { default as HGaugeRing } from "./components/HkGaugeRing";
 export { default as HProgressRing } from "./components/HkProgressRing";
+export { default as HQrCode } from "./components/HkQrCode";
 export { default as HRollingNumber } from "./components/HkRollingNumber";
 export { default as HLocalePickerPopup } from "./components/HkLocalePickerPopup";
 export { default as HHoverRevealAction } from "./components/HkHoverRevealAction";
@@ -357,3 +359,15 @@ export {
   formatMs,
   type RelativeTimeT,
 } from "./utils/format";
+
+export {
+  DIAL_CODES,
+  flagEmoji,
+  dialCodeName,
+  formatE164,
+  parseE164,
+  normalizeDial,
+  normalizeNational,
+  type DialCodeEntry,
+  type ParsedE164,
+} from "./data/dialCodes";

--- a/packages/vue/src/utils/qr/qrEncoder.test.ts
+++ b/packages/vue/src/utils/qr/qrEncoder.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { qrMatrix } from "./qrEncoder";
+
+const OTPAUTH =
+  "otpauth://totp/Example:langyo%40example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example";
+
+describe("qrMatrix", () => {
+  it("returns a square boolean matrix for a real otpauth URI", () => {
+    const m = qrMatrix(OTPAUTH);
+    expect(m.length).toBeGreaterThan(0);
+    for (const row of m) {
+      expect(row).toHaveLength(m.length);
+    }
+  });
+
+  it("is deterministic for the same payload", () => {
+    expect(qrMatrix(OTPAUTH)).toEqual(qrMatrix(OTPAUTH));
+  });
+
+  it("places three 7x7 finder patterns on the corners", () => {
+    const m = qrMatrix("HELLO WORLD");
+    const n = m.length;
+    // Finder pattern: dark border ring, light 1-module gap ring, dark 3x3
+    // core. Check the top-left corner box.
+    const expectFinderAt = (r0: number, c0: number) => {
+      for (let r = 0; r < 7; r++) {
+        for (let c = 0; c < 7; c++) {
+          const ring = r === 0 || r === 6 || c === 0 || c === 6;
+          const core = r >= 2 && r <= 4 && c >= 2 && c <= 4;
+          expect(m[r0 + r][c0 + c]).toBe(ring || core);
+        }
+      }
+    };
+    expectFinderAt(0, 0);
+    expectFinderAt(0, n - 7);
+    expectFinderAt(n - 7, 0);
+  });
+
+  it("encodes a balanced module population", () => {
+    const m = qrMatrix(OTPAUTH);
+    const dark = m.flat().filter(Boolean).length;
+    const total = m.length * m.length;
+    // QR data is error-corrected and masked; a healthy code lands well
+    // between an empty and a full grid.
+    expect(dark).toBeGreaterThan(total * 0.2);
+    expect(dark).toBeLessThan(total * 0.8);
+  });
+
+  it("throws when the payload overflows the largest version", () => {
+    expect(() => qrMatrix("x".repeat(5000))).toThrow();
+  });
+});

--- a/packages/vue/src/utils/qr/qrEncoder.ts
+++ b/packages/vue/src/utils/qr/qrEncoder.ts
@@ -1,0 +1,38 @@
+// Thin TS wrapper over the vendored MIT qrcode-generator (Kazuhiko Arase).
+// Exposes a single `qrMatrix` helper used by HkQrCode to render a QR code
+// without any external dependency (the shared pnpm virtual-store layout
+// cannot install new packages in this workspace, so the encoder is vendored
+// as a self-contained ES module).
+
+import qrcode from "./qrcode-generator";
+
+export type QrErrorCorrectionLevel = "L" | "M" | "Q" | "H";
+
+export interface QrMatrixOptions {
+  /** Explicit QR version 1..40, or 0 for auto-detection. Default 0. */
+  typeNumber?: number;
+  /** Error-correction level. Default "M". */
+  errorCorrectionLevel?: QrErrorCorrectionLevel;
+}
+
+/**
+ * Encode `text` as a QR module matrix. `true` = dark module.
+ *
+ * When `typeNumber` is 0 (default), the vendored generator auto-selects the
+ * smallest version that fits the payload and the chosen ECC level.
+ */
+export function qrMatrix(text: string, opts: QrMatrixOptions = {}): boolean[][] {
+  const level = opts.errorCorrectionLevel ?? "M";
+  const typeNumber = opts.typeNumber ?? 0;
+  const qr = qrcode(typeNumber, level);
+  qr.addData(text);
+  qr.make();
+  const count = qr.getModuleCount();
+  const matrix: boolean[][] = [];
+  for (let row = 0; row < count; row++) {
+    const line: boolean[] = [];
+    for (let col = 0; col < count; col++) line.push(qr.isDark(row, col));
+    matrix.push(line);
+  }
+  return matrix;
+}

--- a/packages/vue/src/utils/qr/qrcode-generator.d.ts
+++ b/packages/vue/src/utils/qr/qrcode-generator.d.ts
@@ -1,0 +1,19 @@
+// Type declarations for the vendored MIT qrcode-generator (Kazuhiko Arase).
+// The implementation lives in ./qrcode-generator.js (ESM default export).
+export interface QRCodeModule {
+  /** Add a data segment (default mode "Byte"). */
+  addData(data: string, mode?: string): void;
+  /** Encode the added data and render the module matrix. */
+  make(): void;
+  /** Number of modules per side (the rendered matrix is count x count). */
+  getModuleCount(): number;
+  /** Whether the module at (row, col) is dark. */
+  isDark(row: number, col: number): boolean;
+}
+
+declare function qrcode(
+  typeNumber: number,
+  errorCorrectionLevel: "L" | "M" | "Q" | "H",
+): QRCodeModule;
+
+export default qrcode;

--- a/packages/vue/src/utils/qr/qrcode-generator.js
+++ b/packages/vue/src/utils/qr/qrcode-generator.js
@@ -1,0 +1,2289 @@
+//---------------------------------------------------------------------
+//
+// QR Code Generator for JavaScript
+//
+// Copyright (c) 2009 Kazuhiko Arase
+//
+// URL: http://www.d-project.com/
+//
+// Licensed under the MIT license:
+//  http://www.opensource.org/licenses/mit-license.php
+//
+// The word 'QR Code' is registered trademark of
+// DENSO WAVE INCORPORATED
+//  http://www.denso-wave.com/qrcode/faqpatent-e.html
+//
+//---------------------------------------------------------------------
+
+var qrcode = function() {
+
+  //---------------------------------------------------------------------
+  // qrcode
+  //---------------------------------------------------------------------
+
+  /**
+   * qrcode
+   * @param typeNumber 1 to 40
+   * @param errorCorrectionLevel 'L','M','Q','H'
+   */
+  var qrcode = function(typeNumber, errorCorrectionLevel) {
+
+    var PAD0 = 0xEC;
+    var PAD1 = 0x11;
+
+    var _typeNumber = typeNumber;
+    var _errorCorrectionLevel = QRErrorCorrectionLevel[errorCorrectionLevel];
+    var _modules = null;
+    var _moduleCount = 0;
+    var _dataCache = null;
+    var _dataList = [];
+
+    var _this = {};
+
+    var makeImpl = function(test, maskPattern) {
+
+      _moduleCount = _typeNumber * 4 + 17;
+      _modules = function(moduleCount) {
+        var modules = new Array(moduleCount);
+        for (var row = 0; row < moduleCount; row += 1) {
+          modules[row] = new Array(moduleCount);
+          for (var col = 0; col < moduleCount; col += 1) {
+            modules[row][col] = null;
+          }
+        }
+        return modules;
+      }(_moduleCount);
+
+      setupPositionProbePattern(0, 0);
+      setupPositionProbePattern(_moduleCount - 7, 0);
+      setupPositionProbePattern(0, _moduleCount - 7);
+      setupPositionAdjustPattern();
+      setupTimingPattern();
+      setupTypeInfo(test, maskPattern);
+
+      if (_typeNumber >= 7) {
+        setupTypeNumber(test);
+      }
+
+      if (_dataCache == null) {
+        _dataCache = createData(_typeNumber, _errorCorrectionLevel, _dataList);
+      }
+
+      mapData(_dataCache, maskPattern);
+    };
+
+    var setupPositionProbePattern = function(row, col) {
+
+      for (var r = -1; r <= 7; r += 1) {
+
+        if (row + r <= -1 || _moduleCount <= row + r) continue;
+
+        for (var c = -1; c <= 7; c += 1) {
+
+          if (col + c <= -1 || _moduleCount <= col + c) continue;
+
+          if ( (0 <= r && r <= 6 && (c == 0 || c == 6) )
+              || (0 <= c && c <= 6 && (r == 0 || r == 6) )
+              || (2 <= r && r <= 4 && 2 <= c && c <= 4) ) {
+            _modules[row + r][col + c] = true;
+          } else {
+            _modules[row + r][col + c] = false;
+          }
+        }
+      }
+    };
+
+    var getBestMaskPattern = function() {
+
+      var minLostPoint = 0;
+      var pattern = 0;
+
+      for (var i = 0; i < 8; i += 1) {
+
+        makeImpl(true, i);
+
+        var lostPoint = QRUtil.getLostPoint(_this);
+
+        if (i == 0 || minLostPoint > lostPoint) {
+          minLostPoint = lostPoint;
+          pattern = i;
+        }
+      }
+
+      return pattern;
+    };
+
+    var setupTimingPattern = function() {
+
+      for (var r = 8; r < _moduleCount - 8; r += 1) {
+        if (_modules[r][6] != null) {
+          continue;
+        }
+        _modules[r][6] = (r % 2 == 0);
+      }
+
+      for (var c = 8; c < _moduleCount - 8; c += 1) {
+        if (_modules[6][c] != null) {
+          continue;
+        }
+        _modules[6][c] = (c % 2 == 0);
+      }
+    };
+
+    var setupPositionAdjustPattern = function() {
+
+      var pos = QRUtil.getPatternPosition(_typeNumber);
+
+      for (var i = 0; i < pos.length; i += 1) {
+
+        for (var j = 0; j < pos.length; j += 1) {
+
+          var row = pos[i];
+          var col = pos[j];
+
+          if (_modules[row][col] != null) {
+            continue;
+          }
+
+          for (var r = -2; r <= 2; r += 1) {
+
+            for (var c = -2; c <= 2; c += 1) {
+
+              if (r == -2 || r == 2 || c == -2 || c == 2
+                  || (r == 0 && c == 0) ) {
+                _modules[row + r][col + c] = true;
+              } else {
+                _modules[row + r][col + c] = false;
+              }
+            }
+          }
+        }
+      }
+    };
+
+    var setupTypeNumber = function(test) {
+
+      var bits = QRUtil.getBCHTypeNumber(_typeNumber);
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[Math.floor(i / 3)][i % 3 + _moduleCount - 8 - 3] = mod;
+      }
+
+      for (var i = 0; i < 18; i += 1) {
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+        _modules[i % 3 + _moduleCount - 8 - 3][Math.floor(i / 3)] = mod;
+      }
+    };
+
+    var setupTypeInfo = function(test, maskPattern) {
+
+      var data = (_errorCorrectionLevel << 3) | maskPattern;
+      var bits = QRUtil.getBCHTypeInfo(data);
+
+      // vertical
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 6) {
+          _modules[i][8] = mod;
+        } else if (i < 8) {
+          _modules[i + 1][8] = mod;
+        } else {
+          _modules[_moduleCount - 15 + i][8] = mod;
+        }
+      }
+
+      // horizontal
+      for (var i = 0; i < 15; i += 1) {
+
+        var mod = (!test && ( (bits >> i) & 1) == 1);
+
+        if (i < 8) {
+          _modules[8][_moduleCount - i - 1] = mod;
+        } else if (i < 9) {
+          _modules[8][15 - i - 1 + 1] = mod;
+        } else {
+          _modules[8][15 - i - 1] = mod;
+        }
+      }
+
+      // fixed module
+      _modules[_moduleCount - 8][8] = (!test);
+    };
+
+    var mapData = function(data, maskPattern) {
+
+      var inc = -1;
+      var row = _moduleCount - 1;
+      var bitIndex = 7;
+      var byteIndex = 0;
+      var maskFunc = QRUtil.getMaskFunction(maskPattern);
+
+      for (var col = _moduleCount - 1; col > 0; col -= 2) {
+
+        if (col == 6) col -= 1;
+
+        while (true) {
+
+          for (var c = 0; c < 2; c += 1) {
+
+            if (_modules[row][col - c] == null) {
+
+              var dark = false;
+
+              if (byteIndex < data.length) {
+                dark = ( ( (data[byteIndex] >>> bitIndex) & 1) == 1);
+              }
+
+              var mask = maskFunc(row, col - c);
+
+              if (mask) {
+                dark = !dark;
+              }
+
+              _modules[row][col - c] = dark;
+              bitIndex -= 1;
+
+              if (bitIndex == -1) {
+                byteIndex += 1;
+                bitIndex = 7;
+              }
+            }
+          }
+
+          row += inc;
+
+          if (row < 0 || _moduleCount <= row) {
+            row -= inc;
+            inc = -inc;
+            break;
+          }
+        }
+      }
+    };
+
+    var createBytes = function(buffer, rsBlocks) {
+
+      var offset = 0;
+
+      var maxDcCount = 0;
+      var maxEcCount = 0;
+
+      var dcdata = new Array(rsBlocks.length);
+      var ecdata = new Array(rsBlocks.length);
+
+      for (var r = 0; r < rsBlocks.length; r += 1) {
+
+        var dcCount = rsBlocks[r].dataCount;
+        var ecCount = rsBlocks[r].totalCount - dcCount;
+
+        maxDcCount = Math.max(maxDcCount, dcCount);
+        maxEcCount = Math.max(maxEcCount, ecCount);
+
+        dcdata[r] = new Array(dcCount);
+
+        for (var i = 0; i < dcdata[r].length; i += 1) {
+          dcdata[r][i] = 0xff & buffer.getBuffer()[i + offset];
+        }
+        offset += dcCount;
+
+        var rsPoly = QRUtil.getErrorCorrectPolynomial(ecCount);
+        var rawPoly = qrPolynomial(dcdata[r], rsPoly.getLength() - 1);
+
+        var modPoly = rawPoly.mod(rsPoly);
+        ecdata[r] = new Array(rsPoly.getLength() - 1);
+        for (var i = 0; i < ecdata[r].length; i += 1) {
+          var modIndex = i + modPoly.getLength() - ecdata[r].length;
+          ecdata[r][i] = (modIndex >= 0)? modPoly.getAt(modIndex) : 0;
+        }
+      }
+
+      var totalCodeCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalCodeCount += rsBlocks[i].totalCount;
+      }
+
+      var data = new Array(totalCodeCount);
+      var index = 0;
+
+      for (var i = 0; i < maxDcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < dcdata[r].length) {
+            data[index] = dcdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      for (var i = 0; i < maxEcCount; i += 1) {
+        for (var r = 0; r < rsBlocks.length; r += 1) {
+          if (i < ecdata[r].length) {
+            data[index] = ecdata[r][i];
+            index += 1;
+          }
+        }
+      }
+
+      return data;
+    };
+
+    var createData = function(typeNumber, errorCorrectionLevel, dataList) {
+
+      var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, errorCorrectionLevel);
+
+      var buffer = qrBitBuffer();
+
+      for (var i = 0; i < dataList.length; i += 1) {
+        var data = dataList[i];
+        buffer.put(data.getMode(), 4);
+        buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+        data.write(buffer);
+      }
+
+      // calc num max data.
+      var totalDataCount = 0;
+      for (var i = 0; i < rsBlocks.length; i += 1) {
+        totalDataCount += rsBlocks[i].dataCount;
+      }
+
+      if (buffer.getLengthInBits() > totalDataCount * 8) {
+        throw 'code length overflow. ('
+          + buffer.getLengthInBits()
+          + '>'
+          + totalDataCount * 8
+          + ')';
+      }
+
+      // end code
+      if (buffer.getLengthInBits() + 4 <= totalDataCount * 8) {
+        buffer.put(0, 4);
+      }
+
+      // padding
+      while (buffer.getLengthInBits() % 8 != 0) {
+        buffer.putBit(false);
+      }
+
+      // padding
+      while (true) {
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD0, 8);
+
+        if (buffer.getLengthInBits() >= totalDataCount * 8) {
+          break;
+        }
+        buffer.put(PAD1, 8);
+      }
+
+      return createBytes(buffer, rsBlocks);
+    };
+
+    _this.addData = function(data, mode) {
+
+      mode = mode || 'Byte';
+
+      var newData = null;
+
+      switch(mode) {
+      case 'Numeric' :
+        newData = qrNumber(data);
+        break;
+      case 'Alphanumeric' :
+        newData = qrAlphaNum(data);
+        break;
+      case 'Byte' :
+        newData = qr8BitByte(data);
+        break;
+      case 'Kanji' :
+        newData = qrKanji(data);
+        break;
+      default :
+        throw 'mode:' + mode;
+      }
+
+      _dataList.push(newData);
+      _dataCache = null;
+    };
+
+    _this.isDark = function(row, col) {
+      if (row < 0 || _moduleCount <= row || col < 0 || _moduleCount <= col) {
+        throw row + ',' + col;
+      }
+      return _modules[row][col];
+    };
+
+    _this.getModuleCount = function() {
+      return _moduleCount;
+    };
+
+    _this.make = function() {
+      if (_typeNumber < 1) {
+        var typeNumber = 1;
+
+        for (; typeNumber < 40; typeNumber++) {
+          var rsBlocks = QRRSBlock.getRSBlocks(typeNumber, _errorCorrectionLevel);
+          var buffer = qrBitBuffer();
+
+          for (var i = 0; i < _dataList.length; i++) {
+            var data = _dataList[i];
+            buffer.put(data.getMode(), 4);
+            buffer.put(data.getLength(), QRUtil.getLengthInBits(data.getMode(), typeNumber) );
+            data.write(buffer);
+          }
+
+          var totalDataCount = 0;
+          for (var i = 0; i < rsBlocks.length; i++) {
+            totalDataCount += rsBlocks[i].dataCount;
+          }
+
+          if (buffer.getLengthInBits() <= totalDataCount * 8) {
+            break;
+          }
+        }
+
+        _typeNumber = typeNumber;
+      }
+
+      makeImpl(false, getBestMaskPattern() );
+    };
+
+    _this.createTableTag = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var qrHtml = '';
+
+      qrHtml += '<table style="';
+      qrHtml += ' border-width: 0px; border-style: none;';
+      qrHtml += ' border-collapse: collapse;';
+      qrHtml += ' padding: 0px; margin: ' + margin + 'px;';
+      qrHtml += '">';
+      qrHtml += '<tbody>';
+
+      for (var r = 0; r < _this.getModuleCount(); r += 1) {
+
+        qrHtml += '<tr>';
+
+        for (var c = 0; c < _this.getModuleCount(); c += 1) {
+          qrHtml += '<td style="';
+          qrHtml += ' border-width: 0px; border-style: none;';
+          qrHtml += ' border-collapse: collapse;';
+          qrHtml += ' padding: 0px; margin: 0px;';
+          qrHtml += ' width: ' + cellSize + 'px;';
+          qrHtml += ' height: ' + cellSize + 'px;';
+          qrHtml += ' background-color: ';
+          qrHtml += _this.isDark(r, c)? '#000000' : '#ffffff';
+          qrHtml += ';';
+          qrHtml += '"/>';
+        }
+
+        qrHtml += '</tr>';
+      }
+
+      qrHtml += '</tbody>';
+      qrHtml += '</table>';
+
+      return qrHtml;
+    };
+
+    _this.createSvgTag = function(cellSize, margin, alt, title) {
+
+      var opts = {};
+      if (typeof arguments[0] == 'object') {
+        // Called by options.
+        opts = arguments[0];
+        // overwrite cellSize and margin.
+        cellSize = opts.cellSize;
+        margin = opts.margin;
+        alt = opts.alt;
+        title = opts.title;
+      }
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      // Compose alt property surrogate
+      alt = (typeof alt === 'string') ? {text: alt} : alt || {};
+      alt.text = alt.text || null;
+      alt.id = (alt.text) ? alt.id || 'qrcode-description' : null;
+
+      // Compose title property surrogate
+      title = (typeof title === 'string') ? {text: title} : title || {};
+      title.text = title.text || null;
+      title.id = (title.text) ? title.id || 'qrcode-title' : null;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var c, mc, r, mr, qrSvg='', rect;
+
+      rect = 'l' + cellSize + ',0 0,' + cellSize +
+        ' -' + cellSize + ',0 0,-' + cellSize + 'z ';
+
+      qrSvg += '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"';
+      qrSvg += !opts.scalable ? ' width="' + size + 'px" height="' + size + 'px"' : '';
+      qrSvg += ' viewBox="0 0 ' + size + ' ' + size + '" ';
+      qrSvg += ' preserveAspectRatio="xMinYMin meet"';
+      qrSvg += (title.text || alt.text) ? ' role="img" aria-labelledby="' +
+          escapeXml([title.id, alt.id].join(' ').trim() ) + '"' : '';
+      qrSvg += '>';
+      qrSvg += (title.text) ? '<title id="' + escapeXml(title.id) + '">' +
+          escapeXml(title.text) + '</title>' : '';
+      qrSvg += (alt.text) ? '<description id="' + escapeXml(alt.id) + '">' +
+          escapeXml(alt.text) + '</description>' : '';
+      qrSvg += '<rect width="100%" height="100%" fill="white" cx="0" cy="0"/>';
+      qrSvg += '<path d="';
+
+      for (r = 0; r < _this.getModuleCount(); r += 1) {
+        mr = r * cellSize + margin;
+        for (c = 0; c < _this.getModuleCount(); c += 1) {
+          if (_this.isDark(r, c) ) {
+            mc = c*cellSize+margin;
+            qrSvg += 'M' + mc + ',' + mr + rect;
+          }
+        }
+      }
+
+      qrSvg += '" stroke="transparent" fill="black"/>';
+      qrSvg += '</svg>';
+
+      return qrSvg;
+    };
+
+    _this.createDataURL = function(cellSize, margin) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      return createDataURL(size, size, function(x, y) {
+        if (min <= x && x < max && min <= y && y < max) {
+          var c = Math.floor( (x - min) / cellSize);
+          var r = Math.floor( (y - min) / cellSize);
+          return _this.isDark(r, c)? 0 : 1;
+        } else {
+          return 1;
+        }
+      } );
+    };
+
+    _this.createImgTag = function(cellSize, margin, alt) {
+
+      cellSize = cellSize || 2;
+      margin = (typeof margin == 'undefined')? cellSize * 4 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+
+      var img = '';
+      img += '<img';
+      img += '\u0020src="';
+      img += _this.createDataURL(cellSize, margin);
+      img += '"';
+      img += '\u0020width="';
+      img += size;
+      img += '"';
+      img += '\u0020height="';
+      img += size;
+      img += '"';
+      if (alt) {
+        img += '\u0020alt="';
+        img += escapeXml(alt);
+        img += '"';
+      }
+      img += '/>';
+
+      return img;
+    };
+
+    var escapeXml = function(s) {
+      var escaped = '';
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charAt(i);
+        switch(c) {
+        case '<': escaped += '&lt;'; break;
+        case '>': escaped += '&gt;'; break;
+        case '&': escaped += '&amp;'; break;
+        case '"': escaped += '&quot;'; break;
+        default : escaped += c; break;
+        }
+      }
+      return escaped;
+    };
+
+    var _createHalfASCII = function(margin) {
+      var cellSize = 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r1, r2, p;
+
+      var blocks = {
+        '██': '█',
+        '█ ': '▀',
+        ' █': '▄',
+        '  ': ' '
+      };
+
+      var blocksLastLineNoMargin = {
+        '██': '▀',
+        '█ ': '▀',
+        ' █': ' ',
+        '  ': ' '
+      };
+
+      var ascii = '';
+      for (y = 0; y < size; y += 2) {
+        r1 = Math.floor((y - min) / cellSize);
+        r2 = Math.floor((y + 1 - min) / cellSize);
+        for (x = 0; x < size; x += 1) {
+          p = '█';
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r1, Math.floor((x - min) / cellSize))) {
+            p = ' ';
+          }
+
+          if (min <= x && x < max && min <= y+1 && y+1 < max && _this.isDark(r2, Math.floor((x - min) / cellSize))) {
+            p += ' ';
+          }
+          else {
+            p += '█';
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          ascii += (margin < 1 && y+1 >= max) ? blocksLastLineNoMargin[p] : blocks[p];
+        }
+
+        ascii += '\n';
+      }
+
+      if (size % 2 && margin > 0) {
+        return ascii.substring(0, ascii.length - size - 1) + Array(size+1).join('▀');
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.createASCII = function(cellSize, margin) {
+      cellSize = cellSize || 1;
+
+      if (cellSize < 2) {
+        return _createHalfASCII(margin);
+      }
+
+      cellSize -= 1;
+      margin = (typeof margin == 'undefined')? cellSize * 2 : margin;
+
+      var size = _this.getModuleCount() * cellSize + margin * 2;
+      var min = margin;
+      var max = size - margin;
+
+      var y, x, r, p;
+
+      var white = Array(cellSize+1).join('██');
+      var black = Array(cellSize+1).join('  ');
+
+      var ascii = '';
+      var line = '';
+      for (y = 0; y < size; y += 1) {
+        r = Math.floor( (y - min) / cellSize);
+        line = '';
+        for (x = 0; x < size; x += 1) {
+          p = 1;
+
+          if (min <= x && x < max && min <= y && y < max && _this.isDark(r, Math.floor((x - min) / cellSize))) {
+            p = 0;
+          }
+
+          // Output 2 characters per pixel, to create full square. 1 character per pixels gives only half width of square.
+          line += p ? white : black;
+        }
+
+        for (r = 0; r < cellSize; r += 1) {
+          ascii += line + '\n';
+        }
+      }
+
+      return ascii.substring(0, ascii.length-1);
+    };
+
+    _this.renderTo2dContext = function(context, cellSize) {
+      cellSize = cellSize || 2;
+      var length = _this.getModuleCount();
+      for (var row = 0; row < length; row++) {
+        for (var col = 0; col < length; col++) {
+          context.fillStyle = _this.isDark(row, col) ? 'black' : 'white';
+          context.fillRect(row * cellSize, col * cellSize, cellSize, cellSize);
+        }
+      }
+    }
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrcode.stringToBytes
+  //---------------------------------------------------------------------
+
+  qrcode.stringToBytesFuncs = {
+    'default' : function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        bytes.push(c & 0xff);
+      }
+      return bytes;
+    }
+  };
+
+  qrcode.stringToBytes = qrcode.stringToBytesFuncs['default'];
+
+  //---------------------------------------------------------------------
+  // qrcode.createStringToBytes
+  //---------------------------------------------------------------------
+
+  /**
+   * @param unicodeData base64 string of byte array.
+   * [16bit Unicode],[16bit Bytes], ...
+   * @param numChars
+   */
+  qrcode.createStringToBytes = function(unicodeData, numChars) {
+
+    // create conversion map.
+
+    var unicodeMap = function() {
+
+      var bin = base64DecodeInputStream(unicodeData);
+      var read = function() {
+        var b = bin.read();
+        if (b == -1) throw 'eof';
+        return b;
+      };
+
+      var count = 0;
+      var unicodeMap = {};
+      while (true) {
+        var b0 = bin.read();
+        if (b0 == -1) break;
+        var b1 = read();
+        var b2 = read();
+        var b3 = read();
+        var k = String.fromCharCode( (b0 << 8) | b1);
+        var v = (b2 << 8) | b3;
+        unicodeMap[k] = v;
+        count += 1;
+      }
+      if (count != numChars) {
+        throw count + ' != ' + numChars;
+      }
+
+      return unicodeMap;
+    }();
+
+    var unknownChar = '?'.charCodeAt(0);
+
+    return function(s) {
+      var bytes = [];
+      for (var i = 0; i < s.length; i += 1) {
+        var c = s.charCodeAt(i);
+        if (c < 128) {
+          bytes.push(c);
+        } else {
+          var b = unicodeMap[s.charAt(i)];
+          if (typeof b == 'number') {
+            if ( (b & 0xff) == b) {
+              // 1byte
+              bytes.push(b);
+            } else {
+              // 2bytes
+              bytes.push(b >>> 8);
+              bytes.push(b & 0xff);
+            }
+          } else {
+            bytes.push(unknownChar);
+          }
+        }
+      }
+      return bytes;
+    };
+  };
+
+  //---------------------------------------------------------------------
+  // QRMode
+  //---------------------------------------------------------------------
+
+  var QRMode = {
+    MODE_NUMBER :    1 << 0,
+    MODE_ALPHA_NUM : 1 << 1,
+    MODE_8BIT_BYTE : 1 << 2,
+    MODE_KANJI :     1 << 3
+  };
+
+  //---------------------------------------------------------------------
+  // QRErrorCorrectionLevel
+  //---------------------------------------------------------------------
+
+  var QRErrorCorrectionLevel = {
+    L : 1,
+    M : 0,
+    Q : 3,
+    H : 2
+  };
+
+  //---------------------------------------------------------------------
+  // QRMaskPattern
+  //---------------------------------------------------------------------
+
+  var QRMaskPattern = {
+    PATTERN000 : 0,
+    PATTERN001 : 1,
+    PATTERN010 : 2,
+    PATTERN011 : 3,
+    PATTERN100 : 4,
+    PATTERN101 : 5,
+    PATTERN110 : 6,
+    PATTERN111 : 7
+  };
+
+  //---------------------------------------------------------------------
+  // QRUtil
+  //---------------------------------------------------------------------
+
+  var QRUtil = function() {
+
+    var PATTERN_POSITION_TABLE = [
+      [],
+      [6, 18],
+      [6, 22],
+      [6, 26],
+      [6, 30],
+      [6, 34],
+      [6, 22, 38],
+      [6, 24, 42],
+      [6, 26, 46],
+      [6, 28, 50],
+      [6, 30, 54],
+      [6, 32, 58],
+      [6, 34, 62],
+      [6, 26, 46, 66],
+      [6, 26, 48, 70],
+      [6, 26, 50, 74],
+      [6, 30, 54, 78],
+      [6, 30, 56, 82],
+      [6, 30, 58, 86],
+      [6, 34, 62, 90],
+      [6, 28, 50, 72, 94],
+      [6, 26, 50, 74, 98],
+      [6, 30, 54, 78, 102],
+      [6, 28, 54, 80, 106],
+      [6, 32, 58, 84, 110],
+      [6, 30, 58, 86, 114],
+      [6, 34, 62, 90, 118],
+      [6, 26, 50, 74, 98, 122],
+      [6, 30, 54, 78, 102, 126],
+      [6, 26, 52, 78, 104, 130],
+      [6, 30, 56, 82, 108, 134],
+      [6, 34, 60, 86, 112, 138],
+      [6, 30, 58, 86, 114, 142],
+      [6, 34, 62, 90, 118, 146],
+      [6, 30, 54, 78, 102, 126, 150],
+      [6, 24, 50, 76, 102, 128, 154],
+      [6, 28, 54, 80, 106, 132, 158],
+      [6, 32, 58, 84, 110, 136, 162],
+      [6, 26, 54, 82, 110, 138, 166],
+      [6, 30, 58, 86, 114, 142, 170]
+    ];
+    var G15 = (1 << 10) | (1 << 8) | (1 << 5) | (1 << 4) | (1 << 2) | (1 << 1) | (1 << 0);
+    var G18 = (1 << 12) | (1 << 11) | (1 << 10) | (1 << 9) | (1 << 8) | (1 << 5) | (1 << 2) | (1 << 0);
+    var G15_MASK = (1 << 14) | (1 << 12) | (1 << 10) | (1 << 4) | (1 << 1);
+
+    var _this = {};
+
+    var getBCHDigit = function(data) {
+      var digit = 0;
+      while (data != 0) {
+        digit += 1;
+        data >>>= 1;
+      }
+      return digit;
+    };
+
+    _this.getBCHTypeInfo = function(data) {
+      var d = data << 10;
+      while (getBCHDigit(d) - getBCHDigit(G15) >= 0) {
+        d ^= (G15 << (getBCHDigit(d) - getBCHDigit(G15) ) );
+      }
+      return ( (data << 10) | d) ^ G15_MASK;
+    };
+
+    _this.getBCHTypeNumber = function(data) {
+      var d = data << 12;
+      while (getBCHDigit(d) - getBCHDigit(G18) >= 0) {
+        d ^= (G18 << (getBCHDigit(d) - getBCHDigit(G18) ) );
+      }
+      return (data << 12) | d;
+    };
+
+    _this.getPatternPosition = function(typeNumber) {
+      return PATTERN_POSITION_TABLE[typeNumber - 1];
+    };
+
+    _this.getMaskFunction = function(maskPattern) {
+
+      switch (maskPattern) {
+
+      case QRMaskPattern.PATTERN000 :
+        return function(i, j) { return (i + j) % 2 == 0; };
+      case QRMaskPattern.PATTERN001 :
+        return function(i, j) { return i % 2 == 0; };
+      case QRMaskPattern.PATTERN010 :
+        return function(i, j) { return j % 3 == 0; };
+      case QRMaskPattern.PATTERN011 :
+        return function(i, j) { return (i + j) % 3 == 0; };
+      case QRMaskPattern.PATTERN100 :
+        return function(i, j) { return (Math.floor(i / 2) + Math.floor(j / 3) ) % 2 == 0; };
+      case QRMaskPattern.PATTERN101 :
+        return function(i, j) { return (i * j) % 2 + (i * j) % 3 == 0; };
+      case QRMaskPattern.PATTERN110 :
+        return function(i, j) { return ( (i * j) % 2 + (i * j) % 3) % 2 == 0; };
+      case QRMaskPattern.PATTERN111 :
+        return function(i, j) { return ( (i * j) % 3 + (i + j) % 2) % 2 == 0; };
+
+      default :
+        throw 'bad maskPattern:' + maskPattern;
+      }
+    };
+
+    _this.getErrorCorrectPolynomial = function(errorCorrectLength) {
+      var a = qrPolynomial([1], 0);
+      for (var i = 0; i < errorCorrectLength; i += 1) {
+        a = a.multiply(qrPolynomial([1, QRMath.gexp(i)], 0) );
+      }
+      return a;
+    };
+
+    _this.getLengthInBits = function(mode, type) {
+
+      if (1 <= type && type < 10) {
+
+        // 1 - 9
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 10;
+        case QRMode.MODE_ALPHA_NUM : return 9;
+        case QRMode.MODE_8BIT_BYTE : return 8;
+        case QRMode.MODE_KANJI     : return 8;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 27) {
+
+        // 10 - 26
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 12;
+        case QRMode.MODE_ALPHA_NUM : return 11;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 10;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else if (type < 41) {
+
+        // 27 - 40
+
+        switch(mode) {
+        case QRMode.MODE_NUMBER    : return 14;
+        case QRMode.MODE_ALPHA_NUM : return 13;
+        case QRMode.MODE_8BIT_BYTE : return 16;
+        case QRMode.MODE_KANJI     : return 12;
+        default :
+          throw 'mode:' + mode;
+        }
+
+      } else {
+        throw 'type:' + type;
+      }
+    };
+
+    _this.getLostPoint = function(qrcode) {
+
+      var moduleCount = qrcode.getModuleCount();
+
+      var lostPoint = 0;
+
+      // LEVEL1
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount; col += 1) {
+
+          var sameCount = 0;
+          var dark = qrcode.isDark(row, col);
+
+          for (var r = -1; r <= 1; r += 1) {
+
+            if (row + r < 0 || moduleCount <= row + r) {
+              continue;
+            }
+
+            for (var c = -1; c <= 1; c += 1) {
+
+              if (col + c < 0 || moduleCount <= col + c) {
+                continue;
+              }
+
+              if (r == 0 && c == 0) {
+                continue;
+              }
+
+              if (dark == qrcode.isDark(row + r, col + c) ) {
+                sameCount += 1;
+              }
+            }
+          }
+
+          if (sameCount > 5) {
+            lostPoint += (3 + sameCount - 5);
+          }
+        }
+      };
+
+      // LEVEL2
+
+      for (var row = 0; row < moduleCount - 1; row += 1) {
+        for (var col = 0; col < moduleCount - 1; col += 1) {
+          var count = 0;
+          if (qrcode.isDark(row, col) ) count += 1;
+          if (qrcode.isDark(row + 1, col) ) count += 1;
+          if (qrcode.isDark(row, col + 1) ) count += 1;
+          if (qrcode.isDark(row + 1, col + 1) ) count += 1;
+          if (count == 0 || count == 4) {
+            lostPoint += 3;
+          }
+        }
+      }
+
+      // LEVEL3
+
+      for (var row = 0; row < moduleCount; row += 1) {
+        for (var col = 0; col < moduleCount - 6; col += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row, col + 1)
+              &&  qrcode.isDark(row, col + 2)
+              &&  qrcode.isDark(row, col + 3)
+              &&  qrcode.isDark(row, col + 4)
+              && !qrcode.isDark(row, col + 5)
+              &&  qrcode.isDark(row, col + 6) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount - 6; row += 1) {
+          if (qrcode.isDark(row, col)
+              && !qrcode.isDark(row + 1, col)
+              &&  qrcode.isDark(row + 2, col)
+              &&  qrcode.isDark(row + 3, col)
+              &&  qrcode.isDark(row + 4, col)
+              && !qrcode.isDark(row + 5, col)
+              &&  qrcode.isDark(row + 6, col) ) {
+            lostPoint += 40;
+          }
+        }
+      }
+
+      // LEVEL4
+
+      var darkCount = 0;
+
+      for (var col = 0; col < moduleCount; col += 1) {
+        for (var row = 0; row < moduleCount; row += 1) {
+          if (qrcode.isDark(row, col) ) {
+            darkCount += 1;
+          }
+        }
+      }
+
+      var ratio = Math.abs(100 * darkCount / moduleCount / moduleCount - 50) / 5;
+      lostPoint += ratio * 10;
+
+      return lostPoint;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // QRMath
+  //---------------------------------------------------------------------
+
+  var QRMath = function() {
+
+    var EXP_TABLE = new Array(256);
+    var LOG_TABLE = new Array(256);
+
+    // initialize tables
+    for (var i = 0; i < 8; i += 1) {
+      EXP_TABLE[i] = 1 << i;
+    }
+    for (var i = 8; i < 256; i += 1) {
+      EXP_TABLE[i] = EXP_TABLE[i - 4]
+        ^ EXP_TABLE[i - 5]
+        ^ EXP_TABLE[i - 6]
+        ^ EXP_TABLE[i - 8];
+    }
+    for (var i = 0; i < 255; i += 1) {
+      LOG_TABLE[EXP_TABLE[i] ] = i;
+    }
+
+    var _this = {};
+
+    _this.glog = function(n) {
+
+      if (n < 1) {
+        throw 'glog(' + n + ')';
+      }
+
+      return LOG_TABLE[n];
+    };
+
+    _this.gexp = function(n) {
+
+      while (n < 0) {
+        n += 255;
+      }
+
+      while (n >= 256) {
+        n -= 255;
+      }
+
+      return EXP_TABLE[n];
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrPolynomial
+  //---------------------------------------------------------------------
+
+  function qrPolynomial(num, shift) {
+
+    if (typeof num.length == 'undefined') {
+      throw num.length + '/' + shift;
+    }
+
+    var _num = function() {
+      var offset = 0;
+      while (offset < num.length && num[offset] == 0) {
+        offset += 1;
+      }
+      var _num = new Array(num.length - offset + shift);
+      for (var i = 0; i < num.length - offset; i += 1) {
+        _num[i] = num[i + offset];
+      }
+      return _num;
+    }();
+
+    var _this = {};
+
+    _this.getAt = function(index) {
+      return _num[index];
+    };
+
+    _this.getLength = function() {
+      return _num.length;
+    };
+
+    _this.multiply = function(e) {
+
+      var num = new Array(_this.getLength() + e.getLength() - 1);
+
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        for (var j = 0; j < e.getLength(); j += 1) {
+          num[i + j] ^= QRMath.gexp(QRMath.glog(_this.getAt(i) ) + QRMath.glog(e.getAt(j) ) );
+        }
+      }
+
+      return qrPolynomial(num, 0);
+    };
+
+    _this.mod = function(e) {
+
+      if (_this.getLength() - e.getLength() < 0) {
+        return _this;
+      }
+
+      var ratio = QRMath.glog(_this.getAt(0) ) - QRMath.glog(e.getAt(0) );
+
+      var num = new Array(_this.getLength() );
+      for (var i = 0; i < _this.getLength(); i += 1) {
+        num[i] = _this.getAt(i);
+      }
+
+      for (var i = 0; i < e.getLength(); i += 1) {
+        num[i] ^= QRMath.gexp(QRMath.glog(e.getAt(i) ) + ratio);
+      }
+
+      // recursive call
+      return qrPolynomial(num, 0).mod(e);
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // QRRSBlock
+  //---------------------------------------------------------------------
+
+  var QRRSBlock = function() {
+
+    var RS_BLOCK_TABLE = [
+
+      // L
+      // M
+      // Q
+      // H
+
+      // 1
+      [1, 26, 19],
+      [1, 26, 16],
+      [1, 26, 13],
+      [1, 26, 9],
+
+      // 2
+      [1, 44, 34],
+      [1, 44, 28],
+      [1, 44, 22],
+      [1, 44, 16],
+
+      // 3
+      [1, 70, 55],
+      [1, 70, 44],
+      [2, 35, 17],
+      [2, 35, 13],
+
+      // 4
+      [1, 100, 80],
+      [2, 50, 32],
+      [2, 50, 24],
+      [4, 25, 9],
+
+      // 5
+      [1, 134, 108],
+      [2, 67, 43],
+      [2, 33, 15, 2, 34, 16],
+      [2, 33, 11, 2, 34, 12],
+
+      // 6
+      [2, 86, 68],
+      [4, 43, 27],
+      [4, 43, 19],
+      [4, 43, 15],
+
+      // 7
+      [2, 98, 78],
+      [4, 49, 31],
+      [2, 32, 14, 4, 33, 15],
+      [4, 39, 13, 1, 40, 14],
+
+      // 8
+      [2, 121, 97],
+      [2, 60, 38, 2, 61, 39],
+      [4, 40, 18, 2, 41, 19],
+      [4, 40, 14, 2, 41, 15],
+
+      // 9
+      [2, 146, 116],
+      [3, 58, 36, 2, 59, 37],
+      [4, 36, 16, 4, 37, 17],
+      [4, 36, 12, 4, 37, 13],
+
+      // 10
+      [2, 86, 68, 2, 87, 69],
+      [4, 69, 43, 1, 70, 44],
+      [6, 43, 19, 2, 44, 20],
+      [6, 43, 15, 2, 44, 16],
+
+      // 11
+      [4, 101, 81],
+      [1, 80, 50, 4, 81, 51],
+      [4, 50, 22, 4, 51, 23],
+      [3, 36, 12, 8, 37, 13],
+
+      // 12
+      [2, 116, 92, 2, 117, 93],
+      [6, 58, 36, 2, 59, 37],
+      [4, 46, 20, 6, 47, 21],
+      [7, 42, 14, 4, 43, 15],
+
+      // 13
+      [4, 133, 107],
+      [8, 59, 37, 1, 60, 38],
+      [8, 44, 20, 4, 45, 21],
+      [12, 33, 11, 4, 34, 12],
+
+      // 14
+      [3, 145, 115, 1, 146, 116],
+      [4, 64, 40, 5, 65, 41],
+      [11, 36, 16, 5, 37, 17],
+      [11, 36, 12, 5, 37, 13],
+
+      // 15
+      [5, 109, 87, 1, 110, 88],
+      [5, 65, 41, 5, 66, 42],
+      [5, 54, 24, 7, 55, 25],
+      [11, 36, 12, 7, 37, 13],
+
+      // 16
+      [5, 122, 98, 1, 123, 99],
+      [7, 73, 45, 3, 74, 46],
+      [15, 43, 19, 2, 44, 20],
+      [3, 45, 15, 13, 46, 16],
+
+      // 17
+      [1, 135, 107, 5, 136, 108],
+      [10, 74, 46, 1, 75, 47],
+      [1, 50, 22, 15, 51, 23],
+      [2, 42, 14, 17, 43, 15],
+
+      // 18
+      [5, 150, 120, 1, 151, 121],
+      [9, 69, 43, 4, 70, 44],
+      [17, 50, 22, 1, 51, 23],
+      [2, 42, 14, 19, 43, 15],
+
+      // 19
+      [3, 141, 113, 4, 142, 114],
+      [3, 70, 44, 11, 71, 45],
+      [17, 47, 21, 4, 48, 22],
+      [9, 39, 13, 16, 40, 14],
+
+      // 20
+      [3, 135, 107, 5, 136, 108],
+      [3, 67, 41, 13, 68, 42],
+      [15, 54, 24, 5, 55, 25],
+      [15, 43, 15, 10, 44, 16],
+
+      // 21
+      [4, 144, 116, 4, 145, 117],
+      [17, 68, 42],
+      [17, 50, 22, 6, 51, 23],
+      [19, 46, 16, 6, 47, 17],
+
+      // 22
+      [2, 139, 111, 7, 140, 112],
+      [17, 74, 46],
+      [7, 54, 24, 16, 55, 25],
+      [34, 37, 13],
+
+      // 23
+      [4, 151, 121, 5, 152, 122],
+      [4, 75, 47, 14, 76, 48],
+      [11, 54, 24, 14, 55, 25],
+      [16, 45, 15, 14, 46, 16],
+
+      // 24
+      [6, 147, 117, 4, 148, 118],
+      [6, 73, 45, 14, 74, 46],
+      [11, 54, 24, 16, 55, 25],
+      [30, 46, 16, 2, 47, 17],
+
+      // 25
+      [8, 132, 106, 4, 133, 107],
+      [8, 75, 47, 13, 76, 48],
+      [7, 54, 24, 22, 55, 25],
+      [22, 45, 15, 13, 46, 16],
+
+      // 26
+      [10, 142, 114, 2, 143, 115],
+      [19, 74, 46, 4, 75, 47],
+      [28, 50, 22, 6, 51, 23],
+      [33, 46, 16, 4, 47, 17],
+
+      // 27
+      [8, 152, 122, 4, 153, 123],
+      [22, 73, 45, 3, 74, 46],
+      [8, 53, 23, 26, 54, 24],
+      [12, 45, 15, 28, 46, 16],
+
+      // 28
+      [3, 147, 117, 10, 148, 118],
+      [3, 73, 45, 23, 74, 46],
+      [4, 54, 24, 31, 55, 25],
+      [11, 45, 15, 31, 46, 16],
+
+      // 29
+      [7, 146, 116, 7, 147, 117],
+      [21, 73, 45, 7, 74, 46],
+      [1, 53, 23, 37, 54, 24],
+      [19, 45, 15, 26, 46, 16],
+
+      // 30
+      [5, 145, 115, 10, 146, 116],
+      [19, 75, 47, 10, 76, 48],
+      [15, 54, 24, 25, 55, 25],
+      [23, 45, 15, 25, 46, 16],
+
+      // 31
+      [13, 145, 115, 3, 146, 116],
+      [2, 74, 46, 29, 75, 47],
+      [42, 54, 24, 1, 55, 25],
+      [23, 45, 15, 28, 46, 16],
+
+      // 32
+      [17, 145, 115],
+      [10, 74, 46, 23, 75, 47],
+      [10, 54, 24, 35, 55, 25],
+      [19, 45, 15, 35, 46, 16],
+
+      // 33
+      [17, 145, 115, 1, 146, 116],
+      [14, 74, 46, 21, 75, 47],
+      [29, 54, 24, 19, 55, 25],
+      [11, 45, 15, 46, 46, 16],
+
+      // 34
+      [13, 145, 115, 6, 146, 116],
+      [14, 74, 46, 23, 75, 47],
+      [44, 54, 24, 7, 55, 25],
+      [59, 46, 16, 1, 47, 17],
+
+      // 35
+      [12, 151, 121, 7, 152, 122],
+      [12, 75, 47, 26, 76, 48],
+      [39, 54, 24, 14, 55, 25],
+      [22, 45, 15, 41, 46, 16],
+
+      // 36
+      [6, 151, 121, 14, 152, 122],
+      [6, 75, 47, 34, 76, 48],
+      [46, 54, 24, 10, 55, 25],
+      [2, 45, 15, 64, 46, 16],
+
+      // 37
+      [17, 152, 122, 4, 153, 123],
+      [29, 74, 46, 14, 75, 47],
+      [49, 54, 24, 10, 55, 25],
+      [24, 45, 15, 46, 46, 16],
+
+      // 38
+      [4, 152, 122, 18, 153, 123],
+      [13, 74, 46, 32, 75, 47],
+      [48, 54, 24, 14, 55, 25],
+      [42, 45, 15, 32, 46, 16],
+
+      // 39
+      [20, 147, 117, 4, 148, 118],
+      [40, 75, 47, 7, 76, 48],
+      [43, 54, 24, 22, 55, 25],
+      [10, 45, 15, 67, 46, 16],
+
+      // 40
+      [19, 148, 118, 6, 149, 119],
+      [18, 75, 47, 31, 76, 48],
+      [34, 54, 24, 34, 55, 25],
+      [20, 45, 15, 61, 46, 16]
+    ];
+
+    var qrRSBlock = function(totalCount, dataCount) {
+      var _this = {};
+      _this.totalCount = totalCount;
+      _this.dataCount = dataCount;
+      return _this;
+    };
+
+    var _this = {};
+
+    var getRsBlockTable = function(typeNumber, errorCorrectionLevel) {
+
+      switch(errorCorrectionLevel) {
+      case QRErrorCorrectionLevel.L :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 0];
+      case QRErrorCorrectionLevel.M :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 1];
+      case QRErrorCorrectionLevel.Q :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 2];
+      case QRErrorCorrectionLevel.H :
+        return RS_BLOCK_TABLE[(typeNumber - 1) * 4 + 3];
+      default :
+        return undefined;
+      }
+    };
+
+    _this.getRSBlocks = function(typeNumber, errorCorrectionLevel) {
+
+      var rsBlock = getRsBlockTable(typeNumber, errorCorrectionLevel);
+
+      if (typeof rsBlock == 'undefined') {
+        throw 'bad rs block @ typeNumber:' + typeNumber +
+            '/errorCorrectionLevel:' + errorCorrectionLevel;
+      }
+
+      var length = rsBlock.length / 3;
+
+      var list = [];
+
+      for (var i = 0; i < length; i += 1) {
+
+        var count = rsBlock[i * 3 + 0];
+        var totalCount = rsBlock[i * 3 + 1];
+        var dataCount = rsBlock[i * 3 + 2];
+
+        for (var j = 0; j < count; j += 1) {
+          list.push(qrRSBlock(totalCount, dataCount) );
+        }
+      }
+
+      return list;
+    };
+
+    return _this;
+  }();
+
+  //---------------------------------------------------------------------
+  // qrBitBuffer
+  //---------------------------------------------------------------------
+
+  var qrBitBuffer = function() {
+
+    var _buffer = [];
+    var _length = 0;
+
+    var _this = {};
+
+    _this.getBuffer = function() {
+      return _buffer;
+    };
+
+    _this.getAt = function(index) {
+      var bufIndex = Math.floor(index / 8);
+      return ( (_buffer[bufIndex] >>> (7 - index % 8) ) & 1) == 1;
+    };
+
+    _this.put = function(num, length) {
+      for (var i = 0; i < length; i += 1) {
+        _this.putBit( ( (num >>> (length - i - 1) ) & 1) == 1);
+      }
+    };
+
+    _this.getLengthInBits = function() {
+      return _length;
+    };
+
+    _this.putBit = function(bit) {
+
+      var bufIndex = Math.floor(_length / 8);
+      if (_buffer.length <= bufIndex) {
+        _buffer.push(0);
+      }
+
+      if (bit) {
+        _buffer[bufIndex] |= (0x80 >>> (_length % 8) );
+      }
+
+      _length += 1;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrNumber
+  //---------------------------------------------------------------------
+
+  var qrNumber = function(data) {
+
+    var _mode = QRMode.MODE_NUMBER;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _data;
+
+      var i = 0;
+
+      while (i + 2 < data.length) {
+        buffer.put(strToNum(data.substring(i, i + 3) ), 10);
+        i += 3;
+      }
+
+      if (i < data.length) {
+        if (data.length - i == 1) {
+          buffer.put(strToNum(data.substring(i, i + 1) ), 4);
+        } else if (data.length - i == 2) {
+          buffer.put(strToNum(data.substring(i, i + 2) ), 7);
+        }
+      }
+    };
+
+    var strToNum = function(s) {
+      var num = 0;
+      for (var i = 0; i < s.length; i += 1) {
+        num = num * 10 + chatToNum(s.charAt(i) );
+      }
+      return num;
+    };
+
+    var chatToNum = function(c) {
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      }
+      throw 'illegal char :' + c;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrAlphaNum
+  //---------------------------------------------------------------------
+
+  var qrAlphaNum = function(data) {
+
+    var _mode = QRMode.MODE_ALPHA_NUM;
+    var _data = data;
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _data.length;
+    };
+
+    _this.write = function(buffer) {
+
+      var s = _data;
+
+      var i = 0;
+
+      while (i + 1 < s.length) {
+        buffer.put(
+          getCode(s.charAt(i) ) * 45 +
+          getCode(s.charAt(i + 1) ), 11);
+        i += 2;
+      }
+
+      if (i < s.length) {
+        buffer.put(getCode(s.charAt(i) ), 6);
+      }
+    };
+
+    var getCode = function(c) {
+
+      if ('0' <= c && c <= '9') {
+        return c.charCodeAt(0) - '0'.charCodeAt(0);
+      } else if ('A' <= c && c <= 'Z') {
+        return c.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+      } else {
+        switch (c) {
+        case ' ' : return 36;
+        case '$' : return 37;
+        case '%' : return 38;
+        case '*' : return 39;
+        case '+' : return 40;
+        case '-' : return 41;
+        case '.' : return 42;
+        case '/' : return 43;
+        case ':' : return 44;
+        default :
+          throw 'illegal char :' + c;
+        }
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qr8BitByte
+  //---------------------------------------------------------------------
+
+  var qr8BitByte = function(data) {
+
+    var _mode = QRMode.MODE_8BIT_BYTE;
+    var _data = data;
+    var _bytes = qrcode.stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return _bytes.length;
+    };
+
+    _this.write = function(buffer) {
+      for (var i = 0; i < _bytes.length; i += 1) {
+        buffer.put(_bytes[i], 8);
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // qrKanji
+  //---------------------------------------------------------------------
+
+  var qrKanji = function(data) {
+
+    var _mode = QRMode.MODE_KANJI;
+    var _data = data;
+
+    var stringToBytes = qrcode.stringToBytesFuncs['SJIS'];
+    if (!stringToBytes) {
+      throw 'sjis not supported.';
+    }
+    !function(c, code) {
+      // self test for sjis support.
+      var test = stringToBytes(c);
+      if (test.length != 2 || ( (test[0] << 8) | test[1]) != code) {
+        throw 'sjis not supported.';
+      }
+    }('\u53cb', 0x9746);
+
+    var _bytes = stringToBytes(data);
+
+    var _this = {};
+
+    _this.getMode = function() {
+      return _mode;
+    };
+
+    _this.getLength = function(buffer) {
+      return ~~(_bytes.length / 2);
+    };
+
+    _this.write = function(buffer) {
+
+      var data = _bytes;
+
+      var i = 0;
+
+      while (i + 1 < data.length) {
+
+        var c = ( (0xff & data[i]) << 8) | (0xff & data[i + 1]);
+
+        if (0x8140 <= c && c <= 0x9FFC) {
+          c -= 0x8140;
+        } else if (0xE040 <= c && c <= 0xEBBF) {
+          c -= 0xC140;
+        } else {
+          throw 'illegal char at ' + (i + 1) + '/' + c;
+        }
+
+        c = ( (c >>> 8) & 0xff) * 0xC0 + (c & 0xff);
+
+        buffer.put(c, 13);
+
+        i += 2;
+      }
+
+      if (i < data.length) {
+        throw 'illegal char at ' + (i + 1);
+      }
+    };
+
+    return _this;
+  };
+
+  //=====================================================================
+  // GIF Support etc.
+  //
+
+  //---------------------------------------------------------------------
+  // byteArrayOutputStream
+  //---------------------------------------------------------------------
+
+  var byteArrayOutputStream = function() {
+
+    var _bytes = [];
+
+    var _this = {};
+
+    _this.writeByte = function(b) {
+      _bytes.push(b & 0xff);
+    };
+
+    _this.writeShort = function(i) {
+      _this.writeByte(i);
+      _this.writeByte(i >>> 8);
+    };
+
+    _this.writeBytes = function(b, off, len) {
+      off = off || 0;
+      len = len || b.length;
+      for (var i = 0; i < len; i += 1) {
+        _this.writeByte(b[i + off]);
+      }
+    };
+
+    _this.writeString = function(s) {
+      for (var i = 0; i < s.length; i += 1) {
+        _this.writeByte(s.charCodeAt(i) );
+      }
+    };
+
+    _this.toByteArray = function() {
+      return _bytes;
+    };
+
+    _this.toString = function() {
+      var s = '';
+      s += '[';
+      for (var i = 0; i < _bytes.length; i += 1) {
+        if (i > 0) {
+          s += ',';
+        }
+        s += _bytes[i];
+      }
+      s += ']';
+      return s;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64EncodeOutputStream
+  //---------------------------------------------------------------------
+
+  var base64EncodeOutputStream = function() {
+
+    var _buffer = 0;
+    var _buflen = 0;
+    var _length = 0;
+    var _base64 = '';
+
+    var _this = {};
+
+    var writeEncoded = function(b) {
+      _base64 += String.fromCharCode(encode(b & 0x3f) );
+    };
+
+    var encode = function(n) {
+      if (n < 0) {
+        // error.
+      } else if (n < 26) {
+        return 0x41 + n;
+      } else if (n < 52) {
+        return 0x61 + (n - 26);
+      } else if (n < 62) {
+        return 0x30 + (n - 52);
+      } else if (n == 62) {
+        return 0x2b;
+      } else if (n == 63) {
+        return 0x2f;
+      }
+      throw 'n:' + n;
+    };
+
+    _this.writeByte = function(n) {
+
+      _buffer = (_buffer << 8) | (n & 0xff);
+      _buflen += 8;
+      _length += 1;
+
+      while (_buflen >= 6) {
+        writeEncoded(_buffer >>> (_buflen - 6) );
+        _buflen -= 6;
+      }
+    };
+
+    _this.flush = function() {
+
+      if (_buflen > 0) {
+        writeEncoded(_buffer << (6 - _buflen) );
+        _buffer = 0;
+        _buflen = 0;
+      }
+
+      if (_length % 3 != 0) {
+        // padding
+        var padlen = 3 - _length % 3;
+        for (var i = 0; i < padlen; i += 1) {
+          _base64 += '=';
+        }
+      }
+    };
+
+    _this.toString = function() {
+      return _base64;
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // base64DecodeInputStream
+  //---------------------------------------------------------------------
+
+  var base64DecodeInputStream = function(str) {
+
+    var _str = str;
+    var _pos = 0;
+    var _buffer = 0;
+    var _buflen = 0;
+
+    var _this = {};
+
+    _this.read = function() {
+
+      while (_buflen < 8) {
+
+        if (_pos >= _str.length) {
+          if (_buflen == 0) {
+            return -1;
+          }
+          throw 'unexpected end of file./' + _buflen;
+        }
+
+        var c = _str.charAt(_pos);
+        _pos += 1;
+
+        if (c == '=') {
+          _buflen = 0;
+          return -1;
+        } else if (c.match(/^\s$/) ) {
+          // ignore if whitespace.
+          continue;
+        }
+
+        _buffer = (_buffer << 6) | decode(c.charCodeAt(0) );
+        _buflen += 6;
+      }
+
+      var n = (_buffer >>> (_buflen - 8) ) & 0xff;
+      _buflen -= 8;
+      return n;
+    };
+
+    var decode = function(c) {
+      if (0x41 <= c && c <= 0x5a) {
+        return c - 0x41;
+      } else if (0x61 <= c && c <= 0x7a) {
+        return c - 0x61 + 26;
+      } else if (0x30 <= c && c <= 0x39) {
+        return c - 0x30 + 52;
+      } else if (c == 0x2b) {
+        return 62;
+      } else if (c == 0x2f) {
+        return 63;
+      } else {
+        throw 'c:' + c;
+      }
+    };
+
+    return _this;
+  };
+
+  //---------------------------------------------------------------------
+  // gifImage (B/W)
+  //---------------------------------------------------------------------
+
+  var gifImage = function(width, height) {
+
+    var _width = width;
+    var _height = height;
+    var _data = new Array(width * height);
+
+    var _this = {};
+
+    _this.setPixel = function(x, y, pixel) {
+      _data[y * _width + x] = pixel;
+    };
+
+    _this.write = function(out) {
+
+      //---------------------------------
+      // GIF Signature
+
+      out.writeString('GIF87a');
+
+      //---------------------------------
+      // Screen Descriptor
+
+      out.writeShort(_width);
+      out.writeShort(_height);
+
+      out.writeByte(0x80); // 2bit
+      out.writeByte(0);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Global Color Map
+
+      // black
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+      out.writeByte(0x00);
+
+      // white
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+      out.writeByte(0xff);
+
+      //---------------------------------
+      // Image Descriptor
+
+      out.writeString(',');
+      out.writeShort(0);
+      out.writeShort(0);
+      out.writeShort(_width);
+      out.writeShort(_height);
+      out.writeByte(0);
+
+      //---------------------------------
+      // Local Color Map
+
+      //---------------------------------
+      // Raster Data
+
+      var lzwMinCodeSize = 2;
+      var raster = getLZWRaster(lzwMinCodeSize);
+
+      out.writeByte(lzwMinCodeSize);
+
+      var offset = 0;
+
+      while (raster.length - offset > 255) {
+        out.writeByte(255);
+        out.writeBytes(raster, offset, 255);
+        offset += 255;
+      }
+
+      out.writeByte(raster.length - offset);
+      out.writeBytes(raster, offset, raster.length - offset);
+      out.writeByte(0x00);
+
+      //---------------------------------
+      // GIF Terminator
+      out.writeString(';');
+    };
+
+    var bitOutputStream = function(out) {
+
+      var _out = out;
+      var _bitLength = 0;
+      var _bitBuffer = 0;
+
+      var _this = {};
+
+      _this.write = function(data, length) {
+
+        if ( (data >>> length) != 0) {
+          throw 'length over';
+        }
+
+        while (_bitLength + length >= 8) {
+          _out.writeByte(0xff & ( (data << _bitLength) | _bitBuffer) );
+          length -= (8 - _bitLength);
+          data >>>= (8 - _bitLength);
+          _bitBuffer = 0;
+          _bitLength = 0;
+        }
+
+        _bitBuffer = (data << _bitLength) | _bitBuffer;
+        _bitLength = _bitLength + length;
+      };
+
+      _this.flush = function() {
+        if (_bitLength > 0) {
+          _out.writeByte(_bitBuffer);
+        }
+      };
+
+      return _this;
+    };
+
+    var getLZWRaster = function(lzwMinCodeSize) {
+
+      var clearCode = 1 << lzwMinCodeSize;
+      var endCode = (1 << lzwMinCodeSize) + 1;
+      var bitLength = lzwMinCodeSize + 1;
+
+      // Setup LZWTable
+      var table = lzwTable();
+
+      for (var i = 0; i < clearCode; i += 1) {
+        table.add(String.fromCharCode(i) );
+      }
+      table.add(String.fromCharCode(clearCode) );
+      table.add(String.fromCharCode(endCode) );
+
+      var byteOut = byteArrayOutputStream();
+      var bitOut = bitOutputStream(byteOut);
+
+      // clear code
+      bitOut.write(clearCode, bitLength);
+
+      var dataIndex = 0;
+
+      var s = String.fromCharCode(_data[dataIndex]);
+      dataIndex += 1;
+
+      while (dataIndex < _data.length) {
+
+        var c = String.fromCharCode(_data[dataIndex]);
+        dataIndex += 1;
+
+        if (table.contains(s + c) ) {
+
+          s = s + c;
+
+        } else {
+
+          bitOut.write(table.indexOf(s), bitLength);
+
+          if (table.size() < 0xfff) {
+
+            if (table.size() == (1 << bitLength) ) {
+              bitLength += 1;
+            }
+
+            table.add(s + c);
+          }
+
+          s = c;
+        }
+      }
+
+      bitOut.write(table.indexOf(s), bitLength);
+
+      // end code
+      bitOut.write(endCode, bitLength);
+
+      bitOut.flush();
+
+      return byteOut.toByteArray();
+    };
+
+    var lzwTable = function() {
+
+      var _map = {};
+      var _size = 0;
+
+      var _this = {};
+
+      _this.add = function(key) {
+        if (_this.contains(key) ) {
+          throw 'dup key:' + key;
+        }
+        _map[key] = _size;
+        _size += 1;
+      };
+
+      _this.size = function() {
+        return _size;
+      };
+
+      _this.indexOf = function(key) {
+        return _map[key];
+      };
+
+      _this.contains = function(key) {
+        return typeof _map[key] != 'undefined';
+      };
+
+      return _this;
+    };
+
+    return _this;
+  };
+
+  var createDataURL = function(width, height, getPixel) {
+    var gif = gifImage(width, height);
+    for (var y = 0; y < height; y += 1) {
+      for (var x = 0; x < width; x += 1) {
+        gif.setPixel(x, y, getPixel(x, y) );
+      }
+    }
+
+    var b = byteArrayOutputStream();
+    gif.write(b);
+
+    var base64 = base64EncodeOutputStream();
+    var bytes = b.toByteArray();
+    for (var i = 0; i < bytes.length; i += 1) {
+      base64.writeByte(bytes[i]);
+    }
+    base64.flush();
+
+    return 'data:image/gif;base64,' + base64;
+  };
+
+  //---------------------------------------------------------------------
+  // returns qrcode function.
+
+  return qrcode;
+}();
+
+// multibyte support
+!function() {
+
+  qrcode.stringToBytesFuncs['UTF-8'] = function(s) {
+    // http://stackoverflow.com/questions/18729405/how-to-convert-utf8-string-to-byte-array
+    function toUTF8Array(str) {
+      var utf8 = [];
+      for (var i=0; i < str.length; i++) {
+        var charcode = str.charCodeAt(i);
+        if (charcode < 0x80) utf8.push(charcode);
+        else if (charcode < 0x800) {
+          utf8.push(0xc0 | (charcode >> 6),
+              0x80 | (charcode & 0x3f));
+        }
+        else if (charcode < 0xd800 || charcode >= 0xe000) {
+          utf8.push(0xe0 | (charcode >> 12),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+        // surrogate pair
+        else {
+          i++;
+          // UTF-16 encodes 0x10000-0x10FFFF by
+          // subtracting 0x10000 and splitting the
+          // 20 bits of 0x0-0xFFFFF into two halves
+          charcode = 0x10000 + (((charcode & 0x3ff)<<10)
+            | (str.charCodeAt(i) & 0x3ff));
+          utf8.push(0xf0 | (charcode >>18),
+              0x80 | ((charcode>>12) & 0x3f),
+              0x80 | ((charcode>>6) & 0x3f),
+              0x80 | (charcode & 0x3f));
+        }
+      }
+      return utf8;
+    }
+    return toUTF8Array(s);
+  };
+
+}();
+
+export default qrcode;


### PR DESCRIPTION
Wave: MFA enrollment UX on dev.celestia.world.

- `HkQrCode` — scannable canvas QR for TOTP otpauth URIs. Vendored MIT qrcode-generator (Kazuhiko Arase) as a self-contained ESM module: the shared pnpm virtual-store layout cannot install new packages in this workspace (ERR_PNPM_UNEXPECTED_VIRTUAL_STORE), so zero new deps.
- `HkPhoneInput` — phone field with a left-edge dial-code chip (mirrors the language-chip pattern of HkLocalizedInput): flag + \+86\ + caret opens a searchable country list (desktop popout / mobile sheet via HkMenu). Sanitized national input, `formatE164`/`parseE164` helpers, E.164 on blur.
- `src/data/dialCodes.ts` — ~90-country catalog with en/zh names and ISO-derived flags; China first; shared-prefix resolution (+1/+7) documented.
- i18n keys for en/zh-Hans/zh-Hant; unit tests (encoder structure, helpers, both components). Local verify: vue-tsc clean; 741/743 suite green (2 pre-existing master failures in registerAnimations/HkDatePicker, reproduced on master main checkout).

Version bumped 0.31.3 → 0.32.0.

---
Updated: re-requesting review (lint re-trigger).

---
Rebased onto master (7bdf338).