### PR TITLE
📦 Release the modal width presets in packages/vue 0.40.1.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Version-only bump. npm's 0.40.0 was claimed minutes ago by a same-day publish of the HkTitleBar wave (no modal width resolver in it — verified by tarball grep), so the npm series skips to 0.40.1 to ship #392. crates.io already took the width-preset 0.40.0 from the v0.40.0 tag. Needed so shittim-chest can pin a hikari containing the named modal width presets.

(npm series skip: 0.40.0 taken by the HkTitleBar publish.)
