### PR TITLE
🛡️ Keep the auth card measuring wrapper from collapsing the panel width.

### DIFF
--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -538,6 +538,15 @@
      explicit box-sizing keeps that mapping honest on hosts without a
      global border-box reset. */
   box-sizing: border-box;
+  /* Mirror the card's own sizing contract (.s-auth-card below:
+     `width: 100%; max-width: 28rem`). The card's percentage width now
+     resolves against THIS wrapper, and a bare wrapper inside a centered
+     flex/grid host shrink-wraps to the card's content — collapsing the
+     panel to its intrinsic width. Presenting the same definite sizing
+     context here restores the exact pre-wrapper geometry in every host
+     formatting context. Keep the two declarations in sync. */
+  width: 100%;
+  max-width: 28rem;
   transition: height 0.3s var(--ease-out-expo, cubic-bezier(0.19, 1, 0.22, 1));
 
   &.s-auth-card--measuring {


### PR DESCRIPTION
## What

One CSS fix: `.s-auth-card-height` (the height-measuring wrapper from #381) now mirrors the card's own sizing contract — `width: 100%; max-width: 28rem`.

## Why

The card (`.s-auth-card`) is `width: 100%; max-width: 28rem`, and since #381 its percentage width resolves against the NEW wrapper. A bare wrapper inside centered flex/grid hosts shrink-wraps to the card's content, so every auth panel (sign-in, MFA, register, setup — `HSignInCard` composes `HkAuthCard`) collapsed to its intrinsic content width. Presenting the same definite sizing context on the wrapper restores the exact pre-#381 geometry in every host formatting context; nothing else (height measurement, clip lifecycle, reduced-motion) is affected.

## Verification

HkAuthCard test suite 10/10 on the fixed tree. Reported from the deployed dev-celestia panel (narrower after the 0.36.0/0.37.0 wave).