### PR TITLE
🐛 Stretch the error landing to the full width of its host.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.38.1",
+  "version": "0.38.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkErrorLanding.scss
+++ b/packages/vue/src/components/HkErrorLanding.scss
@@ -15,6 +15,15 @@
   --hel-error: var(--color-error, 226 84 84);
   --hel-warning: var(--color-warning, 222 168 62);
 
+  // The landing owns its full-viewport backdrop, so it must always fill
+  // the host's inline axis. Hosts vary: a plain block (the app overlay's
+  // fixed inset-0 box) already gives block children the full width, but a
+  // CENTERING host — e.g. a standalone mount root that is itself a
+  // centering flex/grid box — shrink-wraps flex/grid items to content
+  // width, which paints this background as one content-wide column and
+  // leaks the host body background down both sides. An explicit
+  // width:100% makes every host render the same edge-to-edge takeover.
+  width: 100%;
   min-height: 100vh;
   min-height: 100dvh;
   display: flex;


### PR DESCRIPTION
## Problem

The chest standalone error page (`error.html`, browser-facing OAuth/API errors — e.g. `unknown_provider` 400) renders the hydrated landing inside a ~470px vertical band: the page's `#error-page-root` mount root is a centering flex box, and flex items shrink-wrap to content width — so `HkErrorLanding`'s own full-viewport backdrop (`rgb(var(--color-background))`) only painted a content-wide column while the skeleton's cooler `246 247 249` body background showed on both sides.

The in-app runtime-error overlay (`ErrorLandingOverlay`) never had this because its host `.error-landing-overlay` is a fixed `inset: 0` plain block — block children fill the host inline axis.

## Fix

One line of CSS + comment: `.hk-error-landing { width: 100% }`, giving the component the same always-fills-its-host semantic the overlay host provides implicitly. Block hosts are unaffected; centering flex/grid hosts now render the identical edge-to-edge takeover. The only consumer in the family is chest's `ErrorLandingCard` (page + overlay variants).

## Verification

- `vitest run src/components/HkErrorLanding.test.tsx` — 7/7 green.
- Band geometry matches the diagnosis exactly (430px card + 2×20px padding = 470px column in the user screenshot).
- Sole consumer audited; overlay/page behavior unchanged where hosts already fill.

Bumps `@celestia-island/hikari` to 0.38.2; chest lockfile bump follows after publish.