### PR TITLE
🐛 Restore the theme partial exports map entry.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.3",
+  "version": "0.32.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,6 +32,7 @@
       "import": "./src/styles/index.scss"
     },
     "./styles/*": "./src/styles/*",
+    "./theme/*": "./src/theme/*",
     "./components/*": "./src/components/*",
     "./plugins": {
       "import": "./src/plugins/index.ts",


### PR DESCRIPTION
The 0.32.2→0.32.3 release wave dropped the "./theme/*" exports entry added in #370 (lost in a package.json conflict resolution during the #369 rebase). Chest imports @celestia-island/hikari/theme/_field — restore the entry and ship as 0.32.4.

---
Checks re-request.

---
Rebased onto master.