### PR TITLE
✅ Cover the interrupted-leave reopen sequence in the enter watchdog test.

### DIFF
--- a/packages/vue/src/components/HkModal.enter-watchdog.test.tsx
+++ b/packages/vue/src/components/HkModal.enter-watchdog.test.tsx
@@ -109,3 +109,52 @@ describe("HkModal enter-class watchdog", () => {
     expect(document.querySelector(".hk-modal-overlay")).toBeNull();
   });
 });
+
+describe("HkModal enter-class watchdog across an interrupted leave", () => {
+  // The exact field-report sequence (2026-09-07 recording, f108-f112):
+  // the modal started closing (scrim fading out), a reopen patched over
+  // the still-live leave on the SAME element, and rAF starvation froze
+  // the re-enter's from-pair — the scrim stayed invisible for seconds
+  // and the eventual close flashed it back at full opacity. The
+  // watchdog must repair both layers of the reopened surface.
+  it("repairs a reopen that froze mid-re-enter on the same element", async () => {
+    vi.useFakeTimers();
+    // Phase 1: open with WORKING rAF so the initial enter completes.
+    const { open } = await mountOpenModal();
+    await vi.advanceTimersByTimeAsync(50);
+    await nextTick();
+
+    // Phase 2: starve rAF, start a close, and reopen while the leave is
+    // still live — the re-enter freezes at its from-pair.
+    freezeRaf();
+    open.value = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(120); // leave live, nothing finalized
+    open.value = true;
+    await nextTick();
+
+    const overlay = document.querySelector<HTMLElement>(".hk-modal-overlay")!;
+    const content = document.querySelector<HTMLElement>(".hk-modal-content")!;
+    expect(overlay).not.toBeNull();
+    expect(content).not.toBeNull();
+    // The frozen re-enter left its from-pair on both layers (the scrim
+    // invisible at opacity 0 while the surface is logically open).
+    expect(overlay.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
+    expect(content.classList.contains("hk-modal-content-enter-from")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(590);
+    expect(overlay.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(overlay.className).toBe("hk-modal-overlay");
+    expect(content.className).toBe("hk-modal-content");
+    // The surface is still open, and closing it afterwards runs a NORMAL
+    // leave (fade from visible) instead of the full-opacity pop.
+    open.value = false;
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(700);
+    await nextTick();
+    expect(document.querySelector(".hk-modal-content")).toBeNull();
+    expect(document.querySelector(".hk-modal-overlay")).toBeNull();
+  });
+});


### PR DESCRIPTION
Test-only follow-up to #414. The frozen-enter regression in #414 covered a fresh mount with starved rAF; the 2026-09-07 field recording's actual sequence was different: the modal began closing (scrim fading), a reopen patched over the still-live leave on the SAME element, and the re-enter froze at its from-pair — scrim invisible for ~2s, then the full-opacity flash on the final close. This PR replays that exact churn (working rAF for the open, starved rAF from the close onward, reopen 120ms into the 250ms leave) and asserts:

- both layers carry the frozen from-pair while the surface is logically open,
- the watchdog repairs both within its budget (590ms: nothing, 690ms: stripped),
- a subsequent close finalizes normally (no residue, exactly one teardown).

Local: vitest HkModal.enter-watchdog 4/4. No production code changes.