### PR TITLE
🐛 Expose the theme partials through the package exports map.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",
@@ -32,6 +32,7 @@
       "import": "./src/styles/index.scss"
     },
     "./styles/*": "./src/styles/*",
+    "./theme/*": "./src/theme/*",
     "./components/*": "./src/components/*",
     "./plugins": {
       "import": "./src/plugins/index.ts",


### PR DESCRIPTION
Adds `"./theme/*": "./src/theme/*"` to the package `exports` map so consumers can resolve the `src/theme` partials (e.g. `_field.scss`) again.

Background: consumers (shittim-chest `WorkspaceCreateModal.scss`) do `@use "@celestia-island/hikari/theme/field"`. The source tree ships a legacy `theme -> src/theme` symlink (#121) that used to satisfy this through filesystem fallback, but:
- npm pack drops the symlink from the published tarball, and
- strict sass (1.103, via vite) resolves package subpaths through the `exports` map only — so `theme/field` errored with `"./theme/_field" is not exported`.

The `./theme/*` wildcard (same shape as the existing `./styles/*` / `./components/*`) maps the subpath into `src/theme/*`; sass canonicalizes the partial (`field` → `_field.scss`) against the target. Verified end-to-end: with this export the chest webui `vite build` passes (was failing before); without it the same build fails on the exact sass error above.

Version `0.32.1 → 0.32.2`. Component tests green, `vue-tsc` clean.