### PR TITLE
✨ Add multi-segment progress and the context usage ring.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkContextRing.scss
+++ b/packages/vue/src/components/HkContextRing.scss
@@ -1,0 +1,123 @@
+// Context-usage ring + hover popover (upstreamed for shittim-chest's
+// session context meter). Layout/typography ride the theme tokens; the
+// per-component segment colors are inline styles built from the
+// `--context-<key>` CSS-variable family supplied by the host palette.
+@use "./hikari-vars" as vars;
+
+.hk-ctx-ring {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  border-radius: var(--radius-full, 999px);
+  -webkit-tap-highlight-color: transparent;
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
+}
+
+// Center label rendered through HProgressRing's overlay slot; font size is
+// set inline from the ring `size` prop.
+.hk-ctx-ring-center {
+  font-weight: 600;
+  line-height: 1;
+  color: rgb(var(--color-text));
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  user-select: none;
+  pointer-events: none;
+}
+
+.hk-ctx-pop {
+  width: 18rem;
+  padding: var(--space-12, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
+  color: rgb(var(--color-text));
+}
+
+.hk-ctx-pop-model {
+  display: flex;
+}
+
+.hk-ctx-pop-total {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-6, 0.375rem);
+  margin-top: var(--space-8, 0.5rem);
+  margin-bottom: var(--space-8, 0.5rem);
+}
+
+.hk-ctx-pop-total-label {
+  color: rgb(var(--color-muted));
+}
+
+.hk-ctx-pop-total-num {
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-ctx-pop-total-of {
+  color: rgb(var(--color-muted));
+}
+
+.hk-ctx-pop-bar {
+  margin-bottom: var(--space-8, 0.5rem);
+}
+
+.hk-ctx-legend {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.hk-ctx-legend-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: var(--space-6, 0.375rem);
+  align-items: baseline;
+  min-width: 0;
+}
+
+.hk-ctx-legend-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  align-self: center;
+  flex-shrink: 0;
+}
+
+.hk-ctx-legend-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-ctx-legend-tokens {
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-ctx-legend-pct {
+  color: rgb(var(--color-muted));
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  min-width: 3ch;
+}
+
+.hk-ctx-est {
+  margin: var(--space-8, 0.5rem) 0 0;
+  padding: 0;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-2xs, 0.625rem);
+  font-style: italic;
+}
+
+.hk-ctx-pop-empty {
+  margin-top: var(--space-8, 0.5rem);
+  color: rgb(var(--color-muted));
+  font-style: italic;
+  font-size: var(--text-2xs, 0.625rem);
+}

--- a/packages/vue/src/components/HkContextRing.test.tsx
+++ b/packages/vue/src/components/HkContextRing.test.tsx
@@ -1,0 +1,258 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, h, nextTick } from "vue";
+
+// HPopover teleports to body and needs popup-manager runtime — stub it
+// with a passthrough that renders its slot while open and records the
+// interaction-relevant props (same pattern as HkModelTag.test.tsx).
+vi.mock("@celestia-island/hikari", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@celestia-island/hikari")>();
+  const { defineComponent, h } = await import("vue");
+  const HPopoverStub = defineComponent({
+    name: "HPopover",
+    props: {
+      modelValue: { type: Boolean, default: false },
+      placement: { type: String, default: "bottom" },
+      sheetOnMobile: { type: Boolean, default: false },
+      title: { type: String, default: "" },
+    },
+    setup(props, { slots }) {
+      return () =>
+        props.modelValue
+          ? h(
+              "div",
+              {
+                class: "popover-stub",
+                "data-placement": props.placement,
+                "data-sheet": String(props.sheetOnMobile),
+              },
+              slots.default?.(),
+            )
+          : null;
+    },
+  });
+  return { ...actual, HPopover: HPopoverStub };
+});
+
+import { HkContextRing } from "./HkContextRing";
+
+/**
+ * HkContextRing contract tests:
+ * - ring renders with a button role, model + usage aria-label and a
+ *   floored center percentage
+ * - zero-token segments are dropped from ring, bar and legend
+ * - popover: click toggles, hover delays follow HkModelTag's choreography,
+ *   sheetOnMobile is on, placement defaults to bottom-start
+ * - legend sorts by tokens desc with correct share math
+ * - contextWindow=null degrades to the gray ring + "–" center
+ */
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+function ringNode(props: Record<string, unknown>) {
+  return h(HkContextRing, props as never);
+}
+
+function baseProps(): Record<string, unknown> {
+  return {
+    model: "qwen3-coder-plus#8",
+    used: 42600,
+    contextWindow: 200000,
+    segments: [
+      { key: "prompt", tokens: 20000 },
+      { key: "thinking", tokens: 22600 },
+    ],
+  };
+}
+
+const openPopup = async (c: HTMLElement) => {
+  c.querySelector(".hk-ctx-ring")?.dispatchEvent(
+    new MouseEvent("click", { bubbles: true }),
+  );
+  await nextTick();
+};
+
+describe("HkContextRing ring", () => {
+  it("renders a button-like trigger with model and floored usage in the label", () => {
+    const c = mount(ringNode(baseProps()));
+    const ring = c.querySelector(".hk-ctx-ring");
+    expect(ring?.getAttribute("role")).toBe("button");
+    expect(ring?.getAttribute("aria-label")).toContain("qwen3-coder-plus#8");
+    // 42600 / 200000 = 21.3% -> floored 21%
+    expect(ring?.getAttribute("aria-label")).toContain("21%");
+    expect(c.querySelector(".hk-ctx-ring-center")?.textContent).toBe("21%");
+  });
+
+  it("shows 100+ once usage passes the window", () => {
+    const c = mount(ringNode({
+      model: "m",
+      used: 220_000,
+      contextWindow: 200_000,
+      segments: [],
+    }));
+    expect(c.querySelector(".hk-ctx-ring-center")?.textContent).toBe("100+");
+  });
+
+  it("draws one arc per nonzero segment and none for zero-token segments", () => {
+    const c = mount(ringNode({
+      ...baseProps(),
+      segments: [
+        { key: "prompt", tokens: 20000 },
+        { key: "tool", tokens: 0 },
+        { key: "output", tokens: 22600 },
+      ],
+    }));
+    const arcs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(arcs).toHaveLength(2);
+  });
+
+  it("degrades to a gray ring with a dash center when the window is null", () => {
+    const c = mount(ringNode({
+      model: "m",
+      used: 100,
+      contextWindow: null,
+      segments: [{ key: "prompt", tokens: 100 }],
+    }));
+    expect(c.querySelector(".hk-ctx-ring-center")?.textContent).toBe("–");
+    expect(c.querySelectorAll(".hk-progress-ring-seg")).toHaveLength(0);
+    expect(c.querySelector(".hk-progress-ring-track")).not.toBeNull();
+  });
+});
+
+describe("HkContextRing popover", () => {
+  it("opens and closes on click", async () => {
+    const c = mount(ringNode(baseProps()));
+    expect(c.querySelector(".hk-ctx-pop")).toBeNull();
+    await openPopup(c);
+    expect(c.querySelector(".hk-ctx-pop")).not.toBeNull();
+    expect(c.querySelector(".hk-ctx-pop-model")).not.toBeNull();
+    // model pill content is rendered inside the popup
+    expect(c.querySelector(".hk-ctx-pop-model")?.textContent).toContain("qwen3-coder-plus");
+    await openPopup(c);
+    expect(c.querySelector(".hk-ctx-pop")).toBeNull();
+  });
+
+  it("opens on hover after the 250ms delay and closes on leave after 120ms", async () => {
+    vi.useFakeTimers();
+    try {
+      const c = mount(ringNode(baseProps()));
+      const ring = c.querySelector(".hk-ctx-ring")!;
+      ring.dispatchEvent(new MouseEvent("mouseenter", { bubbles: true }));
+      vi.advanceTimersByTime(249);
+      await nextTick();
+      expect(c.querySelector(".hk-ctx-pop")).toBeNull();
+      vi.advanceTimersByTime(2);
+      await nextTick();
+      expect(c.querySelector(".hk-ctx-pop")).not.toBeNull();
+
+      ring.dispatchEvent(new MouseEvent("mouseleave", { bubbles: true }));
+      vi.advanceTimersByTime(119);
+      await nextTick();
+      expect(c.querySelector(".hk-ctx-pop")).not.toBeNull();
+      vi.advanceTimersByTime(2);
+      await nextTick();
+      expect(c.querySelector(".hk-ctx-pop")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("toggles with Enter and Space", async () => {
+    const c = mount(ringNode(baseProps()));
+    const ring = c.querySelector(".hk-ctx-ring")!;
+    ring.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+    expect(c.querySelector(".hk-ctx-pop")).not.toBeNull();
+    ring.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    await nextTick();
+    expect(c.querySelector(".hk-ctx-pop")).toBeNull();
+  });
+
+  it("asks HPopover for the mobile bottom sheet by default", async () => {
+    const c = mount(ringNode(baseProps()));
+    await openPopup(c);
+    const stub = c.querySelector(".popover-stub");
+    expect(stub?.getAttribute("data-sheet")).toBe("true");
+    expect(stub?.getAttribute("data-placement")).toBe("bottom-start");
+  });
+
+  it("honours the placement prop", async () => {
+    const c = mount(ringNode({ ...baseProps(), placement: "top-end" }));
+    await openPopup(c);
+    expect(c.querySelector(".popover-stub")?.getAttribute("data-placement")).toBe("top-end");
+  });
+
+  it("renders the segmented bar with the same data as the ring", async () => {
+    const c = mount(ringNode(baseProps()));
+    await openPopup(c);
+    const blocks = c.querySelectorAll(".hk-ctx-pop-bar .hk-progress-bar-seg");
+    expect(blocks).toHaveLength(2);
+    // 20000 / 200000 = 10%, 22600 / 200000 = 11.3%
+    expect((blocks[0] as HTMLElement).style.width).toBe("10%");
+    expect((blocks[1] as HTMLElement).style.width).toBe("11.3%");
+  });
+});
+
+describe("HkContextRing legend", () => {
+  it("sorts rows by tokens desc and computes the window share", async () => {
+    const c = mount(ringNode({
+      model: "m",
+      used: 85000,
+      contextWindow: 200000,
+      segments: [
+        { key: "prompt", tokens: 20000 },
+        { key: "user", tokens: 5000 },
+        { key: "thinking", tokens: 60000 },
+      ],
+    }));
+    await openPopup(c);
+    const rows = c.querySelectorAll(".hk-ctx-legend-row");
+    expect(rows).toHaveLength(3);
+    const labels = Array.from(rows).map((r) => r.querySelector(".hk-ctx-legend-label")?.textContent);
+    expect(labels).toEqual(["Thinking", "Prompt", "User"]);
+    const tokens = Array.from(rows).map((r) => r.querySelector(".hk-ctx-legend-tokens")?.textContent);
+    expect(tokens).toEqual(["60.0k", "20.0k", "5.0k"]);
+    const pcts = Array.from(rows).map((r) => r.querySelector(".hk-ctx-legend-pct")?.textContent);
+    expect(pcts).toEqual(["30%", "10%", "2.5%"]);
+  });
+
+  it("resolves segment labels through the hikari::context i18n keys", async () => {
+    const c = mount(ringNode(baseProps()));
+    await openPopup(c);
+    const labels = Array.from(c.querySelectorAll(".hk-ctx-legend-label")).map((n) => n.textContent);
+    expect(labels).toContain("Thinking");
+    expect(labels).toContain("Prompt");
+  });
+
+  it("lets an explicit label win over the i18n key", async () => {
+    const c = mount(ringNode({
+      ...baseProps(),
+      segments: [{ key: "prompt", label: "System setup", tokens: 20000 }],
+    }));
+    await openPopup(c);
+    expect(c.querySelector(".hk-ctx-legend-label")?.textContent).toBe("System setup");
+  });
+
+  it("shows the estimated footnote only when estimated is set", async () => {
+    const withEst = mount(ringNode({ ...baseProps(), estimated: true }));
+    await openPopup(withEst);
+    expect(withEst.querySelector(".hk-ctx-est")).not.toBeNull();
+    const without = mount(ringNode(baseProps()));
+    await openPopup(without);
+    expect(without.querySelector(".hk-ctx-est")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkContextRing.test.tsx
+++ b/packages/vue/src/components/HkContextRing.test.tsx
@@ -120,6 +120,57 @@ describe("HkContextRing ring", () => {
     expect(arcs).toHaveLength(2);
   });
 
+  it("partitions the occupancy so estimated segments still fill up to the center pct", () => {
+    // Segments sum (20k) intentionally != used (60k): the raw tokens/window
+    // shares would end the fill at 10% while the center claims 30%. The
+    // arcs must instead split the whole 30% proportionally.
+    const c = mount(ringNode({
+      model: "m",
+      used: 60_000,
+      contextWindow: 200_000,
+      segments: [
+        { key: "prompt", tokens: 5_000 },
+        { key: "tool", tokens: 15_000 },
+      ],
+    }));
+    const arcs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(arcs).toHaveLength(2);
+    const R = (28 - 3) / 2;
+    const C = 2 * Math.PI * R;
+    const drawn = [...arcs].reduce(
+      (acc, el) => acc + Number(el.getAttribute("stroke-dasharray")?.split(/\s+/)[0]),
+      0,
+    );
+    // drawn total = 30% of the circumference (within per-arc gap carve)
+    expect(drawn).toBeGreaterThan(0.25 * C);
+    expect(drawn).toBeLessThan(0.30 * C);
+    // Composition ratio preserved up to the inter-arc gap carve: the first
+    // arc (25% of the composition -> 7.5% of the ring) loses the 1%-of-ring
+    // gap, the last arc (75% -> 22.5%) keeps its full share.
+    const len0 = Number(arcs[0].getAttribute("stroke-dasharray")?.split(/\s+/)[0]);
+    const len1 = Number(arcs[1].getAttribute("stroke-dasharray")?.split(/\s+/)[0]);
+    expect(len0).toBeCloseTo((0.075 - 0.01) * C, 5);
+    expect(len1).toBeCloseTo(0.225 * C, 5);
+  });
+
+  it("draws a single muted occupancy arc when composition is all zeros", () => {
+    const c = mount(ringNode({
+      ...baseProps(),
+      segments: [
+        { key: "prompt", tokens: 0 },
+        { key: "tool", tokens: 0 },
+      ],
+    }));
+    const arcs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(arcs).toHaveLength(1);
+    // The muted fallback carries the full 21.3% occupancy.
+    const R = (28 - 3) / 2;
+    const C = 2 * Math.PI * R;
+    const drawn = Number(arcs[0].getAttribute("stroke-dasharray")?.split(/\s+/)[0]);
+    expect(drawn).toBeCloseTo((42_600 / 200_000) * C, 5);
+    expect(arcs[0].getAttribute("style")).toContain("--context-free");
+  });
+
   it("degrades to a gray ring with a dash center when the window is null", () => {
     const c = mount(ringNode({
       model: "m",

--- a/packages/vue/src/components/HkContextRing.tsx
+++ b/packages/vue/src/components/HkContextRing.tsx
@@ -107,15 +107,31 @@ export const HkContextRing = defineComponent({
     const windowPct = (tokens: number) =>
       (tokens / props.contextWindow!) * 100;
 
-    /** Arcs for the ring / blocks for the bar (segments mode). */
-    const chartSegments = computed(() =>
-      usable.value
-        ? visibleSegments.value.map((s) => ({
-            value: windowPct(s.tokens),
-            color: segmentColor(s),
-          }))
-        : [],
-    );
+    /**
+     * Arcs for the ring / blocks for the bar (segments mode).
+     *
+     * The per-category tokens are usually an ESTIMATE while `used` is the
+     * authoritative total, so raw `tokens/window` shares need not sum to
+     * the occupancy the center label claims. The arcs therefore partition
+     * the occupied share proportionally (composition within occupancy);
+     * the legend keeps the raw tokens/window stat. When composition is
+     * unknown but occupancy is known, one muted arc carries the fill so
+     * the ring never under-reports against its own center label.
+     */
+    const chartSegments = computed(() => {
+      if (!usable.value) return [];
+      const occupancy = Math.min(100, usagePct.value!);
+      const sum = visibleSegments.value.reduce((acc, s) => acc + s.tokens, 0);
+      if (sum <= 0) {
+        return occupancy > 0
+          ? [{ value: occupancy, color: segmentColor({ key: "free", tokens: 0 }) }]
+          : [];
+      }
+      return visibleSegments.value.map((s) => ({
+        value: occupancy * (s.tokens / sum),
+        color: segmentColor(s),
+      }));
+    });
 
     /** Legend rows sorted by tokens desc (largest first). */
     const legend = computed(() =>

--- a/packages/vue/src/components/HkContextRing.tsx
+++ b/packages/vue/src/components/HkContextRing.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, ref, type PropType } from "vue";
+import { computed, defineComponent, onBeforeUnmount, ref, type PropType } from "vue";
 import { HModelTag, HPopover, HProgressBar, HProgressRing } from "@celestia-island/hikari";
 
 import type { PopupPlacement } from "./HkPopover";
@@ -167,6 +167,10 @@ export const HkContextRing = defineComponent({
         toggle();
       }
     }
+
+    // HkModelTag never clears on unmount, but a pending show/hide timer
+    // firing on a dead instance is pure waste — drop both here.
+    onBeforeUnmount(clearTimers);
 
     return () => {
       const windowText = hasWindow.value

--- a/packages/vue/src/components/HkContextRing.tsx
+++ b/packages/vue/src/components/HkContextRing.tsx
@@ -1,0 +1,256 @@
+import { computed, defineComponent, ref, type PropType } from "vue";
+import { HModelTag, HPopover, HProgressBar, HProgressRing } from "@celestia-island/hikari";
+
+import type { PopupPlacement } from "./HkPopover";
+import { formatTokenCount } from "../utils/format";
+import { useI18n } from "../i18n/context";
+
+import "./HkContextRing.scss";
+
+/** One context-window component: keyed so the ring color and the default
+ *  i18n label (`hikari::context.<key>`) resolve automatically. */
+export interface HkContextSegment {
+  key: string;
+  /** Overrides the `hikari::context.<key>` i18n label. */
+  label?: string;
+  tokens: number;
+  /** Any CSS color; defaults to `rgb(var(--context-<key>, <fallback>))`. */
+  color?: string;
+}
+
+/**
+ * Fallback "r g b" triples for the ring colors. Chest's extended palette
+ * publishes each component under `--context-<key>` carrying the same
+ * space-separated triple convention as the theme tokens; when the variable
+ * is absent the fallback keeps the ring legible.
+ */
+const KEY_RGB: Record<string, string> = {
+  prompt: "167 139 250", // violet
+  user: "96 165 250", // blue
+  thinking: "251 191 36", // amber
+  tool: "52 211 153", // green
+  output: "251 113 133", // rose
+  free: "120 120 130", // gray
+};
+
+/** Unknown keys fall back to the free gray. */
+const DEFAULT_RGB = "120 120 130";
+
+/** English defaults for the standard keys (inline fallback for t()). */
+const KEY_EN: Record<string, string> = {
+  prompt: "Prompt",
+  user: "User",
+  thinking: "Thinking",
+  tool: "Tool",
+  output: "Output",
+  free: "Free",
+};
+
+function segmentColor(seg: HkContextSegment): string {
+  if (seg.color) return seg.color;
+  return `rgb(var(--context-${seg.key}, ${KEY_RGB[seg.key] ?? DEFAULT_RGB}))`;
+}
+
+/** 0.123 -> "12.3%", 0.3 -> "30%" (one decimal, trailing zero trimmed). */
+function formatPct(pct: number): string {
+  const rounded = Math.round(pct * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
+export const HkContextRing = defineComponent({
+  name: "HkContextRing",
+  props: {
+    /** Model id; shown in the popover via HModelTag. */
+    model: { type: String, required: true },
+    /** Tokens used so far. null (or a missing window) degrades the ring to
+     *  an empty gray ring with a "–" center. */
+    used: { type: Number as PropType<number | null>, default: null },
+    /** Context window size; the ring's 100%. */
+    contextWindow: { type: Number as PropType<number | null>, default: null },
+    segments: { type: Array as PropType<HkContextSegment[]>, default: () => [] },
+    /** Ring diameter in px (card-corner default). */
+    size: { type: Number, default: 28 },
+    strokeWidth: { type: Number, default: 3 },
+    placement: { type: String as PropType<PopupPlacement>, default: "bottom-start" },
+    /** Show the "estimated" footnote in the popover. */
+    estimated: { type: Boolean, default: false },
+  },
+  setup(props) {
+    const { t } = useI18n();
+    const anchorRef = ref<HTMLElement | null>(null);
+    const open = ref(false);
+    let showTimer: ReturnType<typeof setTimeout> | undefined;
+    let hideTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const hasWindow = computed(() => props.contextWindow != null && props.contextWindow > 0);
+    /** null when there is no usable usage/window pair. */
+    const usagePct = computed(() => {
+      if (!hasWindow.value || props.used == null) return null;
+      return (props.used / props.contextWindow!) * 100;
+    });
+
+    /** Center/aria percentage text: floored, "100+" past the window. */
+    const pctText = computed(() => {
+      const p = usagePct.value;
+      if (p == null) return null;
+      return p > 100 ? "100+" : `${Math.floor(p)}%`;
+    });
+
+    const centerText = computed(() => pctText.value ?? "–");
+
+    const usable = computed(() => usagePct.value != null);
+
+    const visibleSegments = computed(() =>
+      props.segments.filter((s) => s && s.tokens > 0),
+    );
+
+    const windowPct = (tokens: number) =>
+      (tokens / props.contextWindow!) * 100;
+
+    /** Arcs for the ring / blocks for the bar (segments mode). */
+    const chartSegments = computed(() =>
+      usable.value
+        ? visibleSegments.value.map((s) => ({
+            value: windowPct(s.tokens),
+            color: segmentColor(s),
+          }))
+        : [],
+    );
+
+    /** Legend rows sorted by tokens desc (largest first). */
+    const legend = computed(() =>
+      usable.value
+        ? [...visibleSegments.value]
+            .sort((a, b) => b.tokens - a.tokens)
+            .map((s) => ({
+              label: s.label ?? t(`hikari::context.${s.key}`, KEY_EN[s.key] ?? s.key),
+              tokens: s.tokens,
+              pct: windowPct(s.tokens),
+              color: segmentColor(s),
+            }))
+        : [],
+    );
+
+    const titleText = computed(() => t("hikari::context.title", "Context usage"));
+
+    const ariaLabel = computed(() => {
+      const base = `${titleText.value}: ${props.model}`;
+      return pctText.value ? `${base} ${pctText.value}` : base;
+    });
+
+    const ringFontSize = computed(() => Math.max(6, Math.round(props.size * 0.3)));
+
+    // Hover choreography copied from HkModelTag: 250ms delay to open,
+    // 120ms to close; hovering the popover keeps it alive.
+    function clearTimers() {
+      if (showTimer) clearTimeout(showTimer);
+      if (hideTimer) clearTimeout(hideTimer);
+      showTimer = undefined;
+      hideTimer = undefined;
+    }
+    function onEnter() {
+      if (hideTimer) clearTimeout(hideTimer);
+      if (showTimer) clearTimeout(showTimer);
+      showTimer = setTimeout(() => { open.value = true; }, 250);
+    }
+    function onLeave() {
+      if (showTimer) clearTimeout(showTimer);
+      hideTimer = setTimeout(() => { open.value = false; }, 120);
+    }
+    function toggle() {
+      clearTimers();
+      open.value = !open.value;
+    }
+    function onKeydown(e: KeyboardEvent) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggle();
+      }
+    }
+
+    return () => {
+      const windowText = hasWindow.value
+        ? formatTokenCount(props.contextWindow!)
+        : "–";
+
+      return (
+        <span
+          class="hk-ctx-ring"
+          role="button"
+          tabindex={0}
+          aria-label={ariaLabel.value}
+          ref={anchorRef}
+          onMouseenter={onEnter}
+          onMouseleave={onLeave}
+          onClick={toggle}
+          onKeydown={onKeydown}
+        >
+          <HProgressRing
+            segments={chartSegments.value}
+            size={props.size}
+            strokeWidth={props.strokeWidth}
+          >
+            <span class="hk-ctx-ring-center" style={{ fontSize: `${ringFontSize.value}px` }}>
+              {centerText.value}
+            </span>
+          </HProgressRing>
+          <HPopover
+            modelValue={open.value}
+            onUpdate:modelValue={(v: boolean) => { open.value = v; }}
+            anchorRef={anchorRef.value}
+            placement={props.placement}
+            offset={6}
+            backdrop={false}
+            sheetOnMobile
+            title={titleText.value}
+            class="hk-ctx-popover"
+          >
+            <div class="hk-ctx-pop" onMouseenter={onEnter} onMouseleave={onLeave}>
+              <div class="hk-ctx-pop-model">
+                <HModelTag model={props.model} />
+              </div>
+              {usable.value ? (
+                <>
+                  <div class="hk-ctx-pop-total">
+                    <span class="hk-ctx-pop-total-label">
+                      {t("hikari::context.used", "Used")}
+                    </span>
+                    <span class="hk-ctx-pop-total-num">
+                      {formatTokenCount(props.used!)}
+                    </span>
+                    <span class="hk-ctx-pop-total-of">
+                      {t("hikari::context.of", "of")}
+                    </span>
+                    <span class="hk-ctx-pop-total-num">
+                      {formatTokenCount(props.contextWindow!)}
+                    </span>
+                  </div>
+                  <div class="hk-ctx-pop-bar">
+                    <HProgressBar segments={chartSegments.value} />
+                  </div>
+                  <ul class="hk-ctx-legend">
+                    {legend.value.map((row, i) => (
+                      <li key={i} class="hk-ctx-legend-row">
+                        <i class="hk-ctx-legend-swatch" style={{ background: row.color }} aria-hidden="true" />
+                        <span class="hk-ctx-legend-label">{row.label}</span>
+                        <span class="hk-ctx-legend-tokens">{formatTokenCount(row.tokens)}</span>
+                        <span class="hk-ctx-legend-pct">{formatPct(row.pct)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  {props.estimated && (
+                    <p class="hk-ctx-est">{t("hikari::context.estimated", "Estimated")}</p>
+                  )}
+                </>
+              ) : (
+                <div class="hk-ctx-pop-empty">
+                  {t("hikari::context.window", "Context window")}: {windowText}
+                </div>
+              )}
+            </div>
+          </HPopover>
+        </span>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkModal.headerLead.test.tsx
+++ b/packages/vue/src/components/HkModal.headerLead.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkModal from "./HkModal";
+
+/**
+ * HkModal headerLead slot contract tests:
+ * - the named slot renders inside .hk-modal-header BEFORE the title
+ * - absent the slot, no new DOM appears (backward compat)
+ * (Existing HkModal tests keep the title/closable/back-guard coverage.)
+ */
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+interface Harness {
+  container: HTMLElement;
+  header: HTMLElement | null;
+}
+
+async function mountModal(
+  props: Record<string, unknown>,
+  slots: Record<string, unknown> = {},
+): Promise<Harness> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const open = ref(true);
+  const Wrapper = defineComponent({
+    setup() {
+      return () =>
+        h(HkModal, {
+          ...props,
+          modelValue: open.value,
+          "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+        }, slots);
+    },
+  });
+  const app = createApp(Wrapper);
+  app.mount(container);
+  mounts.push({ app, container });
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+  return {
+    container,
+    header: document.querySelector(".hk-modal-header"),
+  };
+}
+
+describe("HkModal headerLead slot", () => {
+  it("renders the lead content before the modal title", async () => {
+    const { header } = await mountModal(
+      { title: "Session" },
+      { headerLead: () => h("span", { class: "lead-x", "data-test": "ring" }, "LEAD") },
+    );
+    expect(header).not.toBeNull();
+    const lead = header?.querySelector(".hk-modal-header-lead");
+    expect(lead).not.toBeNull();
+    expect(lead?.querySelector(".lead-x")?.textContent).toBe("LEAD");
+    const children = header ? Array.from(header.children) : [];
+    expect(children[0]?.classList.contains("hk-modal-header-lead")).toBe(true);
+    expect(children[1]?.classList.contains("hk-modal-title")).toBe(true);
+    expect(children[1]?.textContent).toBe("Session");
+  });
+
+  it("keeps the close button as the last header child", async () => {
+    const { header } = await mountModal(
+      { title: "Session", closable: true },
+      { headerLead: () => h("span", "LEAD") },
+    );
+    const children = header ? Array.from(header.children) : [];
+    const last = children[children.length - 1];
+    expect(last?.classList.contains("hk-modal-close")).toBe(true);
+  });
+
+  it("adds no new DOM when the slot is absent", async () => {
+    const { header } = await mountModal({ title: "Session" });
+    expect(header).not.toBeNull();
+    expect(header?.querySelector(".hk-modal-header-lead")).toBeNull();
+    const children = header ? Array.from(header.children) : [];
+    expect(children[0]?.classList.contains("hk-modal-title")).toBe(true);
+  });
+
+  it("shows the header for a title-less modal carrying only headerLead", async () => {
+    const { header } = await mountModal(
+      { title: undefined, closable: false },
+      { headerLead: () => h("span", "LEAD") },
+    );
+    expect(header).not.toBeNull();
+    expect(header?.querySelector(".hk-modal-header-lead")).not.toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -147,6 +147,24 @@
   flex-shrink: 0;
 }
 
+// Compact lead content (e.g. a context ring) rendered before the title.
+// The title's auto right margin overrides the space-between distribution,
+// so the lead + title cluster sits on the left and the close button stays
+// on the right edge.
+.hk-modal-header-lead {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.hk-modal-header--lead {
+  gap: var(--hk-modal-header-lead-gap, 0.75rem);
+
+  .hk-modal-title {
+    margin-right: auto;
+  }
+}
+
 .hk-modal-title {
   font-size: var(--hk-modal-title-font-size, 1.125rem);
   font-weight: var(--hk-modal-title-font-weight, 700);

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -585,7 +585,7 @@ export default defineComponent({
     return () => {
       if (!shouldRender.value) return null;
 
-      const headerShown = props.title || props.closable || slots.header;
+      const headerShown = props.title || props.closable || slots.header || slots.headerLead;
 
       return (
         <Teleport to="body">
@@ -646,7 +646,15 @@ export default defineComponent({
                 >
                   {headerShown && (
                     <>
-                      <div class="hk-modal-header">
+                      <div
+                        class={[
+                          "hk-modal-header",
+                          slots.headerLead ? "hk-modal-header--lead" : "",
+                        ]}
+                      >
+                        {slots.headerLead && (
+                          <div class="hk-modal-header-lead">{slots.headerLead()}</div>
+                        )}
                         <h2 class="hk-modal-title">
                           {slots.header ? (props.title ?? "") : (props.title ?? "")}
                         </h2>

--- a/packages/vue/src/components/HkProgressBar.scss
+++ b/packages/vue/src/components/HkProgressBar.scss
@@ -93,6 +93,22 @@
   }
 }
 
+// Segmented mode: blocks sit flush side by side; the track's own radius
+// and overflow clip shape the pill ends.
+.hk-progress-bar-track--segments {
+  display: flex;
+}
+
+.hk-progress-bar-seg {
+  height: 100%;
+  flex-shrink: 0;
+  // No per-block rounding — flush multi-color blocks would otherwise show
+  // hairlines at the seams.
+  border-radius: 0;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  background: rgb(var(--color-primary));
+}
+
 @keyframes hk-progress-indeterminate {
   0% {
     left: -40%;

--- a/packages/vue/src/components/HkProgressBar.test.tsx
+++ b/packages/vue/src/components/HkProgressBar.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import HkProgressBar from "./HkProgressBar";
+
+/**
+ * HkProgressBar segmented-mode contract tests:
+ * - `segments` renders one flush block per segment with its own width/color
+ * - without `segments` the value/secondary/status behavior is untouched
+ */
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkProgressBar, props as never) });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkProgressBar segmented mode", () => {
+  it("renders one block per segment with width and inline color", () => {
+    const c = mount({
+      segments: [
+        { value: 30, color: "#f00" },
+        { value: 20, color: "#0f0" },
+      ],
+    });
+    const segs = c.querySelectorAll(".hk-progress-bar-seg");
+    expect(segs).toHaveLength(2);
+    expect((segs[0] as HTMLElement).style.width).toBe("30%");
+    expect((segs[0] as HTMLElement).style.background).toBe("#f00");
+    expect((segs[1] as HTMLElement).style.width).toBe("20%");
+    expect((segs[1] as HTMLElement).style.background).toBe("#0f0");
+    // No legacy fills in segmented mode.
+    expect(c.querySelector(".hk-progress-bar-fill")).toBeNull();
+    expect(c.querySelector(".hk-progress-bar-secondary")).toBeNull();
+  });
+
+  it("appends the segment class and tolerates a missing color", () => {
+    const c = mount({
+      segments: [{ value: 40, class: "my-block" }, { value: 10 }],
+    });
+    const seg = c.querySelector(".hk-progress-bar-seg.my-block");
+    expect(seg).not.toBeNull();
+    expect((c.querySelectorAll(".hk-progress-bar-seg")[1] as HTMLElement).style.background).toBe("");
+  });
+
+  it("clamps out-of-range widths", () => {
+    const c = mount({
+      segments: [{ value: -5 }, { value: 120 }],
+    });
+    const segs = c.querySelectorAll(".hk-progress-bar-seg");
+    expect((segs[0] as HTMLElement).style.width).toBe("0%");
+    expect((segs[1] as HTMLElement).style.width).toBe("100%");
+  });
+
+  it("renders an empty track for an empty segments array (no indeterminate sweep)", () => {
+    const c = mount({ segments: [] });
+    expect(c.querySelectorAll(".hk-progress-bar-seg")).toHaveLength(0);
+    expect(c.querySelector(".hk-progress-bar-indeterminate")).toBeNull();
+  });
+});
+
+describe("HkProgressBar single-value mode (backward compat)", () => {
+  it("renders the value fill at its percentage", () => {
+    const c = mount({ value: 65, max: 100 });
+    const fill = c.querySelector(".hk-progress-bar-fill");
+    expect(fill).not.toBeNull();
+    expect((fill as HTMLElement).style.width).toBe("65%");
+    expect(c.querySelectorAll(".hk-progress-bar-seg")).toHaveLength(0);
+  });
+
+  it("still renders the indeterminate sweep when value is null", () => {
+    const c = mount({});
+    expect(c.querySelector(".hk-progress-bar-indeterminate")).not.toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkProgressBar.tsx
+++ b/packages/vue/src/components/HkProgressBar.tsx
@@ -4,6 +4,22 @@ import "./HkProgressBar.scss";
 
 type ProgressBarStatus = "loading" | "done" | "error";
 
+/**
+ * One block of a segmented progress bar. `value` is a percentage (0-100);
+ * blocks are laid left-to-right in order and their values must not sum
+ * past 100.
+ */
+export interface HProgressBarSegment {
+  value: number;
+  /**
+   * Any CSS color — including modern `rgb(var(--x) / a)` space-syntax
+   * colors. Omit to fall back to the theme primary background.
+   */
+  color?: string;
+  /** Extra class appended to this block. */
+  class?: string;
+}
+
 export default defineComponent({
   name: "HkProgressBar",
   props: {
@@ -14,8 +30,17 @@ export default defineComponent({
     size: { type: String as PropType<"xs" | "sm" | "md">, default: "sm" },
     showLabel: { type: Boolean, default: false },
     label: { type: String, default: undefined },
+    /**
+     * Segmented mode: when set (an empty array included) the track renders
+     * one block per segment instead of the `value`/`secondary` fills. Each
+     * segment's width is its percentage; `status` is ignored while
+     * segments are present.
+     */
+    segments: { type: Array as PropType<HProgressBarSegment[]>, default: undefined },
   },
   setup(props) {
+    const segmented = computed(() => props.segments != null);
+
     const pct = computed(() => {
       if (props.value == null) return null;
       return Math.min(100, Math.max(0, (props.value / props.max) * 100));
@@ -28,31 +53,54 @@ export default defineComponent({
 
     const displayLabel = computed(() => {
       if (props.label) return props.label;
+      // Segmented mode has no single value to render — only an explicit
+      // caller label makes sense there.
+      if (segmented.value) return "";
       if (pct.value == null) return "";
       return `${Math.round(pct.value)}%`;
     });
+
+    const segWidth = (value: number) => `${Math.min(100, Math.max(0, value))}%`;
 
     return () => (
       <div class="hk-progress-bar" data-size={props.size}>
         {props.showLabel && (
           <span class="hk-progress-bar-label">{displayLabel.value}</span>
         )}
-        <div class="hk-progress-bar-track">
-          {pct.value != null ? (
-            <>
-              {secondaryPct.value != null && (
-                <div
-                  class={["hk-progress-bar-secondary", `hk-progress-bar-secondary-${props.status}`]}
-                  style={{ width: `${secondaryPct.value}%` }}
-                />
-              )}
+        <div
+          class={[
+            "hk-progress-bar-track",
+            segmented.value ? "hk-progress-bar-track--segments" : "",
+          ]}
+        >
+          {segmented.value ? (
+            (props.segments ?? []).map((s, i) => (
               <div
-                class={["hk-progress-bar-fill", `hk-progress-bar-fill-${props.status}`]}
-                style={{ width: `${pct.value}%` }}
+                key={i}
+                class={["hk-progress-bar-seg", s.class]}
+                style={{
+                  width: segWidth(s.value),
+                  ...(s.color ? { background: s.color } : {}),
+                }}
               />
-            </>
+            ))
           ) : (
-            <div class={["hk-progress-bar-indeterminate", `hk-progress-bar-indeterminate-${props.status}`]} />
+            pct.value != null ? (
+              <>
+                {secondaryPct.value != null && (
+                  <div
+                    class={["hk-progress-bar-secondary", `hk-progress-bar-secondary-${props.status}`]}
+                    style={{ width: `${secondaryPct.value}%` }}
+                  />
+                )}
+                <div
+                  class={["hk-progress-bar-fill", `hk-progress-bar-fill-${props.status}`]}
+                  style={{ width: `${pct.value}%` }}
+                />
+              </>
+            ) : (
+              <div class={["hk-progress-bar-indeterminate", `hk-progress-bar-indeterminate-${props.status}`]} />
+            )
           )}
         </div>
       </div>

--- a/packages/vue/src/components/HkProgressRing.scss
+++ b/packages/vue/src/components/HkProgressRing.scss
@@ -28,6 +28,15 @@
   stroke: var(--hi-color-success, #3fb950);
 }
 
+// Segmented-mode arcs: segments without an explicit `color` fall back to
+// the theme primary (same default as the single-value fill).
+.hk-progress-ring-seg {
+  stroke: var(--hi-color-primary, #58a6ff);
+  transition:
+    stroke-dashoffset 0.3s ease,
+    stroke 0.3s ease;
+}
+
 .hk-progress-ring-exception .hk-progress-ring-fill {
   stroke: var(--hi-color-danger, #f85149);
 }

--- a/packages/vue/src/components/HkProgressRing.test.tsx
+++ b/packages/vue/src/components/HkProgressRing.test.tsx
@@ -66,6 +66,11 @@ describe("HkProgressRing segmented mode", () => {
 
     // The gap leaves no overlap: the arcs stay inside [0, 50%).
     expect(second.off).toBeCloseTo(first.off - first.len - (PROGRESS_RING_SEG_GAP_PCT / 100) * C, 6);
+
+    // Segment arcs are butt-capped: a round cap extends strokeWidth/2 past
+    // each end and would swallow the carved gap at badge sizes.
+    expect(segs[0].getAttribute("stroke-linecap")).toBe("butt");
+    expect(segs[1].getAttribute("stroke-linecap")).toBe("butt");
   });
 
   it("carves no gap after the last segment (full 100 fills the ring)", () => {
@@ -120,6 +125,8 @@ describe("HkProgressRing single-value mode (backward compat)", () => {
     const C = 2 * Math.PI * R;
     const off = Number(fill?.getAttribute("stroke-dashoffset"));
     expect(off).toBeCloseTo(C * (1 - 25 / 100), 6);
+    // The legacy single-value fill keeps its rounded end caps.
+    expect(fill?.getAttribute("stroke-linecap")).toBe("round");
     expect(c.querySelector(".hk-progress-ring")?.getAttribute("aria-valuenow")).toBe("25");
   });
 

--- a/packages/vue/src/components/HkProgressRing.test.tsx
+++ b/packages/vue/src/components/HkProgressRing.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import HkProgressRing, { PROGRESS_RING_SEG_GAP_PCT } from "./HkProgressRing";
+
+/**
+ * HkProgressRing segmented-mode contract tests:
+ * - `segments` renders one circle per visible segment with cumulative
+ *   dashoffset math and a carved inter-segment gap
+ * - without `segments` the single-value fill behavior is untouched
+ * - segments-mode aria-valuenow is the sum of the segment values
+ */
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => h(HkProgressRing, props as never) });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+function dashParts(el: Element): { len: number; off: number; total: number } {
+  const len = Number(el.getAttribute("stroke-dasharray")?.split(/\s+/)[0]);
+  const off = Number(el.getAttribute("stroke-dashoffset"));
+  return { len, off, total: len + Number(el.getAttribute("stroke-dasharray")?.split(/\s+/)[1]) };
+}
+
+describe("HkProgressRing segmented mode", () => {
+  // size 120, strokeWidth 8 -> r = 56
+  const R = (120 - 8) / 2;
+  const C = 2 * Math.PI * R;
+
+  it("renders one circle per visible segment with cumulative offsets and gaps", () => {
+    const c = mount({
+      segments: [
+        { value: 25, color: "#f00" },
+        { value: 25, color: "#0f0" },
+      ],
+    });
+    const segs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(segs).toHaveLength(2);
+    expect(c.querySelector(".hk-progress-ring-fill")).toBeNull();
+
+    // First segment starts at the ring origin; its drawn length loses the
+    // inter-segment gap (it has a following sibling).
+    const first = dashParts(segs[0]);
+    expect(first.len).toBeCloseTo(((25 - PROGRESS_RING_SEG_GAP_PCT) / 100) * C, 6);
+    expect(first.off).toBeCloseTo(C, 6); // offset = C * (1 - start/100), start 0
+    expect((segs[0] as SVGElement).style.stroke).toBe("#f00");
+
+    // Second segment starts at 25% of the ring; no gap carved after the
+    // last arc, so its drawn length is its full share.
+    const second = dashParts(segs[1]);
+    expect(second.len).toBeCloseTo((25 / 100) * C, 6);
+    expect(second.off).toBeCloseTo(C * (1 - 25 / 100), 6);
+    expect((segs[1] as SVGElement).style.stroke).toBe("#0f0");
+
+    // The gap leaves no overlap: the arcs stay inside [0, 50%).
+    expect(second.off).toBeCloseTo(first.off - first.len - (PROGRESS_RING_SEG_GAP_PCT / 100) * C, 6);
+  });
+
+  it("carves no gap after the last segment (full 100 fills the ring)", () => {
+    const c = mount({ segments: [{ value: 100, color: "#00f" }] });
+    const segs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(segs).toHaveLength(1);
+    const d = dashParts(segs[0]);
+    expect(d.len).toBeCloseTo(C, 6);
+  });
+
+  it("skips zero-value segments entirely", () => {
+    const c = mount({ segments: [{ value: 0, color: "#f00" }, { value: 50 }] });
+    const segs = c.querySelectorAll(".hk-progress-ring-seg");
+    expect(segs).toHaveLength(1);
+    const d = dashParts(segs[0]);
+    expect(d.len).toBeCloseTo((50 / 100) * C, 6);
+    // start stays at the origin — the zero segment claimed nothing
+    expect(d.off).toBeCloseTo(C, 6);
+  });
+
+  it("reports the segment sum as aria-valuenow", () => {
+    const c = mount({
+      segments: [
+        { value: 25 },
+        { value: 25 },
+        { value: 25 },
+      ],
+    });
+    const ring = c.querySelector(".hk-progress-ring");
+    expect(ring?.getAttribute("role")).toBe("progressbar");
+    expect(ring?.getAttribute("aria-valuenow")).toBe("75");
+    expect(ring?.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  it("appends the segment class and keeps the track circle", () => {
+    const c = mount({
+      segments: [{ value: 40, class: "my-seg" }],
+    });
+    const seg = c.querySelector(".hk-progress-ring-seg.my-seg");
+    expect(seg).not.toBeNull();
+    expect(c.querySelector(".hk-progress-ring-track")).not.toBeNull();
+  });
+});
+
+describe("HkProgressRing single-value mode (backward compat)", () => {
+  it("renders the legacy fill without segments", () => {
+    const c = mount({ value: 25 });
+    expect(c.querySelectorAll(".hk-progress-ring-seg")).toHaveLength(0);
+    const fill = c.querySelector(".hk-progress-ring-fill");
+    expect(fill).not.toBeNull();
+    const R = (120 - 8) / 2;
+    const C = 2 * Math.PI * R;
+    const off = Number(fill?.getAttribute("stroke-dashoffset"));
+    expect(off).toBeCloseTo(C * (1 - 25 / 100), 6);
+    expect(c.querySelector(".hk-progress-ring")?.getAttribute("aria-valuenow")).toBe("25");
+  });
+
+  it("still honours pct over value", () => {
+    const c = mount({ value: 10, pct: 40 });
+    const fill = c.querySelector(".hk-progress-ring-fill");
+    const R = (120 - 8) / 2;
+    const C = 2 * Math.PI * R;
+    expect(Number(fill?.getAttribute("stroke-dashoffset"))).toBeCloseTo(C * 0.6, 6);
+  });
+});

--- a/packages/vue/src/components/HkProgressRing.tsx
+++ b/packages/vue/src/components/HkProgressRing.tsx
@@ -134,7 +134,10 @@ export default defineComponent({
                     stroke-width={props.strokeWidth}
                     stroke-dasharray={`${lenPx} ${circumference.value - lenPx}`}
                     stroke-dashoffset={circumference.value * (1 - arc.start / 100)}
-                    stroke-linecap="round"
+                    // Butt caps keep the carved gap visible: a round cap
+                    // extends strokeWidth/2 past each arc end, which at
+                    // badge sizes (28px / 3px) fully swallows the 1% gap.
+                    stroke-linecap="butt"
                     transform={`rotate(-90 ${center.value} ${center.value})`}
                     style={arc.color ? { stroke: arc.color } : undefined}
                   />

--- a/packages/vue/src/components/HkProgressRing.tsx
+++ b/packages/vue/src/components/HkProgressRing.tsx
@@ -2,6 +2,30 @@ import { computed, defineComponent, type PropType } from "vue";
 
 import "./HkProgressRing.scss";
 
+/**
+ * One arc of a segmented progress ring. `value` is a percentage of the
+ * full ring (0-100). Segments are laid head-to-tail in order and their
+ * values must not sum past 100.
+ */
+export interface HProgressRingSegment {
+  value: number;
+  /**
+   * Any CSS color — including modern `rgb(var(--x) / a)` space-syntax
+   * colors. Applied as an inline style (not a presentation attribute) so
+   * CSS variables resolve. Omit to fall back to the theme default stroke.
+   */
+  color?: string;
+  /** Extra class appended to this segment's circle. */
+  class?: string;
+}
+
+/**
+ * Visual gap carved between consecutive segments, in percent of the full
+ * ring. Each segment's drawn arc is shortened by this amount when another
+ * segment follows, so the arcs never touch.
+ */
+export const PROGRESS_RING_SEG_GAP_PCT = 1;
+
 export default defineComponent({
   name: "HkProgressRing",
   props: {
@@ -13,6 +37,14 @@ export default defineComponent({
     showLabel: { type: Boolean, default: false },
     /** Whether to render the background track circle. Set false for overlay-only use. */
     showTrack: { type: Boolean, default: true },
+    /**
+     * Segmented mode: when set (an empty array included) each segment is
+     * drawn as its own arc instead of the single `value`/`pct` fill.
+     * Segment values are percentages of the full ring laid head-to-tail;
+     * a ~1% gap is carved between consecutive arcs. `value`/`pct` and
+     * `variant` are ignored while segments are present.
+     */
+    segments: { type: Array as PropType<HProgressRingSegment[]>, default: undefined },
   },
   setup(props, { slots }) {
     const clampedValue = computed(() => Math.min(100, Math.max(0, props.pct ?? props.value)));
@@ -21,6 +53,42 @@ export default defineComponent({
     const circumference = computed(() => 2 * Math.PI * radius.value);
     const dashOffset = computed(() => circumference.value * (1 - clampedValue.value / 100));
 
+    const segmented = computed(() => props.segments != null);
+
+    /**
+     * One arc per visible segment. `start` is the cumulative share of the
+     * previous segments (the arc's beginning along the ring, in percent),
+     * `len` the drawn length in percent — the segment's own share minus
+     * the carved inter-segment gap (only when another segment follows).
+     */
+    const arcs = computed(() => {
+      if (!segmented.value) return [];
+      const out: Array<{ start: number; len: number; color?: string; class?: string }> = [];
+      const visible = (props.segments ?? []).filter((s) => s && s.value > 0);
+      let cursor = 0;
+      visible.forEach((seg, i) => {
+        if (cursor >= 100) return;
+        const share = Math.min(Math.max(seg.value, 0), 100 - cursor);
+        const gap = i < visible.length - 1 ? PROGRESS_RING_SEG_GAP_PCT : 0;
+        const len = Math.max(share - gap, 0);
+        if (len > 0) {
+          out.push({ start: cursor, len, color: seg.color, class: seg.class });
+        }
+        cursor += share;
+      });
+      return out;
+    });
+
+    /** Total claimed by the segments — the segments-mode aria-valuenow. */
+    const segmentsTotal = computed(() => {
+      if (!segmented.value) return clampedValue.value;
+      const sum = (props.segments ?? []).reduce(
+        (acc, s) => acc + Math.max(s?.value ?? 0, 0),
+        0,
+      );
+      return Math.round(Math.min(100, sum) * 10) / 10;
+    });
+
     const variantClass = computed(() => {
       if (props.variant === "success") return "hk-progress-ring-success";
       if (props.variant === "exception") return "hk-progress-ring-exception";
@@ -28,7 +96,6 @@ export default defineComponent({
     });
 
     const textSize = computed(() => Math.round(props.size / 5));
-
     const center = computed(() => props.size / 2);
 
     return () => (
@@ -36,7 +103,7 @@ export default defineComponent({
         class={["hk-progress-ring", variantClass.value]}
         style={{ width: `${props.size}px`, height: `${props.size}px` }}
         role="progressbar"
-        aria-valuenow={clampedValue.value}
+        aria-valuenow={segmentsTotal.value}
         aria-valuemin={0}
         aria-valuemax={100}
       >
@@ -53,22 +120,44 @@ export default defineComponent({
               stroke-linecap="round"
             />
           )}
-          <circle
-            class="hk-progress-ring-fill"
-            cx={center.value}
-            cy={center.value}
-            r={radius.value}
-            fill="none"
-            stroke-width={props.strokeWidth}
-            stroke-dasharray={circumference.value}
-            stroke-dashoffset={dashOffset.value}
-            stroke-linecap="round"
-            transform={`rotate(-90 ${center.value} ${center.value})`}
-          />
+          {segmented.value
+            ? arcs.value.map((arc, i) => {
+                const lenPx = (arc.len / 100) * circumference.value;
+                return (
+                  <circle
+                    key={i}
+                    class={["hk-progress-ring-seg", arc.class]}
+                    cx={center.value}
+                    cy={center.value}
+                    r={radius.value}
+                    fill="none"
+                    stroke-width={props.strokeWidth}
+                    stroke-dasharray={`${lenPx} ${circumference.value - lenPx}`}
+                    stroke-dashoffset={circumference.value * (1 - arc.start / 100)}
+                    stroke-linecap="round"
+                    transform={`rotate(-90 ${center.value} ${center.value})`}
+                    style={arc.color ? { stroke: arc.color } : undefined}
+                  />
+                );
+              })
+            : (
+              <circle
+                class="hk-progress-ring-fill"
+                cx={center.value}
+                cy={center.value}
+                r={radius.value}
+                fill="none"
+                stroke-width={props.strokeWidth}
+                stroke-dasharray={circumference.value}
+                stroke-dashoffset={dashOffset.value}
+                stroke-linecap="round"
+                transform={`rotate(-90 ${center.value} ${center.value})`}
+              />
+            )}
         </svg>
         {props.showLabel && !slots.default && (
           <span class="hk-progress-ring-label" style={{ fontSize: `${textSize.value}px` }}>
-            {Math.round(clampedValue.value)}%
+            {Math.round(segmentsTotal.value)}%
           </span>
         )}
         {slots.default && (

--- a/packages/vue/src/i18n/contextKeys.test.ts
+++ b/packages/vue/src/i18n/contextKeys.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Lightweight i18n completeness guard for the hikari::context.* key family
+ * (added for the HkContextRing popover). Every key must exist in ALL 11
+ * locale chat.json files at the same flat level as the hikari::model.*
+ * keys — a key landing in the wrong file/level silently falls back to
+ * English for every non-en locale (hikari review lessons #373/#374).
+ */
+const modules = import.meta.glob<{ default: Record<string, Record<string, string>> }>(
+  "./locales/*/chat.json",
+  { eager: true },
+);
+
+const EXPECTED_LOCALES = [
+  "ar", "de", "en", "es", "fr", "ja", "ko", "pt", "ru", "zh-Hans", "zh-Hant",
+];
+
+const REQUIRED_KEYS = [
+  "hikari::context.title",
+  "hikari::context.estimated",
+  "hikari::context.used",
+  "hikari::context.of",
+  "hikari::context.window",
+  "hikari::context.prompt",
+  "hikari::context.user",
+  "hikari::context.thinking",
+  "hikari::context.tool",
+  "hikari::context.output",
+  "hikari::context.free",
+];
+
+describe("hikari::context locale keys", () => {
+  it("covers all 11 chat.json locale files", () => {
+    const paths = Object.keys(modules)
+      .map((p) => p.match(/locales\/([^/]+)\/chat\.json/)?.[1])
+      .filter((l): l is string => Boolean(l))
+      .sort();
+    expect(paths).toEqual(EXPECTED_LOCALES);
+  });
+
+  it("defines every hikari::context.* key in every locale", () => {
+    for (const [path, mod] of Object.entries(modules)) {
+      const chat = mod.default.chat ?? {};
+      for (const key of REQUIRED_KEYS) {
+        const value = chat[key];
+        expect(typeof value, `${path} must define ${key}`).toBe("string");
+        expect((value ?? "").length, `${path} ${key} must not be empty`).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/vue/src/i18n/locales/ar/chat.json
+++ b/packages/vue/src/i18n/locales/ar/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "السياق",
     "hikari::model.pricing": "التسعير",
     "hikari::model.noData": "لا توجد مواصفات",
-    "hikari::chat.removeAttachment": "حذف"
+    "hikari::chat.removeAttachment": "حذف",
+    "hikari::context.title": "استخدام السياق",
+    "hikari::context.estimated": "تقديري",
+    "hikari::context.used": "المستخدم",
+    "hikari::context.of": "من",
+    "hikari::context.window": "نافذة السياق",
+    "hikari::context.prompt": "الموجه",
+    "hikari::context.user": "المستخدم",
+    "hikari::context.thinking": "التفكير",
+    "hikari::context.tool": "الأداة",
+    "hikari::context.output": "المخرجات",
+    "hikari::context.free": "المتبقي"
   }
 }

--- a/packages/vue/src/i18n/locales/de/chat.json
+++ b/packages/vue/src/i18n/locales/de/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Kontext",
     "hikari::model.pricing": "Preise",
     "hikari::model.noData": "Keine Spezifikation verfügbar",
-    "hikari::chat.removeAttachment": "Löschen"
+    "hikari::chat.removeAttachment": "Löschen",
+    "hikari::context.title": "Kontextnutzung",
+    "hikari::context.estimated": "Geschätzt",
+    "hikari::context.used": "Verwendet",
+    "hikari::context.of": "von",
+    "hikari::context.window": "Kontextfenster",
+    "hikari::context.prompt": "Prompt",
+    "hikari::context.user": "Benutzer",
+    "hikari::context.thinking": "Denken",
+    "hikari::context.tool": "Tool",
+    "hikari::context.output": "Ausgabe",
+    "hikari::context.free": "Frei"
   }
 }

--- a/packages/vue/src/i18n/locales/en/chat.json
+++ b/packages/vue/src/i18n/locales/en/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Context",
     "hikari::model.pricing": "Pricing",
     "hikari::model.noData": "No spec available",
-    "hikari::chat.removeAttachment": "Delete"
+    "hikari::chat.removeAttachment": "Delete",
+    "hikari::context.title": "Context usage",
+    "hikari::context.estimated": "Estimated",
+    "hikari::context.used": "Used",
+    "hikari::context.of": "of",
+    "hikari::context.window": "Context window",
+    "hikari::context.prompt": "Prompt",
+    "hikari::context.user": "User",
+    "hikari::context.thinking": "Thinking",
+    "hikari::context.tool": "Tool",
+    "hikari::context.output": "Output",
+    "hikari::context.free": "Free"
   }
 }

--- a/packages/vue/src/i18n/locales/es/chat.json
+++ b/packages/vue/src/i18n/locales/es/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Contexto",
     "hikari::model.pricing": "Precios",
     "hikari::model.noData": "Sin especificación disponible",
-    "hikari::chat.removeAttachment": "Eliminar"
+    "hikari::chat.removeAttachment": "Eliminar",
+    "hikari::context.title": "Uso de contexto",
+    "hikari::context.estimated": "Estimado",
+    "hikari::context.used": "Usado",
+    "hikari::context.of": "de",
+    "hikari::context.window": "Ventana de contexto",
+    "hikari::context.prompt": "Indicación",
+    "hikari::context.user": "Usuario",
+    "hikari::context.thinking": "Razonamiento",
+    "hikari::context.tool": "Herramienta",
+    "hikari::context.output": "Salida",
+    "hikari::context.free": "Libre"
   }
 }

--- a/packages/vue/src/i18n/locales/fr/chat.json
+++ b/packages/vue/src/i18n/locales/fr/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Contexte",
     "hikari::model.pricing": "Tarifs",
     "hikari::model.noData": "Aucune spécification disponible",
-    "hikari::chat.removeAttachment": "Supprimer"
+    "hikari::chat.removeAttachment": "Supprimer",
+    "hikari::context.title": "Utilisation du contexte",
+    "hikari::context.estimated": "Estimé",
+    "hikari::context.used": "Utilisé",
+    "hikari::context.of": "sur",
+    "hikari::context.window": "Fenêtre de contexte",
+    "hikari::context.prompt": "Invite",
+    "hikari::context.user": "Utilisateur",
+    "hikari::context.thinking": "Réflexion",
+    "hikari::context.tool": "Outil",
+    "hikari::context.output": "Sortie",
+    "hikari::context.free": "Libre"
   }
 }

--- a/packages/vue/src/i18n/locales/ja/chat.json
+++ b/packages/vue/src/i18n/locales/ja/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "コンテキスト",
     "hikari::model.pricing": "価格",
     "hikari::model.noData": "仕様情報がありません",
-    "hikari::chat.removeAttachment": "削除"
+    "hikari::chat.removeAttachment": "削除",
+    "hikari::context.title": "コンテキスト使用量",
+    "hikari::context.estimated": "推定値",
+    "hikari::context.used": "使用済み",
+    "hikari::context.of": "/",
+    "hikari::context.window": "コンテキストウィンドウ",
+    "hikari::context.prompt": "プロンプト",
+    "hikari::context.user": "ユーザー",
+    "hikari::context.thinking": "思考",
+    "hikari::context.tool": "ツール",
+    "hikari::context.output": "出力",
+    "hikari::context.free": "残り"
   }
 }

--- a/packages/vue/src/i18n/locales/ko/chat.json
+++ b/packages/vue/src/i18n/locales/ko/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "컨텍스트",
     "hikari::model.pricing": "가격",
     "hikari::model.noData": "사양 정보 없음",
-    "hikari::chat.removeAttachment": "삭제"
+    "hikari::chat.removeAttachment": "삭제",
+    "hikari::context.title": "컨텍스트 사용량",
+    "hikari::context.estimated": "추정치",
+    "hikari::context.used": "사용됨",
+    "hikari::context.of": "/",
+    "hikari::context.window": "컨텍스트 윈도우",
+    "hikari::context.prompt": "프롬프트",
+    "hikari::context.user": "사용자",
+    "hikari::context.thinking": "추론",
+    "hikari::context.tool": "도구",
+    "hikari::context.output": "출력",
+    "hikari::context.free": "남음"
   }
 }

--- a/packages/vue/src/i18n/locales/pt/chat.json
+++ b/packages/vue/src/i18n/locales/pt/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Contexto",
     "hikari::model.pricing": "Preços",
     "hikari::model.noData": "Nenhuma especificação disponível",
-    "hikari::chat.removeAttachment": "Excluir"
+    "hikari::chat.removeAttachment": "Excluir",
+    "hikari::context.title": "Uso de contexto",
+    "hikari::context.estimated": "Estimado",
+    "hikari::context.used": "Usado",
+    "hikari::context.of": "de",
+    "hikari::context.window": "Janela de contexto",
+    "hikari::context.prompt": "Instrução",
+    "hikari::context.user": "Usuário",
+    "hikari::context.thinking": "Raciocínio",
+    "hikari::context.tool": "Ferramenta",
+    "hikari::context.output": "Saída",
+    "hikari::context.free": "Livre"
   }
 }

--- a/packages/vue/src/i18n/locales/ru/chat.json
+++ b/packages/vue/src/i18n/locales/ru/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "Контекст",
     "hikari::model.pricing": "Цены",
     "hikari::model.noData": "Нет данных о модели",
-    "hikari::chat.removeAttachment": "Удалить"
+    "hikari::chat.removeAttachment": "Удалить",
+    "hikari::context.title": "Использование контекста",
+    "hikari::context.estimated": "Оценка",
+    "hikari::context.used": "Использовано",
+    "hikari::context.of": "из",
+    "hikari::context.window": "Контекстное окно",
+    "hikari::context.prompt": "Промпт",
+    "hikari::context.user": "Пользователь",
+    "hikari::context.thinking": "Рассуждение",
+    "hikari::context.tool": "Инструмент",
+    "hikari::context.output": "Вывод",
+    "hikari::context.free": "Свободно"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/chat.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "上下文",
     "hikari::model.pricing": "定价",
     "hikari::model.noData": "暂无规格信息",
-    "hikari::chat.removeAttachment": "删除"
+    "hikari::chat.removeAttachment": "删除",
+    "hikari::context.title": "上下文占用",
+    "hikari::context.estimated": "估算值",
+    "hikari::context.used": "已用",
+    "hikari::context.of": "/",
+    "hikari::context.window": "上下文窗口",
+    "hikari::context.prompt": "系统提示词",
+    "hikari::context.user": "用户对话",
+    "hikari::context.thinking": "思考过程",
+    "hikari::context.tool": "工具调用",
+    "hikari::context.output": "回复文本",
+    "hikari::context.free": "剩余"
   }
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/chat.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/chat.json
@@ -33,6 +33,17 @@
     "hikari::model.context": "上下文",
     "hikari::model.pricing": "定價",
     "hikari::model.noData": "暫無規格資訊",
-    "hikari::chat.removeAttachment": "刪除"
+    "hikari::chat.removeAttachment": "刪除",
+    "hikari::context.title": "上下文佔用",
+    "hikari::context.estimated": "估算值",
+    "hikari::context.used": "已用",
+    "hikari::context.of": "/",
+    "hikari::context.window": "上下文視窗",
+    "hikari::context.prompt": "系統提示詞",
+    "hikari::context.user": "使用者對話",
+    "hikari::context.thinking": "思考過程",
+    "hikari::context.tool": "工具呼叫",
+    "hikari::context.output": "回覆文字",
+    "hikari::context.free": "剩餘"
   }
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -340,6 +340,7 @@ export {
 export { HkTokenUsageBadge as HTokenUsageBadge } from "./components/HkTokenUsageBadge";
 export { HkTokenUsagePanel as HTokenUsagePanel } from "./components/HkTokenUsagePanel";
 export { HkModelTag as HModelTag } from "./components/HkModelTag";
+export { HkContextRing as HContextRing, HkContextRing, type HkContextSegment } from "./components/HkContextRing";
 export {
   getModelMeta,
   registerModelCatalog,


### PR DESCRIPTION
## What

- **HkProgressRing**: optional `segments` prop (`{ value, color?, class? }[]`) rendered as consecutive arcs with a 1% carved gap (butt caps keep the gap visible at badge sizes); legacy single-value mode byte-compatible. Segments-mode aria-valuenow = segment sum.
- **HkProgressBar**: optional `segments` prop (flex blocks in the track); legacy paths untouched.
- **HkContextRing** (new, also exported as `HContextRing`): circular context-usage badge — arcs partition the occupied share proportionally (estimated composition never under-fills against the authoritative center pct; a muted occupancy arc covers unknown composition), center % label (floored, "100+" overflow, gray "–" degradation without window/usage), hover popover (250/120ms, HkModelTag choreography) + click toggle + Enter/Space, mobile bottom sheet via `sheetOnMobile`. Popover: model tag, used/of/window line, segmented bar, token-desc legend (share = tokens/contextWindow), estimated footnote. Colors resolve `rgb(var(--context-<key>, <fallback rgb>))` so the chest theme palette can override per slot.
- **HkModal**: new `headerLead` named slot rendered before the title (host surface for the ring at a window's top-left corner); zero new DOM when absent.
- **i18n**: `hikari::context.*` keys (title/estimated/used/of/window/prompt/user/thinking/tool/output/free) across all 11 locales + a key-parity test.
- Version 0.37.0 → 0.38.0.

## Verification

- 5 new test files, 35 component/i18n tests green; full suite 855 passed with only the documented master-inherited failures (registerAnimations, HkDatePicker; HkMenu intermittent flake) — reproduced on master.
- vue-tsc --noEmit exit 0.
- 3-round verify cycle: implementation self-verify → independent adversarial review (fixed: unmount timer leak, doc/impl contract mismatch found in cross-review) → polish round (butt caps, occupancy-normalized arcs + tests).