### PR TITLE
📦 Release HkAuthCard width fix in packages/vue 0.38.1.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.38.0",
+  "version": "0.38.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
0.38.0 was cut from a parent commit that predated #385, so the published tarball ships the collapsed auth panel. Bump to publish the fixed tree.