### PR TITLE
🐛 Rename the PRC dial row and keep the short alias searchable.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkPhoneInput.test.tsx
+++ b/packages/vue/src/components/HkPhoneInput.test.tsx
@@ -117,6 +117,26 @@ describe("HkPhoneInput", () => {
     }
   });
 
+  it("still finds the PRC row when searching the short alias", async () => {
+    const { container } = mountPhone();
+    await openPicker(container);
+    // The row renders the formal zh name (中华人民共和国), which no longer
+    // contains 中国 as a substring — the catalog's zhAlias keeps the old
+    // short form reachable from the search field.
+    const search = document.querySelector<HTMLInputElement>(
+      ".hk-affix-search .hk-input-element",
+    );
+    expect(search, "popup search field renders").toBeTruthy();
+    search!.value = "中国";
+    search!.dispatchEvent(new Event("input"));
+    await nextTick();
+    await nextTick();
+    const rows = pickerRows();
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0].textContent).toContain("China");
+    expect(rows[0].textContent).toContain("+86");
+  });
+
   it("picks a country from the list and refocuses the number field", async () => {
     const { container, events } = mountPhone();
     await openPicker(container);

--- a/packages/vue/src/components/HkPhoneInput.tsx
+++ b/packages/vue/src/components/HkPhoneInput.tsx
@@ -102,14 +102,15 @@ export const HkPhoneInput = defineComponent({
     );
 
     /** Picker rows come from the shared affix catalog shape; the
-     *  keywords haystack keeps the old filter reach: en/zh names, ISO
-     *  code, bare and zero-prefixed dial digits ("86"/"0086"). */
+     *  keywords haystack keeps the old filter reach: en/zh names plus
+     *  the optional zh search alias, ISO code, bare and zero-prefixed
+     *  dial digits ("86"/"0086"). */
     const dialOptions = computed<readonly HkAffixOption[]>(() =>
       props.countries.map((c) => ({
         key: c.iso,
         label: dialCodeName(c, locale),
         meta: `+${c.dial}`,
-        keywords: `${c.en} ${c.zh} ${c.iso} +${c.dial} 00${c.dial}`,
+        keywords: `${c.en} ${c.zh} ${c.zhAlias ?? ""} ${c.iso} +${c.dial} 00${c.dial}`,
       })),
     );
 

--- a/packages/vue/src/data/dialCodes.test.ts
+++ b/packages/vue/src/data/dialCodes.test.ts
@@ -12,7 +12,13 @@ import {
 
 describe("dialCodes catalog", () => {
   it("starts with China and contains the expected shape", () => {
-    expect(DIAL_CODES[0]).toMatchObject({ iso: "cn", dial: "86", en: "China", zh: "中国" });
+    expect(DIAL_CODES[0]).toMatchObject({
+      iso: "cn",
+      dial: "86",
+      en: "China",
+      zh: "中华人民共和国",
+      zhAlias: "中国",
+    });
     for (const entry of DIAL_CODES) {
       expect(entry.iso).toMatch(/^[a-z]{2}$/);
       expect(entry.dial).toMatch(/^\d+$/);

--- a/packages/vue/src/data/dialCodes.ts
+++ b/packages/vue/src/data/dialCodes.ts
@@ -19,6 +19,12 @@ export interface DialCodeEntry {
   en: string;
   /** Simplified Chinese country name. */
   zh: string;
+  /** Search-only Chinese alias — never rendered as the display name.
+   *  HkPhoneInput folds it into the popup's keyword haystack so the old
+   *  short form still finds the entry after a formal rename (e.g. the
+   *  PRC row renamed to 中华人民共和国 no longer contains 中国 as a
+   *  substring). */
+  zhAlias?: string;
 }
 
 /** Flag glyph for an ISO 3166-1 alpha-2 code (regional indicators). */
@@ -43,7 +49,7 @@ export function dialCodeName(entry: DialCodeEntry, locale: string): string {
  * prefixes like +1 / +7).
  */
 export const DIAL_CODES: readonly DialCodeEntry[] = [
-  { iso: "cn", dial: "86", en: "China", zh: "中国" },
+  { iso: "cn", dial: "86", en: "China", zh: "中华人民共和国", zhAlias: "中国" },
   { iso: "hk", dial: "852", en: "Hong Kong (China)", zh: "中国香港" },
   { iso: "mo", dial: "853", en: "Macau (China)", zh: "中国澳门" },
   { iso: "tw", dial: "886", en: "Taiwan (China)", zh: "中国台湾" },


### PR DESCRIPTION
## What

User request: the mainland row in the HkPhoneInput country picker should read **中华人民共和国** instead of 中国.

- `dialCodes` catalog: the cn entry's zh display name becomes 中华人民共和国.
- New optional `zhAlias` catalog field (search-only, never rendered): the cn entry keeps `zhAlias: "中国"` and HkPhoneInput folds it into the popup keyword haystack — because 中华人民共和国 no longer contains 中国 as a substring, without the alias a "中国" search would lose the mainland row entirely. Regression test added (searching 中国 still surfaces the +86 row first).

## Verification

- Targeted vitest: dialCodes + HkPhoneInput + HkAffixPicker → 31/31 (incl. the new alias-search test).
- vue-tsc --noEmit: clean.
- Version bump: packages/vue 0.40.2 → 0.40.3.