### PR TITLE
✨ Let hosts hide the scheme editor name input and set it directly.

### DIFF
--- a/packages/vue/src/components/HkColorSchemeEditor.test.ts
+++ b/packages/vue/src/components/HkColorSchemeEditor.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { createApp, h, nextTick, ref, type Ref } from "vue";
+import { createApp, h, nextTick, onMounted, ref, type Ref } from "vue";
 
 import { registerTokenGroup, useTheme, type TokenGroupDefinition } from "../theme";
 import { HkColorSchemeEditor, type HCustomTheme } from "./HkColorSchemeEditor";
@@ -266,5 +266,28 @@ describe("HkColorSchemeEditor", () => {
     await nextTick();
     expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 255, g: 200, b: 0 });
     expect(ref.value!.getDraft().dark.onSolidIcon).toEqual({ r: 0, g: 200, b: 255 });
+  });
+
+  it("hides the built-in name input under showName=false and takes setThemeName", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let exposed: { getDraft(): { name: string }; setThemeName(n: string): void } | null = null;
+    const app = createApp({
+      setup() {
+        const ed = ref<{ getDraft(): { name: string }; setThemeName(n: string): void } | null>(null);
+        onMounted(() => { exposed = ed.value; });
+        return () => h(HkColorSchemeEditor, { ref: ed, showName: false, initialName: "" });
+      },
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+
+    const label = [...container.querySelectorAll("label")].find((l) =>
+      l.textContent?.includes("Theme name") || l.textContent?.includes("主题名称"),
+    );
+    expect(label).toBeUndefined();
+    exposed!.setThemeName("Host owned name");
+    expect(exposed!.getDraft().name).toBe("Host owned name");
   });
 });

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -147,6 +147,12 @@ export const HkColorSchemeEditor = defineComponent({
     initialGroups: { type: Object as PropType<ThemeTokenGroupModes>, default: undefined },
     /** Prefill the scheme name input (edit/fork flows); empty by default. */
     initialName: { type: String, default: "" },
+    /**
+     * Render the built-in name input. Hosts that own the name field
+     * elsewhere (e.g. a "basic" tab above the editor) hide it and feed the
+     * value through `setThemeName()` — getDraft() still carries it.
+     */
+    showName: { type: Boolean, default: true },
   },
   setup(props, { expose }) {
     const { t } = useI18n();
@@ -214,7 +220,11 @@ export const HkColorSchemeEditor = defineComponent({
 
     onMounted(() => reset());
 
-    expose({ reset, getDraft });
+    function setThemeName(name: string): void {
+      themeName.value = name;
+    }
+
+    expose({ reset, getDraft, setThemeName });
 
     watch(
       () => [
@@ -357,12 +367,14 @@ export const HkColorSchemeEditor = defineComponent({
 
     return () => (
       <div class="s-scheme-dialog">
-        <HInput
-          modelValue={themeName.value}
-          onUpdate:modelValue={(v: string) => { themeName.value = v; }}
-          label={t("hikari::theme.themeName")}
-          placeholder={t("hikari::theme.customThemeName")}
-        />
+        {props.showName && (
+          <HInput
+            modelValue={themeName.value}
+            onUpdate:modelValue={(v: string) => { themeName.value = v; }}
+            label={t("hikari::theme.themeName")}
+            placeholder={t("hikari::theme.customThemeName")}
+          />
+        )}
         <HTabs
           variant="segmented"
           class="s-scheme-mode-switch"


### PR DESCRIPTION
## Summary

Small HkColorSchemeEditor extension for the chest P98 W-C2 editor restructure: the theme NAME moves into a new "基本/basic" tab above the editor, so the host needs the built-in name input gone while still feeding the value into the draft.

- `showName` prop (default true — existing hosts unchanged): hides the built-in name input.
- `setThemeName(name)` exposed alongside reset/getDraft: the host's own field flows into `getDraft().name`.

## Verification

vue-tsc 0; editor suite **8/8** (new: showName=false hides the label; setThemeName flows to getDraft). Version 0.40.18 → 0.40.19.