### PR TITLE
🐛 Stop failing crates.io publish when release tags carry npm versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish to crates.io
 on:
   push:
     tags: [v*]
+  workflow_dispatch:
 
 jobs:
   verify-versions:
@@ -48,15 +49,22 @@ jobs:
             fi
           done
           ROOT_VER=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | head -1)
+          # The v* tag namespace serves the npm release series (packages/vue),
+          # which diverged from the crates workspace series after 0.3.20, so a
+          # release tag generally no longer equals the crates version. Publish
+          # whatever version the workspace itself declares.
           if [ "$ROOT_VER" != "$TAG_VERSION" ]; then
-            echo "::error::workspace.package version ($ROOT_VER) != tag ($TAG_VERSION)"
+            echo "::notice::tag version ($TAG_VERSION) belongs to the npm series; publishing the crates workspace version ($ROOT_VER)"
+          fi
+          if ! [[ "$ROOT_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::workspace.package version ($ROOT_VER) is not a valid semver version"
             FAIL=1
           fi
           if [ "$FAIL" -ne 0 ]; then
-            echo "::error::Version mismatch detected."
+            echo "::error::Version verification failed."
             exit 1
           fi
-          echo "All versions match tag v$TAG_VERSION"
+          echo "All packages resolve to workspace version $ROOT_VER"
 
   publish:
     name: Publish to crates.io
@@ -117,7 +125,7 @@ jobs:
       - name: Skip if already published
         id: check-exists
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | head -1)
           STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/${CRATE}/${VERSION}" || echo "000")
           if [ "$STATUS" = "200" ]; then
             echo "::warning::Version ${VERSION} already published — skipping."


### PR DESCRIPTION
## Root cause

The `v*` tag namespace serves **two independent version series**: the npm package (`packages/vue`, now 0.35.0) and the Rust workspace crates (`[workspace.package] version`, now 0.3.23). After the two series diverged (last tag where they matched: `v0.3.20`, 2026-08-17), the `verify-versions` job in `publish.yml` hard-failed on **every** release tag, because it demanded `tag == workspace version`:

```
##[notice]hikari-components uses workspace version (0.3.23) — OK
##[error]workspace.package version (0.3.23) != tag (0.35.0)        # run 33660330137 (tag v0.35.0)
##[error]Version mismatch detected.
##[error]Process completed with exit code 1.
```

Identical signature on every tag since the split, e.g. run 33623487747 (tag v0.32.0): `workspace.package version (0.3.23) != tag (0.32.0)`.

Consequence: the `publish` job was always **skipped** (never reached `cargo publish`, so this is not a token/secrets failure). crates.io has been stalled at **0.3.20 for all 8 `hikari-*` crates since 2026-08-17**, while git master carries 0.3.23:

| crates.io (max_version) | git master | missing |
|---|---|---|
| 0.3.20 (published 2026-08-17, run 32026688677 = last success) | 0.3.23 | 0.3.21, 0.3.22, 0.3.23 |

Version-series map of tags: `v0.31.1`/`v0.31.2` → workspace 0.3.22; `v0.32.0`…`v0.35.0` → workspace 0.3.23. Workspace 0.3.21 was never tagged, so it is unreproducible from any ref (and unnecessary for `^0.3` resolution).

## Fix

- `verify-versions` now checks **internal consistency** (every member resolves to one valid semver workspace version) instead of npm-tag equality; a tag mismatch becomes an advisory `::notice::`. Locally simulated: tag `0.35.0` vs workspace `0.3.23` now passes; a genuinely divergent member version still fails the job.
- Added `workflow_dispatch` so missed crate versions can be published from an existing ref without minting tags (a new `v0.3.x` tag would also trigger `npm-release.yml` and pollute the npm series with a down-level version; and rerunning old tag-triggered runs cannot pick this fix up, because tag events execute the workflow file from the tag's commit).
- `Skip if already published` now checks the workspace version instead of the tag version, so re-dispatching an already-published version exits neutral (idempotent).

`CRATES_IO_API_TOKEN` exists in repo secrets and was last exercised successfully by run 32026688677; the real publish path (`scripts/publish_crates.py`, dependency-ordered with index waits) is untouched.

## Recovery runbook (after merge)

Publish the current workspace version (the essential backfill — `^0.3.20` consumers then resolve 0.3.23):

```
gh workflow run publish.yml --repo celestia-island/hikari --ref master
```

Optional strict backfill of 0.3.22 from its tag:

```
gh workflow run publish.yml --repo celestia-island/hikari --ref v0.31.2
```