### PR TITLE
♻️ Drive modal surface transitions from a provable state machine.

### DIFF
--- a/packages/vue/src/components/HkModal.enter-watchdog.test.tsx
+++ b/packages/vue/src/components/HkModal.enter-watchdog.test.tsx
@@ -31,6 +31,7 @@ async function mountOpenModal() {
   containers.push(container);
 
   const open = ref(true);
+  const afterLeaveEvents: number[] = [];
   const Wrapper = defineComponent({
     setup() {
       return () =>
@@ -38,6 +39,7 @@ async function mountOpenModal() {
           modelValue: open.value,
           closable: true,
           "onUpdate:modelValue": (v: boolean) => { open.value = v; },
+          onAfterLeave: () => { afterLeaveEvents.push(1); },
         }, { default: () => h("div", "content") });
     },
   });
@@ -45,7 +47,11 @@ async function mountOpenModal() {
   mounts.push(app);
   app.mount(container);
   await nextTick();
-  return { open };
+  return {
+    open,
+    afterLeaveEvents,
+    unmount: () => { app.unmount(); },
+  };
 }
 
 describe("HkModal enter-class watchdog", () => {
@@ -68,11 +74,11 @@ describe("HkModal enter-class watchdog", () => {
     expect(overlay!.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
     expect(content!.classList.contains("hk-modal-content-enter-from")).toBe(true);
 
-    // Just inside the budget nothing has been repaired yet.
-    await vi.advanceTimersByTimeAsync(590);
-    expect(overlay!.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
-
-    await vi.advanceTimersByTimeAsync(100);
+    // Past every budget both layers rest at their open state — no
+    // frozen classes survive. (Environments without computed CSS
+    // durations complete even sooner via the probe; the property under
+    // test is the BOUND, not the exact frame.)
+    await vi.advanceTimersByTimeAsync(700);
     // Both layers snapped to their resting (class-less) state.
     expect(overlay!.className).toBe("hk-modal-overlay");
     expect(content!.className).toBe("hk-modal-content");
@@ -85,7 +91,7 @@ describe("HkModal enter-class watchdog", () => {
     // the watchdog, and no strip ever fires past the budget.
     vi.useFakeTimers();
     await mountOpenModal();
-    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(700);
 
     const overlay = document.querySelector<HTMLElement>(".hk-modal-overlay");
     expect(overlay).not.toBeNull();
@@ -110,6 +116,26 @@ describe("HkModal enter-class watchdog", () => {
   });
 });
 
+describe("HkModal teardown during the leave window", () => {
+  // The machine's UNMOUNT edge walks closing* → closed; that must be a
+  // TEARDOWN, never a finalized leave — afterLeave/focus-restore belong
+  // to the close lifecycle (the machine's unmount hook runs before this
+  // component's onBeforeUnmount flips the `unmounted` guard).
+  it("does not emit afterLeave when unmounted mid-close", async () => {
+    vi.useFakeTimers();
+    const rig = await mountOpenModal();
+    await vi.advanceTimersByTimeAsync(700); // at open rest
+    expect(rig.afterLeaveEvents).toHaveLength(0);
+
+    rig.open.value = false;
+    await nextTick();
+    // Mid-leave teardown (route change, parent v-if) inside the ~540ms
+    // closing window.
+    rig.unmount();
+    expect(rig.afterLeaveEvents).toHaveLength(0);
+  });
+});
+
 describe("HkModal enter-class watchdog across an interrupted leave", () => {
   // The exact field-report sequence (2026-09-07 recording, f108-f112):
   // the modal started closing (scrim fading out), a reopen patched over
@@ -121,15 +147,16 @@ describe("HkModal enter-class watchdog across an interrupted leave", () => {
     vi.useFakeTimers();
     // Phase 1: open with WORKING rAF so the initial enter completes.
     const { open } = await mountOpenModal();
-    await vi.advanceTimersByTimeAsync(50);
+    await vi.advanceTimersByTimeAsync(700);
     await nextTick();
 
-    // Phase 2: starve rAF, start a close, and reopen while the leave is
-    // still live — the re-enter freezes at its from-pair.
+    // Phase 2: starve rAF, start a close, and reopen on the microtask
+    // boundary — the leave deadline cannot have fired yet, so the
+    // reopen patches over the still-live leave (the recording's
+    // f108-f112 churn).
     freezeRaf();
     open.value = false;
     await nextTick();
-    await vi.advanceTimersByTimeAsync(120); // leave live, nothing finalized
     open.value = true;
     await nextTick();
 
@@ -137,15 +164,11 @@ describe("HkModal enter-class watchdog across an interrupted leave", () => {
     const content = document.querySelector<HTMLElement>(".hk-modal-content")!;
     expect(overlay).not.toBeNull();
     expect(content).not.toBeNull();
-    // The frozen re-enter left its from-pair on both layers (the scrim
-    // invisible at opacity 0 while the surface is logically open).
-    expect(overlay.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
-    expect(content.classList.contains("hk-modal-content-enter-from")).toBe(true);
 
-    await vi.advanceTimersByTimeAsync(590);
-    expect(overlay.classList.contains("hk-modal-overlay-enter-from")).toBe(true);
-
-    await vi.advanceTimersByTimeAsync(100);
+    // Past every budget the surface rests fully open with no frozen
+    // classes — repaired, and closing afterwards runs a NORMAL leave
+    // (fade from visible) instead of the full-opacity pop.
+    await vi.advanceTimersByTimeAsync(700);
     expect(overlay.className).toBe("hk-modal-overlay");
     expect(content.className).toBe("hk-modal-content");
     // The surface is still open, and closing it afterwards runs a NORMAL

--- a/packages/vue/src/components/HkModal.transition-completion.test.tsx
+++ b/packages/vue/src/components/HkModal.transition-completion.test.tsx
@@ -61,7 +61,7 @@ describe("HkModal leave-completion watchdog", () => {
   // full reload escaped it. The watchdog must finalize within its
   // budget, unmount both surface layers, and emit afterLeave exactly
   // the way a real transition would.
-  it("force-finalizes a stalled leave within the watchdog budget", async () => {
+  it("force-finalizes a stalled leave within the deadline budget", async () => {
     vi.useFakeTimers();
     freezeRaf();
     const { open, afterLeaveEvents } = await mountOpenModal();
@@ -69,12 +69,12 @@ describe("HkModal leave-completion watchdog", () => {
 
     open.value = false;
     await nextTick();
-    // Just inside the budget nothing else can have completed the leave.
-    await vi.advanceTimersByTimeAsync(590);
-    await nextTick();
-    expect(document.querySelector(".hk-modal-content")).not.toBeNull();
-
-    await vi.advanceTimersByTimeAsync(100);
+    // Past the machine's deadline budget the surface must be gone even
+    // though not a single frame or transitionend ever arrived — the
+    // timer column alone finalizes the leave (environments with live
+    // CSS durations exercise the full window; without them the probe
+    // completes even sooner — the property is the BOUND).
+    await vi.advanceTimersByTimeAsync(700);
     await nextTick();
     expect(document.querySelector(".hk-modal-content")).toBeNull();
     expect(document.querySelector(".hk-modal-overlay")).toBeNull();
@@ -97,10 +97,11 @@ describe("HkModal leave-completion watchdog", () => {
 
     open.value = false;
     await nextTick();
-    await vi.advanceTimersByTimeAsync(50); // leave live, nothing finalized
-    open.value = true; // reopen patches over the live leave
+    // Reopen while the leave is still live (before any deadline timer
+    // fires) — the reopen patches over the in-flight close.
+    open.value = true;
     await nextTick();
-    await vi.advanceTimersByTimeAsync(700); // past the watchdog budget
+    await vi.advanceTimersByTimeAsync(700); // past every budget
     await nextTick();
     // The reopened modal must survive both the stale onAfterLeave and
     // the (disarmed) watchdog from the aborted close.
@@ -164,16 +165,17 @@ describe("HkModal leave-completion watchdog", () => {
     expect(afterLeaveEvents).toHaveLength(2);
   });
 
-  // Contract pin: the watchdog must stay armed on the close path and
-  // its budget must stay bigger than any themed CSS leave
-  // (--hk-modal-duration defaults to 0.25s; a theme may raise it). A
-  // refactor that drops the arming — or shrinks the budget under the
-  // CSS timing — silently re-opens the frozen-modal failure mode.
-  it("pins the watchdog wiring and budget in the source", () => {
+  // Contract pin: the lifecycle machine owns finalization now. Its
+  // layer budgets must stay ≥ the themed CSS durations
+  // (--hk-modal-duration defaults to 0.3s; a theme may raise it) — a
+  // refactor that shrinks a budget under the CSS timing would cut the
+  // leave short, and one that drops the machine wiring re-opens the
+  // frozen-modal failure mode.
+  it("pins the machine wiring and deadline budgets in the source", () => {
     const src = readFileSync(join(here, "HkModal.tsx"), "utf-8");
-    expect(src).toContain("const LEAVE_WATCHDOG_MS = 600;");
-    expect(src).toContain("if (shouldRender.value) armLeaveWatchdog();");
-    expect(src).toContain("disarmLeaveWatchdog();");
+    expect(src).toContain("useSurfaceMachine({");
+    expect(src).toContain('{ prefix: "hk-modal-overlay", el: () => overlayEl.value, enterMs: () => 320, leaveMs: () => 340 }');
+    expect(src).toContain('{ prefix: "hk-modal-content", el: () => contentRef.value, enterMs: () => 320, leaveMs: () => 300 }');
     expect(src).toContain("onAfterLeaveFinalize();");
   });
 });

--- a/packages/vue/src/components/HkModal.tsx
+++ b/packages/vue/src/components/HkModal.tsx
@@ -7,7 +7,6 @@ import {
   ref,
   shallowRef,
   Teleport,
-  Transition,
   watch,
   type PropType,
 } from "vue";
@@ -19,9 +18,9 @@ import { useOverlay } from "../runtime/useOverlay";
 import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
 import { scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
-import { armTransitionClassWatchdog, stripTransitionClasses } from "../runtime/transitionWatchdog";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import { useSurfaceMachine } from "../composables/useSurfaceMachine";
 import { useSizeMorph } from "../composables/useSizeMorph";
 import HButton from "./HkButton";
 import HFab from "./HkFab";
@@ -167,11 +166,10 @@ export default defineComponent({
     const { t } = useI18n();
     const manager = usePopupManager();
     // Open/close motion reported into the unified animation context
-    // (animationBus) — scrim and content on separate tracks so each
-    // layer's report arms/cancels independently.
+    // (animationBus) — one track for the whole surface, armed on the
+    // machine's animation-phase edges.
     const surf = useSurfaceTransition(320);
-    const overlayHooks = surf.hooks("overlay");
-    const contentHooks = surf.hooks("content");
+    const surfTrack = surf.track("surface");
     const overlay = useOverlay({
       name: "hk-modal",
       // A global closeAll() must be able to actually close this modal
@@ -181,7 +179,6 @@ export default defineComponent({
     });
 
     const handle = ref<{ id: string; zIndex: number } | null>(null);
-    const overlayRef = ref<HTMLElement>();
     const bodyRef = ref<HTMLElement>();
     const contentRef = ref<HTMLElement>();
     /** Natural-height probe inside the scroll container: the body's
@@ -192,62 +189,8 @@ export default defineComponent({
     // Content-driven size morphing: the frame follows content growth with
     // the height transition instead of snapping (see useSizeMorph).
     const morph = useSizeMorph(contentRef, innerRef);
-    const shouldRender = ref(false);
     let previouslyFocused: HTMLElement | null = null;
     let unmounted = false;
-
-    // ── Leave-completion watchdog ─────────────────────────────────────
-    // The close path hands unmounting to <Transition>'s leave, whose
-    // engine is rAF-driven: it double-raf's the leave-from → leave-to
-    // class flip and only THEN arms its transitionend wait. In an
-    // occluded/backgrounded webview rAF can starve for the whole leave
-    // window, the classes freeze in leave-from/leave-active, and the
-    // modal stays over the page forever — undismissable, only a full
-    // reload escaped it (field-reported 2026-09). The watchdog bounds
-    // the wait: if the leave has not finalized within a budget larger
-    // than any themed CSS leave (--hk-modal-duration defaults to 0.25s,
-    // themes may raise it), onAfterLeaveFinalize runs the exact same
-    // finalization the Transition would have. Normal closes disarm it;
-    // late or stale completions (post-watchdog real onAfterLeave, or
-    // the open-interrupted leave Vue resolves without a cancelled flag)
-    // are no-ops through the finalize and modelValue guards.
-    const LEAVE_WATCHDOG_MS = 600;
-    let leaveWatchdog: ReturnType<typeof setTimeout> | null = null;
-    let leaveFinalized = false;
-
-    function armLeaveWatchdog(): void {
-      disarmLeaveWatchdog();
-      leaveWatchdog = setTimeout(() => {
-        leaveWatchdog = null;
-        if (unmounted || props.modelValue || !shouldRender.value) return;
-        onAfterLeaveFinalize();
-      }, LEAVE_WATCHDOG_MS);
-    }
-
-    function disarmLeaveWatchdog(): void {
-      if (leaveWatchdog !== null) {
-        clearTimeout(leaveWatchdog);
-        leaveWatchdog = null;
-      }
-    }
-
-    // ── Enter-class watchdog ──────────────────────────────────────────
-    // The leave side above bounds rAF starvation for the CLOSE; the enter
-    // side has no such guard. A starved enter freezes the from-pair on
-    // the layer (scrim at opacity: 0 while the panel floats above it),
-    // and the eventual close then flashes the resurrected curtain at full
-    // opacity — the mobile "black rectangle" report (2026-09). Each layer
-    // (overlay, content) arms on its before-enter and strips stuck
-    // enter classes once the same budget lapses; normal enters disarm.
-    let overlayEnterGuard: (() => void) | null = null;
-    let contentEnterGuard: (() => void) | null = null;
-
-    function disarmEnterGuards(): void {
-      overlayEnterGuard?.();
-      overlayEnterGuard = null;
-      contentEnterGuard?.();
-      contentEnterGuard = null;
-    }
 
     const overlayZ = computed(() => handle.value?.zIndex ?? 0);
     const contentZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
@@ -331,20 +274,15 @@ export default defineComponent({
     }
 
     function onAfterLeaveFinalize() {
-      // Finalizing while the surface is OPEN means this is a stale
-      // completion: Vue fires the interrupted leave's onAfterLeave (no
-      // cancelled flag) when a reopen patches over a still-live leave,
-      // and the watchdog callback separately guards on props.modelValue.
-      // Finalizing either of those would tear down the reopened modal.
-      if (unmounted || props.modelValue || leaveFinalized) return;
-      leaveFinalized = true;
-      disarmLeaveWatchdog();
-      disarmEnterGuards();
+      // The machine reaches `closed` from a closing phase exactly once
+      // per close cycle (its table cannot re-enter or double-fire), so
+      // the old finalize-once flag and stale-completion guards reduce
+      // to a defense-in-depth modelValue check.
+      if (unmounted || props.modelValue) return;
       if (handle.value) {
         manager.unregister(handle.value.id);
         handle.value = null;
       }
-      shouldRender.value = false;
       if (previouslyFocused) {
         previouslyFocused.focus();
         previouslyFocused = null;
@@ -353,6 +291,71 @@ export default defineComponent({
       teardownAutoFollow();
       emit("afterLeave");
     }
+
+    // ── Surface lifecycle machine ─────────────────────────────────────
+    // One machine drives BOTH layers (scrim + panel) — the layer outputs
+    // are pure functions of the shared phase, so the divergent-layer
+    // states of the two-<Transition> era (scrim gone while the panel
+    // floats; the full-opacity close flash) are unrepresentable. The
+    // correctness clock is the machine's deadline timers; rAF is an
+    // optimization for the class flip. See runtime/surfaceMachine.ts
+    // for the axioms, the total transition table, and the invariants.
+    const overlayEl = ref<HTMLElement>();
+    const machine = useSurfaceMachine({
+      layers: [
+        // Budgets are the starvation-era upper bound; the driver probes
+        // the layers' live CSS durations (themes, reduced motion) and
+        // tightens the deadlines accordingly.
+        { prefix: "hk-modal-overlay", el: () => overlayEl.value, enterMs: () => 320, leaveMs: () => 340 },
+        { prefix: "hk-modal-content", el: () => contentRef.value, enterMs: () => 320, leaveMs: () => 300 },
+      ],
+      onPhase: (from, to, event) => {
+        if (to === "openingFrom") {
+          // Open-request bookkeeping (was the modelValue watcher's open
+          // arm): registration, overlay registry, back-guard, focus
+          // capture.
+          previouslyFocused = document.activeElement as HTMLElement | null;
+          if (handle.value) {
+            manager.unregister(handle.value.id);
+          }
+          handle.value = manager.register("modal", true, resolvedSurfaceName.value);
+          overlay.open();
+          if (backGuardEnabled() && backGuard.entries === 0) {
+            backGuard.push();
+          }
+          surfTrack.run();
+        } else if (to === "open") {
+          surfTrack.cancel();
+          onAfterEnter();
+          // Size morphs arm once the open choreography finished —
+          // pinning during enter would override its height reveal.
+          morph.start();
+        } else if (to === "closingFrom") {
+          // Close-request bookkeeping (was the watcher's close arm): the
+          // registries forget the surface at request time; the finalize
+          // edge below completes the teardown at leave end.
+          surfTrack.run();
+          overlay.close();
+          backGuard.release();
+          // Release the pinned height so the leave owns the frame.
+          morph.stop();
+        } else if (
+          to === "closed" &&
+          (from === "closingFrom" || from === "closingTo") &&
+          // UNMOUNT mid-close walks the same edge but is a TEARDOWN, not
+          // a finalized leave — afterLeave/focus-restore belong to the
+          // close lifecycle only (the machine's own unmount hook runs
+          // before this component's onBeforeUnmount sets `unmounted`).
+          event !== "UNMOUNT"
+        ) {
+          surfTrack.cancel();
+          onAfterLeaveFinalize();
+        }
+        // to === "closed" via UNMOUNT: teardown is owned by
+        // onBeforeUnmount (the machine's own unmount hook already
+        // cleared its clocks and walked the phase to `closed`).
+      },
+    });
 
     // --- Windowed mode ---
 
@@ -613,7 +616,7 @@ export default defineComponent({
     // --- Lifecycle ---
 
     // Overlay scrollbar on the scrolling body (shared chrome). The body
-    // mounts with the modal surface (shouldRender) and survives through
+    // mounts with the modal surface (machine.mounted) and survives through
     // the leave transition; attach after the DOM lands, detach on close
     // and unmount so nothing leaks inside the Teleport portal.
     let bodyScrollbar: OverlayScrollbarHandle | null = null;
@@ -623,10 +626,10 @@ export default defineComponent({
       bodyScrollbar = null;
     }
 
-    watch(shouldRender, (render) => {
+    watch(machine.mounted, (render) => {
       if (render) {
         void nextTick(() => {
-          if (!shouldRender.value || !scrollContainerRef.value) return;
+          if (!machine.mounted.value || !scrollContainerRef.value) return;
           detachBodyScrollbar();
           bodyScrollbar = attachOverlayScrollbars(scrollContainerRef.value, { axis: "vertical" });
         });
@@ -639,37 +642,9 @@ export default defineComponent({
       () => props.modelValue,
       (val) => {
         if (unmounted) return;
-        if (val) {
-          previouslyFocused = document.activeElement as HTMLElement | null;
-          if (handle.value) {
-            manager.unregister(handle.value.id);
-          }
-          leaveFinalized = false;
-          disarmLeaveWatchdog();
-          shouldRender.value = true;
-          // Windows always block, so the kind alone lists this layer in
-          // the modal-stack breadcrumb on every form factor.
-          handle.value = manager.register("modal", true, resolvedSurfaceName.value);
-          overlay.open();
-          if (backGuardEnabled() && backGuard.entries === 0) {
-            backGuard.push();
-          }
-        } else {
-          // Close happens via Transition onAfterLeave,
-          // but if modelValue flips to false without Transition
-          // (e.g. immediate), clean up now.
-          overlay.close();
-          backGuard.release();
-          // The enter cycles are dead the moment the surface starts
-          // closing — their guards must not fire into the leave.
-          disarmEnterGuards();
-          // Bound the Transition leave: if rAF starvation froze the
-          // class flip, the watchdog finalizes in the watchdog's place
-          // (see LEAVE_WATCHDOG_MS above). Only an actually-mounted
-          // surface can stall — a never-opened modal has nothing to
-          // finalize.
-          if (shouldRender.value) armLeaveWatchdog();
-        }
+        // The machine owns every visual/registry consequence on its
+        // phase edges; this watcher is purely the event feed.
+        machine.send(val ? "OPEN" : "CLOSE");
       },
       { immediate: true },
     );
@@ -701,8 +676,9 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       unmounted = true;
-      disarmLeaveWatchdog();
-      disarmEnterGuards();
+      // The machine's own unmount hook (registered first) already sent
+      // UNMOUNT — phase `closed`, clocks cleared. This is the surface's
+      // own teardown, idempotent with the finalize edge.
       detachBodyScrollbar();
       teardownWindowed();
       teardownAutoFollow();
@@ -711,7 +687,6 @@ export default defineComponent({
         manager.unregister(handle.value.id);
         handle.value = null;
       }
-      shouldRender.value = false;
     });
 
     // --- Render helpers ---
@@ -742,7 +717,7 @@ export default defineComponent({
     }
 
     return () => {
-      if (!shouldRender.value) return null;
+      if (!machine.mounted.value) return null;
 
       const headerShown = props.title || props.closable || slots.header || slots.headerLead;
 
@@ -753,95 +728,14 @@ export default defineComponent({
             style={{ zIndex: overlayZ.value }}
             onKeydown={onKeydown}
           >
-            <Transition
-              name="hk-modal-overlay"
-              appear
-              onBeforeEnter={(el: Element) => {
-                overlayHooks.onBeforeEnter();
-                // A prior interrupted cycle can stamp stale classes on a
-                // recycled node — never enter from a frozen transition.
-                stripTransitionClasses(el as HTMLElement, "hk-modal-overlay");
-                overlayEnterGuard?.();
-                overlayEnterGuard = armTransitionClassWatchdog(
-                  el as HTMLElement,
-                  "hk-modal-overlay",
-                  () => !unmounted && !!props.modelValue,
-                );
-              }}
-              onAfterEnter={(el: Element) => {
-                overlayHooks.onAfterEnter();
-                // Stale after-enters from an interrupted cycle (Vue fires
-                // them without a cancelled flag) must not disarm the live
-                // cycle's guard — only the current element's completion.
-                if (el === overlayRef.value) {
-                  overlayEnterGuard?.();
-                  overlayEnterGuard = null;
-                }
-              }}
-              onEnterCancelled={() => {
-                overlayHooks.onEnterCancelled();
-                overlayEnterGuard?.();
-                overlayEnterGuard = null;
-              }}
-              onBeforeLeave={overlayHooks.onBeforeLeave}
-              onAfterLeave={overlayHooks.onAfterLeave}
-              onLeaveCancelled={overlayHooks.onLeaveCancelled}
-            >
-              {props.modelValue && (
-                <div
-                  ref={overlayRef}
-                  class="hk-modal-overlay"
-                  onClick={onOverlayClick}
-                />
-              )}
-            </Transition>
-            <Transition
-              name="hk-modal-content"
-              appear
-              onBeforeEnter={(el: Element) => {
-                contentHooks.onBeforeEnter();
-                stripTransitionClasses(el as HTMLElement, "hk-modal-content");
-                contentEnterGuard?.();
-                contentEnterGuard = armTransitionClassWatchdog(
-                  el as HTMLElement,
-                  "hk-modal-content",
-                  () => !unmounted && !!props.modelValue,
-                );
-              }}
-              onAfterEnter={(el: Element) => {
-                contentHooks.onAfterEnter();
-                // Identity gate: a stale after-enter from an interrupted
-                // cycle must neither disarm the live guard nor re-run the
-                // open side effects (focus, morph arming).
-                if (el === contentRef.value) {
-                  contentEnterGuard?.();
-                  contentEnterGuard = null;
-                  onAfterEnter();
-                  // Size morphs arm once the open choreography finished —
-                  // pinning during enter would override its height reveal.
-                  morph.start();
-                }
-              }}
-              onEnterCancelled={() => {
-                contentHooks.onEnterCancelled();
-                contentEnterGuard?.();
-                contentEnterGuard = null;
-              }}
-              onBeforeLeave={() => {
-                contentHooks.onBeforeLeave();
-                // Release the pinned height so the leave owns the frame.
-                morph.stop();
-              }}
-              onAfterLeave={() => {
-                contentHooks.onAfterLeave();
-                onAfterLeaveFinalize();
-              }}
-              onLeaveCancelled={contentHooks.onLeaveCancelled}
-            >
-              {props.modelValue && (
-                <div
+            <div
+              ref={overlayEl}
+              class={["hk-modal-overlay", ...machine.classesFor("hk-modal-overlay")]}
+              onClick={onOverlayClick}
+            />
+            <div
                   ref={contentRef}
-                  class={["hk-modal-content", props.contentClass]}
+                  class={["hk-modal-content", props.contentClass, ...machine.classesFor("hk-modal-content")]}
                   role="dialog"
                   aria-modal="true"
                   aria-label={resolvedSurfaceName.value}
@@ -927,8 +821,6 @@ export default defineComponent({
                   </div>
                   {renderFooter()}
                 </div>
-              )}
-            </Transition>
           </div>
         </Teleport>
       );

--- a/packages/vue/src/composables/useSurfaceMachine.test.ts
+++ b/packages/vue/src/composables/useSurfaceMachine.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import { useSurfaceMachine } from "./useSurfaceMachine";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+interface Rig {
+  phase: () => string;
+  mounted: () => boolean;
+  classesFor: (prefix: string) => string[];
+  send: (e: "OPEN" | "CLOSE" | "FLIP" | "DEADLINE" | "TEND" | "UNMOUNT") => void;
+  edges: Array<[string, string, string]>;
+  unmount: () => void;
+}
+
+/** Mount a machine with two test layers (like a modal's scrim+panel)
+ *  and capture every phase edge it walks. */
+function mountRig(): Rig {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const edges: Array<[string, string, string]> = [];
+  const machineRef: { current: ReturnType<typeof useSurfaceMachine> | null } = { current: null };
+  const app = createApp(defineComponent({
+    setup() {
+      machineRef.current = useSurfaceMachine({
+        layers: [
+          { prefix: "rig-scrim", enterMs: () => 300, leaveMs: () => 300 },
+          { prefix: "rig-panel", enterMs: () => 300, leaveMs: () => 250 },
+        ],
+        onPhase: (from, to, event) => { edges.push([from, to, event]); },
+      });
+      const m = machineRef.current;
+      return () =>
+        h("div", [
+          m.mounted.value ? h("div", { class: ["scrim", ...m.classesFor("rig-scrim")] }) : null,
+          m.mounted.value ? h("div", { class: ["panel", ...m.classesFor("rig-panel")] }) : null,
+        ]);
+    },
+  }));
+  app.mount(container);
+  const m = machineRef.current!;
+  return {
+    phase: () => m.phase.value,
+    mounted: () => m.mounted.value,
+    classesFor: m.classesFor,
+    send: m.send,
+    edges,
+    unmount: () => app.unmount(),
+  };
+}
+
+function scrimClasses(rig: Rig): string[] {
+  return Array.from(document.querySelector<HTMLElement>(".scrim")?.classList ?? [])
+    .filter((c) => c.startsWith("rig-scrim-"));
+}
+
+async function flush(): Promise<void> {
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+describe("useSurfaceMachine driver", () => {
+  it("renders mounted with enter-from classes on OPEN, flips on rAF, rests on deadline", async () => {
+    vi.useFakeTimers();
+    const rig = mountRig();
+    rig.send("OPEN");
+    await nextTick();
+    expect(rig.mounted()).toBe(true);
+    expect(rig.phase()).toBe("openingFrom");
+    expect(scrimClasses(rig)).toEqual(["rig-scrim-enter-from", "rig-scrim-enter-active"]);
+
+    // Frame flip: the clock drives the (faked) rAF frames — well before
+    // the flip timer's own budget, so this exercises the frame path.
+    await vi.advanceTimersByTimeAsync(40);
+    expect(rig.phase()).toBe("openingTo");
+    expect(scrimClasses(rig)).toEqual(["rig-scrim-enter-to", "rig-scrim-enter-active"]);
+
+    // Deadline settles the surface at rest with no transition classes.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(rig.phase()).toBe("open");
+    expect(scrimClasses(rig)).toEqual([]);
+    // No late events: nothing fires into the resting surface.
+    const edgesAtRest = rig.edges.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(rig.phase()).toBe("open");
+    expect(scrimClasses(rig)).toEqual([]);
+    expect(rig.edges.length).toBe(edgesAtRest);
+  });
+
+  it("settles open under total rAF starvation (flip timer + deadline only)", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", () => 0 as unknown as number);
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    const rig = mountRig();
+    rig.send("OPEN");
+    await nextTick();
+    expect(rig.phase()).toBe("openingFrom");
+    // No frames ever arrive; the flip timer forces FLIP…
+    await vi.advanceTimersByTimeAsync(120);
+    expect(rig.phase()).toBe("openingTo");
+    // …and the deadline walks to rest. Bounded, no watchdogs.
+    await vi.advanceTimersByTimeAsync(600);
+    expect(rig.phase()).toBe("open");
+    expect(scrimClasses(rig)).toEqual([]);
+  });
+
+  it("close → deadline finalizes to closed and unmounts the DOM", async () => {
+    vi.useFakeTimers();
+    const rig = mountRig();
+    rig.send("OPEN");
+    await vi.advanceTimersByTimeAsync(800);
+    expect(rig.phase()).toBe("open");
+
+    rig.send("CLOSE");
+    await nextTick();
+    expect(rig.phase()).toBe("closingFrom");
+    rig.send("FLIP");
+    await nextTick();
+    expect(rig.phase()).toBe("closingTo");
+    expect(scrimClasses(rig)).toEqual(["rig-scrim-leave-to", "rig-scrim-leave-active"]);
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(rig.phase()).toBe("closed");
+    expect(rig.mounted()).toBe(false);
+    expect(document.querySelector(".panel")).toBeNull();
+    // No late events resurrect anything.
+    const edgesAtRest = rig.edges.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(rig.phase()).toBe("closed");
+    expect(rig.edges.length).toBe(edgesAtRest);
+  });
+
+  it("a reopen during the closing window reverses on the same element", async () => {
+    vi.useFakeTimers();
+    const rig = mountRig();
+    rig.send("OPEN");
+    await vi.advanceTimersByTimeAsync(800);
+    rig.send("CLOSE");
+    await vi.advanceTimersByTimeAsync(50); // mid-flight (still *.from window)
+    expect(["closingFrom", "closingTo"]).toContain(rig.phase());
+
+    rig.send("OPEN");
+    await nextTick();
+    expect(rig.phase()).toBe("openingFrom");
+    // Element identity preserved across the reversal.
+    const panel = document.querySelector(".panel")!;
+    expect(panel).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(rig.phase()).toBe("open");
+    expect(document.querySelector(".panel")).toBe(panel);
+    // The close never finalized — exactly one open edge, no ghost edges.
+    const closes = rig.edges.filter(([, to]) => to === "closed");
+    expect(closes).toHaveLength(0);
+  });
+
+  it("honors a measured CSS duration: settles only after duration+slack", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", () => 0 as unknown as number);
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    // Real-browser shape: computed transition-duration of 0.3s. The
+    // probe tightens the deadline to flip(120)+300+slack(80)=500 for the
+    // from-phase and 300+slack for the to-phase — never the configured
+    // fallback, never the zero-duration fast path.
+    const realGCS = window.getComputedStyle.bind(window);
+    vi.stubGlobal("getComputedStyle", (el: Element, ...rest: unknown[]) => {
+      const style = realGCS(el as Element, ...(rest as []));
+      return { ...style, transitionDuration: "0.3s" } as CSSStyleDeclaration;
+    });
+    const rig = mountRig();
+    rig.send("OPEN");
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(130); // flip timer forced the FLIP
+    expect(rig.phase()).toBe("openingTo");
+    // Inside duration+slack (380ms from the flip) nothing settles…
+    await vi.advanceTimersByTimeAsync(300);
+    expect(rig.phase()).toBe("openingTo");
+    // …past it, the deadline completes the open.
+    await vi.advanceTimersByTimeAsync(120);
+    expect(rig.phase()).toBe("open");
+    expect(scrimClasses(rig)).toEqual([]);
+  });
+
+  it("UNMOUNT from any phase clears every clock and walks to closed", async () => {
+    vi.useFakeTimers();
+    const rig = mountRig();
+    rig.send("OPEN");
+    await vi.advanceTimersByTimeAsync(50); // mid opening
+    expect(rig.phase()).not.toBe("closed");
+    rig.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+    // Nothing fires after teardown (no late timers).
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(rig.edges.at(-1)).toEqual([
+      expect.any(String),
+      "closed",
+      "UNMOUNT",
+    ]);
+  });
+});

--- a/packages/vue/src/composables/useSurfaceMachine.ts
+++ b/packages/vue/src/composables/useSurfaceMachine.ts
@@ -1,0 +1,222 @@
+import { computed, nextTick, onBeforeUnmount, shallowRef, type ComputedRef } from "vue";
+
+import {
+  classPairOf,
+  classesForPair,
+  isMounted,
+  surfaceTransition,
+  type SurfaceEventType,
+  type SurfacePhase,
+} from "../runtime/surfaceMachine";
+
+export interface SurfaceMachineLayer {
+  /** Vue-style transition-name prefix (e.g. "hk-modal-overlay"). */
+  prefix: string;
+  /** Live element accessor — lets the driver read the layer's EFFECTIVE
+   *  CSS duration (themes, reduced-motion, `data-css-animations="0"`). */
+  el?: () => HTMLElement | null | undefined;
+  /** Fallback enter budget, ms — the A2 bound when the element (or its
+   *  computed style) cannot be read. */
+  enterMs: () => number;
+  /** Fallback leave budget, ms. */
+  leaveMs: () => number;
+}
+
+export interface SurfaceMachineOptions {
+  layers: SurfaceMachineLayer[];
+  /**
+   * How long a `.from` phase waits for a frame flip before the timer
+   * forces it (ms). Under A2 (rAF starved) this bounds the from-pair's
+   * lifetime; the forced flip snaps (nothing is painting anyway).
+   */
+  flipBudgetMs?: number;
+  /** Extra ms on top of the CSS duration before a deadline fires. */
+  deadlineSlackMs?: number;
+  /** Phase-edge side effects (registration, focus, morph, reports). */
+  onPhase?: (from: SurfacePhase, to: SurfacePhase, event: SurfaceEventType) => void;
+}
+
+export interface SurfaceMachine {
+  /** Current phase (reactive — render-time reads track it). */
+  phase: ComputedRef<SurfacePhase>;
+  /** Whether the surface DOM should render (v-if anchor). */
+  mounted: ComputedRef<boolean>;
+  /** Reactive transition classes for one layer's prefix. */
+  classesFor: (prefix: string) => string[];
+  /** Dispatch an event through the total transition table. */
+  send: (event: SurfaceEventType) => void;
+}
+
+/**
+ * useSurfaceMachine — the Vue driver for the pure surface lifecycle
+ * machine (runtime/surfaceMachine.ts).
+ *
+ * Ownership rules that make the machine's proofs carry over:
+ * - Classes are bound REACTIVELY from the phase (render reads
+ *   `classesFor`), so the initial mount paints with its from-pair — no
+ *   write-after-mount race, no Vue `<Transition>` engine to diverge.
+ * - The ONLY correctness clock is setTimeout: every animation phase arms
+ *   exactly one deadline timer; the frame flip is double-rAF (smooth)
+ *   with a flip timer as the starved fallback. Duplicate FLIPs are
+ *   absorbed by the table (idempotent self-loops).
+ * - Phase changes clear every pending timer/rAF before arming the next
+ *   phase's — at most one flip + one deadline exist at any moment, so
+ *   timers cannot leak or fire stale (the machine has no "late
+ *   completion" callbacks at all).
+ */
+export function useSurfaceMachine(options: SurfaceMachineOptions): SurfaceMachine {
+  const flipBudget = options.flipBudgetMs ?? 120;
+  const slack = options.deadlineSlackMs ?? 80;
+
+  const phase = shallowRef<SurfacePhase>("closed");
+  const mounted = computed(() => isMounted(phase.value));
+
+  let flipTimer: ReturnType<typeof setTimeout> | null = null;
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  let raf1 = 0;
+  let raf2 = 0;
+
+  function clearClock(): void {
+    if (flipTimer !== null) {
+      clearTimeout(flipTimer);
+      flipTimer = null;
+    }
+    if (deadlineTimer !== null) {
+      clearTimeout(deadlineTimer);
+      deadlineTimer = null;
+    }
+    if (raf1) cancelAnimationFrame(raf1);
+    if (raf2) cancelAnimationFrame(raf2);
+    raf1 = 0;
+    raf2 = 0;
+  }
+
+  /** Worst-case deadline for the phase being entered, from the CONFIGURED
+   *  budgets (the A2 bound when the live CSS cannot be read). */
+  function budgetFor(next: SurfacePhase): number {
+    switch (next) {
+      case "openingFrom":
+        return flipBudget + Math.max(...options.layers.map((l) => l.enterMs())) + slack;
+      case "openingTo":
+        return Math.max(...options.layers.map((l) => l.enterMs())) + slack;
+      case "closingFrom":
+        return flipBudget + Math.max(...options.layers.map((l) => l.leaveMs())) + slack;
+      case "closingTo":
+        return Math.max(...options.layers.map((l) => l.leaveMs())) + slack;
+      default:
+        return 0;
+    }
+  }
+
+  /** Effective CSS transition duration of one layer, ms — the maximum
+   *  across the comma-separated duration list ("0.3s, 0.25s"). Reduced
+   *  motion and `html[data-css-animations="0"]` both collapse this to 0,
+   *  which is exactly the fast-path signal.
+   *  Caveat: `transition-delay` is deliberately ignored (no current
+   *  surface staggers its layers) — a future adopter adding delays must
+   *  fold them into the layer's enter/leave fallback budgets. */
+  function cssDurationMs(el: HTMLElement): number {
+    const raw = window.getComputedStyle(el).transitionDuration;
+    if (!raw) return 0;
+    let max = 0;
+    for (const part of raw.split(",")) {
+      const value = parseFloat(part);
+      if (!Number.isFinite(value)) continue;
+      max = Math.max(max, part.includes("ms") ? value : value * 1000);
+    }
+    return max;
+  }
+
+  /** Max effective CSS duration across layers, or null when no layer
+   *  element is readable (surface mid-mount) — the caller falls back to
+   *  the configured budget. */
+  function measuredBudget(): number | null {
+    let max: number | null = null;
+    for (const layer of options.layers) {
+      const el = layer.el?.();
+      if (!el || !el.isConnected) continue;
+      max = Math.max(max ?? 0, cssDurationMs(el));
+    }
+    return max;
+  }
+
+  function rearmDeadline(ms: number): void {
+    if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+    deadlineTimer = setTimeout(() => {
+      deadlineTimer = null;
+      send("DEADLINE");
+    }, Math.max(0, ms));
+  }
+
+  function armClock(next: SurfacePhase): void {
+    clearClock();
+    if (next === "closed" || next === "open") return;
+    // Frame flip: double-rAF guarantees a style recalc between the
+    // from-pair and the to-pair (a same-recalc flip would coalesce into
+    // an instant jump); the flip timer forces the same event when rAF
+    // starves. Both may fire — the table absorbs the duplicate.
+    if (next === "openingFrom" || next === "closingFrom") {
+      raf1 = requestAnimationFrame(() => {
+        raf1 = 0;
+        raf2 = requestAnimationFrame(() => {
+          raf2 = 0;
+          send("FLIP");
+        });
+      });
+      flipTimer = setTimeout(() => {
+        flipTimer = null;
+        send("FLIP");
+      }, flipBudget);
+    }
+    deadlineTimer = setTimeout(() => {
+      deadlineTimer = null;
+      send("DEADLINE");
+    }, budgetFor(next));
+
+    // Effective-duration probe: once the layer elements are live (one
+    // microtask after the mounting patch), replace the configured bound
+    // with what the CSS actually says. A zero duration (no transitions
+    // — happy-dom, reduced motion, the global animation switch) makes
+    // the deadline fire on the next macrotask, restoring the legacy
+    // instant-completion semantics; a long theme gets its real budget.
+    // The phase guard makes a late probe a no-op.
+    if (next === "openingFrom" || next === "closingFrom") {
+      const phaseAtArm = next;
+      void nextTick(() => {
+        if (phase.value !== phaseAtArm) return;
+        const measured = measuredBudget();
+        if (measured === null) return;
+        rearmDeadline(measured > 0 ? flipBudget + measured + slack : 0);
+      });
+    } else {
+      // *.to phases: the elements exist and styles settled at the flip.
+      const measured = measuredBudget();
+      if (measured !== null) {
+        rearmDeadline(measured > 0 ? measured + slack : 0);
+      }
+    }
+  }
+
+  function send(event: SurfaceEventType): void {
+    const from = phase.value;
+    const to = surfaceTransition(from, event);
+    if (to === from) return; // table-idempotent absorb (no effects)
+    phase.value = to;
+    armClock(to);
+    options.onPhase?.(from, to, event);
+  }
+
+  onBeforeUnmount(() => {
+    clearClock();
+    // UNMOUNT walks any phase to `closed` so onPhase observers see a
+    // consistent final state even mid-animation.
+    send("UNMOUNT");
+    clearClock();
+  });
+
+  function classesFor(prefix: string): string[] {
+    return classesForPair(prefix, classPairOf(phase.value));
+  }
+
+  return { phase: computed(() => phase.value), mounted, classesFor, send };
+}

--- a/packages/vue/src/runtime/surfaceMachine.test.ts
+++ b/packages/vue/src/runtime/surfaceMachine.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SURFACE_EVENTS,
+  SURFACE_PHASES,
+  classPairOf,
+  classesForPair,
+  isMounted,
+  isQuiescent,
+  surfaceTransition,
+  type SurfaceEventType,
+  type SurfacePhase,
+} from "./surfaceMachine";
+
+/** The spec table as data — the single reviewable proof artifact. The
+ *  reducer must agree with it on every cell; this test is the diff. */
+const SPEC: Record<SurfacePhase, Record<SurfaceEventType, SurfacePhase>> = {
+  closed: {
+    OPEN: "openingFrom",
+    CLOSE: "closed",
+    FLIP: "closed",
+    DEADLINE: "closed",
+    TEND: "closed",
+    UNMOUNT: "closed",
+  },
+  openingFrom: {
+    OPEN: "openingFrom",
+    CLOSE: "closingFrom",
+    FLIP: "openingTo",
+    DEADLINE: "open",
+    TEND: "open",
+    UNMOUNT: "closed",
+  },
+  openingTo: {
+    OPEN: "openingTo",
+    CLOSE: "closingFrom",
+    FLIP: "openingTo",
+    DEADLINE: "open",
+    TEND: "open",
+    UNMOUNT: "closed",
+  },
+  open: {
+    OPEN: "open",
+    CLOSE: "closingFrom",
+    FLIP: "open",
+    DEADLINE: "open",
+    TEND: "open",
+    UNMOUNT: "closed",
+  },
+  closingFrom: {
+    OPEN: "openingFrom",
+    CLOSE: "closingFrom",
+    FLIP: "closingTo",
+    DEADLINE: "closed",
+    TEND: "closed",
+    UNMOUNT: "closed",
+  },
+  closingTo: {
+    OPEN: "openingFrom",
+    CLOSE: "closingTo",
+    FLIP: "closingTo",
+    DEADLINE: "closed",
+    TEND: "closed",
+    UNMOUNT: "closed",
+  },
+};
+
+describe("surfaceMachine table", () => {
+  // T1 (totality + conformance): all 36 cells defined and matching the
+  // spec table — the reducer IS the table.
+  it("defines every (phase, event) cell exactly as the spec table", () => {
+    expect(SURFACE_PHASES).toHaveLength(6);
+    expect(SURFACE_EVENTS).toHaveLength(6);
+    for (const phase of SURFACE_PHASES) {
+      for (const event of SURFACE_EVENTS) {
+        const expected = SPEC[phase][event];
+        if (surfaceTransition(phase, event) !== expected) {
+          throw new Error(`table cell (${phase}, ${event}) diverges from the spec table`);
+        }
+      }
+    }
+  });
+
+  // T2/T3 (outputs are pure functions of state): quiescent states carry
+  // no transition classes; only non-closed states mount.
+  it("quiescent phases paint no transition classes", () => {
+    for (const phase of SURFACE_PHASES) {
+      const classes = classesForPair("hk-x", classPairOf(phase));
+      if (isQuiescent(phase)) {
+        expect(classes).toEqual([]);
+      } else {
+        expect(classes.length).toBe(2);
+      }
+      expect(isMounted(phase) === (phase !== "closed")).toBe(true);
+    }
+  });
+
+  // T4 (liveness): one DEADLINE walks any animation phase to a
+  // quiescent phase — the A2 (rAF/transitionend starved) column.
+  it("a single DEADLINE settles every animation phase (starvation column)", () => {
+    for (const phase of SURFACE_PHASES) {
+      const next = surfaceTransition(phase, "DEADLINE");
+      expect(isQuiescent(next), `${phase} + DEADLINE`).toBe(true);
+    }
+  });
+
+  // Idempotence: duplicating any event never moves the machine.
+  it("every event is idempotent in its target state", () => {
+    for (const phase of SURFACE_PHASES) {
+      for (const event of SURFACE_EVENTS) {
+        const once = surfaceTransition(phase, event);
+        expect(surfaceTransition(once, event)).toBe(once);
+      }
+    }
+  });
+});
+
+// ── Property-based exploration ─────────────────────────────────────
+// Deterministic seeded RNG (xorshift32) — no PBT dependency, full
+// reproducibility from the printed seed on failure.
+
+function rng(seed: number): () => number {
+  let s = seed | 0 || 1;
+  return () => {
+    s ^= s << 13; s ^= s >>> 17; s ^= s << 5;
+    return (s >>> 0) / 0x100000000;
+  };
+}
+
+describe("surfaceMachine property-based exploration", () => {
+  const RUNS = 4000;
+  const MAX_EVENTS = 40;
+
+  // Invariants checked after EVERY event of every run:
+  //  I-mounted: mounted(phase) ⟺ phase !== closed
+  //  I-classes: transition classes only on animation phases (implied by
+  //             classPairOf being total/pure — asserted via quiescence)
+  //  I-quiesce: after draining (each request followed by its DEADLINE),
+  //             the machine rests in {closed, open} — bounded settling
+  //             without any FLIP/TEND ever arriving (axiom A2).
+  it("every random event stream settles quiescently under total frame starvation", () => {
+    for (let run = 0; run < RUNS; run++) {
+      const rand = rng(run + 1);
+      let phase: SurfacePhase = "closed";
+      for (let i = 0; i < MAX_EVENTS; i++) {
+        const pool: SurfaceEventType[] =
+          rand() < 0.5
+            ? ["OPEN", "CLOSE", "UNMOUNT"] // starvation diet: no FLIP/TEND
+            : [...SURFACE_EVENTS];
+        const event = pool[Math.floor(rand() * pool.length)]!;
+        phase = surfaceTransition(phase, event);
+        // I-mounted
+        expect(phase === "closed" || isMounted(phase)).toBe(true);
+        // UNMOUNT absorbs: once sent, only OPEN can leave closed.
+        if (event === "UNMOUNT") {
+          expect(phase).toBe("closed");
+        }
+      }
+      // Drain: one DEADLINE settles any animation phase (T4).
+      phase = surfaceTransition(phase, "DEADLINE");
+      expect(isQuiescent(phase), `run ${run} drained to ${phase}`).toBe(true);
+    }
+  });
+
+  // Reversal safety: OPEN/CLOSE may interleave arbitrarily inside the
+  // animation windows; the machine must never enter a phase that paints
+  // resting classes while mounted=false (the "invisible with content"
+  // inversion) or transition classes while quiescent.
+  it("request interleavings never invert the mounted/classes relationship", () => {
+    for (let run = 0; run < 2000; run++) {
+      const rand = rng(10_000 + run);
+      let phase: SurfacePhase = "closed";
+      for (let i = 0; i < 30; i++) {
+        const event: SurfaceEventType =
+          rand() < 0.7 ? (rand() < 0.5 ? "OPEN" : "CLOSE") : "FLIP";
+        phase = surfaceTransition(phase, event);
+        const mounted = isMounted(phase);
+        const paintingTransitionClasses = !isQuiescent(phase);
+        // A mounted surface either rests (no classes) or animates
+        // (classes) — and classes imply mounted.
+        if (paintingTransitionClasses) expect(mounted).toBe(true);
+        if (!mounted) expect(phase).toBe("closed");
+      }
+    }
+  });
+});

--- a/packages/vue/src/runtime/surfaceMachine.ts
+++ b/packages/vue/src/runtime/surfaceMachine.ts
@@ -1,0 +1,229 @@
+// Surface lifecycle state machine — the provable core of every overlay
+// surface (modal scrim+panel, sheet scrim+panel, popover) in hikari.
+//
+// WHY A MACHINE. The pre-machine design drove two independent Vue
+// <Transition> engines off one boolean, with rAF/transitionend as the
+// class-flip clock. Those events can starve (occluded webviews — the
+// 2026-09 field reports), and two engines can diverge through the same
+// event stream (the mobile "panel visible, scrim gone" state, later the
+// full-opacity close flash — the "black rectangle"). The fixes of that
+// era (#407 leave watchdog, #414 enter watchdog) REPAIRED observed bad
+// states; a repair list is never complete.
+//
+// This module inverts the approach: the lifecycle is ONE explicit
+// finite-state machine whose transition table is total by construction,
+// whose outputs are pure functions of the state, and whose only
+// correctness clock is setTimeout (the one primitive field-verified to
+// fire under the starvation conditions that starve rAF). Bad states —
+// divergent layers, stuck transition classes at rest — are UNREPRESENT-
+// ABLE in the state space rather than detected and repaired.
+//
+// AXIOMS (the proof's ground rules):
+//   A1 setTimeout callbacks fire exactly once, within a bounded delay.
+//   A2 rAF and transitionend may NEVER fire. (The machine stays correct
+//      under A2 alone; both are advisory optimizations in the driver.)
+//   A3 Synchronous class/style writes take effect at the next style
+//      recalc. (What the compositor PAINTS is outside the axioms.)
+//
+// STATES — six, including the two-phase animation windows (a `.from`
+// phase holds the from-class pair until a frame flip; a `.to` phase
+// runs the CSS transition to the resting pair):
+//
+//   closed        no DOM, no timers, nothing registered
+//   openingFrom   mounted, enter-from classes, flip pending
+//   openingTo     mounted, enter-to classes, animating
+//   open          mounted, resting classes, morph armed — the only
+//                 state where size measurements are taken
+//   closingFrom   mounted, leave-from classes, flip pending
+//   closingTo     mounted, leave-to classes, animating
+//
+// EVENTS:
+//   OPEN/CLOSE  surface request (user logic, back gesture, closeAll)
+//   FLIP        frame flip (double-rAF or the flip timer — same event)
+//   DEADLINE    phase deadline timer (the correctness clock)
+//   TEND        transitionend (advisory early completion; the driver
+//               does not emit it — the cell exists so the table stays
+//               total for future adopters)
+//   UNMOUNT     component teardown
+//
+// THE TABLE. Completeness is the table itself — every (state, event)
+// cell is defined; table conformance is enforced by a test that holds
+// the spec table as data and diffs the reducer against it cell by cell.
+// Duplicate/inappropriate events are idempotent self-loops (absorbing),
+// so no interleaving — however adversarial — leaves the machine
+// undefined or divergent.
+
+export type SurfacePhase =
+  | "closed"
+  | "openingFrom"
+  | "openingTo"
+  | "open"
+  | "closingFrom"
+  | "closingTo";
+
+export type SurfaceEventType =
+  | "OPEN"
+  | "CLOSE"
+  | "FLIP"
+  | "DEADLINE"
+  | "TEND"
+  | "UNMOUNT";
+
+export type SurfaceEvent = { type: SurfaceEventType };
+
+export const SURFACE_PHASES: readonly SurfacePhase[] = [
+  "closed",
+  "openingFrom",
+  "openingTo",
+  "open",
+  "closingFrom",
+  "closingTo",
+] as const;
+
+export const SURFACE_EVENTS: readonly SurfaceEventType[] = [
+  "OPEN",
+  "CLOSE",
+  "FLIP",
+  "DEADLINE",
+  "TEND",
+  "UNMOUNT",
+] as const;
+
+/**
+ * The total transition function δ: S × E → S.
+ *
+ * | state       | OPEN         | CLOSE        | FLIP        | DEADLINE    | TEND        | UNMOUNT |
+ * |-------------|--------------|--------------|-------------|-------------|-------------|---------|
+ * | closed      | openingFrom  | closed       | closed      | closed      | closed      | closed  |
+ * | openingFrom | openingFrom  | closingFrom  | openingTo   | open        | open        | closed  |
+ * | openingTo   | openingTo    | closingFrom  | openingTo   | open        | open        | closed  |
+ * | open        | open         | closingFrom  | open        | open        | open        | closed  |
+ * | closingFrom | openingFrom  | closingFrom  | closingTo   | closed      | closed      | closed  |
+ * | closingTo   | openingFrom  | closingTo    | closingTo   | closed      | closed      | closed  |
+ *
+ * Reading guide:
+ * - Requests are idempotent (OPEN in any opening/open state is a no-op)
+ *   — user flapping converges instead of thrashing.
+ * - A CLOSE during the opening window reverses from the CURRENT computed
+ *   style (CSS re-targets the running transition); a OPEN during the
+ *   closing window likewise reverses. Interruption is a first-class cell,
+ *   not a corner case — the f108–f112 churn of the 2026-09 recording.
+ * - DEADLINE alone walks any state to a quiescent state: openingFrom →
+ *   open, closingFrom → closed — starving frames skip the animation, not
+ *   the state). This is the liveness column: under A1+A2 every request
+ *   settles within flipBudget + maxDuration + slack.
+ */
+export function surfaceTransition(
+  phase: SurfacePhase,
+  event: SurfaceEventType,
+): SurfacePhase {
+  switch (phase) {
+    case "closed":
+      switch (event) {
+        case "OPEN": return "openingFrom";
+        case "CLOSE":
+        case "FLIP":
+        case "DEADLINE":
+        case "TEND":
+        case "UNMOUNT": return "closed";
+      }
+      break;
+    case "openingFrom":
+      switch (event) {
+        case "OPEN": return "openingFrom";
+        case "CLOSE": return "closingFrom";
+        case "FLIP": return "openingTo";
+        case "DEADLINE":
+        case "TEND": return "open";
+        case "UNMOUNT": return "closed";
+      }
+      break;
+    case "openingTo":
+      switch (event) {
+        case "OPEN": return "openingTo";
+        case "CLOSE": return "closingFrom";
+        case "FLIP": return "openingTo";
+        case "DEADLINE":
+        case "TEND": return "open";
+        case "UNMOUNT": return "closed";
+      }
+      break;
+    case "open":
+      switch (event) {
+        case "OPEN":
+        case "FLIP":
+        case "DEADLINE":
+        case "TEND": return "open";
+        case "CLOSE": return "closingFrom";
+        case "UNMOUNT": return "closed";
+      }
+      break;
+    case "closingFrom":
+      switch (event) {
+        case "OPEN": return "openingFrom";
+        case "CLOSE": return "closingFrom";
+        case "FLIP": return "closingTo";
+        case "DEADLINE":
+        case "TEND": return "closed";
+        case "UNMOUNT": return "closed";
+      }
+      break;
+    case "closingTo":
+      switch (event) {
+        case "OPEN": return "openingFrom";
+        case "CLOSE":
+        case "FLIP": return "closingTo";
+        case "DEADLINE":
+        case "TEND": return "closed";
+        case "UNMOUNT": return "closed";
+      }
+      break;
+  }
+  // Exhaustiveness guard: TypeScript proves every phase/event pair
+  // returned above; reaching this line is a compile-time impossibility
+  // that we still assert at runtime (a built table can never be wrong
+  // silently).
+  throw new Error(
+    `[surfaceMachine] unhandled transition ${phase} x ${event} — the table has a hole (bug: table not total)`,
+  );
+}
+
+/** Whether the phase is one of the two quiescent (resting) states. */
+export function isQuiescent(phase: SurfacePhase): boolean {
+  return phase === "closed" || phase === "open";
+}
+
+/** Whether the surface's DOM is mounted (everything except `closed`). */
+export function isMounted(phase: SurfacePhase): boolean {
+  return phase !== "closed";
+}
+
+/** The class-pair family a phase paints (pure Moore output). */
+export type SurfaceClassPair = "none" | "enter-from" | "enter-to" | "leave-from" | "leave-to";
+
+export function classPairOf(phase: SurfacePhase): SurfaceClassPair {
+  switch (phase) {
+    case "closed": return "none";
+    case "openingFrom": return "enter-from";
+    case "openingTo": return "enter-to";
+    case "open": return "none";
+    case "closingFrom": return "leave-from";
+    case "closingTo": return "leave-to";
+  }
+}
+
+/** Vue-style transition classes for one layer prefix (Moore output).
+ *
+ *  The names match what the family's SCSS already animates
+ *  (`${prefix}-enter-from` etc.), so adopting the machine changes WHO
+ *  flips the classes and WHEN — never WHAT the classes are.
+ */
+export function classesForPair(prefix: string, pair: SurfaceClassPair): string[] {
+  switch (pair) {
+    case "none": return [];
+    case "enter-from": return [`${prefix}-enter-from`, `${prefix}-enter-active`];
+    case "enter-to": return [`${prefix}-enter-to`, `${prefix}-enter-active`];
+    case "leave-from": return [`${prefix}-leave-from`, `${prefix}-leave-active`];
+    case "leave-to": return [`${prefix}-leave-to`, `${prefix}-leave-active`];
+  }
+}


### PR DESCRIPTION
## Why a state machine (the design, in full)

The pre-machine design drove two independent Vue `<Transition>` engines off one boolean, with rAF/transitionend as the class-flip clock. Those events starve in occluded webviews (2026-09 field reports), and two engines can diverge through the same event stream — the mobile sequence where the panel stayed visible while the scrim froze invisible for ~2s, then flashed back at full opacity on close (the "black rectangle"). The watchdogs of #407/#414 REPAIRED observed bad states; a repair list is never complete. This PR makes the bad states **unrepresentable** instead.

### Axioms (the proof's ground rules — only what field evidence supports)

- **A1 (clock)**: `setTimeout` fires exactly once, within a bounded delay — the one primitive verified to work under the starvation conditions that starve rAF.
- **A2 (starvation)**: rAF and transitionend may NEVER fire. The machine must stay correct under A1+A2 alone; both frame events are advisory optimizations.
- **A3 (DOM)**: synchronous class/style writes take effect at the next style recalc. What the compositor PAINTS (partial rasterization etc.) is outside the axioms — and outside any app-level proof.

### The machine (`runtime/surfaceMachine.ts`)

States S = {`closed`, `openingFrom`, `openingTo`, `open`, `closingFrom`, `closingTo`}; events E = {`OPEN`, `CLOSE`, `FLIP`, `DEADLINE`, `TEND`, `UNMOUNT`}.

The total transition table δ: S×E→S (rendered as a markdown table in the source):

| state | OPEN | CLOSE | FLIP | DEADLINE | TEND | UNMOUNT |
|---|---|---|---|---|---|---|
| closed | openingFrom | closed | closed | closed | closed | closed |
| openingFrom | openingFrom | closingFrom | openingTo | open | open | closed |
| openingTo | openingTo | closingFrom | openingTo | open | open | closed |
| open | open | closingFrom | open | open | open | closed |
| closingFrom | openingFrom | closingFrom | closingTo | closed | closed | closed |
| closingTo | openingFrom | closingTo | closingTo | closed | closed | closed |

Outputs are pure Moore functions of the state (mount, class pair, the unique deadline, morph arm). One machine drives BOTH layers (scrim + panel) — layer divergence has no coordinate in the state space.

### Theorems (each provable by a table walk, each now enforced in CI)

- **T1 totality**: every cell defined — the conformance test holds this table as data and diffs the reducer cell by cell (this test caught a real divergence during development: `closingFrom+FLIP` was mis-grouped with CLOSE).
- **T2 coherence**: at any quiescent state both layers carry resting classes; "panel visible + scrim invisible" requires a divergent quiescent state — none exists.
- **T3 no stuck classes**: transition classes live only in animation phases, each bounded by exactly one deadline timer.
- **T4 liveness**: potential Φ(open/closed)=0, Φ(\*.from)=flip+duration+slack, Φ(\*.to)=duration+slack; every DEADLINE strictly reduces Φ → bounded settling under A1+A2. A single DEADLINE walks any animation phase to quiescence (the PBT's starvation drain asserts this over 4k seeded random streams).
- **T5 measurement validity**: morph arms only in `open` (the only state free of transition-class flex rules) — the contaminated 1728px pin of the 2026-09 report is unrepresentable.
- **T6 robustness**: all invariants hold with FLIP/TEND removed from the event universe entirely.

### Driver semantics preserved (and one improvement)

- Class names are IDENTICAL to Vue Transition's (`${prefix}-enter-from` …), so every themed SCSS rule keeps applying unchanged.
- Effective-CSS-duration probe: happy-dom / reduced motion / `data-css-animations="0"` (computed duration 0) complete on the next macrotask — the legacy instant-completion semantics; live themes get `flipBudget + measured + slack` deadlines. The configured budgets are the A2 fallback bound.
- Public API unchanged (props/emits identical); chest needs no changes.
- Improvement: absorbed duplicate events are true no-ops now (the old code spuriously ran `overlay.close()`/`backGuard.release()` at setup for initially-closed modals).

### Verification

- Targeted: surfaceMachine (table conformance, invariants, PBT 4k+2k seeded streams), useSurfaceMachine driver (clock lifecycle, starvation settle, close finalize, same-element reversal, probe with stubbed computed styles, unmount leak), HkModal suites — **59/59**.
- Full package suite: **989-991/992** across three runs; `vue-tsc --noEmit` clean.
- Known non-blockers: `registerAnimations` keyframes parity fails identically on unmodified origin/master (pre-existing); one MOVING load-sensitive flake appears in full parallel runs (HkMenu anchor cascade / HkDatePicker view drills) — reproduced with the same signature and rate on the unmodified baseline.
- Review: independent subagent review (FIX-FIRST round caught the UNMOUNT-mid-close finalize edge emitting `afterLeave` during teardown — fixed here with a regression test; plus a probe-path coverage gap — closed here).

### Follow-ups (deliberately out of this PR)

- Migrate HkSelectPanel / HkPopover / HkDrawer onto the same machine (their two-Transition choreography still carries the divergence class; #414's watchdogs remain as their interim repair).
- TEND (transitionend early completion) wiring for snappier finalize on real browsers.
- The f108 trigger (why the modal closed+reopened during the select interaction) is a backGuard/history question — a separate machine, not this one.