### PR TITLE
✨ Unify affix chip pickers behind a shared searchable list component.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.32.4",
+  "version": "0.33.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAffixPicker.scss
+++ b/packages/vue/src/components/HkAffixPicker.scss
@@ -1,0 +1,277 @@
+/* HkAffixPicker — the shared "affix chip + searchable popup list".
+ * Field hosts drop this into an HkInput prefix/suffix slot; the chip
+ * visuals come from the host through the scoped chip slot (hosts layer
+ * their own class on top via chipClass), while the popup — search,
+ * selected tags, option rows, custom row — is fully standardized here. */
+
+/* ── chip base ────────────────────────────────────────────────────────
+ * Neutral clickable chip; hosts override visually via their own class
+ * (HkPhoneInput's dial chip, HkLocalizedInput's badge chip, …). */
+.hk-affix-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  max-width: 11rem;
+  padding: 2px 6px 2px 4px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-text));
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: rgb(var(--color-primary) / 14%);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+}
+
+.hk-affix-chip-label {
+  font-weight: 600;
+  font-size: var(--text-sm, 14px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hk-affix-chip-caret {
+  flex: none;
+  color: rgb(var(--color-muted));
+}
+
+/* ── popup head: tags (multi) + search ─────────────────────────────── */
+.hk-affix-head {
+  display: flex;
+  flex-direction: column;
+}
+
+.hk-affix-search {
+  padding: 8px 10px 6px;
+}
+
+.hk-affix-tags {
+  padding: 10px 10px 8px;
+  border-bottom: 1px solid var(--border-faint);
+}
+
+.hk-affix-tag-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: min(18rem, 100%);
+  max-width: 24rem;
+}
+
+/* One selected entry: [flag] label (meta) •active-dot   ×]
+ * The × arms on the first activation (danger tint) and erases on the
+ * second; desktop hover previews the × so the row reads as deletable. */
+.hk-affix-tag {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 2.25rem;
+  padding: 4px var(--space-16);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: rgb(var(--color-surface) / var(--opacity-half, 50%));
+  transition: border-color 0.12s ease, background 0.12s ease;
+
+  &:hover {
+    border-color: rgb(var(--color-primary) / 40%);
+  }
+
+  &[data-active] {
+    border-color: rgb(var(--color-primary) / 45%);
+    background: rgb(var(--color-primary) / 12%);
+
+    .hk-affix-tag-text {
+      font-weight: 600;
+    }
+  }
+
+  &[data-armed] {
+    border-color: rgb(var(--color-danger, 240 70 80) / 55%);
+    background: rgb(var(--color-danger, 240 70 80) / 12%);
+  }
+}
+
+.hk-affix-tag-body {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgb(var(--color-text));
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+}
+
+.hk-affix-tag-flag {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  line-height: 1;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
+    sans-serif;
+}
+
+.hk-affix-tag-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-affix-tag-meta {
+  flex-shrink: 0;
+  color: rgb(var(--color-muted));
+  font-size: calc(var(--text-xs) * 0.92);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-affix-tag-dot {
+  flex-shrink: 0;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgb(var(--color-primary));
+}
+
+.hk-affix-tag-x {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: rgb(var(--color-muted));
+  cursor: pointer;
+  appearance: none;
+  transition: color 0.12s ease, background 0.12s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: rgb(var(--color-danger, 240 70 80));
+    background: rgb(var(--color-danger, 240 70 80) / 12%);
+  }
+
+  [data-armed] & {
+    color: rgb(var(--color-danger, 240 70 80));
+    background: rgb(var(--color-danger, 240 70 80) / 18%);
+  }
+}
+
+/* ── option rows ────────────────────────────────────────────────────── */
+.hk-affix-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px 6px 8px;
+  min-width: 13rem;
+  max-width: min(19rem, calc(100vw - 2rem));
+  max-height: 17rem;
+  overflow-y: auto;
+}
+
+.hk-affix-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 4px 8px;
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-text));
+  font-size: var(--text-sm, 14px);
+  text-align: left;
+  cursor: pointer;
+  appearance: none;
+  transition: background 0.1s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(var(--color-primary) / 10%);
+    outline: none;
+  }
+
+  &[data-active] {
+    background: rgb(var(--color-primary) / 16%);
+    font-weight: 600;
+  }
+
+  &[data-disabled] {
+    opacity: 0.5;
+    cursor: default;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+
+  /* The "Use <query>" free-text row reads as an add affordance. */
+  &[data-custom="true"] {
+    color: rgb(var(--color-primary));
+
+    .hk-affix-row-label {
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+.hk-affix-row-flag {
+  flex: none;
+  font-size: calc(var(--text-base, 15px) * 1.05);
+  line-height: 1;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
+    sans-serif;
+}
+
+.hk-affix-row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-affix-row-meta {
+  flex: none;
+  color: rgb(var(--color-muted));
+  font-size: calc(var(--text-sm, 14px) * 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-affix-empty {
+  padding: 14px 12px;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-sm, 14px);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-affix-chip,
+  .hk-affix-row,
+  .hk-affix-tag,
+  .hk-affix-tag-x {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkAffixPicker.test.tsx
+++ b/packages/vue/src/components/HkAffixPicker.test.tsx
@@ -1,0 +1,237 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+import HkAffixPicker, { type HkAffixOption } from "./HkAffixPicker";
+
+const OPTIONS: HkAffixOption[] = [
+  { key: "cn", label: "China", meta: "+86", flag: "🇨🇳", keywords: "zhongguo 中国 0086" },
+  { key: "jp", label: "Japan", meta: "+81", flag: "🇯🇵" },
+  { key: "us", label: "United States", meta: "+1", flag: "🇺🇸" },
+];
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+interface MountOptions {
+  mode?: "single" | "multi";
+  selected?: string | string[];
+  activeKey?: string;
+  allowCustom?: boolean;
+  searchable?: boolean;
+  closeOnSelect?: boolean;
+  disabled?: boolean;
+}
+
+function mountPicker(opts: MountOptions = {}) {
+  const events = {
+    select: [] as string[],
+    remove: [] as string[],
+    custom: [] as string[],
+    open: [] as boolean[],
+  };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(HkAffixPicker, {
+        options: OPTIONS,
+        mode: opts.mode ?? "single",
+        selected: opts.selected ?? "",
+        activeKey: opts.activeKey,
+        allowCustom: opts.allowCustom ?? false,
+        searchable: opts.searchable ?? true,
+        closeOnSelect: opts.closeOnSelect,
+        disabled: opts.disabled ?? false,
+        onSelect: (key: string) => events.select.push(key),
+        onRemove: (key: string) => events.remove.push(key),
+        onCustom: (q: string) => events.custom.push(q),
+        "onUpdate:open": (v: boolean) => events.open.push(v),
+      }),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { events, container };
+}
+
+function queryChip(container: HTMLElement): HTMLButtonElement {
+  const chip = container.querySelector<HTMLButtonElement>(".hk-affix-chip");
+  expect(chip, "affix chip renders").toBeTruthy();
+  return chip!;
+}
+
+async function openPopup(container: HTMLElement) {
+  queryChip(container).click();
+  await nextTick();
+  await nextTick();
+}
+
+function rows(): HTMLButtonElement[] {
+  return [...document.querySelectorAll<HTMLButtonElement>(".hk-affix-row")];
+}
+
+function tags(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>(".hk-affix-tag")];
+}
+
+function tag(label: string): HTMLElement | undefined {
+  return tags().find(
+    (t) => (t.querySelector(".hk-affix-tag-text")?.textContent ?? "") === label,
+  );
+}
+
+function searchInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(".hk-affix-search input");
+  expect(input, "search field renders").toBeTruthy();
+  return input!;
+}
+
+async function typeQuery(value: string) {
+  const input = searchInput();
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+  await nextTick();
+}
+
+async function untilSettled(check: () => number): Promise<void> {
+  const deadline = Date.now() + 800;
+  while (check() > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await nextTick();
+  }
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkAffixPicker", () => {
+  it("renders the default chip content with the selected option's label", () => {
+    const { container } = mountPicker({ selected: "jp" });
+    expect(queryChip(container).textContent).toContain("Japan");
+  });
+
+  it("single mode lists every option, marks the active one, closes on pick", async () => {
+    const { events, container } = mountPicker({ selected: "cn" });
+    await openPopup(container);
+    expect(rows()).toHaveLength(3);
+    expect(rows()[0].hasAttribute("data-active")).toBe(true);
+    rows()[1].click();
+    await nextTick();
+    expect(events.select.at(-1)).toBe("jp");
+    // Single mode closes after the pick (leave transition may linger).
+    await untilSettled(() => rows().length);
+    expect(rows()).toHaveLength(0);
+  });
+
+  it("filters rows by label, meta and keywords", async () => {
+    const { container } = mountPicker();
+    await openPopup(container);
+    await typeQuery("+81");
+    expect(rows().map((r) => r.textContent)).toEqual([expect.stringContaining("Japan")]);
+    await typeQuery("0086");
+    expect(rows().map((r) => r.textContent)).toEqual([expect.stringContaining("China")]);
+    await typeQuery("zzz");
+    expect(rows()).toHaveLength(0);
+    expect(document.querySelector(".hk-affix-empty")?.textContent).toContain("No matches");
+  });
+
+  it("multi mode renders selected tags and offers only the remaining rows", async () => {
+    const { container } = mountPicker({ mode: "multi", selected: ["cn", "jp"], activeKey: "cn" });
+    await openPopup(container);
+    expect(tags().map((t) => t.querySelector(".hk-affix-tag-text")?.textContent)).toEqual([
+      "China",
+      "Japan",
+    ]);
+    // The active key's tag carries the dot.
+    expect(tags()[0].querySelector(".hk-affix-tag-dot")).toBeTruthy();
+    expect(tags()[1].querySelector(".hk-affix-tag-dot")).toBeNull();
+    // Rows exclude the already-selected keys.
+    expect(rows().map((r) => r.textContent)).toEqual([expect.stringContaining("United States")]);
+  });
+
+  it("multi mode keeps the popup open when a row is picked", async () => {
+    const { events, container } = mountPicker({ mode: "multi", selected: ["cn"] });
+    await openPopup(container);
+    rows()[0].click();
+    await nextTick();
+    expect(events.select.at(-1)).toBe("jp");
+    expect(rows().length).toBeGreaterThan(0);
+  });
+
+  it("two-step tag delete: × arms, × again confirms; body click disarms", async () => {
+    const { events, container } = mountPicker({ mode: "multi", selected: ["cn", "jp"] });
+    await openPopup(container);
+    const x = tags()[0].querySelector<HTMLButtonElement>(".hk-affix-tag-x")!;
+    x.click();
+    await nextTick();
+    expect(tags()[0].hasAttribute("data-armed")).toBe(true);
+    expect(events.remove).toHaveLength(0);
+    // Second activation confirms — the tag leaves the list.
+    x.click();
+    await nextTick();
+    expect(events.remove).toEqual(["cn"]);
+    // Body click on an ARMED tag disarms it instead of picking.
+    const jpBody = tag("Japan")!.querySelector<HTMLButtonElement>(".hk-affix-tag-body")!;
+    tag("Japan")!.querySelector<HTMLButtonElement>(".hk-affix-tag-x")!.click();
+    await nextTick();
+    expect(tag("Japan")?.hasAttribute("data-armed")).toBe(true);
+    jpBody.click();
+    await nextTick();
+    expect(tag("Japan")?.hasAttribute("data-armed")).toBe(false);
+    expect(events.select).toHaveLength(0);
+  });
+
+  it("tag body click emits select; close-on-select default keeps multi open", async () => {
+    const { events, container } = mountPicker({ mode: "multi", selected: ["cn", "jp"] });
+    await openPopup(container);
+    tags()[1].querySelector<HTMLButtonElement>(".hk-affix-tag-body")!.click();
+    await nextTick();
+    expect(events.select.at(-1)).toBe("jp");
+    expect(rows().length).toBeGreaterThan(0);
+  });
+
+  it("allowCustom offers a Use-row for unmatched queries and suppresses it on exact matches", async () => {
+    const { events, container } = mountPicker({ allowCustom: true });
+    await openPopup(container);
+    await typeQuery("gitee.com");
+    const custom = document.querySelector<HTMLButtonElement>('.hk-affix-row[data-custom="true"]');
+    expect(custom?.textContent).toContain('Use "gitee.com"');
+    custom!.click();
+    await nextTick();
+    expect(events.custom).toEqual(["gitee.com"]);
+    // Single mode closed on the custom pick — wait out the leave ghost,
+    // then reopen for the exact-match phase.
+    await untilSettled(() => rows().length);
+    await openPopup(container);
+    await typeQuery("Japan");
+    expect(document.querySelector('.hk-affix-row[data-custom="true"]')).toBeNull();
+    expect(rows().map((r) => r.textContent)).toEqual([expect.stringContaining("Japan")]);
+  });
+
+  it("Enter in the search picks the first row, or the custom row when nothing matches", async () => {
+    const { events, container } = mountPicker({ allowCustom: true });
+    await openPopup(container);
+    await typeQuery("uni");
+    searchInput().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    expect(events.select.at(-1)).toBe("us");
+    // Single mode closed on the pick — reopen before the custom phase.
+    await untilSettled(() => rows().length);
+    await openPopup(container);
+    await typeQuery("gitee.com");
+    searchInput().dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    expect(events.custom.at(-1)).toBe("gitee.com");
+  });
+
+  it("disables the chip and ignores interaction while disabled", async () => {
+    const { container } = mountPicker({ disabled: true });
+    expect(queryChip(container).disabled).toBe(true);
+    await openPopup(container);
+    expect(rows()).toHaveLength(0);
+  });
+});

--- a/packages/vue/src/components/HkAffixPicker.tsx
+++ b/packages/vue/src/components/HkAffixPicker.tsx
@@ -1,0 +1,438 @@
+import { computed, defineComponent, ref, watch, type PropType, type SlotsType } from "vue";
+
+import { ChevronDown, Plus, Search, X } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import HkInput from "./HkInput";
+import HkListTransition from "./HkListTransition";
+import HkMenu from "./HkMenu";
+import "./HkAffixPicker.scss";
+
+/** One pickable entry of the affix picker's searchable list. */
+export interface HkAffixOption {
+  /** Stable identity — the value emitted back to the host. */
+  key: string;
+  /** Primary row/tag text (country name, platform, autonym…). */
+  label: string;
+  /** Secondary muted text (dial code, locale code, domain…). */
+  meta?: string;
+  /** Optional leading glyph (flag emoji or any short symbol). */
+  flag?: string;
+  /** Extra haystack for the search filter (aliases, codes, digits). */
+  keywords?: string;
+  disabled?: boolean;
+}
+
+/**
+ * HkAffixPicker — the standardized "affix chip + searchable popup list"
+ * control. A chip rides the prefix (left) or suffix (right) slot of a
+ * host field (compose it inside an `HkInput` affix slot); clicking it
+ * opens one canonical popup:
+ *
+ *   - a SEARCH FIELD on top (live filter over label / meta / keywords);
+ *   - in `multi` mode, a TAG LIST of the currently selected keys with
+ *     the shared arm-delete guard: the row's × arms on the first tap
+ *     (danger tint) and erases on the second — desktop hover IS the
+ *     preview, so a single click erases there; the popup stays open so
+ *     several tags can be managed in one pass;
+ *   - the option rows themselves: single mode shows every option and
+ *     closes on pick; multi mode lists the NOT-yet-selected options and
+ *     stays open for batch adds;
+ *   - with `allowCustom`, a trailing "Use <query>" row appears whenever
+ *     the typed query is not an exact label match — free-text entries
+ *     without leaving the keyboard flow (Enter picks the first row, or
+ *     the custom row when nothing matches).
+ *
+ * The picker owns ZERO field semantics: selection state lives with the
+ * host (`selected` key(s) in, events out), and the chip visuals come
+ * from the host through the scoped `chip` slot — the same component
+ * therefore serves dial codes, translation languages, git platform
+ * prefixes or any future "constrained value behind a chip" field.
+ */
+export const HkAffixPicker = defineComponent({
+  name: "HkAffixPicker",
+  props: {
+    /** The full catalog of pickable entries. */
+    options: { type: Array as PropType<readonly HkAffixOption[]>, required: true },
+    /** "single" closes on pick and shows a check on the active row;
+     *  "multi" renders the tag list and keeps the popup open. */
+    mode: { type: String as PropType<"single" | "multi">, default: "single" },
+    /** Selected key(s). A string in single mode, an array in multi. */
+    selected: {
+      type: [String, Array] as PropType<string | readonly string[]>,
+      default: "",
+    },
+    /** The entry currently being acted on (edited language, active
+     *  platform) — marks its tag with the active dot. */
+    activeKey: { type: String, default: undefined },
+    /** Which affix edge the chip rides — only steers the popup anchor
+     *  placement (bottom-start vs bottom-end). */
+    side: { type: String as PropType<"prefix" | "suffix">, default: "prefix" },
+    /** Show the filter field (default true). */
+    searchable: { type: Boolean, default: true },
+    /** Offer a "Use <query>" row for free-text entries. */
+    allowCustom: { type: Boolean, default: false },
+    /** Override the default close-on-pick (single: true, multi: false).
+     *  E.g. a multi picker that should close after each add passes
+     *  true; a single picker that should stay open passes false. */
+    closeOnSelect: { type: Boolean, default: undefined },
+    disabled: { type: Boolean, default: false },
+    /** Popup / chip aria labels; defaulted from the i18n bundle. */
+    title: { type: String, default: undefined },
+    searchPlaceholder: { type: String, default: undefined },
+    emptyText: { type: String, default: undefined },
+    /** Extra class on the chip button (host field styling hooks). */
+    chipClass: { type: String, default: undefined },
+    /** Accessible name of the chip button (defaults to its content). */
+    chipLabel: { type: String, default: undefined },
+  },
+  emits: {
+    /** A row or tag body was picked (multi add / single choose). */
+    select: (_key: string) => true,
+    /** A tag's armed × confirmed — the host drops that key. */
+    remove: (_key: string) => true,
+    /** The "Use <query>" row fired with the typed text. */
+    custom: (_query: string) => true,
+    "update:open": (_open: boolean) => true,
+  },
+  slots: Object as SlotsType<{
+    /** Chip inner content; scoped `open` mirrors the popup state. */
+    chip?: (scope: { open: boolean }) => unknown;
+  }>,
+  setup(props, { emit, slots }) {
+    const { t } = useI18n();
+
+    const open = ref(false);
+    const chipRef = ref<HTMLElement | null>(null);
+    const query = ref("");
+    /** Key of the tag whose delete is ARMED (× tapped once). */
+    const armedKey = ref<string | null>(null);
+
+    // A fresh open starts calm: empty filter, no armed tag.
+    watch(open, (v) => {
+      if (!v) {
+        query.value = "";
+        armedKey.value = null;
+      }
+      emit("update:open", v);
+    });
+
+    const selectedKeys = computed<readonly string[]>(() =>
+      Array.isArray(props.selected) ? props.selected : props.selected ? [props.selected] : [],
+    );
+
+    const activeSet = computed<readonly string[]>(() =>
+      props.mode === "single" ? selectedKeys.value : props.activeKey ? [props.activeKey] : [],
+    );
+
+    /** Rows of the pick list. Multi hides already-selected keys (they
+     *  live in the tag list instead); single always shows everything. */
+    const filteredRows = computed<readonly HkAffixOption[]>(() => {
+      const base =
+        props.mode === "multi"
+          ? props.options.filter((o) => !selectedKeys.value.includes(o.key))
+          : props.options;
+      const q = query.value.trim().toLowerCase();
+      if (!q) return base;
+      return base.filter((o) => {
+        if (o.label.toLowerCase().includes(q)) return true;
+        if (o.meta && o.meta.toLowerCase().includes(q)) return true;
+        if (o.key.toLowerCase().includes(q)) return true;
+        return !!o.keywords && o.keywords.toLowerCase().includes(q);
+      });
+    });
+
+    /** Exact label match suppresses the custom row while the user is
+     *  simply re-typing an existing entry. */
+    const exactMatch = computed(
+      () =>
+        !!query.value.trim() &&
+        props.options.some(
+          (o) => o.label.toLowerCase() === query.value.trim().toLowerCase(),
+        ),
+    );
+
+    const customVisible = computed(
+      () => props.allowCustom && !!query.value.trim() && !exactMatch.value,
+    );
+
+    const resolvedCloseOnSelect = computed(() =>
+      props.closeOnSelect === undefined ? props.mode === "single" : props.closeOnSelect,
+    );
+
+    /** Tags of the multi picker: selected keys in host order; keys not
+     *  present in the catalog degrade to their raw key as the label. */
+    const tagEntries = computed<readonly HkAffixOption[]>(() =>
+      selectedKeys.value.map(
+        (key) => props.options.find((o) => o.key === key) ?? { key, label: key },
+      ),
+    );
+
+    function toggle() {
+      if (!props.disabled) open.value = !open.value;
+    }
+
+    function pick(option: HkAffixOption) {
+      if (option.disabled) return;
+      emit("select", option.key);
+      if (resolvedCloseOnSelect.value) open.value = false;
+    }
+
+    function confirmRemove(key: string) {
+      armedKey.value = null;
+      emit("remove", key);
+    }
+
+    function toggleArm(key: string) {
+      armedKey.value = armedKey.value === key ? null : key;
+    }
+
+    function useCustom() {
+      const q = query.value.trim();
+      if (!q) return;
+      emit("custom", q);
+      if (props.mode === "single") open.value = false;
+      else query.value = "";
+    }
+
+    function onSearchEnter() {
+      const rows = filteredRows.value;
+      if (rows.length > 0 && !rows[0].disabled) {
+        pick(rows[0]);
+        return;
+      }
+      if (customVisible.value) useCustom();
+    }
+
+    function interpolate(template: string, vars: Record<string, string>): string {
+      return Object.entries(vars).reduce(
+        (acc, [k, v]) => acc.split(`{${k}}`).join(v),
+        template,
+      );
+    }
+
+    return () => {
+      const rows = filteredRows.value;
+      const tags = props.mode === "multi" ? tagEntries.value : [];
+      const title = props.title ?? t("hikari::affixPicker.title", "Options");
+      const searchPlaceholder =
+        props.searchPlaceholder ?? t("hikari::affixPicker.search", "Search");
+      const emptyText = props.emptyText ?? t("hikari::affixPicker.empty", "No matches");
+      const removeLabel = t("hikari::affixPicker.remove", "Remove");
+      const confirmLabel = t("hikari::affixPicker.confirmDelete", "Confirm remove");
+      const placement = props.side === "suffix" ? "bottom-end" : "bottom-start";
+      return (
+        <>
+          <button
+            ref={(el: unknown) => {
+              chipRef.value = (el as HTMLElement) ?? null;
+            }}
+            type="button"
+            class={["hk-affix-chip", props.chipClass]}
+            disabled={props.disabled}
+            aria-haspopup="menu"
+            aria-expanded={open.value}
+            aria-label={props.chipLabel}
+            title={props.chipLabel}
+            onMousedown={(e: MouseEvent) => e.preventDefault()}
+            onClick={(e: MouseEvent) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggle();
+            }}
+          >
+            {slots.chip
+              ? slots.chip({ open: open.value })
+              : (
+                <>
+                  <span class="hk-affix-chip-label">
+                    {props.mode === "single"
+                      ? (props.options.find((o) => o.key === props.selected)?.label ??
+                        props.selected)
+                      : t("hikari::affixPicker.selectedCount", "{count} selected")
+                          .split("{count}")
+                          .join(String(selectedKeys.value.length))}
+                  </span>
+                  <ChevronDown size={12} class="hk-affix-chip-caret" aria-hidden="true" />
+                </>
+              )}
+          </button>
+          <HkMenu
+            variant="popup"
+            items={[]}
+            open={open.value}
+            onUpdate:open={(v: boolean) => {
+              open.value = v;
+            }}
+            anchorRef={chipRef.value}
+            placement={placement}
+            matchAnchorWidth={false}
+            title={title}
+          >
+            {{
+              header: () => (
+                <div class="hk-affix-head">
+                  {props.mode === "multi" && tags.length > 0 && (
+                    <div
+                      class="hk-affix-tags"
+                      role="group"
+                      aria-label={t("hikari::affixPicker.selected", "Selected")}
+                    >
+                      <HkListTransition
+                        tag="div"
+                        variant="reveal"
+                        move
+                        appear
+                        class="hk-affix-tag-list"
+                      >
+                        {tags.map((tag) => {
+                          const armed = armedKey.value === tag.key;
+                          return (
+                            <div
+                              key={tag.key}
+                              class="hk-affix-tag"
+                              data-active={activeSet.value.includes(tag.key) || undefined}
+                              data-armed={armed || undefined}
+                            >
+                              <button
+                                type="button"
+                                class="hk-affix-tag-body"
+                                title={`${tag.label}${tag.meta ? ` (${tag.meta})` : ""}`}
+                                aria-label={`${t("hikari::affixPicker.switchTo", "Switch to")} ${tag.label}`}
+                                onClick={(e: MouseEvent) => {
+                                  e.stopPropagation();
+                                  if (armed) {
+                                    armedKey.value = null;
+                                    return;
+                                  }
+                                  pick(tag);
+                                }}
+                              >
+                                {tag.flag && (
+                                  <span class="hk-affix-tag-flag" aria-hidden="true">
+                                    {tag.flag}
+                                  </span>
+                                )}
+                                <span class="hk-affix-tag-text">{tag.label}</span>
+                                {tag.meta && (
+                                  <span class="hk-affix-tag-meta">{tag.meta}</span>
+                                )}
+                                {activeSet.value.includes(tag.key) && (
+                                  <span class="hk-affix-tag-dot" aria-hidden="true" />
+                                )}
+                              </button>
+                              <button
+                                type="button"
+                                class="hk-affix-tag-x"
+                                aria-label={armed ? confirmLabel : `${removeLabel} — ${tag.label}`}
+                                title={armed ? confirmLabel : `${removeLabel} — ${tag.label}`}
+                                // The × arms on the first activation and
+                                // confirms on the second (touch guard); on
+                                // desktop the hover already previewed the
+                                // intent, so the first click erases.
+                                onClick={(e: MouseEvent) => {
+                                  e.stopPropagation();
+                                  if (armed) confirmRemove(tag.key);
+                                  else toggleArm(tag.key);
+                                }}
+                                onMousedown={(e: MouseEvent) => e.preventDefault()}
+                              >
+                                <X size={11} />
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </HkListTransition>
+                    </div>
+                  )}
+                  {props.searchable && (
+                    <div class="hk-affix-search" role="search">
+                      <HkInput
+                        modelValue={query.value}
+                        onUpdate:modelValue={(v: string) => {
+                          query.value = v;
+                        }}
+                        size="sm"
+                        placeholder={searchPlaceholder}
+                        aria-label={searchPlaceholder}
+                        autocomplete="off"
+                        onKeydown={(e: KeyboardEvent) => {
+                          if (e.key === "Enter" && !e.isComposing) {
+                            e.preventDefault();
+                            onSearchEnter();
+                          }
+                        }}
+                      >
+                        {{
+                          prefixIcon: () => <Search size={13} aria-hidden="true" />,
+                        }}
+                      </HkInput>
+                    </div>
+                  )}
+                </div>
+              ),
+              default: () =>
+                rows.length > 0 || customVisible.value ? (
+                  <div class="hk-affix-list">
+                    {rows.map((option) => {
+                      const active =
+                        props.mode === "single"
+                          ? selectedKeys.value.includes(option.key)
+                          : false;
+                      return (
+                        <button
+                          key={option.key}
+                          type="button"
+                          class="hk-affix-row"
+                          data-active={active || undefined}
+                          data-disabled={option.disabled || undefined}
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation();
+                            pick(option);
+                          }}
+                        >
+                          {option.flag && (
+                            <span class="hk-affix-row-flag" aria-hidden="true">
+                              {option.flag}
+                            </span>
+                          )}
+                          <span class="hk-affix-row-label">{option.label}</span>
+                          {option.meta && (
+                            <span class="hk-affix-row-meta">{option.meta}</span>
+                          )}
+                        </button>
+                      );
+                    })}
+                    {customVisible.value && (
+                      <button
+                        type="button"
+                        class="hk-affix-row"
+                        data-custom="true"
+                        onClick={(e: MouseEvent) => {
+                          e.stopPropagation();
+                          useCustom();
+                        }}
+                      >
+                        <Plus size={13} class="hk-affix-row-flag" aria-hidden="true" />
+                        <span class="hk-affix-row-label">
+                          {interpolate(
+                            t("hikari::affixPicker.useCustom", 'Use "{query}"'),
+                            { query: query.value.trim() },
+                          )}
+                        </span>
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <div class="hk-affix-empty">{emptyText}</div>
+                ),
+            }}
+          </HkMenu>
+        </>
+      );
+    };
+  },
+});
+
+export default HkAffixPicker;

--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -13,30 +13,21 @@
   opacity: 0.75;
 }
 
-/* The wrapped language chip riding the input's right edge. A button so
- * it is focusable/AT-reachable, but it must never steal the field's
- * click-to-edit: pointer events stop at the chip boundary (handled in
- * TSX) and mousedown is suppressed to keep focus inside the input. */
+/* The wrapped language chip riding the input's right edge, layered on the
+ * shared .hk-affix-chip base (the picker owns hover/disabled/focus). It
+ * must never steal the field's click-to-edit: pointer events stop at the
+ * chip boundary (handled in the picker) and mousedown is suppressed to
+ * keep focus inside the input. */
 .hk-localized-input-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
   padding: 0;
-  border: none;
+  border-radius: var(--radius-sm, 999px);
   background: transparent;
   color: rgb(var(--color-muted));
-  cursor: pointer;
-  border-radius: var(--radius-sm, 999px);
-  transition: color 0.15s ease;
 
   &:hover:not(:disabled),
   &:focus-visible:not(:disabled) {
+    background: transparent;
     color: rgb(var(--color-text));
-  }
-
-  &:disabled {
-    cursor: default;
-    opacity: 0.55;
   }
 
   /* Dim while no translation exists yet — same affordance level as an
@@ -86,205 +77,7 @@
   }
 }
 
-/* ── language list (menu header) ────────────────────────────────────
- * One row per language currently present — including the one being
- * edited. LEFT = the already-edited translation text (italic enter-text
- * hint while it holds nothing), RIGHT = the same language chip as the
- * closed field. Clicking the chip ARMS the delete: the row turns
- * danger-red and the × overlays the chip in the same slot (desktop:
- * hovering the row swaps the × in without arming); clicking the × erases
- * the translation. The list squashes/expands around adds and removals
- * via HkListTransition. */
-.hk-localized-input-tags {
-  padding: 10px 0 8px;
-  border-bottom: 1px solid var(--border-faint);
-}
-
-/* Rows live inside the HkListTransition container (keyed by language). */
-.hk-localized-input-tag-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  /* Wider than the old two-line pill cloud: a full row carries the
-   * translation text AND the language chip, and desktop popouts should
-   * not crumple them into one tight box. `min(18rem, 100%)` keeps the
-   * floor from overflowing tiny (sub-320px) mobile viewports — the
-   * sheet list can never scroll horizontally because of it. */
-  min-width: min(18rem, 100%);
-  max-width: 24rem;
-}
-
-.hk-localized-input-tag {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 2.375rem;
-  /* 16px leading padding puts the row's text exactly on the shared text
-   * edge: the mobile sheet's title inset (2×--space-16 over the list's
-   * own 1×--space-16) and the desktop popout's option text edge
-   * (8px panel + 16px row). */
-  padding: 5px var(--space-16);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  background: rgb(var(--color-surface) / var(--opacity-half, 50%));
-  overflow: hidden;
-  transition: border-color 0.12s ease, background 0.12s ease;
-
-  &:hover {
-    border-color: rgb(var(--color-primary) / 40%);
-  }
-
-  /* The language being edited right now. */
-  &[data-active] {
-    border-color: rgb(var(--color-primary) / 45%);
-    background: rgb(var(--color-primary) / 12%);
-  }
-
-  /* Armed delete: the whole row reads as the danger zone — the chip is
-   * about to be replaced by its confirm ×. */
-  &[data-armed] {
-    border-color: rgb(var(--color-danger, 240 70 80) / 55%);
-    background: rgb(var(--color-danger, 240 70 80) / 12%);
-  }
-}
-
-.hk-localized-input-tag-body {
-  flex: 1;
-  min-width: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: rgb(var(--color-text));
-  font-size: var(--text-sm);
-  line-height: 1.4;
-  text-align: left;
-  cursor: pointer;
-  appearance: none;
-}
-
-.hk-localized-input-tag-flag {
-  flex-shrink: 0;
-  font-size: var(--text-sm);
-  line-height: 1;
-}
-
-.hk-localized-input-tag-text {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  /* No translation yet (usually the language being edited): an italic
-   * "enter text" hint asks for input instead of a bare punctuation
-   * glyph — the row reads as an empty slot, not a dash. */
-  &[data-empty] {
-    color: rgb(var(--color-muted));
-    opacity: 0.8;
-    font-style: italic;
-  }
-}
-
-.hk-localized-input-tag[data-active] .hk-localized-input-tag-text {
-  font-weight: 600;
-}
-
-/* The language chip — same grammar as the closed field's chip. */
-.hk-localized-input-tag-locale {
-  flex: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  border: 0;
-  border-radius: 999px;
-  background: rgb(var(--color-primary) / 14%);
-  color: rgb(var(--color-text));
-  font-size: var(--text-xs);
-  line-height: 1.4;
-  cursor: pointer;
-  appearance: none;
-  transition: color 0.12s ease, background 0.12s ease;
-
-  &:hover,
-  &:focus-visible {
-    background: rgb(var(--color-primary) / 22%);
-  }
-}
-
-.hk-localized-input-tag-label {
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 9rem;
-}
-
-.hk-localized-input-tag-code {
-  flex-shrink: 0;
-  color: rgb(var(--color-muted));
-  font-size: calc(var(--text-xs) * 0.86);
-}
-
-/* Active marker dot — mirrors HkBadge's dot treatment. */
-.hk-localized-input-tag-dot {
-  flex-shrink: 0;
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: rgb(var(--color-primary));
-}
-
-/* The chip's slot hosts BOTH the chip and the confirm ×: the × overlays
- * the chip absolutely (inset:0), so arm/hover swaps the two in place —
- * zero layout animation, zero reflow, nothing slides. The row never
- * changes its geometry, which is exactly what makes the armed state feel
- * instant (the previous width-transition version reflowed the row and
- * was visibly laggy). */
-.hk-localized-input-tag-slot {
-  position: relative;
-  display: inline-flex;
-  flex: none;
-}
-
-.hk-localized-input-tag-x {
-  position: absolute;
-  inset: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: rgb(var(--color-danger, 240 70 80));
-  cursor: pointer;
-  opacity: 0;
-  pointer-events: none;
-  appearance: none;
-  transition: opacity 0.1s ease;
-
-  &:hover,
-  &:focus-visible {
-    background: rgb(var(--color-danger, 240 70 80) / 12%);
-  }
-}
-
-.hk-localized-input-tag[data-armed] .hk-localized-input-tag-x,
-.hk-localized-input-tag:hover .hk-localized-input-tag-x,
-.hk-localized-input-tag-x:focus-visible {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .hk-localized-input-tag,
-  .hk-localized-input-tag-locale,
-  .hk-localized-input-tag-x,
   .hk-localized-input-chip {
     transition: none;
   }

--- a/packages/vue/src/components/HkLocalizedInput.test.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.test.tsx
@@ -55,9 +55,9 @@ function mountInput(opts: MountOptions = {}) {
 /**
  * Reactive harness — a REAL v-model parent: `update:translations` /
  * `update:modelValue` flow back into the props, so the language list
- * (which renders from `props.translations`) updates live while the menu
- * stays open, exactly as in an application. One-way `mountInput` cannot
- * show that (its props never change). */
+ * (which renders from `props.translations`) updates live while the
+ * popup stays open, exactly as in an application. One-way `mountInput`
+ * cannot show that (its props never change). */
 function mountReactive(opts: MountOptions = {}) {
   const events = {
     modelValue: [] as string[],
@@ -109,57 +109,53 @@ function queryField(container: HTMLElement): HTMLInputElement | HTMLTextAreaElem
   return field!;
 }
 
-async function openMenu(container: HTMLElement) {
+async function openPicker(container: HTMLElement) {
   queryChip(container).click();
   await nextTick();
   await nextTick();
 }
 
-function menuRows(): HTMLElement[] {
-  return [...document.querySelectorAll<HTMLButtonElement>(".hk-menu-row")];
+/** Addable-language rows inside the opened popup's pick list. */
+function pickerRows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>(".hk-affix-row")];
 }
 
-/** Language rows inside the opened menu's header list. */
-function menuTags(): HTMLElement[] {
-  return [...document.querySelectorAll<HTMLElement>(".hk-localized-input-tag")];
+/** Language tags of the already-present translations. */
+function pickerTags(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>(".hk-affix-tag")];
 }
 
 function tagLabels(): string[] {
-  return menuTags().map(
-    (t) => t.querySelector(".hk-localized-input-tag-label")?.textContent ?? "",
+  return pickerTags().map(
+    (t) => t.querySelector(".hk-affix-tag-text")?.textContent ?? "",
   );
 }
 
-/** The language row whose chip label is `label`. */
+/** The tag whose label is `label`. */
 function tag(label: string): HTMLElement | undefined {
-  return menuTags().find(
-    (t) => (t.querySelector(".hk-localized-input-tag-label")?.textContent ?? "") === label,
+  return pickerTags().find(
+    (t) => (t.querySelector(".hk-affix-tag-text")?.textContent ?? "") === label,
   );
 }
 
-/** The row body (text zone — switch target) of the language row. */
+/** The tag body (switch target) of the language tag. */
 function tagBody(label: string): HTMLButtonElement | undefined {
-  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-body") ?? undefined;
+  return tag(label)?.querySelector<HTMLButtonElement>(".hk-affix-tag-body") ?? undefined;
 }
 
-/** The language chip (arm-delete target) of the row. */
-function tagLocale(label: string): HTMLButtonElement | undefined {
-  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-locale") ?? undefined;
-}
-
-/** The confirm × on the row. */
+/** The arm/confirm × of the language tag. */
 function tagX(label: string): HTMLButtonElement | undefined {
-  return tag(label)?.querySelector<HTMLButtonElement>(".hk-localized-input-tag-x") ?? undefined;
+  return tag(label)?.querySelector<HTMLButtonElement>(".hk-affix-tag-x") ?? undefined;
 }
 
-/** Full two-step erase: arm via the chip, then confirm on the ×. The
- *  TransitionGroup keeps the leaving row mounted through its leave window
- *  (jsdom has no CSS engine, so the ghost clears on the next-frame
- *  fallback) — poll until the row is really gone. */
-async function eraseViaArm(container: HTMLElement, label: string) {
-  tagLocale(label)!.click();
+/** Full two-step erase: the × arms (danger tint), the second activation
+ *  confirms. The leaving tag lingers through its transition window (jsdom
+ *  has no CSS engine, so the ghost clears on the next-frame fallback) —
+ *  poll until the tag is really gone. */
+async function eraseViaArm(label: string) {
+  tagX(label)!.click();
   await nextTick();
-  expect(tag(label)?.hasAttribute("data-armed"), "row is armed before the confirm ×").toBe(true);
+  expect(tag(label)?.hasAttribute("data-armed"), "tag is armed before the confirm ×").toBe(true);
   tagX(label)!.click();
   await nextTick();
   await nextTick();
@@ -170,14 +166,23 @@ async function eraseViaArm(container: HTMLElement, label: string) {
   }
 }
 
-/** Wait for the menu's leave-transition window to finish — rows linger
+/** Wait for the popup's leave-transition window to finish — rows linger
  *  briefly after a close while the popout animates shut. */
-async function untilMenuSettled(): Promise<void> {
+async function untilPickerSettled(): Promise<void> {
   const deadline = Date.now() + 800;
-  while (menuRows().length > 0 && Date.now() < deadline) {
+  while (pickerRows().length > 0 && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 10));
     await nextTick();
   }
+}
+
+async function typeIntoSearch(value: string) {
+  const input = document.querySelector<HTMLInputElement>(".hk-affix-search input");
+  expect(input, "search field renders").toBeTruthy();
+  input!.value = value;
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+  await nextTick();
 }
 
 afterEach(() => {
@@ -196,29 +201,28 @@ describe("HkLocalizedInput", () => {
     expect(queryField(container).value).toBe("Plant overview");
   });
 
-  it("carries the locale code only inside the opened menu rows", async () => {
+  it("carries the locale code only inside the opened popup", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    // The chip stays code-free while the menu is closed.
+    // The chip stays code-free while the popup is closed.
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
-    await openMenu(container);
-    // Rows show the bare label plus a small code suffix — no parens form.
-    const row = tag("简体中文");
-    expect(row, "row for the filled translation renders").toBeTruthy();
-    expect(row!.querySelector(".hk-localized-input-tag-code")?.textContent).toBe("zh-Hans");
-    expect(row!.textContent).not.toContain("(zh-Hans)");
-    // "Add language" cascade children still carry the parenthesized code.
-    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
-    addRow!.click();
-    await nextTick();
-    await nextTick();
-    const childLabels = menuRows().map((r) => r.textContent ?? "");
-    expect(childLabels.some((l) => l.includes("日本語 (ja)"))).toBe(true);
-    // Filled languages are not offered in the add cascade.
-    expect(childLabels.some((l) => l.includes("English (en)"))).toBe(false);
-    // The chip STILL shows no code while the menu is open.
+    await openPicker(container);
+    // Tags show the bare label plus a muted code suffix — no parens form.
+    const zhTag = tag("简体中文");
+    expect(zhTag, "tag for the filled translation renders").toBeTruthy();
+    expect(zhTag!.querySelector(".hk-affix-tag-meta")?.textContent).toBe("zh-Hans");
+    expect(zhTag!.textContent).not.toContain("(zh-Hans)");
+    // Addable rows carry their code as the muted meta too.
+    const jaRow = pickerRows().find((r) => (r.textContent ?? "").includes("日本語"));
+    expect(jaRow, "addable row for the missing language renders").toBeTruthy();
+    expect(jaRow!.querySelector(".hk-affix-row-meta")?.textContent).toBe("ja");
+    // Filled languages are not offered as add rows.
+    expect(
+      pickerRows().some((r) => (r.textContent ?? "").includes("English")),
+    ).toBe(false);
+    // The chip STILL shows no code while the popup is open.
     expect(queryChip(container).textContent).not.toContain("(");
   });
 
@@ -241,56 +245,39 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)?.en).toBeUndefined();
   });
 
-  it("renders a row for every language, including the one being edited — text left, chip right", async () => {
+  it("renders a tag for every present language — the edited one active", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    // Every language in the map is a row — the edited one included, marked active.
+    await openPicker(container);
+    // Every language in the map is a tag — the edited one marked active.
     expect(tagLabels()).toEqual(expect.arrayContaining(["English", "简体中文"]));
-    const activeTag = menuTags().find((t) => t.hasAttribute("data-active"));
-    expect(activeTag?.querySelector(".hk-localized-input-tag-label")?.textContent).toBe("English");
-    // LEFT = the translation text, RIGHT = the language chip.
-    const zhRow = tag("简体中文")!;
-    const text = zhRow.querySelector(".hk-localized-input-tag-text")!;
-    expect(text.textContent).toBe("工厂总览");
-    expect(text.hasAttribute("data-empty")).toBe(false);
-    const enRow = tag("English")!;
-    expect(
-      enRow.querySelector(".hk-localized-input-tag-text")?.textContent,
-    ).toBe("Plant overview");
-    // The dedicated delete cascade is gone — rows carry their own arm/× pair.
-    const allRows = menuRows().map((r) => r.textContent ?? "");
-    expect(allRows.some((l) => l.includes("Delete language"))).toBe(false);
-    expect(allRows.some((l) => l.includes("Add language"))).toBe(true);
-    // One chip + one × per row.
-    for (const row of menuTags()) {
-      expect(row.querySelector(".hk-localized-input-tag-locale"), "chip on every row").toBeTruthy();
-      expect(row.querySelector(".hk-localized-input-tag-x"), "confirm × on every row").toBeTruthy();
+    const activeTag = pickerTags().find((t) => t.hasAttribute("data-active"));
+    expect(activeTag?.querySelector(".hk-affix-tag-text")?.textContent).toBe("English");
+    // One body + one arm/confirm × per tag.
+    for (const t of pickerTags()) {
+      expect(t.querySelector(".hk-affix-tag-body"), "body on every tag").toBeTruthy();
+      expect(t.querySelector(".hk-affix-tag-x"), "× on every tag").toBeTruthy();
     }
+    // Addable rows exist beside the tags.
+    expect(pickerRows().some((r) => (r.textContent ?? "").includes("日本語"))).toBe(true);
   });
 
-  it("lists the edited language even while it holds no translation (italic hint)", async () => {
+  it("lists the edited language even while it holds no translation", async () => {
     const { container } = mountInput({ modelValue: "Plant overview" });
-    await openMenu(container);
-    // The field edits English with nothing stored yet — still listed.
+    await openPicker(container);
+    // The field edits English with nothing stored yet — still listed, active.
     expect(tagLabels()).toEqual(["English"]);
-    const row = tag("English")!;
-    const text = row.querySelector(".hk-localized-input-tag-text")!;
-    // No bare dash: an i18n "enter text" hint asks for input instead.
-    expect(text.textContent).toBe("Enter text in the field");
-    expect(text.hasAttribute("data-empty")).toBe(true);
-    expect(text.classList.contains("hk-localized-input-tag-text")).toBe(true);
-    expect(row.hasAttribute("data-active")).toBe(true);
+    expect(tag("English")?.hasAttribute("data-active")).toBe(true);
   });
 
-  it("switches to an existing language via its row body: commits text, loads its value, closes the menu", async () => {
+  it("switches to an existing language via its tag body: commits text, loads its value, closes the popup", async () => {
     const { events, container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
+    await openPicker(container);
     const body = tagBody("简体中文");
     expect(body).toBeTruthy();
     body!.click();
@@ -301,25 +288,19 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
     expect(queryChip(container).textContent).toContain("简体中文");
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
-    // Menu closed after the switch (rows linger briefly through
-    // the popout's close animation).
-    await untilMenuSettled();
-    expect(menuRows().length).toBe(0);
+    // Popup closed after the switch (rows linger briefly through the
+    // popout's close animation).
+    await untilPickerSettled();
+    expect(pickerRows().length).toBe(0);
   });
 
-  it("adds a fresh language via the cascade: closes menu, empty field, chip follows", async () => {
+  it("adds a fresh language from the pick list: closes, empty field, chip follows", async () => {
     const { events, container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview" },
     });
-    await openMenu(container);
-    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
-    expect(addRow).toBeTruthy();
-    addRow!.click();
-    await nextTick();
-    await nextTick();
-    // Cascade child rows render for the not-yet-added languages.
-    const jaRow = menuRows().find((r) => (r.textContent ?? "").includes("日本語"));
+    await openPicker(container);
+    const jaRow = pickerRows().find((r) => (r.textContent ?? "").includes("日本語"));
     expect(jaRow).toBeTruthy();
     jaRow!.click();
     await nextTick();
@@ -329,12 +310,29 @@ describe("HkLocalizedInput", () => {
     expect(events.translations.at(-1)).toMatchObject({ en: "Plant overview" });
     expect(queryChip(container).textContent).toContain("日本語");
     expect(queryChip(container).textContent).not.toContain("(ja)");
-    await untilMenuSettled();
-    expect(menuRows().length).toBe(0);
+    await untilPickerSettled();
+    expect(pickerRows().length).toBe(0);
+  });
+
+  it("search filters the addable rows live", async () => {
+    const { container } = mountInput({
+      modelValue: "Plant overview",
+      translations: { en: "Plant overview" },
+    });
+    await openPicker(container);
+    await typeIntoSearch("日");
+    expect(pickerRows().map((r) => r.textContent)).toEqual([
+      expect.stringContaining("日本語"),
+    ]);
+    await typeIntoSearch("zzz");
+    expect(pickerRows()).toHaveLength(0);
+    expect(document.querySelector(".hk-affix-empty")?.textContent).toContain(
+      "No matching language",
+    );
   });
 
   it("disables the chip when the catalog is exhausted", () => {
-    // Exhausted = nothing the menu could offer: no translation to
+    // Exhausted = nothing the picker could offer: no translation to
     // switch to or erase (empty map), and no language left to add
     // (single-language catalog whose only entry is the source language).
     const container = document.createElement("div");
@@ -368,8 +366,8 @@ describe("HkLocalizedInput", () => {
     app.mount(container);
     mounts.push({ app, container });
     expect(queryChip(container).disabled).toBe(false);
-    await openMenu(container);
-    // Only the current language's row remains in the list.
+    await openPicker(container);
+    // Only the current language's tag remains in the list.
     expect(tagLabels()).toEqual(["English"]);
   });
 
@@ -378,7 +376,7 @@ describe("HkLocalizedInput", () => {
       modelValue: "",
       translations: { "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
+    await openPicker(container);
     const body = tagBody("简体中文");
     body!.click();
     await nextTick();
@@ -393,7 +391,7 @@ describe("HkLocalizedInput", () => {
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
+    await openPicker(container);
     const body = tagBody("简体中文");
     body!.click();
     await nextTick();
@@ -407,12 +405,8 @@ describe("HkLocalizedInput", () => {
       modelValue: "Plant overview",
       translations: { en: "Plant overview" },
     });
-    await openMenu(container);
-    const addRow = menuRows().find((r) => (r.textContent ?? "").includes("Add language"));
-    addRow!.click();
-    await nextTick();
-    await nextTick();
-    const jaRow = menuRows().find((r) => (r.textContent ?? "").includes("日本語"));
+    await openPicker(container);
+    const jaRow = pickerRows().find((r) => (r.textContent ?? "").includes("日本語"));
     jaRow!.click();
     await nextTick();
     await nextTick();
@@ -452,9 +446,8 @@ describe("HkLocalizedInput", () => {
     });
     app.mount(container);
     mounts.push({ app, container });
-    await openMenu(container);
-    const row = tag("简体中文");
-    expect(row?.querySelector(".hk-localized-input-tag-flag")?.textContent).toBe("🇨🇳");
+    await openPicker(container);
+    expect(tag("简体中文")?.querySelector(".hk-affix-tag-flag")?.textContent).toBe("🇨🇳");
   });
 
   it("follows a sourceLang change without stealing focus", async () => {
@@ -494,105 +487,54 @@ describe("HkLocalizedInput", () => {
     expect(document.activeElement).not.toBe(queryField(container));
   });
 
-  it("arms only the tapped row and disarms it on a second tap", async () => {
+  it("arms only the tapped tag and disarms on a second tap", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    tagLocale("简体中文")!.click();
+    await openPicker(container);
+    tagX("简体中文")!.click();
     await nextTick();
     expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(true);
     expect(tag("English")?.hasAttribute("data-armed")).toBe(false);
-    // Tapping the same chip again disarms.
-    tagLocale("简体中文")!.click();
+    // Tapping the same × again disarms.
+    tagX("简体中文")!.click();
     await nextTick();
     expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(false);
-    // Arming a sibling disarms the previous row.
-    tagLocale("简体中文")!.click();
+    // Arming a sibling disarms the previous tag.
+    tagX("简体中文")!.click();
     await nextTick();
-    tagLocale("English")!.click();
+    tagX("English")!.click();
     await nextTick();
     expect(tag("English")?.hasAttribute("data-armed")).toBe(true);
     expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(false);
   });
 
-  it("keeps the confirm × out of the tab order until the row is armed", async () => {
+  it("names the tag body by its action and the × by its current step", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    const x = tagX("简体中文")!;
-    // Disarmed: not tabbable, hidden from AT — the arm step is the guard.
-    expect(x.tabIndex).toBe(-1);
-    expect(x.getAttribute("aria-hidden")).toBe("true");
-    // Arm: the × becomes the next tab stop and announces itself.
-    tagLocale("简体中文")!.click();
+    await openPicker(container);
+    expect(tagBody("简体中文")?.getAttribute("aria-label")).toBe("Switch to 简体中文");
+    // Calm × announces the remove; armed × announces the confirm.
+    expect(tagX("简体中文")?.getAttribute("aria-label")).toBe("Remove — 简体中文");
+    tagX("简体中文")!.click();
     await nextTick();
-    expect(x.tabIndex).toBe(0);
-    expect(x.hasAttribute("aria-hidden")).toBe(false);
+    expect(tagX("简体中文")?.getAttribute("aria-label")).toBe("Confirm remove");
   });
 
-  it("swaps the chip for the × in place — one slot, no layout shift", async () => {
+  it("disarms every tag when the popup closes", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    const row = tag("简体中文")!;
-    const slot = row.querySelector(".hk-localized-input-tag-slot")!;
-    // Both controls share the chip's slot; the × overlays it (absolute
-    // in CSS), so arming never reflows the row or slides the label.
-    expect(slot.querySelector(".hk-localized-input-tag-locale")).toBeTruthy();
-    const x = slot.querySelector(".hk-localized-input-tag-x")!;
-    expect(x.getAttribute("aria-hidden")).toBe("true");
-    tagLocale("简体中文")!.click();
-    await nextTick();
-    expect(x.getAttribute("aria-hidden")).toBeNull();
-    expect(row.hasAttribute("data-armed")).toBe(true);
-    // The chip itself stays in the DOM (covered by the ×) — the swap is
-    // purely visual.
-    expect(slot.querySelector(".hk-localized-input-tag-locale")).toBeTruthy();
-  });
-
-  it("names the row body by its action and the arm/confirm controls by their step", async () => {
-    const { container } = mountInput({
-      modelValue: "Plant overview",
-      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
-    });
-    await openMenu(container);
-    expect(tagBody("简体中文")?.getAttribute("aria-label")).toBe("Switch to 简体中文 (zh-Hans)");
-    // The chip labels the ARM step (Remove translation), the × the
-    // confirm step (Confirm delete).
-    expect(tagLocale("简体中文")?.getAttribute("aria-label")).toBe(
-      "Remove translation — 简体中文 (zh-Hans)",
-    );
-    expect(tagX("简体中文")?.getAttribute("aria-label")).toBe(
-      "Confirm delete — 简体中文 (zh-Hans)",
-    );
-    // Arm: the chip relabels to its actual action (cancel), leaves the
-    // tab order, and the × takes the sole tab stop of the slot.
-    tagLocale("简体中文")!.click();
-    await nextTick();
-    expect(tagLocale("简体中文")?.getAttribute("aria-label")).toBe(
-      "Cancel delete — 简体中文 (zh-Hans)",
-    );
-    expect(tagLocale("简体中文")?.tabIndex).toBe(-1);
-    expect(tagX("简体中文")?.tabIndex).toBe(0);
-  });
-
-  it("disarms every row when the menu closes", async () => {
-    const { container } = mountInput({
-      modelValue: "Plant overview",
-      translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
-    });
-    await openMenu(container);
-    tagLocale("简体中文")!.click();
+    await openPicker(container);
+    tagX("简体中文")!.click();
     await nextTick();
     expect(tag("简体中文")?.hasAttribute("data-armed")).toBe(true);
-    // Close the menu, then reopen it: the armed state must not survive —
-    // a stale armed row would turn the next open into an armed delete
+    // Close the popup, then reopen it: the armed state must not survive —
+    // a stale armed tag would turn the next open into an armed delete
     // waiting to fire.
     queryChip(container).click();
     await nextTick();
@@ -604,32 +546,32 @@ describe("HkLocalizedInput", () => {
     expect(tag("English")?.hasAttribute("data-armed")).toBe(false);
   });
 
-  it("erases a non-current translation via arm → confirm × and keeps the menu open", async () => {
+  it("erases a non-current translation via arm → confirm and keeps the popup open", async () => {
     const { events, container } = mountReactive({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    await eraseViaArm(container, "简体中文");
+    await openPicker(container);
+    await eraseViaArm("简体中文");
     // The map loses only the erased language; no edit-state events fire.
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(events.modelValue).toEqual([]);
     expect(events.languagechange).toEqual([]);
     expect(queryField(container).value).toBe("Plant overview");
     expect(queryChip(container).textContent).toContain("English");
-    // The menu STAYS open and the list updates live.
+    // The popup STAYS open and the list updates live.
     expect(tagLabels()).toEqual(["English"]);
-    expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
+    expect(pickerRows().some((r) => (r.textContent ?? "").includes("日本語"))).toBe(true);
   });
 
-  it("erases several translations in one pass while the menu stays open", async () => {
+  it("erases several translations in one pass while the popup stays open", async () => {
     const { events, container } = mountReactive({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览", ja: "プラント概覧" },
     });
-    await openMenu(container);
-    await eraseViaArm(container, "简体中文");
-    await eraseViaArm(container, "日本語");
+    await openPicker(container);
+    await eraseViaArm("简体中文");
+    await eraseViaArm("日本語");
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(tagLabels()).toEqual(["English"]);
   });
@@ -642,20 +584,20 @@ describe("HkLocalizedInput", () => {
     });
     // Switch to zh-Hans first so erasing it means erasing the edited
     // language while the source still holds a translation.
-    await openMenu(container);
+    await openPicker(container);
     tagBody("简体中文")!.click();
     await nextTick();
     await nextTick();
     expect(queryChip(container).textContent).toContain("简体中文");
     expect(queryChip(container).textContent).not.toContain("(zh-Hans)");
-    await openMenu(container);
-    await eraseViaArm(container, "简体中文");
+    await openPicker(container);
+    await eraseViaArm("简体中文");
     expect(events.translations.at(-1)).toEqual({ en: "Plant overview" });
     expect(events.modelValue.at(-1)).toBe("Plant overview");
     expect(events.languagechange.at(-1)).toBe("en");
     expect(queryChip(container).textContent).toContain("English");
     expect(queryChip(container).textContent).not.toContain("(en)");
-    // The menu stays open after an erase.
+    // The popup stays open after an erase.
     expect(tagLabels()).toEqual(["English"]);
   });
 
@@ -665,8 +607,8 @@ describe("HkLocalizedInput", () => {
       sourceLang: "en",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
-    await eraseViaArm(container, "English");
+    await openPicker(container);
+    await eraseViaArm("English");
     expect(events.translations.at(-1)).toEqual({ "zh-Hans": "工厂总览" });
     expect(events.modelValue.at(-1)).toBe("工厂总览");
     expect(events.languagechange.at(-1)).toBe("zh-Hans");
@@ -679,30 +621,28 @@ describe("HkLocalizedInput", () => {
       modelValue: "Plant overview",
       translations: { en: "Plant overview" },
     });
-    await openMenu(container);
-    await eraseViaArm(container, "English");
+    await openPicker(container);
+    await eraseViaArm("English");
     expect(events.translations.at(-1)).toEqual({});
     expect(events.modelValue.at(-1)).toBe("");
-    // The edited language row stays (italic hint); the menu stays open.
+    // The edited language tag stays (active); the popup stays open.
     expect(tagLabels()).toEqual(["English"]);
-    expect(tag("English")?.querySelector(".hk-localized-input-tag-text")?.textContent).toBe(
-      "Enter text in the field",
-    );
-    expect(menuRows().some((r) => (r.textContent ?? "").includes("Add language"))).toBe(true);
+    expect(tag("English")?.hasAttribute("data-active")).toBe(true);
+    expect(pickerRows().some((r) => (r.textContent ?? "").includes("日本語"))).toBe(true);
   });
 
-  it("dismisses the menu when the active row's body is clicked", async () => {
+  it("dismisses the popup when the active tag's body is clicked", async () => {
     const { container } = mountInput({
       modelValue: "Plant overview",
       translations: { en: "Plant overview", "zh-Hans": "工厂总览" },
     });
-    await openMenu(container);
+    await openPicker(container);
     tagBody("English")!.click();
     await nextTick();
     await nextTick();
-    await untilMenuSettled();
-    expect(menuRows().length).toBe(0);
-    expect(menuTags().length).toBe(0);
+    await untilPickerSettled();
+    expect(pickerRows().length).toBe(0);
+    expect(pickerTags().length).toBe(0);
   });
 
   it("multiline renders a textarea with the chip intact", () => {

--- a/packages/vue/src/components/HkLocalizedInput.tsx
+++ b/packages/vue/src/components/HkLocalizedInput.tsx
@@ -1,13 +1,12 @@
 import { computed, defineComponent, nextTick, ref, watch, type PropType } from "vue";
 
-import { ChevronDown, Languages, X } from "lucide-vue-next";
+import { ChevronDown, Languages } from "lucide-vue-next";
 
 import { useI18n } from "../i18n/context";
 
+import HkAffixPicker, { type HkAffixOption } from "./HkAffixPicker";
 import HkBadge from "./HkBadge";
 import HkInput from "./HkInput";
-import HkListTransition from "./HkListTransition";
-import HkMenu, { type HkMenuItem } from "./HkMenu";
 import "./HkLocalizedInput.scss";
 
 /** One selectable language in the editor's language menu. */
@@ -24,9 +23,6 @@ export interface HkLocaleOption {
   flag?: string;
 }
 
-/** Marker key for the "Add language" cascade root (never a real locale). */
-const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
-
 /**
  * HkLocalizedInput — single-field multilingual text editor.
  *
@@ -37,35 +33,27 @@ const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
  * axis), and a small badge-like language chip rides the right edge:
  *
  *   - Click the field itself → normal text editing for the chip's language.
- *   - Click the chip → the language menu (`HkMenu`, so desktop gets an
- *     anchored popout and mobile a bottom-up sheet — identical behavior
- *     to the app-level language switcher). The menu body is a LANGUAGE
- *     LIST — one row per language currently present, INCLUDING the one
- *     being edited (its row carries the active tint and shows an italic
- *     "enter text" hint while it holds no text):
- *       · LEFT side of a row = the already-edited translation text;
- *       · RIGHT side = the same language chip as the closed field —
- *         click it to ARM deletion: the row turns danger-red and an ×
- *         button appears IN PLACE of the chip (no slide, no layout
- *         shift — just an instant swap in the same slot);
- *       · clicking the × erases the translation for real. On TOUCH the
- *         arm is the guard (tap the chip, then tap the × that appears);
- *         on DESKTOP hovering the row swaps in the × and a single click
- *         on it erases — the hover IS the preview, the click the
- *         confirm. The menu stays open so several translations can be
- *         wiped in one pass; the list updates live with squeeze-in /
- *         squeeze-out list transitions (HkListTransition, which reports
- *         to the animation context and honors reduced motion). Deleting
- *         the language being edited moves the field to `sourceLang` if
- *         that still holds a translation, else to the first remaining
- *         translation (or `sourceLang` itself once the map is empty);
- *       · an "Add language" cascade into the full locale catalog; picking
- *         one closes the menu and drops the field straight into edit
- *         state for the freshly added language.
+ *   - Click the chip → the shared HkAffixPicker (multi-select, right
+ *     anchored, closes on pick so the field is immediately editable):
+ *       · a TAG LIST of every language currently present — the one being
+ *         edited carries the active dot. The × on a tag arms the delete
+ *         (danger tint) and a second tap erases; the popup stays open
+ *         after removals so several translations can be wiped in one
+ *         pass, with squeeze-in / squeeze-out list transitions
+ *         (HkListTransition, animation-context aware);
+ *       · a SEARCHABLE list of the languages NOT yet present — typing
+ *         filters, picking adds the language and drops the field
+ *         straight into edit state for it. This replaces the old
+ *         "Add language" cascade: same coverage, one fewer navigation
+ *         step, and it scales to large locale catalogs.
+ *
+ *   - Deleting the language being edited moves the field to `sourceLang`
+ *     if that still holds a translation, else to the first remaining
+ *     translation (or `sourceLang` itself once the map is empty).
  *
  * The chip shows ONLY the language label (the app-provided autonym,
  * e.g. "简体中文"); the locale code appears ONLY inside the opened menu
- * (as a small suffix on each tag) so the code never burns space inside
+ * (as a muted suffix on each tag) so the code never burns space inside
  * the field. The popup participates in the shared modal/dropdown stacking
  * contexts via HkMenu's popup-manager integration — safe inside modals.
  *
@@ -82,7 +70,7 @@ const ADD_LANGUAGE_KEY = "__hkLocalizedInputAdd";
  *   - switching languages commits the current text, swaps `modelValue`
  *     to the target language's stored text ("" when none), and refocuses
  *     the field.
- *   - erasing a language via the armed × emits `update:translations`
+ *   - erasing a language via its armed × emits `update:translations`
  *     without that key; erasing the language being edited additionally
  *     swaps `modelValue` and emits `languagechange` for the fallback
  *     language (sourceLang first, then the first remaining translation,
@@ -127,18 +115,7 @@ export const HkLocalizedInput = defineComponent({
     const { t } = useI18n();
 
     const editLang = ref(props.sourceLang);
-    const menuOpen = ref(false);
-    const chipRef = ref<HTMLElement | null>(null);
     const rootRef = ref<HTMLElement | null>(null);
-    /** Code of the tag whose delete is ARMED (chip tapped but the × not
-     *  confirmed yet). At most one row is armed at a time. */
-    const armedCode = ref<string | null>(null);
-
-    // Closing the menu disarms any armed row — the next open starts
-    // calm instead of showing a red delete waiting to fire.
-    watch(menuOpen, (open) => {
-      if (!open) armedCode.value = null;
-    });
 
     // Follow the app locale: whenever the parent's sourceLang changes
     // (the app-level language switch moved), commit the current text
@@ -167,44 +144,26 @@ export const HkLocalizedInput = defineComponent({
      *  code appears only inside the opened menu. */
     const chipLabel = computed(() => localeLabel(editLang.value));
 
-    /** Catalog entries not yet present in the translations map (and not
-     *  currently being edited) — the "Add language" cascade children. */
-    const addableOptions = computed(() =>
-      props.localeOptions.filter(
-        (o) =>
-          o.code !== editLang.value &&
-          !filledCodes.value.includes(o.code),
-      ),
-    );
-
-    /** The menu's action rows: only the "Add language" cascade remains —
-     *  existing translations live in the tag list above it. */
-    const menuItems = computed<HkMenuItem[]>(() =>
-      addableOptions.value.length > 0
-        ? [
-            {
-              key: ADD_LANGUAGE_KEY,
-              label: t("hikari::localizedInput.addLanguage", "Add language"),
-              children: addableOptions.value.map((o) => ({
-                key: o.code,
-                label: `${localeLabel(o.code)} (${o.code})`,
-                flag: o.flag,
-              })),
-            },
-          ]
-        : [],
-    );
-
-    /** Rows of the language list: EVERY language that holds a translation
-     *  — the currently edited one included, even while it is still empty.
+    /** Tags of the picker: EVERY language that holds a translation —
+     *  the currently edited one included, even while it is still empty.
      *  Filled entries keep their insertion order; the edited language is
      *  appended when it has no text yet (or moves with the order it was
      *  filled in otherwise). */
-    const langRows = computed(() => {
+    const selectedCodes = computed<readonly string[]>(() => {
       const codes = [...filledCodes.value];
       if (!codes.includes(editLang.value)) codes.push(editLang.value);
       return codes;
     });
+
+    /** Catalog entries not yet present — the picker's add rows. */
+    const addableCount = computed(
+      () =>
+        props.localeOptions.filter(
+          (o) =>
+            o.code !== editLang.value &&
+            !filledCodes.value.includes(o.code),
+        ).length,
+    );
 
     /** The chip is useful while ANY interaction remains: at least one
      *  row to switch to / erase, or one language left to add. */
@@ -212,37 +171,20 @@ export const HkLocalizedInput = defineComponent({
       () =>
         props.disabled ||
         (filledCodes.value.length === 0 &&
-          addableOptions.value.length === 0 &&
-          langRows.value.length <= 1),
+          addableCount.value === 0 &&
+          selectedCodes.value.length <= 1),
     );
 
-    /** Accessible label of a row's language chip: arming the delete for
-     *  this language (the × that then appears confirms it). */
-    function armLabel(code: string): string {
-      return `${t("hikari::localizedInput.removeTranslation", "Remove translation")} — ${localeLabel(code)} (${code})`;
-    }
-
-    /** Accessible label of the SAME chip while the row is armed: clicking
-     *  it again cancels — the label must follow the actual action (the ×
-     *  on top of it owns the confirm). */
-    function cancelLabel(code: string): string {
-      return `${t("hikari::localizedInput.cancelDelete", "Cancel delete")} — ${localeLabel(code)} (${code})`;
-    }
-
-    /** Accessible label of the confirm ×: erases the translation for
-     *  real after the arm step. */
-    function confirmLabel(code: string): string {
-      return `${t("hikari::localizedInput.confirmDelete", "Confirm delete")} — ${localeLabel(code)} (${code})`;
-    }
-
-    /** Accessible name of a row body: the control switches the field to
-     *  that language — the raw translation text is visible content (and
-     *  the empty hint reads as a passive prompt, not the action), so the
-     *  name must identify the ACTION (title is ignored by the accname
-     *  algorithm once the element has text content). */
-    function switchLabel(code: string): string {
-      return `${t("hikari::localizedInput.switchLanguage", "Switch to")} ${localeLabel(code)} (${code})`;
-    }
+    /** The shared picker catalog: autonym label, locale code as the
+     *  muted meta suffix, flag when the app provides one. */
+    const affixOptions = computed<readonly HkAffixOption[]>(() =>
+      props.localeOptions.map((o) => ({
+        key: o.code,
+        label: o.label,
+        meta: o.code,
+        flag: o.flag,
+      })),
+    );
 
     function commitTranslations(code: string, value: string) {
       const next = { ...props.translations };
@@ -265,61 +207,50 @@ export const HkLocalizedInput = defineComponent({
     function focusField() {
       nextTick(() => {
         // HkInput does not expose a focus method; its element is the
-        // only input/textarea inside this component's root (the menu
+        // only input/textarea inside this component's root (the popup
         // teleports to body), so a scoped query resolves it reliably.
         const el = rootRef.value?.querySelector<HTMLElement>("input, textarea");
         el?.focus();
       });
     }
 
-    /** Switch the edited language (row body or freshly added one):
+    /** Switch the edited language (tag body or a freshly added one):
      *  commit the current text, swap the field to the target language,
-     *  close the menu, and resume editing focused. */
+     *  close the picker, and resume editing focused. */
     function switchLanguage(code: string, opts: { viaWatch?: boolean } = {}) {
-      if (!code || code === ADD_LANGUAGE_KEY) return;
+      if (!code) return;
       if (code === editLang.value) {
-        // Already editing it (row body click on the active row): just
-        // dismiss the menu and hand focus back to the field.
+        // Already editing it (tag body click on the active tag): just
+        // dismiss the picker and hand focus back to the field.
         if (!opts.viaWatch) {
-          menuOpen.value = false;
           focusField();
         }
         return;
       }
       commitTranslations(editLang.value, props.modelValue);
       editLang.value = code;
-      armedCode.value = null;
       emit("update:modelValue", (props.translations[code] ?? "").trim());
       if (!opts.viaWatch) {
-        menuOpen.value = false;
         focusField();
       }
       emit("languagechange", code);
     }
 
-    /** Arm (or disarm) a row's delete: the chip click turns the row red
-     *  and swaps the chip slot for the confirm ×. One armed row at a
-     *  time — arming a sibling disarms the previous one. */
-    function toggleArm(code: string) {
-      armedCode.value = armedCode.value === code ? null : code;
-    }
-
-    /** Erase a language's translation via its armed row's ×: drop the key
+    /** Erase a language's translation via its armed tag ×: drop the key
      *  from `translations`, and when the erased language is the one
      *  being edited move the field to a fallback — the source language
      *  if it still holds a translation, else the first remaining
      *  translation, else the source language itself. Erasing another
-     *  language never disturbs the edit state. The menu STAYS open so
-     *  the list updates live (with the squeeze-out transition) and
-     *  further rows can be erased. */
+     *  language never disturbs the edit state. The picker STAYS open so
+     *  the tag list updates live (with the squeeze-out transition) and
+     *  further tags can be erased. */
     function eraseLanguage(code: string) {
-      // A ghost row (mid-leave after an earlier erase, or a stale × from
-      // a parent re-render) can still be clicked — erasing an already
-      // absent key must not re-emit or disturb the edit state.
+      // A ghost tag (mid-leave after an earlier erase, or a stale ×
+      // from a parent re-render) can still be clicked — erasing an
+      // already absent key must not re-emit or disturb the edit state.
       if (!(code in props.translations)) return;
       const next = { ...props.translations };
       delete next[code];
-      armedCode.value = null;
       emit("update:translations", next);
       if (code === editLang.value) {
         const remaining = Object.keys(next).filter(
@@ -335,12 +266,7 @@ export const HkLocalizedInput = defineComponent({
       }
     }
 
-    function onMenuSelect(key: string) {
-      switchLanguage(key);
-    }
-
     return () => {
-      const rows = langRows.value;
       return (
         <div class="hk-localized-input" ref={rootRef} data-multiline={props.multiline || undefined}>
           <HkInput
@@ -360,150 +286,42 @@ export const HkLocalizedInput = defineComponent({
                 <Languages size={15} class="hk-localized-input-lead" aria-hidden="true" />
               ),
               suffix: () => (
-                <button
-                  ref={(el: unknown) => {
-                    chipRef.value = (el as HTMLElement) ?? null;
-                  }}
-                  type="button"
-                  class="hk-localized-input-chip"
+                <HkAffixPicker
+                  options={affixOptions.value}
+                  mode="multi"
+                  side="suffix"
+                  selected={selectedCodes.value}
+                  activeKey={editLang.value}
                   disabled={chipDisabled.value}
-                  data-empty={filledCodes.value.length === 0 || undefined}
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen.value}
-                  aria-label={t(
+                  closeOnSelect={true}
+                  chipClass="hk-localized-input-chip"
+                  chipLabel={t(
                     "hikari::localizedInput.chooseLanguage",
                     "Choose editing language",
                   )}
-                  onClick={(e: MouseEvent) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    menuOpen.value = !menuOpen.value;
-                  }}
-                  onMousedown={(e: MouseEvent) => e.preventDefault()}
+                  title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
+                  searchPlaceholder={t(
+                    "hikari::localizedInput.addLanguage",
+                    "Add language",
+                  )}
+                  emptyText={t("hikari::localizedInput.noMatches", "No matching language")}
+                  onSelect={(code: string) => switchLanguage(code)}
+                  onRemove={(code: string) => eraseLanguage(code)}
                 >
-                  <HkBadge variant="primary" size="sm" class="hk-localized-input-chip-badge">
-                    {chipLabel.value}
-                  </HkBadge>
-                  <ChevronDown size={12} class="hk-localized-input-chip-caret" />
-                </button>
+                  {{
+                    chip: () => (
+                      <>
+                        <HkBadge variant="primary" size="sm" class="hk-localized-input-chip-badge">
+                          {chipLabel.value}
+                        </HkBadge>
+                        <ChevronDown size={12} class="hk-localized-input-chip-caret" />
+                      </>
+                    ),
+                  }}
+                </HkAffixPicker>
               ),
             }}
           </HkInput>
-          <HkMenu
-            variant="popup"
-            items={menuItems.value}
-            open={menuOpen.value}
-            onUpdate:open={(v: boolean) => {
-              menuOpen.value = v;
-            }}
-            onSelect={onMenuSelect}
-            anchorRef={chipRef.value}
-            placement="bottom-end"
-            title={t("hikari::localizedInput.chooseLanguage", "Choose editing language")}
-          >
-            {{
-              header: () => (
-                <div
-                  class="hk-localized-input-tags"
-                  role="group"
-                  aria-label={t(
-                    "hikari::localizedInput.translations",
-                    "Existing translations",
-                  )}
-                >
-                  <HkListTransition
-                    tag="div"
-                    variant="reveal"
-                    move
-                    appear
-                    class="hk-localized-input-tag-list"
-                  >
-                    {rows.map((code) => {
-                    const active = code === editLang.value;
-                    const option = props.localeOptions.find((o) => o.code === code);
-                    const value = (props.translations[code] ?? "").trim();
-                    return (
-                      <div
-                        key={code}
-                        class="hk-localized-input-tag"
-                        data-active={active || undefined}
-                        data-armed={armedCode.value === code || undefined}
-                      >
-                        <button
-                          type="button"
-                          class="hk-localized-input-tag-body"
-                          title={`${localeLabel(code)} (${code})`}
-                          aria-label={switchLabel(code)}
-                          onClick={() => switchLanguage(code)}
-                        >
-                          {option?.flag && (
-                            <span class="hk-localized-input-tag-flag">{option.flag}</span>
-                          )}
-                          <span
-                            class="hk-localized-input-tag-text"
-                            data-empty={!value || undefined}
-                          >
-                            {value ||
-                              t(
-                                "hikari::localizedInput.emptyRow",
-                                "Enter text in the field",
-                              )}
-                          </span>
-                        </button>
-                        <span class="hk-localized-input-tag-slot">
-                          <button
-                            type="button"
-                            class="hk-localized-input-tag-locale"
-                            aria-label={armedCode.value === code ? cancelLabel(code) : armLabel(code)}
-                            title={armedCode.value === code ? cancelLabel(code) : armLabel(code)}
-                            // While armed the confirm × covers this chip and
-                            // owns the confirmation; the chip becomes the
-                            // cancel control — and leaves the tab order (the
-                            // × takes its tab stop) so the armed row exposes
-                            // exactly one actionable control at a time.
-                            tabindex={armedCode.value === code ? -1 : 0}
-                            onClick={(e: MouseEvent) => {
-                              e.stopPropagation();
-                              toggleArm(code);
-                            }}
-                            onMousedown={(e: MouseEvent) => e.preventDefault()}
-                          >
-                            <span class="hk-localized-input-tag-label">{localeLabel(code)}</span>
-                            <span class="hk-localized-input-tag-code">{code}</span>
-                            {active && (
-                              <span class="hk-localized-input-tag-dot" aria-hidden="true" />
-                            )}
-                          </button>
-                          <button
-                            type="button"
-                            class="hk-localized-input-tag-x"
-                            aria-label={confirmLabel(code)}
-                            title={confirmLabel(code)}
-                            // Hidden via CSS until armed/hovered; keep it out
-                            // of the tab order while it is invisible, so
-                            // keyboard users cannot fire the delete on an
-                            // unseen control — the chip arms first, then the
-                            // × becomes the next tab stop (focus-visible
-                            // reveals it, see scss). It OVERLAYS the chip in
-                            // the same slot: the row never reflows.
-                            tabindex={armedCode.value === code ? 0 : -1}
-                            aria-hidden={armedCode.value === code ? undefined : true}
-                            onClick={(e: MouseEvent) => {
-                              e.stopPropagation();
-                              eraseLanguage(code);
-                            }}
-                          >
-                            <X size={11} />
-                          </button>
-                        </span>
-                      </div>
-                    );
-                  })}
-                  </HkListTransition>
-                </div>
-              ),
-            }}
-          </HkMenu>
         </div>
       );
     };

--- a/packages/vue/src/components/HkPhoneInput.scss
+++ b/packages/vue/src/components/HkPhoneInput.scss
@@ -5,32 +5,12 @@
 }
 
 /* The dial-code chip riding the field's LEFT edge — flag glyph + "+86"
- * + caret, mirroring the language-tag chip pattern of HkLocalizedInput
- * (which rides the right edge). A button so it is focusable and
- * AT-reachable; mousedown is suppressed in TSX so clicking it never
- * steals focus from the number field before the menu opens. */
+ * + caret, layered on the shared .hk-affix-chip base (hover, disabled,
+ * focus handling live there). A button so it is focusable and
+ * AT-reachable; mousedown is suppressed in the shared picker so
+ * clicking it never steals focus from the number field. */
 .hk-phone-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
   max-width: 11rem;
-  padding: 2px 6px 2px 4px;
-  border: none;
-  border-radius: var(--radius-sm, 6px);
-  background: transparent;
-  color: rgb(var(--color-text));
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease;
-
-  &:hover:not(:disabled),
-  &:focus-visible:not(:disabled) {
-    background: rgb(var(--color-primary) / 14%);
-  }
-
-  &:disabled {
-    cursor: default;
-    opacity: 0.6;
-  }
 }
 
 .hk-phone-chip-flag {
@@ -53,88 +33,4 @@
 .hk-phone-chip-caret {
   flex: none;
   color: rgb(var(--color-muted));
-}
-
-/* ── country list (menu) ────────────────────────────────────────────
- * The search box caps the menu header; rows below it scroll inside the
- * popup/sheet list surface (HkSelectPanel caps and scrolls the popout,
- * and the mobile sheet body scrolls natively). */
-.hk-phone-dial-search {
-  padding: 8px 10px 6px;
-}
-
-.hk-phone-dial-list {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding: 4px 6px 8px;
-  /* Roomier than the 2px HkMenu gutter so rows read as a picker. */
-  min-width: 13rem;
-  max-width: min(19rem, calc(100vw - 2rem));
-}
-
-.hk-phone-dial-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  min-height: 2.25rem;
-  padding: 4px 8px;
-  border: none;
-  border-radius: var(--radius-sm, 6px);
-  background: transparent;
-  color: rgb(var(--color-text));
-  font-size: var(--text-sm, 14px);
-  text-align: left;
-  cursor: pointer;
-  appearance: none;
-  transition: background 0.1s ease;
-
-  &:hover,
-  &:focus-visible {
-    background: rgb(var(--color-primary) / 10%);
-    outline: none;
-  }
-
-  &[data-active] {
-    background: rgb(var(--color-primary) / 16%);
-    font-weight: 600;
-  }
-}
-
-.hk-phone-dial-flag {
-  flex: none;
-  font-size: calc(var(--text-base, 15px) * 1.05);
-  line-height: 1;
-  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
-    sans-serif;
-}
-
-.hk-phone-dial-name {
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.hk-phone-dial-code {
-  flex: none;
-  color: rgb(var(--color-muted));
-  font-size: calc(var(--text-sm, 14px) * 0.9);
-  font-variant-numeric: tabular-nums;
-}
-
-.hk-phone-dial-empty {
-  padding: 14px 12px;
-  color: rgb(var(--color-muted));
-  font-size: var(--text-sm, 14px);
-  text-align: center;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hk-phone-chip,
-  .hk-phone-dial-row {
-    transition: none;
-  }
 }

--- a/packages/vue/src/components/HkPhoneInput.test.tsx
+++ b/packages/vue/src/components/HkPhoneInput.test.tsx
@@ -72,7 +72,7 @@ async function openPicker(container: HTMLElement) {
 }
 
 function pickerRows(): HTMLElement[] {
-  return [...document.querySelectorAll<HTMLButtonElement>(".hk-phone-dial-row")];
+  return [...document.querySelectorAll<HTMLButtonElement>(".hk-affix-row")];
 }
 
 describe("HkPhoneInput", () => {

--- a/packages/vue/src/components/HkPhoneInput.tsx
+++ b/packages/vue/src/components/HkPhoneInput.tsx
@@ -1,6 +1,6 @@
 import { computed, defineComponent, nextTick, ref, useAttrs, watch, type PropType } from "vue";
 
-import { ChevronDown, Search } from "lucide-vue-next";
+import { ChevronDown } from "lucide-vue-next";
 
 import { useI18n } from "../i18n/context";
 
@@ -14,18 +14,19 @@ import {
   type DialCodeEntry,
 } from "../data/dialCodes";
 
+import HkAffixPicker, { type HkAffixOption } from "./HkAffixPicker";
 import HkInput from "./HkInput";
-import HkMenu from "./HkMenu";
 import "./HkPhoneInput.scss";
 
 /**
  * HkPhoneInput — phone-number field with a country dial-code picker.
  *
- * Mirrors the language-tag chip pattern of HkLocalizedInput but for
- * dial codes: a leading chip inside the field (flag glyph + "+86" +
- * caret) opens a searchable country list. The chip rides the LEFT edge
- * of the field — the natural reading order for "which country, then
- * which number" — while the number itself is typed after it.
+ * A leading chip inside the field (flag glyph + "+86" + caret) opens
+ * the shared HkAffixPicker (single-select, searchable): flag + country
+ * name + dial code per row, live filter on top. The chip rides the
+ * LEFT edge of the field — the natural reading order for "which
+ * country, then which number" — while the number itself is typed after
+ * it.
  *
  *   - `modelValue` is the NATIONAL number only ("13812345678"); the
  *     country selection lives in `dialCode` ("+86" shape, normalized on
@@ -34,11 +35,6 @@ import "./HkPhoneInput.scss";
  *   - The chip shows the resolved country's flag plus the dial code in
  *     canonical "+…" shape. Unknown dial codes fall back to showing
  *     the normalized code alone (no flag).
- *   - The picker menu (`HkMenu`, desktop popout + mobile bottom sheet)
- *     lists the catalog in its defined order, flag + localized name +
- *     dial code per row, with a live filter field on top. Filtering
- *     matches the country's English/Chinese name, its ISO code, and
- *     the bare dial digits ("86", "0086" or "86" both hit China).
  *   - Picking a row emits `update:dialCode` ("+…"), `dialchange`
  *     (same value) and refocuses the number field. Blurring the field
  *     emits `change` with the composed E.164 — use it to validate or
@@ -93,15 +89,7 @@ export const HkPhoneInput = defineComponent({
     const { t, locale } = useI18n();
     const attrs = useAttrs();
 
-    const menuOpen = ref(false);
-    const chipRef = ref<HTMLElement | null>(null);
     const rootRef = ref<HTMLElement | null>(null);
-    const query = ref("");
-
-    // A fresh open starts with an empty filter.
-    watch(menuOpen, (open) => {
-      if (!open) query.value = "";
-    });
 
     /** Canonical "+86" derived from the prop, whatever shape it is in. */
     const canonicalDial = computed(() => {
@@ -115,28 +103,27 @@ export const HkPhoneInput = defineComponent({
       resolveDial(props.dialCode, undefined, props.countries),
     );
 
-    /** Searchable rows: filter against en/zh names, ISO code, dial. */
-    const filteredRows = computed(() => {
-      const q = query.value.trim().toLowerCase();
-      const qDial = q.replace(/\D/g, "");
-      if (!q) return props.countries;
-      return props.countries.filter((c) => {
-        if (c.iso.toLowerCase().includes(q)) return true;
-        if (qDial && c.dial.includes(qDial)) return true;
-        return (
-          c.en.toLowerCase().includes(q) ||
-          c.zh.toLowerCase().includes(q)
-        );
-      });
-    });
+    /** Picker rows come from the shared affix catalog shape; the
+     *  keywords haystack keeps the old filter reach: en/zh names, ISO
+     *  code, bare and zero-prefixed dial digits ("86"/"0086"). */
+    const dialOptions = computed<readonly HkAffixOption[]>(() =>
+      props.countries.map((c) => ({
+        key: c.iso,
+        label: dialCodeName(c, locale),
+        meta: `+${c.dial}`,
+        flag: flagEmoji(c.iso),
+        keywords: `${c.en} ${c.zh} ${c.iso} +${c.dial} 00${c.dial}`,
+      })),
+    );
 
-    function pickCountry(entry: DialCodeEntry) {
+    function pickCountry(iso: string) {
+      const entry = props.countries.find((c) => c.iso === iso);
+      if (!entry) return;
       const dial = `+${entry.dial}`;
-      menuOpen.value = false;
       emit("update:dialCode", dial);
       emit("dialchange", dial);
       // Refocus the number field so pick-then-type flows without a
-      // second tap (the chip's menu is the only focusable sibling).
+      // second tap (the chip's popup is the only focusable sibling).
       nextTick(() => {
         const el = rootRef.value?.querySelector<HTMLElement>("input");
         el?.focus();
@@ -162,7 +149,6 @@ export const HkPhoneInput = defineComponent({
     }
 
     return () => {
-      const rows = filteredRows.value;
       const active = activeEntry.value;
       const nameFor = (entry: DialCodeEntry) =>
         dialCodeName(entry, locale);
@@ -194,113 +180,41 @@ export const HkPhoneInput = defineComponent({
           >
             {{
               prefix: () => (
-                <button
-                  ref={(el: unknown) => {
-                    chipRef.value = (el as HTMLElement) ?? null;
-                  }}
-                  type="button"
-                  class="hk-phone-chip"
+                <HkAffixPicker
+                  options={dialOptions.value}
+                  mode="single"
+                  side="prefix"
+                  selected={active?.iso ?? ""}
                   disabled={props.disabled || props.readonly}
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen.value}
-                  aria-label={t(
-                    "hikari::phoneInput.chooseCountry",
-                    "Choose country code",
+                  chipClass="hk-phone-chip"
+                  chipLabel={
+                    active
+                      ? `${nameFor(active)} ${chipLabel()} — ${t("hikari::phoneInput.chooseCountry", "Choose country code")}`
+                      : t("hikari::phoneInput.chooseCountry", "Choose country code")
+                  }
+                  title={t("hikari::phoneInput.chooseCountry", "Choose country code")}
+                  searchPlaceholder={t(
+                    "hikari::phoneInput.searchCountries",
+                    "Search country or code",
                   )}
-                  title={active ? `${nameFor(active)} ${chipLabel()}` : chipLabel()}
-                  onMousedown={(e: MouseEvent) => e.preventDefault()}
-                  onClick={(e: MouseEvent) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (!props.disabled && !props.readonly) {
-                      menuOpen.value = !menuOpen.value;
-                    }
-                  }}
+                  emptyText={t("hikari::phoneInput.noMatches", "No matching country")}
+                  onSelect={pickCountry}
                 >
-                  <span class="hk-phone-chip-flag" aria-hidden="true">
-                    {active ? flagEmoji(active.iso) : ""}
-                  </span>
-                  <span class="hk-phone-chip-dial">{chipLabel()}</span>
-                  <ChevronDown size={12} class="hk-phone-chip-caret" aria-hidden="true" />
-                </button>
+                  {{
+                    chip: () => (
+                      <>
+                        <span class="hk-phone-chip-flag" aria-hidden="true">
+                          {active ? flagEmoji(active.iso) : ""}
+                        </span>
+                        <span class="hk-phone-chip-dial">{chipLabel()}</span>
+                        <ChevronDown size={12} class="hk-phone-chip-caret" aria-hidden="true" />
+                      </>
+                    ),
+                  }}
+                </HkAffixPicker>
               ),
             }}
           </HkInput>
-          <HkMenu
-            variant="popup"
-            items={[]}
-            open={menuOpen.value}
-            onUpdate:open={(v: boolean) => {
-              menuOpen.value = v;
-            }}
-            anchorRef={chipRef.value}
-            placement="bottom-start"
-            matchAnchorWidth={false}
-            title={t("hikari::phoneInput.chooseCountry", "Choose country code")}
-          >
-            {{
-              header: () => (
-                <div class="hk-phone-dial-search" role="search">
-                  <HkInput
-                    modelValue={query.value}
-                    onUpdate:modelValue={(v: string) => {
-                      query.value = v;
-                    }}
-                    size="sm"
-                    placeholder={t(
-                      "hikari::phoneInput.searchCountries",
-                      "Search country or code",
-                    )}
-                    aria-label={t(
-                      "hikari::phoneInput.searchCountries",
-                      "Search country or code",
-                    )}
-                    autocomplete="off"
-                    onKeydown={(e: KeyboardEvent) => {
-                      // Enter picks the first filtered row.
-                      if (e.key === "Enter" && !e.isComposing && rows.length > 0) {
-                        e.preventDefault();
-                        pickCountry(rows[0]);
-                      }
-                    }}
-                  >
-                    {{
-                      prefixIcon: () => (
-                        <Search size={13} aria-hidden="true" />
-                      ),
-                    }}
-                  </HkInput>
-                </div>
-              ),
-              default: () =>
-                rows.length > 0 ? (
-                  <div class="hk-phone-dial-list">
-                    {rows.map((entry) => {
-                      const selected = entry.iso === active?.iso;
-                      return (
-                        <button
-                          key={entry.iso}
-                          type="button"
-                          class="hk-phone-dial-row"
-                          data-active={selected || undefined}
-                          onClick={() => pickCountry(entry)}
-                        >
-                          <span class="hk-phone-dial-flag" aria-hidden="true">
-                            {flagEmoji(entry.iso)}
-                          </span>
-                          <span class="hk-phone-dial-name">{nameFor(entry)}</span>
-                          <span class="hk-phone-dial-code">+{entry.dial}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                ) : (
-                  <div class="hk-phone-dial-empty">
-                    {t("hikari::phoneInput.noMatches", "No matching country")}
-                  </div>
-                ),
-            }}
-          </HkMenu>
         </div>
       );
     };

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -152,5 +152,15 @@
     "hikari::phoneInput.chooseCountry": "Choose country code",
     "hikari::phoneInput.searchCountries": "Search country or code",
     "hikari::phoneInput.noMatches": "No matching country"
-  }
+  },
+  "hikari::affixPicker.title": "Options",
+  "hikari::affixPicker.search": "Search",
+  "hikari::affixPicker.empty": "No matches",
+  "hikari::affixPicker.selected": "Selected",
+  "hikari::affixPicker.selectedCount": "{count} selected",
+  "hikari::affixPicker.switchTo": "Switch to",
+  "hikari::affixPicker.remove": "Remove",
+  "hikari::affixPicker.confirmDelete": "Confirm remove",
+  "hikari::affixPicker.useCustom": "Use \"{query}\"",
+  "hikari::localizedInput.noMatches": "No matching language"
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -156,5 +156,15 @@
     "hikari::phoneInput.chooseCountry": "选择国家区号",
     "hikari::phoneInput.searchCountries": "搜索国家或区号",
     "hikari::phoneInput.noMatches": "没有匹配的国家"
-  }
+  },
+  "hikari::affixPicker.title": "选项",
+  "hikari::affixPicker.search": "搜索",
+  "hikari::affixPicker.empty": "没有匹配项",
+  "hikari::affixPicker.selected": "已选择",
+  "hikari::affixPicker.selectedCount": "已选 {count} 项",
+  "hikari::affixPicker.switchTo": "切换到",
+  "hikari::affixPicker.remove": "移除",
+  "hikari::affixPicker.confirmDelete": "确认移除",
+  "hikari::affixPicker.useCustom": "使用「{query}」",
+  "hikari::localizedInput.noMatches": "没有匹配的语言"
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -156,5 +156,15 @@
     "hikari::phoneInput.chooseCountry": "選擇國家區碼",
     "hikari::phoneInput.searchCountries": "搜尋國家或區碼",
     "hikari::phoneInput.noMatches": "沒有符合的國家"
-  }
+  },
+  "hikari::affixPicker.title": "選項",
+  "hikari::affixPicker.search": "搜尋",
+  "hikari::affixPicker.empty": "沒有符合項目",
+  "hikari::affixPicker.selected": "已選擇",
+  "hikari::affixPicker.selectedCount": "已選 {count} 項",
+  "hikari::affixPicker.switchTo": "切換到",
+  "hikari::affixPicker.remove": "移除",
+  "hikari::affixPicker.confirmDelete": "確認移除",
+  "hikari::affixPicker.useCustom": "使用「{query}」",
+  "hikari::localizedInput.noMatches": "沒有符合的語言"
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -35,6 +35,7 @@ export { default as HNavItem } from "./components/HkNavItem";
 export { default as HNumberInput } from "./components/HkNumberInput";
 export { default as HPasswordInput } from "./components/HkPasswordInput";
 export { default as HPhoneInput } from "./components/HkPhoneInput";
+export { default as HAffixPicker, type HkAffixOption } from "./components/HkAffixPicker";
 export { default as HPhaseTransition } from "./components/HkPhaseTransition";
 export { default as HGaugeRing } from "./components/HkGaugeRing";
 export { default as HProgressRing } from "./components/HkProgressRing";


### PR DESCRIPTION
## What

New shared component **HkAffixPicker** (`HAffixPicker`): the standardized
"affix chip + searchable popup list" control, plus refactors of both
existing chip-picking fields onto it.

### HkAffixPicker
- A chip (prefix or suffix of any `HkInput` via the affix slot) opens one
  canonical popup: live SEARCH over label/meta/keywords, standardized
  option rows (flag + label + muted meta), and an optional
  `allowCustom` "Use <query>" row for free-text entries (Enter picks the
  first row, or the custom row when nothing matches).
- **single** mode (default): check-marked active row, closes on pick.
- **multi** mode: selected entries render as TAGS above the search with
  the shared arm-delete guard (× arms on first tap, confirms on second;
  popup stays open for batch adds/removals); rows list the
  not-yet-selected options; `closeOnSelect` overridable; `activeKey`
  marks the tag currently being acted on.
- Host owns all state (keys in, `select`/`remove`/`custom` events out);
  chip visuals come from the scoped `chip` slot — the same component
  serves dial codes, translation languages, git platform prefixes, or
  any future "constrained value behind a chip" field.

### Refactors (public APIs unchanged)
- **HkPhoneInput**: dial-code chip + country list now ride the picker
  (single, prefix, searchable). Behavior preserved: E.164 on blur,
  pick-then-type refocus, dial/keyword search reach ("86"/"0086").
- **HkLocalizedInput**: language chip now opens the picker (multi,
  suffix, closes on pick). The "Add language" cascade is replaced by a
  SEARCHABLE add list (same coverage, one fewer navigation step); tags
  keep the active dot, flags, muted code suffix and the two-step ×
  delete. Two deliberate simplifications: the translation text no
  longer renders inside the tag (the autonym + code do), and the
  empty-translation italic hint is dropped (the active dot plus the
  visibly empty field carry the state).

i18n: new `hikari::affixPicker.*` keys (en / zh-Hans / zh-Hant) +
`localizedInput.noMatches`. Version → 0.33.0.

## Verification
- vue-tsc clean; full suite 750/752 — the 2 failures are the
  pre-existing master ones (registerAnimations, HkDatePicker, documented
  in #369).
- 45 tests cover the new component and both refactors (15 in
  HkAffixPicker.test.tsx incl. search/custom/arm/aria; updated
  localized + phone suites).