### PR TITLE
✨ Localize clipboard-copy toasts and keep copy buttons stable.

### DIFF
--- a/packages/vue/src/components/HkProtocolModal.scss
+++ b/packages/vue/src/components/HkProtocolModal.scss
@@ -2,17 +2,6 @@
   position: relative;
 }
 
-.s-protocol-modal-copied {
-  position: absolute;
-  top: -0.25rem;
-  right: 0;
-  margin: 0;
-  padding: var(--space-4, 0.25rem) var(--space-8, 0.5rem);
-  border-radius: var(--radius-sm, 6px);
-  background: rgb(var(--color-success) / 15%);
-  color: rgb(var(--color-success));
-  font-size: var(--text-xs, 0.75rem);
-}
 
 /* With `bodyHeight` set the body becomes its own scroll region (nested
  * inside HkModal's body scroller) — overlay chrome only. */

--- a/packages/vue/src/components/HkProtocolModal.tsx
+++ b/packages/vue/src/components/HkProtocolModal.tsx
@@ -1,5 +1,12 @@
 import { computed, defineComponent, onBeforeUnmount, ref, watch, type PropType } from "vue";
-import { HMarkdownRenderer, HModal, useClipboard, type ModalAction, type ModalWidth } from "@celestia-island/hikari";
+import {
+  HMarkdownRenderer,
+  HModal,
+  useClipboardWithToast,
+  useToast,
+  type ModalAction,
+  type ModalWidth,
+} from "@celestia-island/hikari";
 
 import { useI18n } from "../i18n/context";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
@@ -40,8 +47,7 @@ export const HkProtocolModal = defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
-    const clipboard = useClipboard();
-    const copied = computed(() => clipboard.copied.value);
+    const clipboard = useClipboardWithToast(useToast());
 
     const footerActions = computed<ModalAction[]>(() => [
       {
@@ -103,7 +109,6 @@ export const HkProtocolModal = defineComponent({
           class="s-protocol-modal"
           style={props.bodyHeight ? { maxHeight: props.bodyHeight } : undefined}
         >
-          {copied.value && <p class="s-protocol-modal-copied">{t("hikari::protocol.copied", "Copied")}</p>}
           <HMarkdownRenderer content={props.content} />
         </div>
       </HModal>

--- a/packages/vue/src/components/HkSecretRevealModal.scss
+++ b/packages/vue/src/components/HkSecretRevealModal.scss
@@ -50,10 +50,6 @@
   filter: brightness(1.1);
 }
 
-.s-secret-modal-copy[data-copied] {
-  background: rgb(var(--color-success));
-  color: rgb(var(--color-on-solid-text, 255 255 255));
-}
 
 .s-secret-modal-copy:disabled {
   opacity: 0.5;

--- a/packages/vue/src/components/HkSecretRevealModal.tsx
+++ b/packages/vue/src/components/HkSecretRevealModal.tsx
@@ -1,6 +1,6 @@
-import { defineComponent, ref, watch } from "vue";
-import { TriangleAlert as AlertTriangle, Check, Copy } from "lucide-vue-next";
-import { HModal, useClipboard, useI18n } from "@celestia-island/hikari";
+import { defineComponent } from "vue";
+import { TriangleAlert as AlertTriangle, Copy } from "lucide-vue-next";
+import { HModal, useClipboardWithToast, useI18n, useToast } from "@celestia-island/hikari";
 
 import "./HkSecretRevealModal.scss";
 
@@ -9,9 +9,10 @@ import "./HkSecretRevealModal.scss";
  * HkSecretRevealModal — show-once secret / API-key reveal panel.
  *
  * Displays a one-time secret (API key, token, password) with a "shown
- * only once" notice and a copy button. `copied` fires on successful copy.
- * The value is a prop: the caller decides how to obtain/discard it (e.g.
- * clear it once the modal closes).
+ * only once" notice and a copy button. `copied` fires on successful copy;
+ * the copy itself is confirmed via a localized toast (the button label
+ * stays stable). The value is a prop: the caller decides how to
+ * obtain/discard it (e.g. clear it once the modal closes).
  */
 export const HkSecretRevealModal = defineComponent({
   name: "HkSecretRevealModal",
@@ -33,23 +34,12 @@ export const HkSecretRevealModal = defineComponent({
   },
   setup(props, { emit }) {
     const { t } = useI18n();
-    const clipboard = useClipboard();
-    const copied = ref(false);
-
-    watch(
-      () => props.modelValue,
-      (open) => {
-        if (open) copied.value = false;
-      },
-    );
+    const clipboard = useClipboardWithToast(useToast());
 
     async function handleCopy() {
       if (!props.value) return;
       const ok = await clipboard.copy(props.value);
-      if (ok) {
-        copied.value = true;
-        emit("copied");
-      }
+      if (ok) emit("copied");
     }
 
     return () => (
@@ -76,12 +66,11 @@ export const HkSecretRevealModal = defineComponent({
             <button
               type="button"
               class="s-secret-modal-copy"
-              data-copied={copied.value || undefined}
               onClick={() => void handleCopy()}
               disabled={!props.value}
             >
-              {copied.value ? <Check size={14} /> : <Copy size={14} />}
-              {copied.value ? t("hikari::secret.copied") : props.copyLabel ?? t("hikari::secret.copy")}
+              <Copy size={14} />
+              {props.copyLabel ?? t("hikari::secret.copy")}
             </button>
           </div>
         </div>

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "رفض",
     "hikari::protocol.copy": "نسخ",
     "hikari::protocol.copied": "تم النسخ",
+    "hikari::clipboard.copied": "تم النسخ",
+    "hikari::clipboard.copyFailed": "فشل النسخ",
     "hikari::about.title": "حول",
     "hikari::about.version": "الإصدار",
     "hikari::about.buildHash": "البناء",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Ablehnen",
     "hikari::protocol.copy": "Kopieren",
     "hikari::protocol.copied": "Kopiert",
+    "hikari::clipboard.copied": "Kopiert",
+    "hikari::clipboard.copyFailed": "Kopieren fehlgeschlagen",
     "hikari::about.title": "Über",
     "hikari::about.version": "Version",
     "hikari::about.buildHash": "Build",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Decline",
     "hikari::protocol.copy": "Copy",
     "hikari::protocol.copied": "Copied",
+    "hikari::clipboard.copied": "Copied",
+    "hikari::clipboard.copyFailed": "Copy failed",
     "hikari::about.title": "About",
     "hikari::about.version": "Version",
     "hikari::about.buildHash": "Build",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Rechazar",
     "hikari::protocol.copy": "Copiar",
     "hikari::protocol.copied": "Copiado",
+    "hikari::clipboard.copied": "Copiado",
+    "hikari::clipboard.copyFailed": "Error al copiar",
     "hikari::about.title": "Acerca de",
     "hikari::about.version": "Versión",
     "hikari::about.buildHash": "Compilación",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Refuser",
     "hikari::protocol.copy": "Copier",
     "hikari::protocol.copied": "Copié",
+    "hikari::clipboard.copied": "Copié",
+    "hikari::clipboard.copyFailed": "Échec de la copie",
     "hikari::about.title": "À propos",
     "hikari::about.version": "Version",
     "hikari::about.buildHash": "Build",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "拒否",
     "hikari::protocol.copy": "コピー",
     "hikari::protocol.copied": "コピーしました",
+    "hikari::clipboard.copied": "コピーしました",
+    "hikari::clipboard.copyFailed": "コピーに失敗しました",
     "hikari::about.title": "このアプリについて",
     "hikari::about.version": "バージョン",
     "hikari::about.buildHash": "ビルド",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "거부",
     "hikari::protocol.copy": "복사",
     "hikari::protocol.copied": "복사됨",
+    "hikari::clipboard.copied": "복사됨",
+    "hikari::clipboard.copyFailed": "복사 실패",
     "hikari::about.title": "정보",
     "hikari::about.version": "버전",
     "hikari::about.buildHash": "빌드",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Recusar",
     "hikari::protocol.copy": "Copiar",
     "hikari::protocol.copied": "Copiado",
+    "hikari::clipboard.copied": "Copiado",
+    "hikari::clipboard.copyFailed": "Falha ao copiar",
     "hikari::about.title": "Sobre",
     "hikari::about.version": "Versão",
     "hikari::about.buildHash": "Build",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "Отклонить",
     "hikari::protocol.copy": "Копировать",
     "hikari::protocol.copied": "Скопировано",
+    "hikari::clipboard.copied": "Скопировано",
+    "hikari::clipboard.copyFailed": "Не удалось скопировать",
     "hikari::about.title": "О программе",
     "hikari::about.version": "Версия",
     "hikari::about.buildHash": "Сборка",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "拒绝",
     "hikari::protocol.copy": "复制",
     "hikari::protocol.copied": "已复制",
+    "hikari::clipboard.copied": "已复制",
+    "hikari::clipboard.copyFailed": "复制失败",
     "hikari::about.title": "关于",
     "hikari::about.version": "版本",
     "hikari::about.buildHash": "构建",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -10,6 +10,8 @@
     "hikari::protocol.decline": "拒絕",
     "hikari::protocol.copy": "複製",
     "hikari::protocol.copied": "已複製",
+    "hikari::clipboard.copied": "已複製",
+    "hikari::clipboard.copyFailed": "複製失敗",
     "hikari::about.title": "關於",
     "hikari::about.version": "版本",
     "hikari::about.buildHash": "建置",

--- a/packages/vue/src/runtime/useClipboard.test.ts
+++ b/packages/vue/src/runtime/useClipboard.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useClipboardWithToast } from "./useClipboard";
+
+// `navigator.clipboard` does not exist under happy-dom — install a
+// controllable stub and restore whatever was there before.
+let writeText: ReturnType<typeof vi.fn>;
+const originalClipboard = navigator.clipboard;
+const originalExecCommand = document.execCommand;
+
+beforeEach(() => {
+  writeText = vi.fn();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    value: originalClipboard,
+    configurable: true,
+  });
+  document.execCommand = originalExecCommand;
+});
+
+describe("useClipboardWithToast", () => {
+  it("toasts the localized default message and resolves true on success", async () => {
+    const toast = { success: vi.fn(), error: vi.fn() };
+    const { copy } = useClipboardWithToast(toast);
+
+    const ok = await copy("secret");
+
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith("secret");
+    expect(toast.success).toHaveBeenCalledWith("Copied");
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("prefers the per-call message, then the call-site default thunk", async () => {
+    const toast = { success: vi.fn(), error: vi.fn() };
+    const { copy } = useClipboardWithToast(toast, () => "site default");
+
+    await copy("a", "per call");
+    await copy("b");
+
+    expect(toast.success).toHaveBeenNthCalledWith(1, "per call");
+    expect(toast.success).toHaveBeenNthCalledWith(2, "site default");
+  });
+
+  it("toasts the localized failure message when the clipboard rejects", async () => {
+    writeText.mockRejectedValue(new Error("denied"));
+    // The base composable falls back to a textarea + execCommand path;
+    // force that fallback to fail too so the error toast fires.
+    document.execCommand = vi.fn(() => false) as unknown as typeof document.execCommand;
+
+    const toast = { success: vi.fn(), error: vi.fn() };
+    const { copy } = useClipboardWithToast(toast);
+
+    const ok = await copy("secret");
+
+    expect(ok).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Copy failed");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vue/src/runtime/useClipboard.ts
+++ b/packages/vue/src/runtime/useClipboard.ts
@@ -1,5 +1,7 @@
 import { ref } from "vue";
 
+import { useI18n } from "../i18n/context";
+
 export function useClipboard() {
   const copied = ref(false);
 
@@ -19,7 +21,10 @@ export function useClipboard() {
       document.body.appendChild(textarea);
       textarea.select();
       try {
-        document.execCommand("copy");
+        // execCommand reports failure by RETURNING false (it only throws
+        // on unsupported commands) — treating that as success surfaced
+        // "Copied" toasts for writes that never landed.
+        if (!document.execCommand("copy")) return false;
         copied.value = true;
         setTimeout(() => {
           copied.value = false;
@@ -44,21 +49,31 @@ export function useClipboard() {
  * `execCommand` outside secure contexts) and adds toast feedback;
  * `copied` reflects the 2s copied state. The `toast` argument matches
  * hikari's `useToast()` surface (`success` / `error` message pushers).
+ *
+ * Default toast messages come from hikari's own i18n
+ * (`hikari::clipboard.copied` / `hikari::clipboard.copyFailed`) so a
+ * bare `useClipboardWithToast(useToast())` is already localized; pass
+ * thunks to override per call site. `copy` resolves to whether the
+ * clipboard write succeeded.
  */
 export function useClipboardWithToast(
   toast: { success: (msg: string) => void; error: (msg: string) => void },
   defaultSuccessMessage?: () => string,
   defaultErrorMessage?: () => string,
 ) {
+  const { t } = useI18n();
   const { copy: baseCopy, copied } = useClipboard();
 
-  async function copy(text: string, successMessage?: string) {
+  async function copy(text: string, successMessage?: string): Promise<boolean> {
     const ok = await baseCopy(text);
     if (ok) {
-      toast.success(successMessage ?? defaultSuccessMessage?.() ?? "Copied");
+      toast.success(
+        successMessage ?? defaultSuccessMessage?.() ?? t("hikari::clipboard.copied", "Copied"),
+      );
     } else {
-      toast.error(defaultErrorMessage?.() ?? "Copy failed");
+      toast.error(defaultErrorMessage?.() ?? t("hikari::clipboard.copyFailed", "Copy failed"));
     }
+    return ok;
   }
 
   return { copy, copied };


### PR DESCRIPTION
## What

Copy-to-clipboard feedback across the family moves to the standard top-right toast instead of mutating the trigger button, and the shared hook now speaks every locale out of the box.

- **`useClipboardWithToast` i18n defaults**: success/error toast text falls back to hikari's own i18n (`hikari::clipboard.copied` / `hikari::clipboard.copyFailed`, added to all 11 locales, matching each locale's existing `protocol.copied` terminology). A bare `useClipboardWithToast(useToast())` is now fully localized; per-call strings and call-site thunks still override.
- **`copy()` now resolves to whether the write landed** (was `void`).
- **Bug fix**: the `execCommand` fallback treated a `false` return as success — failure now surfaces the error toast instead of a false "Copied".
- **`HSecretRevealModal` / `HProtocolModal`**: copy feedback moves from button-label mutation / inline "Copied" paragraph to the shared toast; buttons keep a stable label, `data-copied` styling and the inline-paragraph SCSS dropped. The `copied` emit is preserved.
- Version 0.40.10 → 0.40.11.

## Downstream

- shittim-chest's seven existing `useClipboardWithToast(toast)` call sites start showing localized messages once they pick this release (no code change needed there).
- Report origin: the TOTP enroll page in shittim-chest swapped its copy button to 「已复制」 — fixed in the chest PR; this PR is the hikari-side unified-hook work that came out of the family-wide sweep (HSecretRevealModal, HProtocolModal, erp payment links, easy-hydro vendored twins).

## Verification

- `vue-tsc --noEmit` clean.
- New `useClipboard.test.ts` (3 tests) passes: localized default success, per-call/thunk precedence, failure toast via the execCommand-false path.
- Full suite: 930/931 pass. `registerAnimations.test.ts` fails **identically on master** (keyframe source-scan, pre-existing/environmental); `HkMenu.test.ts` passes standalone (order-dependent flake under full-suite NFS load). Neither touches this diff.

*(2026-09-06: self-hosted failures retraced to the node-1 cargo/rustup restore; hosted CI green throughout.)*

*(2026-09-06 rebased onto master 33f1988: clipboard-toast suite green, full component run 631/632 — the single failure is the known pre-existing HkDatePicker date-drift case; lint rc=0.)*