### PR TITLE
📦 Advance the package to 0.40.13 after the 0.40.12 release race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.12",
+  "version": "0.40.13",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
The 18:00Z manual npm-release dispatch published 0.40.12 from pre-#410 master (e29ace0 tree), racing this PR wave — the merged master's package.json 0.40.12 can therefore never reach the registry under that number. The v0.40.12 tag has been repointed at e29ace0 to match the published tarball, and master moves to 0.40.13 for the real #410 release (errorReporting plugin + unified boundary). Version-only bump; nothing else to bundle.