### PR TITLE
✨ Publish the theme toggle trigger border variable and add the mode-extra slot.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.17",
+  "version": "0.40.18",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -145,6 +145,8 @@ export const HkColorSchemeEditor = defineComponent({
     initialLight: { type: Object as PropType<ThemeSchemeTokens>, default: undefined },
     /** Prefill extension token groups (per mode); defaults to registry defaults. */
     initialGroups: { type: Object as PropType<ThemeTokenGroupModes>, default: undefined },
+    /** Prefill the scheme name input (edit/fork flows); empty by default. */
+    initialName: { type: String, default: "" },
   },
   setup(props, { expose }) {
     const { t } = useI18n();
@@ -153,7 +155,7 @@ export const HkColorSchemeEditor = defineComponent({
     // through a computed so config-file labels follow the live locale.
     const activeLocale = computed(() => useI18n().locale);
     const modeTab = ref<string>("dark");
-    const themeName = ref("");
+    const themeName = ref(props.initialName ?? "");
 
     const dark = reactive<ThemeSchemeTokens>({ ...defaultDark });
     const light = reactive<ThemeSchemeTokens>({ ...defaultLight });
@@ -196,7 +198,7 @@ export const HkColorSchemeEditor = defineComponent({
 
     function reset(): void {
       modeTab.value = useTheme().effectiveMode.value;
-      themeName.value = t("hikari::theme.customThemeName");
+      themeName.value = props.initialName ?? t("hikari::theme.customThemeName");
       Object.assign(dark, props.initialDark ?? defaultDark);
       Object.assign(light, props.initialLight ?? defaultLight);
       // Optional slots: a legacy prefill omitting them must reset to white

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -13,11 +13,19 @@
   height: 1.75rem;
   min-width: 1.75rem;
   padding: 0 var(--space-6, 0.375rem);
-  border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
+  /* Host/theme-tunable: borderless chrome sets --hk-theme-toggle-btn-border:
+   * transparent (e.g. the BA brand look). */
+  border: 1px solid var(--hk-theme-toggle-btn-border, var(--border-faint, rgb(var(--color-border) / 12%)));
   background: rgb(var(--color-surface));
   color: rgb(var(--color-text-secondary, var(--color-muted)));
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
+}
+
+/* Host strip under the mode group (mode-extra slot). */
+.s-theme-mode-extra {
+  margin-top: var(--space-8, 0.5rem);
+  width: 100%;
 }
 
 .s-theme-toggle-btn:hover {

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -228,6 +228,41 @@ describe("HkThemeToggle color-mode group", () => {
     const activeBtn = document.body.querySelector<HTMLButtonElement>(".s-theme-item-btn[data-active]");
     expect(activeBtn?.querySelector(".s-theme-item-check")).toBeTruthy();
   });
+  it("renders the mode-extra strip under the mode group when provided", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(HkThemeToggle, { externalCustomize: true }, {
+          "mode-extra": () => h("div", { class: "dpi-mark", "data-x": "1" }, "dpi"),
+        }),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+    openMenu(container);
+    await settle();
+
+    const strip = document.body.querySelector(".s-theme-menu .s-theme-mode-extra");
+    expect(strip).toBeTruthy();
+    expect(strip!.querySelector(".dpi-mark")).toBeTruthy();
+    // It sits inside the menu, after the mode row and before the divider.
+    const menu = document.body.querySelector(".s-theme-menu")!;
+    const children = [...menu.children].map((c) => c.className);
+    const extraIdx = children.indexOf("s-theme-mode-extra");
+    expect(extraIdx).toBeGreaterThan(children.indexOf("s-theme-mode-row"));
+    expect(children[extraIdx + 1]).toContain("hk-divider");
+  });
+
+  it("omits the mode-extra strip when no slot is provided", async () => {
+    let container: HTMLElement;
+    const mounted = mountToggle(true);
+    container = mounted.container;
+    await settle();
+    openMenu(container);
+    await settle();
+    expect(document.body.querySelector(".s-theme-menu .s-theme-mode-extra")).toBeNull();
+  });
 });
 
 describe("HkThemeToggle item slots", () => {

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -52,6 +52,10 @@ export interface ThemeItemScope {
  *    it entirely; the built-in custom-delete overlay is suppressed, so
  *    the host renders delete/edit itself where it wants them.
  *
+ * `mode-extra` — a host strip rendered directly under the color-mode
+ * group (before the divider). Mode-adjacent host chrome that is NOT a
+ * theme-editor concern lives here (e.g. display-scale control).
+ *
  * Color-mode group: the unified HTabs strip in segmented (radiogroup)
  * working mode (Auto | Light | Dark) — same pill chrome as every other
  * group. In AUTO mode the Light/Dark halves merge into the strip's
@@ -253,8 +257,15 @@ export const HkThemeToggle = defineComponent({
                     </button>
                   ),
                 }}
-              </HTabs>
+</HTabs>
             </div>
+
+            {/* Host extension point directly under the mode group (P98: the
+                 chest DPI control lives here — mode-adjacent chrome, not a theme
+                 editor tab). Rendered only when the host provides the slot. */}
+            {slots["mode-extra"] ? (
+              <div class="s-theme-mode-extra">{slots["mode-extra"]()}</div>
+            ) : null}
 
             <HDivider spacing="md" />
 


### PR DESCRIPTION
## Summary

Two small HkThemeToggle anatomy extensions for the chest P98 theme work (both host-driven, default rendering byte-identical):

- **Trigger border becomes tunable**: `.s-theme-toggle-btn` border reads `var(--hk-theme-toggle-btn-border, <current faint border>)`. Borderless chrome (the 什亭之匣 brand look — user feedback: the split sun/chevron trigger should float like the neighboring search button) sets the variable to `transparent`; industrial skins can keep or restyle it.
- **New scoped slot `mode-extra`**: a host strip rendered directly under the color-mode group (before the divider) for mode-adjacent chrome that is not a theme-editor concern — chest will host its display-scale (DPI) control there, moving it out of the theme editor to sit at the same level as 自动/浅色/深色. Renders only when the host provides the slot.

## Verification

- HkThemeToggle tests **10/10** (new: mode-extra renders inside the menu between the mode row and the divider; absent without the slot). vue-tsc clean, eslint clean. Version 0.40.17 → 0.40.18.