### PR TITLE
✨ Add host-customizable leading and trailing slots to theme toggle rows.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.14",
+  "version": "0.40.15",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -222,3 +222,33 @@
     margin-right: 2.75rem;
   }
 }
+
+/* ── Host-provided row anatomy (item-leading / item-trailing) ───────────
+ * When the host renders the item-leading slot, EVERY row carries the
+ * fixed icon cell (not just the active row's check), so names align
+ * across the list; the cell keeps the unified menu-item icon metrics.
+ */
+.s-theme-item-lead {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  color: inherit;
+}
+
+/* When the host renders the item-trailing slot, every row reserves a
+ * REAL trailing column (the slot owns it — the built-in custom-delete
+ * overlay is suppressed), so trailing affordances align across rows
+ * instead of floating over the pill's edge. The custom-name clearance
+ * for the overlay delete no longer applies in this mode. */
+.s-theme-item-trailing {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4, 0.25rem);
+  flex-shrink: 0;
+  margin-inline-start: var(--space-4, 0.25rem);
+}
+
+.s-theme-item-row[data-trailing="slot"] .s-theme-item-name {
+  margin-right: 0;
+}

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -229,3 +229,91 @@ describe("HkThemeToggle color-mode group", () => {
     expect(activeBtn?.querySelector(".s-theme-item-check")).toBeTruthy();
   });
 });
+
+describe("HkThemeToggle item slots", () => {
+  function mountSlotted(
+    lead: (scope: { id: string }) => unknown,
+    trail: (scope: { id: string }) => unknown,
+  ): HTMLElement {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(HkThemeToggle, {
+          externalCustomize: true,
+        }, {
+          "item-leading": lead,
+          "item-trailing": trail,
+        }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    return container;
+  }
+
+  it("renders the leading slot on every row in place of the selected-check cell", async () => {
+    const seen: string[] = [];
+    const container = mountSlotted(
+      (scope) => { seen.push(scope.id); return h("i", { class: "lead-mark" }); },
+      () => null,
+    );
+    await settle();
+    openMenu(container);
+    await settle();
+
+    const rows = [...document.body.querySelectorAll<HTMLElement>(".s-theme-menu .s-theme-item-row")];
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    // Every row — active or not — carries the slot cell; no check cell is
+    // rendered alongside (the slot owns the leading zone).
+    for (const row of rows) {
+      expect(row.querySelector(".s-theme-item-lead .lead-mark")).toBeTruthy();
+      expect(row.querySelector(".s-theme-item-check")).toBeNull();
+    }
+    expect(seen.length).toBe(rows.length);
+  });
+
+  it("reserves the trailing column and suppresses the built-in delete overlay", async () => {
+    useTheme().addCustomTheme(anyPresetTokens());
+    const container = mountSlotted(
+      () => null,
+      (scope) => h("i", { class: "trail-mark", "data-id": scope.id }),
+    );
+    await settle();
+    openMenu(container);
+    await settle();
+
+    const rows = [...document.body.querySelectorAll<HTMLElement>(".s-theme-menu .s-theme-item-row")];
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+    let customRows = 0;
+    for (const row of rows) {
+      expect(row.hasAttribute("data-trailing")).toBe(true);
+      expect(row.getAttribute("data-trailing")).toBe("slot");
+      expect(row.querySelector(".s-theme-item-trailing .trail-mark")).toBeTruthy();
+      // The slot owns the trailing zone: the built-in overlay is gone
+      // even on custom rows.
+      expect(row.querySelector(".s-theme-item-delete")).toBeNull();
+      if (row.hasAttribute("data-custom")) customRows += 1;
+    }
+    expect(customRows).toBe(1);
+  });
+
+  it("scopes each row with its resolved preset definition", async () => {
+    const presets: Array<unknown> = [];
+    const container = mountSlotted(
+      (scope) => { presets.push((scope as { preset?: unknown }).preset); return null; },
+      () => null,
+    );
+    await settle();
+    openMenu(container);
+    await settle();
+
+    // Built-in rows resolve to their preset table entry (tokens present).
+    expect(presets.length).toBeGreaterThanOrEqual(2);
+    for (const preset of presets) {
+      const p = preset as { dark?: { primary?: unknown }; light?: { primary?: unknown } } | undefined;
+      expect(p).toBeTruthy();
+      expect(p!.dark?.primary).toBeTruthy();
+      expect(p!.light?.primary).toBeTruthy();
+    }
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -4,10 +4,13 @@ import {
   HDivider,
   HPopover,
   solarAltitude,
+  themePresets,
   useI18n,
   useTheme,
+  type CustomThemePreset,
   type PopupPlacement,
   type ThemeId,
+  type ThemePreset,
 } from "@celestia-island/hikari";
 
 import { HColorSchemeDialog, type HCustomTheme } from "./HkColorSchemeDialog";
@@ -19,6 +22,18 @@ import "./HkThemeToggle.scss";
  *  refresh) on every altitude tick. */
 const AUTO_MERGE_KEYS = ["light", "dark"];
 
+/** Scoped payload handed to the `item-leading` / `item-trailing` slots:
+ *  one object per theme row, carrying enough identity for the host to
+ *  render swatches or affordances without re-deriving the preset. */
+export interface ThemeItemScope {
+  id: ThemeId;
+  name: string;
+  isCustom: boolean;
+  /** The row's full definition — the built-in preset table entry for
+   *  stock/registered themes, the user's stored scheme for customs. */
+  preset: ThemePreset | CustomThemePreset | undefined;
+}
+
 /**
  * HkThemeToggle — light/dark/auto theme control over hikari's theme engine.
  *
@@ -27,6 +42,15 @@ const AUTO_MERGE_KEYS = ["light", "dark"];
  * cycles light/dark (auto keeps a Monitor glyph); the popover offers the
  * color-mode group and preset/custom theme selection (custom themes are
  * removable), and opens HColorSchemeDialog to create a new custom scheme.
+ *
+ * Theme rows are host-customizable through two scoped slots (both render
+ * in the popover AND the mobile bottom sheet — same DOM):
+ *  · `item-leading` — replaces the selected-check cell; renders for
+ *    every row in the fixed icon cell so names align regardless of the
+ *    active row. Scope: `ThemeItemScope` (id/name/isCustom/preset).
+ *  · `item-trailing` — reserves a trailing column on every row and owns
+ *    it entirely; the built-in custom-delete overlay is suppressed, so
+ *    the host renders delete/edit itself where it wants them.
  *
  * Color-mode group: the unified HTabs strip in segmented (radiogroup)
  * working mode (Auto | Light | Dark) — same pill chrome as every other
@@ -58,7 +82,15 @@ export const HkThemeToggle = defineComponent({
   },
   setup(props, { emit, slots }) {
     const { t } = useI18n();
-    const { currentTheme, currentMode, effectiveMode, geo, setTheme, setMode, toggleMode, allThemeList, addCustomTheme, removeCustomTheme } = useTheme();
+    const { currentTheme, currentMode, effectiveMode, geo, setTheme, setMode, toggleMode, allThemeList, addCustomTheme, removeCustomTheme, customThemes } = useTheme();
+
+    /** Resolve a row's full definition for the item slots: the live
+     *  preset table first (stock + registered brand themes), then the
+     *  user's stored custom schemes. */
+    function presetOf(id: ThemeId): ThemePreset | CustomThemePreset | undefined {
+      if (id in themePresets) return themePresets[id as keyof typeof themePresets];
+      return customThemes.value.find((c) => c.id === id);
+    }
 
     const menuOpen = ref(false);
     const triggerRef = ref<HTMLElement | null>(null);
@@ -227,37 +259,61 @@ export const HkThemeToggle = defineComponent({
             <HDivider spacing="md" />
 
             <div class="s-theme-menu-label">{t("hikari::theme.themes")}</div>
-            {allThemeList.value.map((th) => (
-              // One full-width pill per row — the delete affordance for
-              // custom themes OVERLAYS the pill's trailing edge instead
-              // of reserving a trailing column, so built-in rows carry
-              // no dead space (a bottom sheet once showed a permanent
-              // ~40px empty strip right of every row) and every pill
-              // and highlight shares the exact same width.
-              <div key={th.id} class="s-theme-item-row" data-custom={th.isCustom || undefined}>
-                <button
-                  type="button"
-                  class="s-theme-item-btn"
-                  data-active={currentTheme.value === th.id || undefined}
-                  onClick={() => onSelectTheme(th.id)}
+            {allThemeList.value.map((th) => {
+              // Host-customizable row anatomy. `item-leading` replaces the
+              // selected-check cell and renders for EVERY row (fixed icon
+              // cell, so names stay aligned); `item-trailing` reserves a
+              // real trailing column for every row and takes full
+              // ownership of the affordances there — the built-in custom
+              // delete overlay is suppressed in that mode, so the host
+              // renders delete (and anything else) itself. Without the
+              // slots the rows behave exactly as before: check only on
+              // the active row, delete overlaid on custom rows only.
+              const scope: ThemeItemScope = {
+                id: th.id,
+                name: th.name,
+                isCustom: th.isCustom,
+                preset: presetOf(th.id),
+              };
+              const leadingSlot = slots["item-leading"];
+              const trailingSlot = slots["item-trailing"];
+              return (
+                <div
+                  key={th.id}
+                  class="s-theme-item-row"
+                  data-custom={th.isCustom || undefined}
+                  data-trailing={trailingSlot ? "slot" : undefined}
                 >
-                  {currentTheme.value === th.id && (
-                    <span class="hk-menu-item-icon s-theme-item-check"><Check size={14} /></span>
-                  )}
-                  <span class="s-theme-item-name">{th.name}</span>
-                </button>
-                {th.isCustom && (
                   <button
                     type="button"
-                    class="s-theme-item-delete"
-                    title={t("hikari::theme.deleteTheme")}
-                    onClick={() => removeCustomTheme(th.id)}
+                    class="s-theme-item-btn"
+                    data-active={currentTheme.value === th.id || undefined}
+                    onClick={() => onSelectTheme(th.id)}
                   >
-                    <Trash2 size={12} />
+                    {leadingSlot ? (
+                      <span class="hk-menu-item-icon s-theme-item-lead">
+                        {leadingSlot(scope)}
+                      </span>
+                    ) : currentTheme.value === th.id ? (
+                      <span class="hk-menu-item-icon s-theme-item-check"><Check size={14} /></span>
+                    ) : null}
+                    <span class="s-theme-item-name">{th.name}</span>
                   </button>
-                )}
-              </div>
-            ))}
+                  {trailingSlot ? (
+                    <span class="s-theme-item-trailing">{trailingSlot(scope)}</span>
+                  ) : th.isCustom ? (
+                    <button
+                      type="button"
+                      class="s-theme-item-delete"
+                      title={t("hikari::theme.deleteTheme")}
+                      onClick={() => removeCustomTheme(th.id)}
+                    >
+                      <Trash2 size={12} />
+                    </button>
+                  ) : null}
+                </div>
+              );
+            })}
 
             <button
               type="button"


### PR DESCRIPTION
**Motivation (user-reported):** the theme picker's rows offer no host-facing anatomy — the leading cell exists only as the active row's check glyph and the trailing edge only for the built-in custom-delete overlay. Hosts (chest) need per-row content on BOTH sides: color swatches on the left, an edit entry (open the scheme editor seeded from that theme) on the right — in the dropdown AND the mobile bottom sheet.

**API** — two scoped slots over the same DOM both surfaces render:
- `item-leading` — replaces the check cell; renders for EVERY row in the fixed menu-item icon cell so names align regardless of active row.
- `item-trailing` — reserves a trailing column on every row and owns it entirely; the built-in delete overlay is suppressed in this mode.
- Scope: `ThemeItemScope { id, name, isCustom, preset }` — `preset` is the row's resolved definition (live preset table entry, or the stored custom scheme), so hosts render swatches without re-deriving tokens.

**Compatibility:** without the slots the rows behave exactly as before (check only on active row, delete overlay only on custom rows) — the existing anatomy test passes unchanged.

**Verification:** 3 new cases (leading renders on every row and replaces the check; trailing reserves the column and suppresses the overlay even on customs; scope carries resolved preset tokens) + 5 existing HkThemeToggle tests + window-close contract — all green; vue-tsc clean. Version 0.40.15 (release follows the merge).