### PR TITLE
🐛 Fix HkBoard fan fan-out, zoom anchoring, and pointer capture lifecycle.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkBoard.tsx
+++ b/packages/vue/src/components/HkBoard.tsx
@@ -44,6 +44,7 @@ import { useBoardCamera } from "../composables/useBoardCamera";
 import HkMinimap, { type MinimapBox } from "./HkMinimap";
 import {
   boardBBox,
+  boardStepRung,
   type BoardCamera,
   type BoardPoint,
   type BoardRect,
@@ -52,13 +53,19 @@ import {
 import {
   boardAnchor,
   boardEdgePath,
+  boardFanOrdinals,
   boardViaPath,
   type BoardAnchorMode,
   type BoardEdgeStyle,
 } from "../utils/boardEdges";
 import "./HkBoard.scss";
 
-/** A node on the board. `hidden` nodes are junction-only (invisible). */
+/**
+ * A node on the board. `hidden` nodes are junction-only (invisible).
+ * During a node drag the board mutates the node objects IN PLACE and
+ * emits the live reference through `node-move` / `nodeClick` — pass
+ * deep-reactive, mutable node objects, not frozen copies.
+ */
 export interface BoardNodeInput {
   id: string;
   x: number;
@@ -138,16 +145,7 @@ export default defineComponent({
     });
 
     /** Edges sharing a `from` node fan across its border (天女散花). */
-    const fanOrdinal = computed(() => {
-      const counters = new Map<string, number>();
-      const ordinals = new Map<string, { index: number; count: number }>();
-      for (const e of props.edges) {
-        const next = (counters.get(e.from) ?? 0) + 1;
-        counters.set(e.from, next);
-        ordinals.set(e.id, { index: next - 1, count: counters.get(e.from)! });
-      }
-      return ordinals;
-    });
+    const fanOrdinal = computed(() => boardFanOrdinals(props.edges));
 
     const edgePaths = computed(() => {
       const rects = rectOf.value;
@@ -209,6 +207,9 @@ export default defineComponent({
     let panState: { px: number; py: number } | null = null;
     let pinchBase: { cam: BoardCamera; dist: number; mid: BoardPoint } | null = null;
     let dragState: { node: BoardNodeInput; sx: number; sy: number; ox: number; oy: number; moved: boolean } | null = null;
+    // Every node press is tracked (draggable or not) so read-only boards
+    // — SCADA scenes, mind maps — still get `nodeClick` on a short tap.
+    let pressed: { id: string; pointerId: number; x: number; y: number } | null = null;
 
     const localPoint = (e: PointerEvent | WheelEvent): BoardPoint => {
       const rect = viewportRef.value?.getBoundingClientRect();
@@ -230,23 +231,39 @@ export default defineComponent({
 
     let resizeObs: ResizeObserver | null = null;
 
+    /** Snapshot the camera + current finger pair as the pinch baseline —
+     *  at gesture start, or whenever the pair's composition changes — so
+     *  the scale keeps following the fingers 1:1 without a jump. */
+    function rearmPinch(): void {
+      const [a, b] = [...pointers.values()];
+      if (!a || !b) return;
+      const rect = viewportRef.value?.getBoundingClientRect();
+      pinchBase = {
+        cam: { ...camera.value },
+        dist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
+        mid: {
+          x: (a.x + b.x) / 2 - (rect?.left ?? 0),
+          y: (a.y + b.y) / 2 - (rect?.top ?? 0),
+        },
+      };
+    }
+
     function onPointerDown(e: PointerEvent): void {
       if (!props.interactive) return;
+      // Defensive prune: tracked pointers no gesture is using are stale
+      // (their up/cancel AND capture loss were both lost) — drop them so
+      // the next single-finger touch cannot become a phantom pinch.
+      if (pointers.size > 0 && !pinchBase && !panState && !dragState) pointers.clear();
       pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-      if (pointers.size === 2) {
-        // pinch begins: snapshot camera + finger geometry
-        const [a, b] = [...pointers.values()];
-        pinchBase = {
-          cam: { ...camera.value },
-          dist: Math.hypot(a.x - b.x, a.y - b.y) || 1,
-          mid: localPoint(e),
-        };
-        panState = null;
-        return;
-      }
+      // Capture EVERY finger: up/cancel are only guaranteed while capture
+      // holds, and an uncaptured pinch finger would never leave `pointers`.
+      viewportRef.value?.setPointerCapture(e.pointerId);
       if (pointers.size === 1) {
         panState = { px: e.clientX, py: e.clientY };
-        viewportRef.value?.setPointerCapture(e.pointerId);
+      } else if (pointers.size === 2) {
+        // pinch begins: snapshot camera + finger geometry, suspend panning
+        rearmPinch();
+        panState = null;
       }
     }
 
@@ -256,10 +273,12 @@ export default defineComponent({
       if (pinchBase && pointers.size >= 2) {
         const [a, b] = [...pointers.values()];
         const dist = Math.hypot(a.x - b.x, a.y - b.y) || 1;
+        const rect = viewportRef.value?.getBoundingClientRect();
         const mid = {
-          x: (a.x + b.x) / 2 - (viewportRef.value?.getBoundingClientRect().left ?? 0),
-          y: (a.y + b.y) / 2 - (viewportRef.value?.getBoundingClientRect().top ?? 0),
+          x: (a.x + b.x) / 2 - (rect?.left ?? 0),
+          y: (a.y + b.y) / 2 - (rect?.top ?? 0),
         };
+        pinchBase.mid = mid;
         cam.pinchZoom(pinchBase.cam, dist / pinchBase.dist, mid);
         return;
       }
@@ -280,17 +299,62 @@ export default defineComponent({
     }
 
     function onPointerUp(e: PointerEvent): void {
-      pointers.delete(e.pointerId);
-      if (pointers.size < 2 && pinchBase) {
-        pinchBase = null;
-        cam.settlePinch();
-      }
-      if (pointers.size === 0) panState = null;
-      if (dragState && !dragState.moved) emit("nodeClick", dragState.node);
+      const press = pressed;
+      pressed = null;
       dragState = null;
+      retirePointer(e.pointerId);
+      // nodeClick: a press that belongs to THIS pointer and stayed within
+      // the drag slop clicks — regardless of `draggable`.
+      if (press && press.pointerId === e.pointerId
+        && Math.abs(e.clientX - press.x) + Math.abs(e.clientY - press.y) < 3) {
+        const node = props.nodes.find((n) => n.id === press.id);
+        if (node) emit("nodeClick", node);
+      }
+    }
+
+    function onPointerCancel(e: PointerEvent): void {
+      // An aborted gesture must never synthesize a click: prune state only.
+      pressed = null;
+      dragState = null;
+      retirePointer(e.pointerId);
+    }
+
+    /** A pointer left the gesture (up, cancel, or capture loss): prune it,
+     *  re-baseline or settle the pinch, and hand panning to any surviving
+     *  pointer so a pinch that ends with one finger down keeps panning. */
+    function retirePointer(pointerId: number): void {
+      if (!pointers.delete(pointerId)) return;
+      if (pinchBase && pointers.size >= 2) {
+        // The pinch pair composition changed (a finger lifted while two
+        // or more remain): re-baseline onto the surviving pair.
+        rearmPinch();
+        return;
+      }
+      if (pinchBase) {
+        const mid = pinchBase.mid;
+        pinchBase = null;
+        cam.settlePinch(mid);
+      }
+      const rest = pointers.values().next().value;
+      panState = rest ? { px: rest.x, py: rest.y } : null;
+    }
+
+    /** Capture-loss backstop: up/cancel are only guaranteed while pointer
+     *  capture holds; a pointer that was released without an up is pruned
+     *  here — otherwise the next single-finger touch would silently become
+     *  a phantom pinch. The event fires on the capture target and does not
+     *  bubble, hence the capture-phase listener; after a normal up it is a
+     *  no-op (the pointer was already pruned there). */
+    function onLostPointerCapture(e: PointerEvent): void {
+      pressed = null;
+      dragState = null;
+      retirePointer(e.pointerId);
     }
 
     function onNodePointerDown(e: PointerEvent, node: BoardNodeInput): void {
+      pressed = { id: node.id, pointerId: e.pointerId, x: e.clientX, y: e.clientY };
+      // Draggable nodes own the gesture (no board pan); every other press
+      // bubbles on so the board can pan — and still click on a short tap.
       if (!props.interactive || !node.draggable) return;
       e.stopPropagation();
       dragState = { node, sx: e.clientX, sy: e.clientY, ox: node.x, oy: node.y, moved: false };
@@ -308,12 +372,17 @@ export default defineComponent({
       resizeObs = new ResizeObserver(refreshSize);
       if (viewportRef.value) resizeObs.observe(viewportRef.value);
       viewportRef.value?.addEventListener("wheel", onWheel, { passive: false });
+      // Capture phase: lostpointercapture does not bubble and fires on the
+      // element that held capture.
+      viewportRef.value?.addEventListener("lostpointercapture", onLostPointerCapture, true);
       if (props.fitOnMount) cam.fit();
     });
 
     onBeforeUnmount(() => {
+      cam.stop(); // kill any in-flight tween rAF
       resizeObs?.disconnect();
       viewportRef.value?.removeEventListener("wheel", onWheel);
+      viewportRef.value?.removeEventListener("lostpointercapture", onLostPointerCapture, true);
     });
 
     expose({
@@ -332,7 +401,7 @@ export default defineComponent({
         onPointerdown={onPointerDown}
         onPointermove={onPointerMove}
         onPointerup={onPointerUp}
-        onPointercancel={onPointerUp}
+        onPointercancel={onPointerCancel}
       >
         <div class="hk-board-grid" style={gridStyle.value} />
         <div class="hk-board-world" style={worldStyle.value}>
@@ -384,7 +453,7 @@ export default defineComponent({
               minZoomPercent={Math.round(props.minK * 100)}
               maxZoomPercent={Math.round(props.maxK * 100)}
               showReset
-              onZoomTo={(percent: number) => cam.zoomToPercent(percent)}
+              onZoomTo={(percent: number) => cam.zoomToK(boardStepRung(camera.value.k, percent / 100))}
               onReset={() => cam.fit()}
               onPanDelta={(dx: number, dy: number) => cam.panBy(dx, dy)}
             />

--- a/packages/vue/src/composables/useBoardCamera.ts
+++ b/packages/vue/src/composables/useBoardCamera.ts
@@ -63,12 +63,15 @@ export interface UseBoardCameraReturn {
   zoomOut: () => void;
   /** Raw (unquantized, unanimated) pinch zoom — call per pointermove. */
   pinchZoom: (base: BoardCamera, ratio: number, anchor: BoardPoint) => void;
-  /** Snap the post-pinch camera onto the nearest rung (animated). */
-  settlePinch: () => void;
+  /** Snap the post-pinch camera onto the nearest rung (animated), keeping
+   *  the world point under `anchor` (the pinch midpoint) fixed. */
+  settlePinch: (anchor?: BoardPoint) => void;
   panBy: (dx: number, dy: number) => void;
   setCamera: (cam: BoardCamera, opts?: { animate?: boolean }) => void;
   fit: () => void;
   reset: () => void;
+  /** Cancel any in-flight tween and its pending rAF (call on unmount). */
+  stop: () => void;
 }
 
 export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraReturn {
@@ -82,6 +85,12 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
 
   const camera = ref<BoardCamera>({ x: 0, y: 0, k: 1 });
   const isAnimating = ref(false);
+
+  // fit() may park the camera BELOW the interaction minimum (show the
+  // whole board wins over the zoom ladder, as in HkImageViewer) — the
+  // clamp floor follows it down so the fitted framing survives; any
+  // quantized gesture lands back on the ladder at ≥ minK.
+  let kFloor = minK;
 
   let raf = 0;
   let tweenFrom: BoardCamera = { x: 0, y: 0, k: 1 };
@@ -100,7 +109,7 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
   const contentRect = (): BoardRect => toValue(content);
 
   const clampCam = (cam: BoardCamera): BoardCamera => {
-    const k = Math.min(maxK, Math.max(minK, cam.k));
+    const k = Math.min(maxK, Math.max(kFloor, cam.k));
     return boardClampPan({ ...cam, k }, contentRect(), viewport());
   };
 
@@ -135,13 +144,16 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
   };
 
   function zoomByFactor(factor: number, anchor?: BoardPoint): void {
-    const next = boardZoomAt(camera.value, camera.value.k * factor, anchorPoint(anchor));
-    animateTo({ ...next, k: quantizeBoardK(next.k) });
+    // Quantize FIRST, then solve the anchored pan for the QUANTIZED k —
+    // anchoring on the raw k and swapping in the quantized one afterwards
+    // lets the anchored world point jump by the raw/quantized ratio.
+    const k = quantizeBoardK(camera.value.k * factor);
+    animateTo(boardZoomAt(camera.value, k, anchorPoint(anchor)));
   }
 
   function zoomToK(targetK: number, anchor?: BoardPoint): void {
-    const next = boardZoomAt(camera.value, targetK, anchorPoint(anchor));
-    animateTo({ ...next, k: quantizeBoardK(next.k) });
+    const k = quantizeBoardK(targetK);
+    animateTo(boardZoomAt(camera.value, k, anchorPoint(anchor)));
   }
 
   function zoomToPercent(percent: number, anchor?: BoardPoint): void {
@@ -162,9 +174,11 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
     camera.value = clampCam(boardZoomAt(base, base.k * ratio, anchor));
   }
 
-  function settlePinch(): void {
-    const settled = { ...camera.value, k: quantizeBoardK(camera.value.k) };
-    animateTo(settled);
+  function settlePinch(anchor?: BoardPoint): void {
+    // Same quantize-then-anchor discipline as the wheel path: the pinch
+    // midpoint stays pinned to its world point while k snaps onto the rung.
+    const k = quantizeBoardK(camera.value.k);
+    animateTo(boardZoomAt(camera.value, k, anchorPoint(anchor)));
   }
 
   function panBy(dx: number, dy: number): void {
@@ -181,7 +195,9 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
   }
 
   function fit(): void {
-    animateTo(boardFit(contentRect(), viewport()));
+    const target = boardFit(contentRect(), viewport());
+    kFloor = Math.min(minK, target.k);
+    animateTo(target);
   }
 
   function reset(): void {
@@ -214,5 +230,6 @@ export function useBoardCamera(options: UseBoardCameraOptions): UseBoardCameraRe
     setCamera,
     fit,
     reset,
+    stop: stopTween,
   };
 }

--- a/packages/vue/src/utils/boardCamera.test.ts
+++ b/packages/vue/src/utils/boardCamera.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   BOARD_FIT_CAP,
+  BOARD_K_MAX,
   BOARD_ZOOM_FACTOR,
   boardBBox,
   boardClampPan,
   boardEaseOutCubic,
   boardFit,
   boardLevelOf,
+  boardStepRung,
   boardToScreen,
   boardTweenCam,
   boardToWorld,
@@ -51,6 +53,20 @@ describe("boardCamera — anchor zoom", () => {
     expect(zoomed.k).toBe(1.5);
   });
 
+  it("keeps the anchor world point fixed when zooming to a QUANTIZED rung", () => {
+    // The settle path (wheel notch / pinch release) must quantize k FIRST
+    // and then solve the anchored pan for the quantized k — anchoring on
+    // the raw k and swapping the rung in afterwards jumps the world point.
+    const cam = { x: 40, y: -20, k: 2.3 };
+    const anchor = { x: 300, y: 200 };
+    const worldBefore = boardToWorld(cam, anchor.x, anchor.y);
+    const settled = boardZoomAt(cam, quantizeBoardK(cam.k), anchor);
+    const worldAfter = boardToWorld(settled, anchor.x, anchor.y);
+    expect(worldAfter.x).toBeCloseTo(worldBefore.x, 6);
+    expect(worldAfter.y).toBeCloseTo(worldBefore.y, 6);
+    expect(settled.k).toBe(quantizeBoardK(cam.k));
+  });
+
   it("round-trips screen→world→screen", () => {
     const cam = { x: -130, y: 88, k: 1.3 };
     const p = boardToScreen(cam, 42, -7);
@@ -82,6 +98,45 @@ describe("boardCamera — pan clamp + fit", () => {
     expect(cam.k).toBeCloseTo(Math.min((800 - 80) / 2000, (600 - 80) / 1200), 6);
     const tiny = boardFit({ x: 0, y: 0, w: 60, h: 40 }, viewport);
     expect(tiny.k).toBeLessThanOrEqual(BOARD_FIT_CAP);
+  });
+
+  it("shrinks below the interaction minimum to fit very wide boards", () => {
+    // 8000 world px in an 800 px viewport: fit k = 720/8000 = 0.09, far
+    // below the old 0.2 floor that cropped such boards on open.
+    const wide = { x: 0, y: 0, w: 8000, h: 600 };
+    const cam = boardFit(wide, viewport);
+    expect(cam.k).toBeCloseTo((800 - 80) / 8000, 6);
+    expect(cam.k).toBeLessThan(0.2);
+    // the whole board lands inside the viewport
+    const tl = boardToScreen(cam, 0, 0);
+    const br = boardToScreen(cam, 8000, 600);
+    expect(tl.x).toBeGreaterThanOrEqual(0);
+    expect(br.x).toBeLessThanOrEqual(viewport.w);
+  });
+});
+
+describe("boardCamera — minimap step rungs", () => {
+  const lastRung = BOARD_ZOOM_FACTOR ** 28; // ≈3.92 — last rung below the cap
+
+  it("pushes a linear +5% step that nearest-rounds onto the current rung", () => {
+    // from 392%, the + button targets 397% — nearest rounding falls back
+    // onto rung 28 (the dead band), so the step resolves one rung further
+    // and clamps to the cap.
+    expect(quantizeBoardK(3.97)).toBeCloseTo(lastRung, 5);
+    expect(boardStepRung(lastRung, 3.97)).toBe(BOARD_K_MAX);
+  });
+
+  it("pushes a linear −5% step onto the rung below, not the current one", () => {
+    expect(boardStepRung(lastRung, 3.87)).toBeCloseTo(BOARD_ZOOM_FACTOR ** 27, 5);
+  });
+
+  it("leaves steps that already resolve to a different rung untouched", () => {
+    expect(boardStepRung(1, 1.05)).toBeCloseTo(BOARD_ZOOM_FACTOR, 5);
+    expect(boardStepRung(1, 0.95)).toBeCloseTo(BOARD_ZOOM_FACTOR ** -1, 5);
+  });
+
+  it("steps from the ladder floor up onto the nearest live rung", () => {
+    expect(boardStepRung(0.2, 0.25)).toBeCloseTo(BOARD_ZOOM_FACTOR ** -28, 5);
   });
 });
 

--- a/packages/vue/src/utils/boardCamera.ts
+++ b/packages/vue/src/utils/boardCamera.ts
@@ -14,7 +14,9 @@
  *  - pan is CLAMPED so the content bbox can never be pushed fully out of
  *    view (half a viewport of slack on each side); content smaller than
  *    the viewport re-centers;
- *  - `boardFit` fits the whole bbox (pad + floor + cap);
+ *  - `boardFit` fits the whole bbox (pad + cap) and may shrink as far as
+ *    needed to show the whole board — fit sits below the interaction
+ *    ladder freely;
  *  - `boardTweenCam` eases between two cameras with an ease-out curve and
  *    GEOMETRIC k interpolation (log-space lerp) so animated zooms still
  *    land exactly on ladder rungs.
@@ -51,8 +53,6 @@ export interface BoardViewport {
 export const BOARD_ZOOM_FACTOR = 1.05;
 export const BOARD_K_MIN = 0.2;
 export const BOARD_K_MAX = 4;
-/** fit() may shrink as far as needed to show the whole board. */
-export const BOARD_FIT_FLOOR = 0.2;
 /** fit() never blows above this (nearly-empty boards). */
 export const BOARD_FIT_CAP = 1.25;
 /** Padding around the bbox used by fit(), world px. */
@@ -85,6 +85,26 @@ export function quantizeBoardStep(base: number, ratio: number): number {
   const raw = base * ratio;
   const level = Math.round(boardLevelOf(raw) - boardLevelOf(base));
   return boardClampK(base * boardKOf(level));
+}
+
+/**
+ * Quantize a fixed-step zoom target (the minimap ± button: linear ±5% on
+ * a geometric ladder) into a rung, in the step's DIRECTION. Nearest-rung
+ * rounding alone can collapse onto the rung the camera already sits on —
+ * from the last reachable rung below the cap, a +5% percent target rounds
+ * straight back to it and the press does nothing. A target that resolves
+ * to the current rung is therefore pushed ONE rung further in the press
+ * direction (clamped to the global bounds); targets that already resolve
+ * elsewhere are untouched.
+ */
+export function boardStepRung(currentK: number, targetK: number): number {
+  const clamped = boardClampK(targetK);
+  const rung = quantizeBoardK(clamped);
+  const currentLevel = Math.round(boardLevelOf(boardClampK(currentK)));
+  const rungLevel = Math.round(boardLevelOf(rung));
+  if (rungLevel !== currentLevel) return rung;
+  const dir = clamped >= currentK ? 1 : -1;
+  return boardClampK(boardKOf(currentLevel + dir));
 }
 
 export function boardToScreen(cam: BoardCamera, wx: number, wy: number): BoardPoint {
@@ -136,19 +156,20 @@ export function boardClampPan(
 
 /**
  * Fit the whole content bbox into the viewport (centered, padded). Wide
- * boards shrink fully into view; tiny boards never blow up past the cap.
+ * boards shrink as far as needed to show everything — fit is allowed
+ * below the interaction minimum (the ladder is for gestures, not for
+ * the initial framing); tiny boards never blow up past the cap.
  */
 export function boardFit(
   content: BoardRect,
   viewport: BoardViewport,
-  opts: { pad?: number; floor?: number; cap?: number } = {},
+  opts: { pad?: number; cap?: number } = {},
 ): BoardCamera {
   const pad = opts.pad ?? BOARD_FIT_PAD;
-  const floor = opts.floor ?? BOARD_FIT_FLOOR;
   const cap = opts.cap ?? BOARD_FIT_CAP;
   const kw = content.w > 0 ? (viewport.w - pad * 2) / content.w : cap;
   const kh = content.h > 0 ? (viewport.h - pad * 2) / content.h : cap;
-  const k = Math.min(cap, Math.max(floor, Math.min(kw, kh)));
+  const k = Math.min(cap, Math.min(kw, kh));
   return {
     k,
     x: (viewport.w - content.w * k) / 2 - content.x * k,

--- a/packages/vue/src/utils/boardEdges.test.ts
+++ b/packages/vue/src/utils/boardEdges.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   boardAnchor,
   boardEdgePath,
+  boardFanOrdinals,
   boardViaPath,
   type BoardNodeRect,
 } from "./boardEdges";
@@ -36,6 +37,39 @@ describe("boardEdges — anchor modes", () => {
     expect(first.y).toBeLessThan(second.y);
     expect(second.y).toBeLessThan(third.y);
     expect(new Set([first.y, second.y, third.y]).size).toBe(3);
+  });
+});
+
+describe("boardEdges — fan ordinals", () => {
+  it("gives a single edge the full fan (count = 1, no spread)", () => {
+    const ord = boardFanOrdinals([{ id: "e1", from: "a" }]);
+    expect(ord.get("e1")).toEqual({ index: 0, count: 1 });
+  });
+
+  it("spreads three edges from one node as {0,3} {1,3} {2,3}", () => {
+    const ord = boardFanOrdinals([
+      { id: "e1", from: "a" },
+      { id: "e2", from: "a" },
+      { id: "e3", from: "a" },
+    ]);
+    expect(ord.get("e1")).toEqual({ index: 0, count: 3 });
+    expect(ord.get("e2")).toEqual({ index: 1, count: 3 });
+    expect(ord.get("e3")).toEqual({ index: 2, count: 3 });
+  });
+
+  it("counts each source node independently", () => {
+    const ord = boardFanOrdinals([
+      { id: "e1", from: "a" },
+      { id: "e2", from: "b" },
+      { id: "e3", from: "a" },
+    ]);
+    expect(ord.get("e1")).toEqual({ index: 0, count: 2 });
+    expect(ord.get("e2")).toEqual({ index: 0, count: 1 });
+    expect(ord.get("e3")).toEqual({ index: 1, count: 2 });
+  });
+
+  it("returns an empty map for empty input", () => {
+    expect(boardFanOrdinals([]).size).toBe(0);
   });
 });
 

--- a/packages/vue/src/utils/boardEdges.ts
+++ b/packages/vue/src/utils/boardEdges.ts
@@ -35,6 +35,29 @@ export interface BoardPoint {
   y: number;
 }
 
+/**
+ * Fan ordinals for a set of edges: every edge sharing a `from` node gets
+ * its `{ index, count }` slot in the 天女散花 spread across that node's
+ * exit border. Two passes — totals first, then positions — so `count` is
+ * the FINAL total per node (a running count would feed the first edges
+ * count = 1 and collapse the whole fan onto one anchor point). Edges from
+ * different nodes are counted independently.
+ */
+export function boardFanOrdinals(
+  edges: ReadonlyArray<{ id: string; from: string }>,
+): Map<string, { index: number; count: number }> {
+  const totals = new Map<string, number>();
+  for (const e of edges) totals.set(e.from, (totals.get(e.from) ?? 0) + 1);
+  const seen = new Map<string, number>();
+  const ordinals = new Map<string, { index: number; count: number }>();
+  for (const e of edges) {
+    const index = seen.get(e.from) ?? 0;
+    seen.set(e.from, index + 1);
+    ordinals.set(e.id, { index, count: totals.get(e.from)! });
+  }
+  return ordinals;
+}
+
 export interface BoardNodeRect {
   x: number;
   y: number;


### PR DESCRIPTION
Review-fix wave for HkBoard (#375), packages/vue 0.35.0 → 0.35.1.

**Fixes**
- **Fan ordinal fan-out**: extracted `boardFanOrdinals` into `utils/boardEdges.ts` (two passes: totals per `from` node, then positions), so `count` is the final total — a 3-edge fan now spreads {0,3},{1,3},{2,3} across the whole exit border instead of {0,1},{1,2},{2,3} collapsing onto one anchor.
- **Zoom anchor vs quantize order**: `zoomByFactor` / `zoomToK` / `settlePinch` now quantize k FIRST and then solve the anchored pan via `boardZoomAt`, so the anchored world point no longer jumps by the raw/quantized ratio (up to ~2.4%); `settlePinch` accepts an anchor and HkBoard passes the live pinch midpoint.
- **Pointer lifecycle** (modeled on HkImageViewer): capture on every pointerdown, capture-phase `lostpointercapture` backstop prunes lost pointers (no more phantom pinch), pinch re-baselines when its finger pair changes, and after a pinch ends the surviving finger takes over panning (panState restored instead of dead); stale tracked pointers are pruned defensively on pointerdown.
- **nodeClick for all nodes**: pressed node id + start position tracked on every node pointerdown; a <3px tap emits `nodeClick` regardless of `draggable` — read-only boards (SCADA / mind maps) get clicks again.
- **pointercancel** has its own handler that prunes drag/pan/pinch/press state WITHOUT synthesizing a click.
- **Fit floor**: `boardFit` no longer applies BOARD_FIT_FLOOR (the doc always said fit may shrink as far as needed) — boards wider than ~(viewport−80)/0.2 world px now open fully fitted; `useBoardCamera` instead lowers its clamp floor to the fitted k so the deep-fit framing survives clamping while every quantized gesture lands back on the ≥ minK ladder.
- **Minimap zoom dead band**: new `boardStepRung(currentK, targetK)` quantizes the minimap's linear ±5% step into the ladder in the press direction when nearest-rounding would collapse onto the current rung (e.g. + from 392% now reaches 400% instead of doing nothing). Programmatic `zoomToPercent` behavior is unchanged.
- **Tween leak**: `useBoardCamera` exposes `stop()`; HkBoard cancels the tween rAF in `onBeforeUnmount` (also removes the new capture-phase listener).
- **Docs**: `BoardNodeInput` now documents that drags mutate node objects in place and emit the live reference, so consumers must pass deep-reactive, mutable nodes.

**Verification**
- `vitest run` (packages/vue), final full suite: **797 tests, 795 passed, 2 failed** — the 2 failures are the pre-existing stable baseline failures (`registerAnimations > registers exactly the keyframes declared in the source tree`, `HkDatePicker > marks the selected day and today in the grid`); failure set == baseline.
- Baseline evidence: pristine baseline (stash) runs under identical load show the same stable 2 plus a flaky timing/date-dependent pool (HkMenu cascade synthetic anchor / HkDateTimePicker year chevrons / HkDatePicker month-grid drill / HkBlockingToast timeoutMs), each passing in isolation and none touching board files; the 10 new unit tests (fan ordinals ×4, anchor-preservation at quantized rung, fit-below-floor, step rungs ×4) all pass.
- `vue-tsc --noEmit`: clean.
- Per §7.2 no builds were run; version bump mirrors #376 (npm series only; crates workspace stays 0.3.23 per #378).