### PR TITLE
📝 Document the code syntax token family contract.

### DIFF
--- a/packages/components/src/production/code_highlight.rs
+++ b/packages/components/src/production/code_highlight.rs
@@ -52,6 +52,14 @@ fn copy_to_clipboard(text: &str) -> bool {
 
 pub struct CodeHighlightComponent;
 
+/// NOTE ON THEMING: unlike the Vue-side HkToolBlock (which reads the
+/// host theme's --code-* family, see packages/vue/src/tokens.scss), this
+/// Rust/WASM component ships self-contained palettes as deliberate
+/// content: each `data-palette` selects a full, explicit token set. Hosts
+/// that render this component with their own highlight pass can either
+/// pick one of these palettes or ignore `data-palette` and style their
+/// own `.language-*` classes with the host theme's --code-* tokens —
+/// the component never injects palette CSS unless a palette is chosen.
 /// Selectable syntax highlighting palettes inspired by popular Neovim colorschemes.
 /// Each palette defines CSS variables for syntax token colors.
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -1,3 +1,22 @@
+/* ── Syntax highlighting palette family: --code-* ───────────────────
+ * Token names consumed by hikari's highlighted-code surfaces (the
+ * HkToolBlock syntax layer and its JSON viewer, see HkToolBlock.scss).
+ * The VALUES are intentionally NOT defined here: the family is owned by
+ * the host theme, which maps each token to mode-aware colors. The
+ * canonical mapping (dark = One Dark, light = GitHub Light) lives in the
+ * celestia webui theme.scss; components reference the tokens with their
+ * original One Dark values as fallbacks so standalone consumers render
+ * unchanged. Extend this family only by adding a --code-* token with a
+ * fallback equal to the current visual.
+ *   --code-keyword  hljs-keyword / selector-tag       (purple)
+ *   --code-builtin  hljs-built_in                     (purple → blue in light)
+ *   --code-string   hljs-string                       (green)
+ *   --code-number   hljs-number / literal / attr      (orange → blue in light)
+ *   --code-comment  hljs-comment / doctag             (grey, italic)
+ *   --code-function hljs-title.function_              (blue)
+ *   --code-type     hljs-type / class title           (yellow → green in light)
+ *   --code-variable hljs-variable / template-var      (red → orange in light)
+ */
 /* hikari color aliases — fallback values for theme tokens.
    These CSS variables are used by hikari components (HkButton, HkCard,
    HkInput, HkSelect, etc.) and are expected to be overridden by


### PR DESCRIPTION
## What

Comment-only change across both hikari packages:

1. `packages/vue/src/tokens.scss` — document the `--code-*` syntax palette family at the token file: the eight token names, their hljs classes, and the design rule (values owned by the host theme; components reference tokens with One Dark fallbacks). Extends the earlier HkToolBlock tokenization (#380).
2. `packages/components/src/production/code_highlight.rs` — note at the `CodePalette` enum how the Rust/WASM component's self-contained palettes relate to host theming (deliberate content palettes; hosts style `.language-*` themselves for theme-following output).

## Verification

- Comment-only: no code paths touched. Rust and SCSS files unchanged semantically.
- CI will confirm (fmt/clippy/test).