### PR TITLE
🎨 Expose the channel tokens through the styles path as channels.scss.

### DIFF
--- a/packages/vue/src/styles/theme/channels.scss
+++ b/packages/vue/src/styles/theme/channels.scss
@@ -1,0 +1,162 @@
+// Vendored from packages/vue/src/tokens.scss so npm registry installs can
+// resolve it — the exports map only exposes ./styles/*, and consumers that
+// build their own shell (non-chest webuis) need the --color-* channel
+// defaults + resolved --hi-* aliases at CSS level, before the runtime
+// (initTheme) injects inline overrides. Edit the upstream file, then
+// re-copy; do not hand-edit here.
+
+/* ── Syntax highlighting palette family: --code-* ───────────────────
+ * Token names consumed by hikari's highlighted-code surfaces (the
+ * HkToolBlock syntax layer and its JSON viewer, see HkToolBlock.scss).
+ * The VALUES are intentionally NOT defined here: the family is owned by
+ * the host theme, which maps each token to mode-aware colors. The
+ * canonical mapping (dark = One Dark, light = GitHub Light) lives in the
+ * celestia webui theme.scss; components reference the tokens with their
+ * original One Dark values as fallbacks so standalone consumers render
+ * unchanged. Extend this family only by adding a --code-* token with a
+ * fallback equal to the current visual.
+ *   --code-keyword  hljs-keyword / selector-tag       (purple)
+ *   --code-builtin  hljs-built_in                     (purple → blue in light)
+ *   --code-string   hljs-string                       (green)
+ *   --code-number   hljs-number / literal / attr      (orange → blue in light)
+ *   --code-comment  hljs-comment / doctag             (grey, italic)
+ *   --code-function hljs-title.function_              (blue)
+ *   --code-type     hljs-type / class title           (yellow → green in light)
+ *   --code-variable hljs-variable / template-var      (red → orange in light)
+ */
+/* hikari color aliases — fallback values for theme tokens.
+   These CSS variables are used by hikari components (HkButton, HkCard,
+   HkInput, HkSelect, etc.) and are expected to be overridden by
+   consuming apps via initTheme() or custom theme CSS. */
+:root {
+  --c-primary-faint: rgb(var(--color-primary, 122 162 247) / 5%);
+  --c-primary-subtle: rgb(var(--color-primary, 122 162 247) / 8%);
+  --c-primary-dim: rgb(var(--color-primary, 122 162 247) / 10%);
+  --c-primary-light: rgb(var(--color-primary, 122 162 247) / 15%);
+  --c-primary-overlay: rgb(var(--color-primary, 122 162 247) / 15%);
+  --c-primary-medium: rgb(var(--color-primary, 122 162 247) / 25%);
+  --c-primary-strong: rgb(var(--color-primary, 122 162 247) / 40%);
+  --c-primary-intense: rgb(var(--color-primary, 122 162 247) / 40%);
+  --c-error-dim: rgb(var(--color-error, 247 118 142) / 10%);
+  --c-error-overlay: rgb(var(--color-error, 247 118 142) / 20%);
+  --c-error-strong: rgb(var(--color-error, 247 118 142) / 50%);
+  --shadow-elevated: 0 8px 32px rgb(0 0 0 / 15%);
+  --shadow-dropdown: 0 4px 24px rgb(0 0 0 / 12%), 0 0 0 1px rgb(255 255 255 / 4%);
+  --shadow-button: 0 4px 14px rgb(var(--color-primary, 122 162 247) / 35%);
+  --shadow-button-danger: 0 4px 14px rgb(var(--color-error, 247 118 142) / 35%);
+  --shadow-focus: 0 0 0 3px rgb(var(--color-primary, 122 162 247) / 12%);
+  --shadow-focus-error: 0 0 0 3px rgb(var(--color-error, 247 118 142) / 12%);
+  --border-input: rgb(var(--color-border, 100 100 100) / 15%);
+  --border-faint: rgb(var(--color-border, 100 100 100) / 10%);
+  --border-subtle: rgb(var(--color-border, 100 100 100) / 12%);
+
+  /* Icon-button state bridge — HkIconButtonVars references this vocabulary
+     but nothing ever defined it, so every var() without an in-file fallback
+     was invalid at computed-value time: non-ghost variants had no active
+     background, focus rings and glow vanished, and one missing item even
+     invalidated the whole transition shorthand (all icon buttons lost their
+     hover/press animation). Defined once here as live expressions over the
+     theme triplets so they track whichever palette is active; the -dark
+     variants are the pressed-step of their base slot. */
+  --hi-icon-color: rgb(var(--color-text, 30 30 30));
+  --hi-icon-size-xs: 0.75rem;
+  --hi-icon-size-sm: 1rem;
+  --hi-icon-size-md: 1.25rem;
+  --hi-icon-size-lg: 1.5rem;
+  --hi-duration-instant: var(--duration-instant, 0.1s);
+  --hi-border-color-focus: rgb(var(--color-primary, 122 162 247));
+  --hi-glow-color: transparent;
+  --hi-bg-surface-dark: rgb(var(--color-muted, 108 108 108) / 12%);
+  --hi-color-primary-dark: color-mix(in srgb, rgb(var(--color-primary, 122 162 247)) 82%, #000);
+  --hi-color-secondary-dark: color-mix(in srgb, rgb(var(--color-secondary, 81 154 115)) 82%, #000);
+  --hi-color-danger-dark: color-mix(in srgb, rgb(var(--color-error, 200 50 50)) 82%, #000);
+  --hi-color-success-dark: color-mix(in srgb, rgb(var(--color-success, 0 150 0)) 82%, #000);
+  --hi-color-text-on-secondary: rgb(var(--color-on-solid, 255 255 255));
+  --hi-color-text-on-danger: rgb(var(--color-on-solid, 255 255 255));
+  --hi-color-text-on-success: rgb(var(--color-on-solid, 255 255 255));
+}
+
+/* Static default light theme — renders correctly even without initTheme().
+   initTheme() overrides these at runtime via inline styles on
+   documentElement, which beat stylesheet :root declarations. */
+:root {
+  --color-primary: 122 162 247;
+  --color-on-primary: 255 255 255;
+  --color-on-solid: 255 255 255;
+  --color-on-solid-text: 255 255 255;
+  --color-on-solid-icon: 255 255 255;
+  --color-secondary: 81 154 115;
+  --color-accent: 247 181 0;
+  --color-text: 30 30 30;
+  --color-text-secondary: 102 102 102;
+  --color-text-tertiary: 140 140 140;
+  --color-muted: 108 108 108;
+  --color-border: 100 100 100;
+  --color-focused-border: 122 162 247;
+  --color-background: 214 236 240;
+  --color-surface: 240 244 248;
+  --color-success: 14 184 64;
+  --color-error: 247 118 142;
+  --color-warning: 238 214 119;
+  --color-info: 106 190 214;
+
+  --hi-color-primary: rgb(var(--color-primary));
+  --hi-color-secondary: rgb(var(--color-secondary));
+  --hi-color-surface: rgb(var(--color-surface));
+  --hi-color-background: rgb(var(--color-background));
+  --hi-color-border: rgb(var(--color-border));
+  --hi-color-text-primary: rgb(var(--color-text));
+  --hi-color-text-secondary: rgb(var(--color-text-secondary));
+  --hi-color-muted: rgb(var(--color-muted));
+  --hi-color-on-primary: rgb(var(--color-on-primary));
+  /* Deprecated in-tree: luminance-computed contrast, kept only for external
+     consumers. In-tree components use the on-solid slots instead. */
+  --hi-color-text-on-primary: rgb(var(--color-on-primary));
+  --hi-color-text-on-solid: rgb(var(--color-on-solid-text, 255 255 255));
+  --hi-color-icon-on-solid: rgb(var(--color-on-solid-icon, 255 255 255));
+  --hi-color-success: rgb(var(--color-success));
+  --hi-color-error: rgb(var(--color-error));
+  --hi-color-warning: rgb(var(--color-warning));
+  --hi-color-info: rgb(var(--color-info));
+
+  /* Design tokens consumed by hikari components. These used to live only in
+     plana-ui's token set; without them the background/backdrop declarations
+     of fields and surfaces resolve to nothing. Values align with plana-ui. */
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --opacity-half: 0.92;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+  --duration-fast: 0.15s;
+  --duration-short: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  --s-footer-height: 3rem;
+  --z-header: 30;
+  --z-sidebar: 40;
+  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+}


### PR DESCRIPTION
## What

Re-opening of #388 rebased onto the latest master (the previous PR's commit range got polluted by unrelated master commits that tripped lint-commits/nightly after #389/#390 landed).

`src/tokens.scss` (the `:root` block defining the `--color-*` channel triplets and their resolved `--hi-color-*` aliases) sits at `src/` top level, outside the `./styles/*` exports path. Registry consumers cannot `@use` it, and the runtime only injects the channels as inline styles after mount — non-chest shells building their own webview chrome get no CSS-level channel defaults, surfacing as white-on-white pages on light OS themes (first consumer: evernight's flasher, evernight-appliance #18).

## Fix

Vendor `tokens.scss` byte-identical as `styles/theme/channels.scss` (same pattern as `themes.scss`; no package.json change — covered by the existing `./styles/*` exports). Consumers add one `@use` line. Behavior for chest is unchanged: runtime inline overrides still win after `initTheme`.