### PR TITLE
✨ Add HkTitleBar, a hybrid-shell caption bar component.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTitleBar.scss
+++ b/packages/vue/src/components/HkTitleBar.scss
@@ -1,0 +1,128 @@
+// HkTitleBar — hybrid-shell caption bar.
+//
+// Colors ride the theme channels (--color-*) so the bar follows whatever
+// preset/mode the host app is in. Drag is pure CSS app-region (Tauri and
+// Electron both honor it); interactive children opt out with no-drag.
+// Text selection is chrome-disabled across the whole bar.
+
+.hk-titlebar {
+  --hk-tb-height: 32px;
+  --hk-tb-bg: color-mix(in srgb, rgb(var(--color-surface, 240 244 248)) 80%, transparent);
+  --hk-tb-border: rgb(var(--color-border, 100 100 100) / 0.25);
+  --hk-tb-fg: rgb(var(--color-text-secondary, 102 102 102));
+  --hk-tb-fg-strong: rgb(var(--color-text, 30 30 30));
+  --hk-tb-hover: rgb(var(--color-primary, 122 162 247) / 0.12);
+  --hk-tb-active: rgb(var(--color-primary, 122 162 247) / 0.2);
+  --hk-tb-focus: rgb(var(--color-primary, 122 162 247) / 0.6);
+  --hk-tb-close-hover: #e81123;
+  --hk-tb-close-active: #f1707a;
+  --hk-tb-radius-close: 0 8px 0 0;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--hk-tb-height);
+  display: flex;
+  align-items: center;
+  z-index: var(--z-titlebar, 100001);
+  user-select: none;
+  -webkit-user-select: none;
+  background: var(--hk-tb-bg);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--hk-tb-border);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  -webkit-app-region: drag;
+  app-region: drag;
+}
+
+.hk-titlebar-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-left: 12px;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.hk-titlebar-icon {
+  width: 16px;
+  height: 16px;
+  display: block;
+  pointer-events: none;
+}
+
+.hk-titlebar-title-text {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--hk-tb-fg-strong);
+}
+
+.hk-titlebar-subtitle {
+  font-size: 10px;
+  color: var(--hk-tb-fg);
+  opacity: 0.7;
+  padding-left: 8px;
+  white-space: nowrap;
+}
+
+.hk-titlebar-spacer {
+  flex: 1;
+}
+
+.hk-titlebar-actions {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+.hk-titlebar-btn {
+  width: 46px;
+  height: var(--hk-tb-height);
+  border: none;
+  background: transparent;
+  color: var(--hk-tb-fg);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.12s ease, color 0.12s ease;
+  outline: none;
+  padding: 0;
+}
+
+.hk-titlebar-btn:hover {
+  background: var(--hk-tb-hover);
+  color: var(--hk-tb-fg-strong);
+}
+
+.hk-titlebar-btn:active {
+  background: var(--hk-tb-active);
+}
+
+/* Only the rightmost (close) button carries the window's top-right
+   corner radius; the other captions highlight as plain rectangles. */
+.hk-titlebar-btn-close {
+  border-radius: 0 8px 0 0;
+}
+
+.hk-titlebar-btn-close:hover {
+  background: var(--hk-tb-close-hover);
+  color: #fff;
+}
+
+.hk-titlebar-btn-close:active {
+  background: var(--hk-tb-close-active);
+  color: #fff;
+}
+
+.hk-titlebar-btn:focus-visible {
+  outline: 2px solid var(--hk-tb-focus);
+  outline-offset: -2px;
+}
+
+/* Host apps offset their own root container below the bar:
+   #app { position: absolute; top: var(--hk-tb-height); … } */

--- a/packages/vue/src/components/HkTitleBar.tsx
+++ b/packages/vue/src/components/HkTitleBar.tsx
@@ -1,0 +1,132 @@
+import { defineComponent, onBeforeUnmount, onMounted, ref } from "vue";
+
+import "./HkTitleBar.scss";
+
+/**
+ * HkTitleBar — hybrid-shell window caption bar.
+ *
+ * A pure visual + event component: it renders the bar (app icon, title,
+ * subtitle, draggable surface, right-side caption buttons) and EMITS
+ * `minimize` / `toggle-maximize` / `close` / custom-button clicks. It
+ * never touches a shell API itself — the host (Tauri, Electron, …) wires
+ * those events to its own window controls, keeping hikari dependency-free.
+ *
+ * Dragging is pure CSS (`app-region: drag` on the bar, `no-drag` on the
+ * interactive children) — supported by Tauri (WebView2/WKWebView/WebKitGTK)
+ * and Electron alike; no JS drag logic needed.
+ *
+ * Text selection is disabled across the bar (captions are chrome, not
+ * content).
+ *
+ * Buttons are selective: `showMinimize` / `showMaximize` / `showClose`
+ * (defaults true/true/true) and `customActions` render extra icon buttons
+ * to the LEFT of minimize, each emitting `action` with its id.
+ *
+ * The maximized state is data-driven: the host passes `maximized` and the
+ * component swaps the maximize/restore glyph — no shell probing inside.
+ */
+export default defineComponent({
+  name: "HkTitleBar",
+  props: {
+    title: { type: String, default: "" },
+    subtitle: { type: String, default: "" },
+    /** App icon rendered left of the title (img src or inline node). */
+    icon: { type: String, default: "" },
+    maximized: { type: Boolean, default: false },
+    showMinimize: { type: Boolean, default: true },
+    showMaximize: { type: Boolean, default: true },
+    showClose: { type: Boolean, default: true },
+    /** Extra icon buttons rendered left of minimize. */
+    customActions: {
+      type: Array as () => { id: string; label: string; icon?: unknown }[],
+      default: () => [],
+    },
+  },
+  emits: {
+    minimize: () => true,
+    "toggle-maximize": () => true,
+    close: () => true,
+    /** A custom action button was clicked (id from `customActions`). */
+    action: (_id: string) => true,
+  },
+  setup(props, { emit, slots }) {
+    return () => (
+      <div class="hk-titlebar" data-drag-region>
+        {slots.left?.() ?? (
+          <span class="hk-titlebar-title">
+            {props.icon && <img class="hk-titlebar-icon" src={props.icon} alt="" />}
+            <span class="hk-titlebar-title-text">{props.title}</span>
+            {props.subtitle && (
+              <span class="hk-titlebar-subtitle">{props.subtitle}</span>
+            )}
+          </span>
+        )}
+        <span class="hk-titlebar-spacer" />
+        <div class="hk-titlebar-actions">
+          {slots.actions?.()}
+          {props.customActions.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              class="hk-titlebar-btn"
+              title={a.label}
+              aria-label={a.label}
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                emit("action", a.id);
+              }}
+            >
+              {a.icon}
+            </button>
+          ))}
+          {props.showMinimize && (
+            <button
+              type="button"
+              class="hk-titlebar-btn"
+              title="Minimize"
+              aria-label="Minimize"
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                emit("minimize");
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="M5 12h14" /></svg>
+            </button>
+          )}
+          {props.showMaximize && (
+            <button
+              type="button"
+              class="hk-titlebar-btn"
+              title={props.maximized ? "Restore" : "Maximize"}
+              aria-label={props.maximized ? "Restore" : "Maximize"}
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                emit("toggle-maximize");
+              }}
+            >
+              {props.maximized ? (
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="8" width="13" height="13" rx="2" /><path d="M8 8V5a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2h-3" /></svg>
+              ) : (
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="4" y="4" width="16" height="16" rx="2" /></svg>
+              )}
+            </button>
+          )}
+          {props.showClose && (
+            <button
+              type="button"
+              class="hk-titlebar-btn hk-titlebar-btn-close"
+              title="Close"
+              aria-label="Close"
+              onClick={(e: MouseEvent) => {
+                e.stopPropagation();
+                emit("close");
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg>
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  },
+});

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -79,6 +79,7 @@ export { default as HWindowedItem } from "./components/HkWindowedItem";
 export { default as HDateTimePicker } from "./components/HkDateTimePicker";
 export { default as HDatePicker } from "./components/HkDatePicker";
 export { default as HTimeline } from "./components/HkTimeline";
+export { default as HTitleBar } from "./components/HkTitleBar";
 export { default as HStepFlow } from "./components/HkStepFlow";
 export type { StepFlowSlotProps } from "./components/HkStepFlow";
 


### PR DESCRIPTION
## What

Per the flasher feedback loop (evernight-appliance #18): a **pure visual + event caption bar** for hybrid-shell windows (Tauri/Electron/…), keeping hikari dependency-free — the component never touches a shell API.

- **Text selection chrome-disabled** across the bar (captions are chrome, not content).
- **Dragging is pure CSS** (`app-region: drag` on the bar, `no-drag` on interactive children) — honored by Tauri (WebView2/WKWebView/WebKitGTK) and Electron alike; no JS drag logic.
- **App icon slot** left of the title (`icon` prop or `left` slot).
- **Selective caption buttons**: `showMinimize`/`showMaximize`/`showClose` (default true/true/true) and `customActions` rendering extra icon buttons **left of minimize**, each emitting `action(id)`.
- Maximize/restore glyph is data-driven via the `maximized` prop (no shell probing inside); colors ride the theme channels.

Host wiring example (flasher):

```tsx
<HTitleBar title="evernight Flasher" icon={logoUrl} maximized={…}
  onMinimize={() => win.minimize()} onToggle-maximize={…} onClose={…} />
```

## Verification

- vue-tsc clean.
- First consumer: evernight-appliance flasher (follow-up PR replaces its vanilla JS caption bar with this component).