### PR TITLE
📦 Release HkBoard in packages/vue 0.35.0.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
0.34.0 已被并行的 #374 抢先占用发布，HkBoard（#375，f629b44d）合入晚于该 tag——0.35.0 是携带画板原语的首个发布版本。纯版本抬号。