### PR TITLE
📦 Prepare the 0.32.3 release of the component library.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.2",
+  "version": "0.32.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Version bump to publish the QR code and phone input components (merged via #369 after v0.32.2 was tagged).