### PR TITLE
🔧 Export ThemeItemScope from the package index for slot consumers.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.15",
+  "version": "0.40.16",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -303,7 +303,7 @@ export { deepMerge, isPlainObject, getPath, setPath, delPath } from "./utils/obj
 export { HkAdminShell as HAdminShell } from "./components/HkAdminShell";
 export { HkAdminHeader as HAdminHeader } from "./components/HkAdminHeader";
 export { HkNavSidebar as HNavSidebar } from "./components/HkNavSidebar";
-export { HkThemeToggle as HThemeToggle } from "./components/HkThemeToggle";
+export { HkThemeToggle as HThemeToggle, type ThemeItemScope } from "./components/HkThemeToggle";
 export { HkAuthCard as HAuthCard } from "./components/HkAuthCard";
 export { default as HAuthMethodList } from "./components/HkAuthMethodList";
 export { HkSignInCard as HSignInCard } from "./components/HkSignInCard";


### PR DESCRIPTION
Type-export-only follow-up to #412: the barrel shipped the item slots' runtime surface but not `ThemeItemScope`, so hosts (chest) cannot type their slot renderers against the public API. vue-tsc clean; version 0.40.16 (release follows).