### PR TITLE
🐛 Stop the minimap surface from claiming drag gestures on touch inputs.

### DIFF
--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -11,6 +11,10 @@
   cursor: pointer;
   overflow: hidden;
   pointer-events: auto;
+  /* The minimap owns its own drag gestures — the surrounding pannable
+     surface must never claim them (mobile browsers would otherwise fire
+     pointercancel and kill the drag). */
+  touch-action: none;
 
   &:hover {
     border-color: rgb(var(--color-primary) / 0.3);


### PR DESCRIPTION
## Summary
- Sets `touch-action: none` on the HkMinimap root surface so the minimap owns its own drag gestures; on mobile browsers the surrounding pannable surface otherwise claims the gesture and fires `pointercancel`, killing the drag mid-move.
- Discovered during the 2026-09-03 workspace audit: the fix existed only as an uncommitted WIP in the main checkout (rescued via `git stash`, now landed here). `HkBoard.scss` already sets the same property for the board canvas (#375); the embedded minimap in `HkImageViewer` remained uncovered.

## Test plan
- [x] SCSS-only change; no behavior change on pointer/mouse input paths
- [ ] CI lint + build gates