### PR TITLE
📦 Release the field label association in packages/vue 0.40.4.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Version-only bump. npm's 0.40.3 was claimed by a concurrent publish of the dial-row rename (no HkInput label/spellcheck change in it), so the npm series skips to 0.40.4 to ship #397.

(npm series skip: 0.40.3 taken by the concurrent dial-row publish.)
