### PR TITLE
🐛 Fill the mobile context sheet and catalog the world model lineup.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.7",
+  "version": "0.40.8",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkContextRing.scss
+++ b/packages/vue/src/components/HkContextRing.scss
@@ -36,6 +36,15 @@
   color: rgb(var(--color-text));
 }
 
+/* Mobile sheet mode: the docked sheet spans the viewport, so the fixed
+ * 18rem pop would hug the sheet's left edge with dead space to the right.
+ * Fill the sheet instead — the panel chrome keeps its own symmetric
+ * horizontal gutters (the glass content padding), so the bar and legend
+ * get equal left/right insets. Desktop stays anchored at 18rem. */
+.hk-popover-panel.hk-is-sheet .hk-ctx-pop {
+  width: 100%;
+}
+
 .hk-ctx-pop-model {
   display: flex;
 }

--- a/packages/vue/src/components/HkModelCatalog.test.ts
+++ b/packages/vue/src/components/HkModelCatalog.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { getModelMeta, registerModelCatalog } from "./HkModelCatalog";
+
+/**
+ * The simulated-world roster (integration world_service `agent_models`):
+ * every model id a chest card can carry must resolve a context window, or
+ * its context ring degrades to the empty "–" state — the "only the sample
+ * card shows usage" regression. The builtin catalog is the fallback that
+ * keeps unknown-to-nothing lineups legible.
+ */
+const WORLD_LINEUP = [
+  "glm-5.3-flash",
+  "claude-opus-5",
+  "deepseek-v4-pro",
+  "deepseek-v4-flash",
+  "gemini-3.1-flash-preview",
+  "gpt-5.5-pro",
+  "gemini-3.1-pro-preview",
+  "gpt-5.4",
+  "gpt-5.4-nano",
+  "claude-haiku-4-5",
+  "gemini-3-flash",
+  "qwen3.7:14b",
+  "qwen3.8:27b",
+];
+
+describe("HkModelCatalog builtin specs", () => {
+  it("resolves every world-lineup model id to a positive context window", () => {
+    for (const model of WORLD_LINEUP) {
+      const meta = getModelMeta(model);
+      expect(meta, `${model} resolves`).toBeDefined();
+      expect(meta?.contextWindow ?? 0, `${model} window`).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps ollama-style colon tags whole (only # splits)", () => {
+    expect(getModelMeta("qwen3.7:14b")?.contextWindow).toBe(262_144);
+    expect(getModelMeta("qwen3.8:27b")?.contextWindow).toBe(262_144);
+  });
+
+  it("still strips a #tag before lookup", () => {
+    expect(getModelMeta("deepseek-v4-pro#2")?.contextWindow).toBe(128_000);
+    expect(getModelMeta("claude-opus-5#7")?.contextWindow).toBe(200_000);
+  });
+
+  it("lets the registered catalog win over the builtin entries", () => {
+    registerModelCatalog({ "claude-opus-5": { contextWindow: 999 } });
+    expect(getModelMeta("claude-opus-5")?.contextWindow).toBe(999);
+  });
+});

--- a/packages/vue/src/components/HkModelCatalog.ts
+++ b/packages/vue/src/components/HkModelCatalog.ts
@@ -64,6 +64,59 @@ const BUILTIN_CATALOG: HModelCatalog = {
     pricing: { in: 2, out: 8 },
     vision: true, reasoning: true, tools: true,
   },
+  "glm-5.3-flash": {
+    contextWindow: 128_000, maxOutput: 32_000,
+    pricing: { in: 0.5, out: 2 },
+    vision: false, reasoning: true, tools: true,
+  },
+  "gpt-5.5-pro": {
+    contextWindow: 400_000, maxOutput: 100_000,
+    pricing: { in: 10, out: 50, cached: 1 },
+    vision: true, reasoning: true, tools: true,
+  },
+  "gpt-5.4": {
+    contextWindow: 400_000, maxOutput: 64_000,
+    pricing: { in: 2.5, out: 15, cached: 0.25 },
+    vision: true, reasoning: true, tools: true,
+  },
+  "gpt-5.4-nano": {
+    contextWindow: 400_000, maxOutput: 16_000,
+    pricing: { in: 0.2, out: 1.2, cached: 0.05 },
+    vision: false, reasoning: false, tools: true,
+  },
+  "claude-opus-5": {
+    contextWindow: 200_000, maxOutput: 64_000,
+    pricing: { in: 5, out: 25, cached: 0.5 },
+    vision: true, reasoning: true, tools: true,
+  },
+  "claude-haiku-4-5": {
+    contextWindow: 200_000, maxOutput: 32_000,
+    pricing: { in: 0.8, out: 4, cached: 0.08 },
+    vision: false, reasoning: false, tools: true,
+  },
+  "gemini-3.1-pro-preview": {
+    contextWindow: 1_000_000, maxOutput: 64_000,
+    pricing: { in: 5, out: 30 },
+    vision: true, reasoning: true, tools: true,
+  },
+  "gemini-3.1-flash-preview": {
+    contextWindow: 1_000_000, maxOutput: 64_000,
+    pricing: { in: 1.5, out: 10 },
+    vision: true, reasoning: true, tools: true,
+  },
+  "gemini-3-flash": {
+    contextWindow: 1_000_000, maxOutput: 32_000,
+    pricing: { in: 1.5, out: 9 },
+    vision: true, reasoning: false, tools: true,
+  },
+  "qwen3.7:14b": {
+    contextWindow: 262_144, maxOutput: 32_768,
+    vision: false, reasoning: true, tools: true,
+  },
+  "qwen3.8:27b": {
+    contextWindow: 262_144, maxOutput: 32_768,
+    vision: false, reasoning: true, tools: true,
+  },
 };
 
 /**


### PR DESCRIPTION
## Problem

User-reported on mobile (demo chest, node-overview cards):

1. **Context-usage bottom sheet hugs the left edge.** `HkContextRing`'s popover content is a fixed `18rem`; on <768px viewports HPopover docks it as a full-width bottom sheet, so the model tag / total / progress bar / legend all sit in a narrow left column with dead space to the right.
2. **Only one card shows context usage, the rest show "–".** The integration world service assigns 13 distinct model ids across its agent roster; hikari's builtin catalog only knew `deepseek-v4-pro` and `deepseek-v4-flash`. `getModelMeta()` returning undefined ⇒ `contextWindow = null` ⇒ the ring degrades to the empty gray "–" state for every other card — exactly the reported "只有示例数据有上下文用量".

## Fix

- Sheet mode: `.hk-popover-panel.hk-is-sheet .hk-ctx-pop { width: 100% }` — the pop fills the sheet and the panel chrome's symmetric glass gutters (`--space-4` each side) provide equal left/right insets. Desktop anchored mode keeps the 18rem popover.
- Catalog: add plausible builtin specs for the missing lineup — `claude-opus-5`, `claude-haiku-4-5`, `gpt-5.5-pro`, `gpt-5.4`, `gpt-5.4-nano`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-preview`, `gemini-3-flash`, `qwen3.7:14b`, `qwen3.8:27b`, `glm-5.3-flash` — so every world-roster card resolves a context window. Colon-tagged ollama-style ids stay whole (only `#` splits).
- Tests: new `HkModelCatalog.test.ts` (world lineup all resolve, colon tags, `#tag` stripping, registry precedence). Existing `HkContextRing` suite green.
- packages/vue 0.40.7 → 0.40.8.

## Verification

- `vitest run HkModelCatalog.test.ts HkContextRing.test.tsx`: 20/20 green.
- `vue-tsc --noEmit`: green.
- Full packages/vue suite: 900/903; the 3 failures (`registerAnimations` keyframe drift, `HkDatePicker` date-guard, `HkMenu` cascade flake) reproduce identically on pristine master — pre-existing, unrelated.

## Consumer note

shittim-chest consumes `@celestia-island/hikari": "^*"` off the registry; a chest lockfile bump PR lands this in the demo/dev build after release.