### PR TITLE
🐛 Cap the anchored theme menu at its designed measure and disambiguate the mode glyphs.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.21",
+  "version": "0.40.22",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -47,7 +47,22 @@
   flex-direction: column;
   gap: var(--space-4, 0.25rem);
   min-width: 13rem;
+  max-width: 22rem;
   padding: var(--space-8, 0.5rem);
+}
+
+/*
+ * The anchored popover panel is shrink-to-fit (width: max-content, #421),
+ * so any long-form prose in a host slot (mode-extra hint paragraphs) would
+ * otherwise set the panel's PREFERRED width — the menu once opened at the
+ * hint's single-line ideal width (~870px), stretching the segmented mode
+ * group full-bleed and leaving a wide void right of every row. The cap
+ * above clamps the menu's max-content contribution instead. The sheet
+ * branch is excluded: it stretches to the viewport by design, and its
+ * width never derives from content.
+ */
+.hk-popover-panel.hk-is-sheet .s-theme-menu {
+  max-width: none;
 }
 
 .s-theme-menu-label {

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -1,5 +1,5 @@
 import { computed, defineComponent, onUnmounted, ref, watch, type PropType } from "vue";
-import { Check, ChevronDown, Monitor, Moon, Palette, Sun, Trash as Trash2 } from "lucide-vue-next";
+import { Check, ChevronDown, Monitor, MoonStar, Palette, Sun, Trash as Trash2 } from "lucide-vue-next";
 import {
   HDivider,
   HPopover,
@@ -159,9 +159,9 @@ export const HkThemeToggle = defineComponent({
     function modeOptions(): TabItem[] {
       const auto = isAutoMode.value;
       return [
-        { key: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={14} /> },
-        { key: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={14} />, disabled: auto },
-        { key: "dark", label: t("hikari::theme.modeDark"), icon: <Moon size={14} />, disabled: auto },
+        { key: "system", label: t("hikari::theme.modeAuto"), icon: <Monitor size={16} /> },
+        { key: "light", label: t("hikari::theme.modeLight"), icon: <Sun size={16} />, disabled: auto },
+        { key: "dark", label: t("hikari::theme.modeDark"), icon: <MoonStar size={16} />, disabled: auto },
       ];
     }
 
@@ -205,11 +205,11 @@ export const HkThemeToggle = defineComponent({
           aria-label={t("hikari::theme.mode")}
         >
           {currentMode.value === "system" ? (
-            <Monitor size={14} />
+            <Monitor size={16} />
           ) : effectiveMode.value === "dark" ? (
-            <Moon size={14} />
+            <MoonStar size={16} />
           ) : (
-            <Sun size={14} />
+            <Sun size={16} />
           )}
         </button>
         <button
@@ -252,7 +252,7 @@ export const HkThemeToggle = defineComponent({
                       aria-label={t("hikari::theme.autoAltitudeTip")}
                       onClick={resolveAutoToManual}
                     >
-                      {altitudeNight.value ? <Moon size={14} /> : <Sun size={14} />}
+                      {altitudeNight.value ? <MoonStar size={16} /> : <Sun size={16} />}
                       <span class="s-theme-mode-autoalt-value">{altitudeText.value}</span>
                     </button>
                   ),


### PR DESCRIPTION
## What

Fixes the two demo.dev.cw regressions reported after #421 made the popover panel shrink-to-fit:

**1. Menu opens at ~viewport width.** `width: max-content` lets the content's PREFERRED width drive the panel. chest's `mode-extra` slot renders the DPI hint paragraph (68 CJK chars, single-line ideal width **861px** measured) — so the panel opened at 861px + padding, clamped by `100vw - 16px`. Measured repro (playground, chest-slot replica):

| | panel width |
|---|---|
| with hint paragraph (before) | **887px** |
| with hint paragraph (after) | **378px** (= 22rem cap + padding) |
| no hint | 282px / 285px (content-fit, unchanged) |

Fix: `.s-theme-menu` declares its designed measure — `max-width: 22rem` on the anchored branch only; the mobile sheet branch (`.hk-is-sheet`) keeps `max-width: none` (verified: 390px viewport → sheet 382px full-bleed, menu `max-width: none`).

This also heals the collateral artifacts of the inflated width:
- the `block`-variant segmented mode group no longer stretches full-bleed with long divider lines between segments (the「装饰衬线」),
- theme rows no longer leave a wide void on the right.

**2. Mode glyphs read as lightbulbs.** The hollow Moon crescent at 14px genuinely parses as a lightbulb (user report ×2; an unprimed vision check independently read it as one). Mode glyphs are now 16px and the moon is `MoonStar` (moon + star, unambiguous night glyph); Monitor/Sun keep their shapes.

## Verification

- `vue-tsc --noEmit` clean; `HkThemeToggle.test.ts` 10/10.
- Puppeteer probes (playground, this branch): anchored cap 378px, content-fit 285px, sheet branch uncapped (above).
- Vision check of the fixed menu: segmented control compact, sun/moon no longer read as lightbulbs.

## Version

`packages/vue` 0.40.22 (tag-triggered npm release after merge).