### PR TITLE
♻️ Migrate the popover and drawer surfaces onto the state machine.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.19",
+  "version": "0.40.20",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkDrawer.tsx
+++ b/packages/vue/src/components/HkDrawer.tsx
@@ -6,7 +6,6 @@ import {
   onMounted,
   ref,
   Teleport,
-  Transition,
   watch,
   type PropType,
 } from "vue";
@@ -19,6 +18,7 @@ import { usePopupManager } from "../runtime/usePopupManager";
 import { createBackGuard } from "../runtime/backStack";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import { useSurfaceMachine } from "../composables/useSurfaceMachine";
 import HIconButton from "./HkIconButton";
 import HIcon from "./HkIcon";
 import "./window-close.scss";
@@ -57,10 +57,9 @@ export default defineComponent({
     const { t } = useI18n();
     const manager = usePopupManager();
     // Open/close motion reported into the unified animation context
-    // (animationBus) — scrim and sliding panel on separate tracks.
-    const surf = useSurfaceTransition(320);
-    const scrimHooks = surf.hooks("scrim");
-    const panelHooks = surf.hooks("panel");
+    // (animationBus) — one track for the whole surface, armed on the
+    // machine's animation-phase edges.
+    const surfTrack = useSurfaceTransition(320).track("surface");
     const overlayHook = useOverlay({
       name: "hk-drawer",
       // A global closeAll() must be able to actually close this drawer
@@ -89,25 +88,6 @@ export default defineComponent({
       bodyScrollbar = null;
     }
 
-    watch(() => props.modelValue, (open) => {
-      if (unmounted) return;
-      if (open) {
-        void nextTick(() => {
-          if (!props.modelValue || !bodyRef.value) return;
-          detachBodyScrollbar();
-          // The wrapper (not the panel) is the track host: the panel also
-          // contains the header/footer bands, and rails spanning those
-          // would light up in the wrong place.
-          bodyScrollbar = attachOverlayScrollbars(bodyRef.value, {
-            axis: "vertical",
-            host: bodyWrapRef.value,
-          });
-        });
-      } else {
-        detachBodyScrollbar();
-      }
-    });
-
     /**
      * Window-first back priority: while this drawer is the topmost open
      * window, the back gesture closes it instead of navigating the
@@ -118,6 +98,80 @@ export default defineComponent({
     const backGuard = createBackGuard({
       onBack: () => {
         if (backGuardEnabled()) close();
+      },
+    });
+
+    // ── Surface lifecycle machine ─────────────────────────────────────
+    // One machine drives the overlay scrim and the sliding panel — the
+    // layers are outputs of the shared phase, so the divergent-layer
+    // states of the two-<Transition> era are unrepresentable (see
+    // runtime/surfaceMachine.ts). The panel prefix follows the side
+    // prop; all four sides share the same 0.3s CSS timing.
+    const overlayEl = ref<HTMLElement>();
+    const machine = useSurfaceMachine({
+      layers: [
+        // Budgets are the starvation-era bounds over the SCSS truths
+        // (overlay 0.3s/0.3s, panel slides 0.3s/0.3s); the driver probes
+        // the live CSS durations and tightens them.
+        { prefix: "hk-drawer-overlay", el: () => overlayEl.value, enterMs: () => 320, leaveMs: () => 320 },
+        { prefix: "hk-drawer-left", el: () => panelRef.value, enterMs: () => 320, leaveMs: () => 320 },
+        { prefix: "hk-drawer-right", el: () => panelRef.value, enterMs: () => 320, leaveMs: () => 320 },
+        { prefix: "hk-drawer-top", el: () => panelRef.value, enterMs: () => 320, leaveMs: () => 320 },
+        { prefix: "hk-drawer-bottom", el: () => panelRef.value, enterMs: () => 320, leaveMs: () => 320 },
+      ],
+      onPhase: (from, to, event) => {
+        if (to === "openingFrom") {
+          surfTrack.run();
+          cleanup();
+          // Register with the drawer title so the modal-stack breadcrumb
+          // labels this layer by name — a drawer is a window on every
+          // form factor and must never fall back to a generic label.
+          handle.value = manager.register("drawer", true, props.title);
+          overlayHook.open();
+          previouslyFocused = document.activeElement as HTMLElement | null;
+          if (backGuardEnabled() && backGuard.entries === 0) {
+            backGuard.push();
+          }
+          // Scrollbar chrome mounts with the panel (was the modelValue
+          // watcher's open arm, nextTick after the DOM lands).
+          void nextTick(() => {
+            // props.modelValue (not machine.mounted): a same-tick
+            // open→close flap is already in closingFrom — still mounted —
+            // and must not attach a scrollbar onto the dying surface.
+            if (!props.modelValue || !bodyRef.value) return;
+            detachBodyScrollbar();
+            // The wrapper (not the panel) is the track host: the panel
+            // also contains the header/footer bands, and rails spanning
+            // those would light up in the wrong place.
+            bodyScrollbar = attachOverlayScrollbars(bodyRef.value, {
+              axis: "vertical",
+              host: bodyWrapRef.value,
+            });
+          });
+        } else if (to === "open") {
+          surfTrack.cancel();
+          const el = panelRef.value;
+          if (el) focusFirst(el);
+        } else if (to === "closingFrom") {
+          surfTrack.run();
+          // Register/unregister WITH the open state so a closed-but-
+          // mounted drawer does not linger in the overlay registry
+          // (isOverlayOpen must reflect reality). The popup manager
+          // handle is torn down by the finalize edge below or by
+          // cleanup() on unmount.
+          overlayHook.close();
+          backGuard.release();
+          detachBodyScrollbar();
+        } else if (
+          to === "closed" &&
+          (from === "closingFrom" || from === "closingTo") &&
+          // UNMOUNT mid-close is a teardown, not a finalized leave —
+          // afterLeave/focus-restore belong to the close lifecycle only.
+          event !== "UNMOUNT"
+        ) {
+          surfTrack.cancel();
+          onDrawerAfterLeave();
+        }
       },
     });
 
@@ -149,11 +203,6 @@ export default defineComponent({
       if (props.closable) close();
     }
 
-    function onDrawerAfterEnter() {
-      const el = panelRef.value;
-      if (el) focusFirst(el);
-    }
-
     function onDrawerAfterLeave() {
       cleanup();
       if (previouslyFocused) {
@@ -174,25 +223,9 @@ export default defineComponent({
       () => props.modelValue,
       (val) => {
         if (unmounted) return;
-        if (val) {
-          cleanup();
-          // Register with the drawer title so the modal-stack breadcrumb
-          // labels this layer by name — a drawer is a window on every
-          // form factor and must never fall back to a generic label.
-          handle.value = manager.register("drawer", true, props.title);
-          overlayHook.open();
-          previouslyFocused = document.activeElement as HTMLElement | null;
-          if (backGuardEnabled() && backGuard.entries === 0) {
-            backGuard.push();
-          }
-        } else {
-          // Register/unregister WITH the open state so a closed-but-mounted
-          // drawer does not linger in the overlay registry (isOverlayOpen
-          // must reflect reality). The popup manager handle is torn down by
-          // the leave transition or by cleanup() on unmount.
-          overlayHook.close();
-          backGuard.release();
-        }
+        // The machine owns every visual/registry consequence on its
+        // phase edges; this watcher is purely the event feed.
+        machine.send(val ? "OPEN" : "CLOSE");
       },
       { immediate: true },
     );
@@ -231,42 +264,22 @@ export default defineComponent({
       cleanup();
     });
 
-    return () => (
+    return () => {
+      if (!machine.mounted.value) return null;
+      const panelPrefix = `hk-drawer-${props.side}`;
+      return (
       <Teleport to="body">
-        <Transition
-          name="hk-drawer-overlay"
-          appear
-          onBeforeEnter={scrimHooks.onBeforeEnter}
-          onAfterEnter={scrimHooks.onAfterEnter}
-          onBeforeLeave={scrimHooks.onBeforeLeave}
-          onAfterLeave={scrimHooks.onAfterLeave}
-        >
-          {props.modelValue && props.overlay ? (
-            <div
-              class="hk-drawer-overlay"
-              style={{ zIndex: overlayZ.value }}
-              onClick={onOverlayClick}
-            />
-          ) : null}
-        </Transition>
-        <Transition
-          name={`hk-drawer-${props.side}`}
-          appear
-          onBeforeEnter={panelHooks.onBeforeEnter}
-          onAfterEnter={() => {
-            panelHooks.onAfterEnter();
-            onDrawerAfterEnter();
-          }}
-          onBeforeLeave={panelHooks.onBeforeLeave}
-          onAfterLeave={() => {
-            panelHooks.onAfterLeave();
-            onDrawerAfterLeave();
-          }}
-        >
-          {props.modelValue ? (
-            <div
+        {props.overlay ? (
+          <div
+            ref={overlayEl}
+            class={["hk-drawer-overlay", ...machine.classesFor("hk-drawer-overlay")]}
+            style={{ zIndex: overlayZ.value }}
+            onClick={onOverlayClick}
+          />
+        ) : null}
+        <div
               ref={panelRef}
-              class={["hk-drawer-panel", `hk-drawer-${props.side}`, props.panelClass]}
+              class={["hk-drawer-panel", `hk-drawer-${props.side}`, props.panelClass, ...machine.classesFor(panelPrefix)]}
               style={panelStyle.value}
               role="dialog"
               aria-label={props.title}
@@ -304,9 +317,8 @@ export default defineComponent({
                 <div class="hk-drawer-footer">{slots.footer()}</div>
               ) : null}
             </div>
-          ) : null}
-        </Transition>
       </Teleport>
-    );
+      );
+    };
   },
 });

--- a/packages/vue/src/components/HkPopover.tsx
+++ b/packages/vue/src/components/HkPopover.tsx
@@ -7,7 +7,6 @@ import {
   onUnmounted,
   ref,
   Teleport,
-  Transition,
   useAttrs,
   watch,
   type PropType,
@@ -17,6 +16,7 @@ import { usePopupManager, type PopupHandle } from "../runtime/usePopupManager";
 import { useBreakpoint } from "../runtime/useBreakpoint";
 import { useI18n } from "../i18n/context";
 import { useSurfaceTransition } from "../composables/useSurfaceTransition";
+import { useSurfaceMachine } from "../composables/useSurfaceMachine";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { onceFrame } from "../runtime/animationBus";
 import HIconButton from "./HkIconButton";
@@ -88,6 +88,13 @@ export default defineComponent({
 
     const { isMobile } = useBreakpoint();
     const sheetMode = computed(() => props.sheetOnMobile && isMobile.value);
+    /** The form factor this surface OPENED in. The render branches on it
+     *  (not the live sheetMode) so a viewport crossing the mobile
+     *  breakpoint mid-flight closes in the shape the surface was born in
+     *  — the anchored popup must not flash in for the closing window of
+     *  a dying sheet (or vice versa). Set on the machine's opening edge;
+     *  the next open adopts whatever the viewport calls for. */
+    const activeBranch = ref<"sheet" | "anchored">("anchored");
 
     // Crossing the mobile/desktop breakpoint mid-flight would leave a
     // SHEET-mode panel hung between two form factors — close it and let
@@ -99,14 +106,87 @@ export default defineComponent({
     });
 
     // Open/close motion reported into the unified animation context
-    // through the same standard hook wiring every surface shares
-    // (useSurfaceTransition) — this component was the pattern's
-    // origin and now consumes it like the rest. Scrim and panel ride
-    // separate named tracks (window-layer contract, ./_scrim-fade.scss)
-    // so the backdrop's fade reports and settles on its own.
-    const surfaceAnim = useSurfaceTransition(300);
-    const anim = surfaceAnim.hooks();
-    const scrimAnim = surfaceAnim.hooks("scrim");
+    // (animationBus) — one track for the whole surface, armed on the
+    // machine's animation-phase edges.
+    const surfTrack = useSurfaceTransition(300).track("surface");
+
+    // ── Surface lifecycle machine ─────────────────────────────────────
+    // One machine drives the sheet scrim and the panel in BOTH form
+    // factors (the mobile sheet and the anchored popup) — the layers are
+    // outputs of the shared phase, so the divergent-layer states of the
+    // two-<Transition> era are unrepresentable (see
+    // runtime/surfaceMachine.ts).
+    const scrimRef = ref<HTMLElement>();
+    const machine = useSurfaceMachine({
+      layers: [
+        // Budgets are the starvation-era bounds over the SCSS truths
+        // (scrim 0.25s/0.2s, sheet panel 0.3s/0.25s, anchored pop
+        // 0.2s/0.15s); the driver probes the live CSS durations and
+        // tightens them.
+        { prefix: "hk-popover-scrim", el: () => scrimRef.value, enterMs: () => 270, leaveMs: () => 240 },
+        // The machine classes land on the INNER panel div — the probe
+        // must read that element, not the positioning host (a classless
+        // host reads duration 0 and kills the animation in real
+        // browsers; the el-carries-the-classes invariant of #417/#418).
+        { prefix: "hk-popover-sheet", el: () => panelRef.value, enterMs: () => 320, leaveMs: () => 280 },
+        { prefix: "hk-popover", el: () => panelRef.value, enterMs: () => 240, leaveMs: () => 190 },
+      ],
+      onPhase: (from, to, event) => {
+        if (to === "openingFrom") {
+          surfTrack.run();
+          activeBranch.value = sheetMode.value ? "sheet" : "anchored";
+          // The open arm of the old modelValue watcher, verbatim.
+          fullCleanup();
+          // Blocking follows the sheet decision: anchored (desktop) the
+          // popover is a hidden breadcrumb level, docked as a bottom
+          // sheet (mobile) it is a window layer and must be listed —
+          // hence the i18n `title` riding along.
+          handle.value = manager.register(
+            "dropdown",
+            false,
+            props.title || undefined,
+            sheetMode.value,
+          );
+          if (sheetMode.value) {
+            // Bottom sheet: nothing to anchor-measure; the scrim handles
+            // dismissal (the outside-click shield is desktop-only).
+            nextTick(() => {
+              panelRef.value?.focus?.();
+              // The sheet mounts on this render — attach the overlay
+              // once the DOM has landed (sheet panels scroll; desktop
+              // popovers size to content and need none).
+              if (machine.mounted.value && sheetMode.value && panelRef.value) {
+                detachPanelScrollbar();
+                panelScrollbar = attachOverlayScrollbars(panelRef.value, {
+                  axis: "vertical",
+                  host: panelHostRef.value,
+                });
+              }
+            });
+          } else {
+            computeInitialCoords();
+            attachObservers();
+            attachOutsideClickShield();
+            nextTick(() => {
+              computePosition();
+              schedulePosition();
+            });
+          }
+        } else if (to === "closingFrom") {
+          surfTrack.run();
+          // The close arm of the old watcher.
+          detachObservers();
+          detachOutsideClickShield();
+        } else if (
+          to === "closed" &&
+          (from === "closingFrom" || from === "closingTo") &&
+          event !== "UNMOUNT"
+        ) {
+          surfTrack.cancel();
+          onPopupAfterLeave();
+        }
+      },
+    });
 
     // Suppress native browser tooltips while the popover is open — and
     // not just on the anchor itself: a `title` on ANY descendant fires
@@ -385,47 +465,9 @@ export default defineComponent({
     watch(
       () => props.modelValue,
       (open) => {
-        if (open) {
-          fullCleanup();
-          // Blocking follows the sheet decision: anchored (desktop) the
-          // popover is a hidden breadcrumb level, docked as a bottom
-          // sheet (mobile) it is a window layer and must be listed —
-          // hence the i18n `title` riding along.
-          handle.value = manager.register(
-            "dropdown",
-            false,
-            props.title || undefined,
-            sheetMode.value,
-          );
-          if (sheetMode.value) {
-            // Bottom sheet: nothing to anchor-measure; the scrim handles
-            // dismissal (the outside-click shield is desktop-only).
-            nextTick(() => {
-              panelRef.value?.focus?.();
-              // The sheet mounts on this render — attach the overlay
-              // once the DOM has landed (sheet panels scroll; desktop
-              // popovers size to content and need none).
-              if (props.modelValue && sheetMode.value && panelRef.value) {
-                detachPanelScrollbar();
-                panelScrollbar = attachOverlayScrollbars(panelRef.value, {
-                  axis: "vertical",
-                  host: panelHostRef.value,
-                });
-              }
-            });
-          } else {
-            computeInitialCoords();
-            attachObservers();
-            attachOutsideClickShield();
-            nextTick(() => {
-              computePosition();
-              schedulePosition();
-            });
-          }
-        } else {
-          detachObservers();
-          detachOutsideClickShield();
-        }
+        // The machine owns every visual/registry consequence on its
+        // phase edges; this watcher is purely the event feed.
+        machine.send(open ? "OPEN" : "CLOSE");
       },
       { immediate: true },
     );
@@ -497,7 +539,7 @@ export default defineComponent({
     const panelZ = computed(() => (handle.value?.zIndex ?? 0) + 1);
 
     const panelStyle = computed(() => {
-      if (sheetMode.value) {
+      if (activeBranch.value === "sheet") {
         // Bottom sheet: sits flush on the viewport bottom edge (the
         // host-tunable --hk-sheet-bottom-gap lift is still honored so the
         // sheet belongs to the HkModal/HkSelect sheet family — the family
@@ -527,49 +569,39 @@ export default defineComponent({
       };
     });
 
-    return () => (
+    return () => {
+      if (!machine.mounted.value) return null;
+      const sheetBranch = activeBranch.value === "sheet";
+      const panelPrefix = sheetBranch ? "hk-popover-sheet" : "hk-popover";
+      return (
       <Teleport to="body">
         {/* Window-layer contract (./_scrim-fade.scss): the sheet scrim
-            fades in place under its own transition name — it used to
-            mount and unmount bare, snapping the dim curtain on and off
-            around the sliding panel. z rides the live registration,
+            fades in place under its own transition name (machine output)
+            — it never mounts bare, so the dim curtain never snaps on or
+            off around the sliding panel. z rides the live registration,
             which outlives the close until the leave fade finishes. */}
-        <Transition name="hk-popover-scrim" appear {...scrimAnim}>
-          {sheetMode.value && props.modelValue && props.closeOnBackdrop ? (
-            <div
-              class="hk-popover-scrim"
-              style={{ zIndex: backdropZ.value }}
-              onClick={() => close()}
-            />
-          ) : null}
-        </Transition>
-        {props.backdrop && !sheetMode.value && props.modelValue && (
+        {sheetBranch && props.closeOnBackdrop ? (
+          <div
+            ref={scrimRef}
+            class={["hk-popover-scrim", ...machine.classesFor("hk-popover-scrim")]}
+            style={{ zIndex: backdropZ.value }}
+            onClick={() => close()}
+          />
+        ) : null}
+        {props.backdrop && !sheetBranch && props.modelValue && (
           <div
             class="hk-popover-backdrop"
             style={{ zIndex: backdropZ.value }}
           />
         )}
-        <Transition
-          name={sheetMode.value ? "hk-popover-sheet" : "hk-popover"}
-          appear
-          onBeforeEnter={anim.onBeforeEnter}
-          onAfterEnter={anim.onAfterEnter}
-          onBeforeLeave={anim.onBeforeLeave}
-          onAfterLeave={() => {
-            anim.onAfterLeave();
-            onPopupAfterLeave();
-          }}
-          onEnterCancelled={anim.onEnterCancelled}
-          onLeaveCancelled={anim.onLeaveCancelled}
-        >
-          {props.modelValue ? (
-            <div ref={panelHostRef} style={panelStyle.value}>
+        <div ref={panelHostRef} style={panelStyle.value}>
               <div
                 ref={panelRef}
                 class={[
                   "hk-popover-panel",
-                  ...(sheetMode.value ? ["hk-is-sheet"] : [`hk-popover-${resolvedPlacement.value}`]),
+                  ...(sheetBranch ? ["hk-is-sheet"] : [`hk-popover-${resolvedPlacement.value}`]),
                   props.glass ? "hii-dropdown-content" : "",
+                  ...machine.classesFor(panelPrefix),
                   ...(typeof attrs.class === "string" ? [attrs.class]
                     : Array.isArray(attrs.class) ? attrs.class as string[]
                     : attrs.class && typeof attrs.class === "object"
@@ -578,15 +610,15 @@ export default defineComponent({
                       : []),
                 ]}
                 role="dialog"
-                aria-modal={sheetMode.value ? "true" : undefined}
+                aria-modal={sheetBranch ? "true" : undefined}
                 aria-label={props.title || undefined}
-                tabindex={sheetMode.value ? "-1" : undefined}
+                tabindex={sheetBranch ? "-1" : undefined}
                 onKeydown={onPanelKeydown}
               >
-                {sheetMode.value && (
+                {sheetBranch && (
                   <div class="hk-popover-sheet-grabber" aria-hidden="true" onClick={() => close()} />
                 )}
-                {sheetMode.value && (
+                {sheetBranch && (
                   // Sheet heading row — the title and the close button on
                   // one vertically-centered line (2026-09-04 user report:
                   // the bare title band read too small and hung right of
@@ -610,10 +642,9 @@ export default defineComponent({
                 )}
                 {slots.default?.()}
               </div>
-            </div>
-          ) : null}
-        </Transition>
+        </div>
       </Teleport>
-    );
+      );
+    };
   },
 });

--- a/packages/vue/src/components/HkStatusBar.test.tsx
+++ b/packages/vue/src/components/HkStatusBar.test.tsx
@@ -142,14 +142,14 @@ describe("HkStatusBar", () => {
     tag.dispatchEvent(tap());
     await nextTick();
     expect(onRetry).toHaveBeenCalledTimes(1);
-    // happy-dom never fires transitionend, so the panel is guaranteed to
-    // still be mid leave-animation here (the leave class can only be
-    // removed by the transition's after-leave hook). The Transition's
-    // direct child is the positioning wrapper around the panel, so the
-    // leave class lands on it and the real panel must sit INSIDE it.
-    const tail = document.body.querySelector<HTMLElement>('[class*="hk-popover-leave"]');
-    expect(tail).not.toBeNull();
-    expect(tail?.querySelector(".hk-popover-panel")).not.toBeNull();
+    // Machine era: in no-transition environments (happy-dom's computed
+    // durations read 0) the close settles on the microtask queue — the
+    // rAF-era lingering leave window is gone. Assert the dismissal
+    // completed: the panel unmounted, exactly one retry ever fired.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    expect(document.body.querySelector(".hk-popover-panel")).toBeNull();
+    expect(onRetry).toHaveBeenCalledTimes(1);
   });
 
   it("a scroll-like touch ending over the tag does not retry", async () => {

--- a/packages/vue/src/components/HkThemeToggle.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.test.ts
@@ -299,12 +299,16 @@ describe("HkThemeToggle item slots", () => {
     const rows = [...document.body.querySelectorAll<HTMLElement>(".s-theme-menu .s-theme-item-row")];
     expect(rows.length).toBeGreaterThanOrEqual(2);
     // Every row — active or not — carries the slot cell; no check cell is
-    // rendered alongside (the slot owns the leading zone).
+    // rendered alongside (the slot owns the leading zone). Exactly ONE
+    // slot cell per row in the DOM — the machine-era popover re-renders
+    // per phase (class outputs are reactive), so slot invocation counts
+    // are no longer 1:1 with rows; DOM uniqueness is the invariant.
     for (const row of rows) {
       expect(row.querySelector(".s-theme-item-lead .lead-mark")).toBeTruthy();
+      expect(row.querySelectorAll(".lead-mark")).toHaveLength(1);
       expect(row.querySelector(".s-theme-item-check")).toBeNull();
     }
-    expect(seen.length).toBe(rows.length);
+    expect(seen.length).toBeGreaterThanOrEqual(rows.length);
   });
 
   it("reserves the trailing column and suppresses the built-in delete overlay", async () => {

--- a/packages/vue/src/components/scrim-fade.contract.test.ts
+++ b/packages/vue/src/components/scrim-fade.contract.test.ts
@@ -75,10 +75,13 @@ describe("window-layer scrim fade contract", () => {
   });
 
   it("the popover sheet scrim fades instead of mounting bare", () => {
+    // Machine era: the scrim's fade classes are machine outputs under a
+    // prefix DISTINCT from the panel's slide names — the contract
+    // survives as the layer wiring.
     const src = read("HkPopover.tsx");
-    expect(src).toContain('<Transition name="hk-popover-scrim"');
-    expect(src).toContain('surfaceAnim.hooks("scrim")');
+    expect(src).toContain('prefix: "hk-popover-scrim"');
+    expect(src).toContain("useSurfaceMachine({");
     // The panel's sheet name stays the slide family — distinct from the scrim.
-    expect(src).toContain('"hk-popover-sheet"');
+    expect(src).toContain('prefix: "hk-popover-sheet"');
   });
 });

--- a/packages/vue/src/composables/useSurfaceMachine.test.ts
+++ b/packages/vue/src/composables/useSurfaceMachine.test.ts
@@ -19,8 +19,11 @@ interface Rig {
 }
 
 /** Mount a machine with two test layers (like a modal's scrim+panel)
- *  and capture every phase edge it walks. */
-function mountRig(): Rig {
+ *  and capture every phase edge it walks. `probed` wires live element
+ *  accessors — in happy-dom the probe reads a 0 duration, which selects
+ *  the no-transition fast path; without probes the machine runs on the
+ *  configured fallback budgets (the starvation-era behavior). */
+function mountRig(probed = false): Rig {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const edges: Array<[string, string, string]> = [];
@@ -29,8 +32,18 @@ function mountRig(): Rig {
     setup() {
       machineRef.current = useSurfaceMachine({
         layers: [
-          { prefix: "rig-scrim", enterMs: () => 300, leaveMs: () => 300 },
-          { prefix: "rig-panel", enterMs: () => 300, leaveMs: () => 250 },
+          {
+            prefix: "rig-scrim",
+            ...(probed ? { el: () => document.querySelector<HTMLElement>(".scrim") } : {}),
+            enterMs: () => 300,
+            leaveMs: () => 300,
+          },
+          {
+            prefix: "rig-panel",
+            ...(probed ? { el: () => document.querySelector<HTMLElement>(".panel") } : {}),
+            enterMs: () => 300,
+            leaveMs: () => 250,
+          },
         ],
         onPhase: (from, to, event) => { edges.push([from, to, event]); },
       });
@@ -172,7 +185,7 @@ describe("useSurfaceMachine driver", () => {
       const style = realGCS(el as Element, ...(rest as []));
       return { ...style, transitionDuration: "0.3s" } as CSSStyleDeclaration;
     });
-    const rig = mountRig();
+    const rig = mountRig(true);
     rig.send("OPEN");
     await nextTick();
     await vi.advanceTimersByTimeAsync(130); // flip timer forced the FLIP
@@ -184,6 +197,47 @@ describe("useSurfaceMachine driver", () => {
     await vi.advanceTimersByTimeAsync(120);
     expect(rig.phase()).toBe("open");
     expect(scrimClasses(rig)).toEqual([]);
+  });
+
+  it("TEND: a matching transitionend completes the phase early", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", () => 0 as unknown as number);
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    const realGCS = window.getComputedStyle.bind(window);
+    vi.stubGlobal("getComputedStyle", (el: Element, ...rest: unknown[]) => {
+      const style = realGCS(el as Element, ...(rest as []));
+      return { ...style, transitionDuration: "0.3s" } as CSSStyleDeclaration;
+    });
+    const rig = mountRig(true);
+    rig.send("OPEN");
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(130); // flip forced → openingTo
+    expect(rig.phase()).toBe("openingTo");
+    const panel = document.querySelector<HTMLElement>(".panel")!;
+
+    // happy-dom's TransitionEvent ignores its init dict — synthesize
+    // the event and stamp elapsedTime on the instance.
+    const endEvent = (elapsedSeconds: number): Event => {
+      const ev = new Event("transitionend");
+      Object.defineProperty(ev, "elapsedTime", { value: elapsedSeconds });
+      return ev;
+    };
+
+    // A fast property's end event (elapsed < measured budget) is ignored…
+    panel.dispatchEvent(endEvent(0.1));
+    expect(rig.phase()).toBe("openingTo");
+
+    // …the slowest property's end event lands → the surface settles open
+    // immediately, ahead of the deadline timer.
+    panel.dispatchEvent(endEvent(0.3));
+    expect(rig.phase()).toBe("open");
+    await nextTick();
+    expect(scrimClasses(rig)).toEqual([]);
+    // No late deadline fires afterwards.
+    const edgesAtRest = rig.edges.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(rig.phase()).toBe("open");
+    expect(rig.edges.length).toBe(edgesAtRest);
   });
 
   it("UNMOUNT from any phase clears every clock and walks to closed", async () => {

--- a/packages/vue/src/composables/useSurfaceMachine.ts
+++ b/packages/vue/src/composables/useSurfaceMachine.ts
@@ -76,6 +76,11 @@ export function useSurfaceMachine(options: SurfaceMachineOptions): SurfaceMachin
   let raf1 = 0;
   let raf2 = 0;
 
+  /** transitionend listeners for the TEND early completion (see
+   *  armTend) — cleared with every clock reset so a phase change can
+   *  never inherit the previous phase's listeners. */
+  let tendCleanups: Array<() => void> = [];
+
   function clearClock(): void {
     if (flipTimer !== null) {
       clearTimeout(flipTimer);
@@ -85,10 +90,51 @@ export function useSurfaceMachine(options: SurfaceMachineOptions): SurfaceMachin
       clearTimeout(deadlineTimer);
       deadlineTimer = null;
     }
+    for (const off of tendCleanups) off();
+    tendCleanups = [];
     if (raf1) cancelAnimationFrame(raf1);
     if (raf2) cancelAnimationFrame(raf2);
     raf1 = 0;
     raf2 = 0;
+  }
+
+  /** TEND wiring — the advisory early-completion event. Real browsers
+   *  fire transitionend when the slowest property lands; the deadline
+   *  timer stays armed as the bound (starved or cancelled transitions
+   *  never fire it — the machine stays correct either way, TEND only
+   *  shortens the settle latency). Filter rules:
+   *  - e.target must be the layer element itself (child bubbles — the
+   *    content's own transitions — must not complete the surface);
+   *  - elapsedTime must match the measured budget (the SLOWEST
+   *    property's end event; faster properties of the same element are
+   *    ignored). The table absorbs a TEND in any phase, so a late or
+   *    duplicated event is a no-op. */
+  function armTend(expectedMs: number): void {
+    // Several layers may share one element (drawer sides, popover
+    // branches) — one listener per ELEMENT, not per layer.
+    const seen = new Set<HTMLElement>();
+    for (const layer of options.layers) {
+      const el = layer.el?.();
+      if (!el || !el.isConnected || seen.has(el)) continue;
+      seen.add(el);
+      const onEnd = (e: TransitionEvent) => {
+        if (e.target !== el) return;
+        // An event without a numeric elapsedTime cannot be validated
+        // against the budget — ignore it (the deadline stays the bound;
+        // TEND is strictly an optimization).
+        if (typeof e.elapsedTime !== "number") return;
+        const elapsedMs = e.elapsedTime * 1000;
+        // Two-sided epsilon: only the SLOWEST property's end event — the
+        // one landing at the measured budget — completes the surface.
+        // Faster properties are below the window; an unrelated LONGER
+        // transition on the element (consumer classes ride the panel)
+        // is above it and must not fire the surface's completion.
+        if (elapsedMs + 60 < expectedMs || elapsedMs - 60 > expectedMs) return;
+        send("TEND");
+      };
+      el.addEventListener("transitionend", onEnd);
+      tendCleanups.push(() => el.removeEventListener("transitionend", onEnd));
+    }
   }
 
   /** Worst-case deadline for the phase being entered, from the CONFIGURED
@@ -208,8 +254,12 @@ export function useSurfaceMachine(options: SurfaceMachineOptions): SurfaceMachin
       // *.to phases: the elements exist and styles settled at the flip.
       const measured = measuredBudget();
       if (measured !== null) {
-        if (measured > 0) rearmDeadline(measured + slack);
-        else completeNow();
+        if (measured > 0) {
+          rearmDeadline(measured + slack);
+          armTend(measured);
+        } else {
+          completeNow();
+        }
       }
     }
   }


### PR DESCRIPTION
P4 — the final wave of the surface state-machine program (#417 = P1+P2 machine core + HkModal; #418 = P3 HkSelectPanel). With this PR every windowed surface in hikari (modal, select panel/dropdown family, popover, drawer) is driven by ONE provable machine; no `<Transition>`-driven surface choreography remains in the library.

## What moves

**HkDrawer** — overlay scrim + sliding panel (four `hk-drawer-{side}` prefixes sharing the panel element) as machine layers; registration, back-guard, focus capture/restore, scrollbar chrome and `afterLeave` (finalize edge only, never on UNMOUNT teardown) on phase edges. One deliberate improvement found in review: the initial open-with-true mount now attaches the scrollbar (the old non-immediate watcher missed it).

**HkPopover** — same shape plus the born-branch (`activeBranch`) form-factor pinning introduced in #418: the conditional sheet scrim, the desktop backdrop, and both panel prefixes (`hk-popover` / `hk-popover-sheet`) are machine outputs keyed on the branch the surface opened in. Review caught a real-browser-only P1 during development: the duration probe initially read the classless positioning host, which measures 0 and silently kills the anchored pop animation outside happy-dom — fixed by restoring the #417/#418 invariant "the layer's `el` is the element carrying its machine classes".

**TEND (transitionend early completion)** — now wired in the driver: when a `*.to` phase runs with a measured CSS duration, transitionend listeners arm (one per element, target-filtered, numeric-`elapsedTime` guarded, two-sided ±60ms epsilon so only the SLOWEST property's event completes the surface, never a faster property or an unrelated longer consumer transition) and the surface settles the moment the animation truly lands instead of waiting out the slack. The deadline timer remains the standing bound under A2 starvation — TEND is strictly an optimization, absorbed safely by the table in any phase.

## Test adaptations (intents preserved)

- HkThemeToggle slot test: machine class outputs are reactive, so phase transitions re-render and slot invocation counts are no longer 1:1 with rows — the invariant re-pinned to DOM uniqueness (exactly one slot cell per row, no check cell).
- HkStatusBar toggle test: the rAF-era lingering-leave window is gone in no-transition environments (microtask settle from #418) — now asserts completed dismissal with exactly one retry.
- New TEND driver regression (fast event ignored → final event settles early → nothing fires over the following 5s); driver rig parameterized probed/unprobed so the fallback-budget starvation tests and the live-measurement tests each exercise their behavior class.

## Verification

- Targeted family batch: 51/51; machine+driver suites: 13/13; `vue-tsc --noEmit` clean.
- Full package suite: **987/988** — the single failure is `registerAnimations` keyframes parity, pre-existing and reproduced identically on unmodified master.
- Independent review verdict FIX-FIRST → its P1 (probe/class pairing) and all four P2s (dead fn, scrollbar flap-corner guard, TEND listener dedupe, epsilon upper bound) are folded in and re-verified.

## Program close-out

All four planned waves are in. The 2026-09 mobile recording's failure family (divergent scrim/panel states, stuck transition classes, the black-rectangle flash precondition, contaminated size pins) is now unrepresentable-by-construction across the entire surface family, with the table + PBT as the standing proof artifacts in CI.