### PR TITLE
🔧 Make the just install step idempotent and race-free.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,9 +58,14 @@ jobs:
 
       - name: Install just
         run: |
-          curl -sSL https://github.com/casey/just/releases/download/1.55.1/just-1.55.1-x86_64-unknown-linux-musl.tar.gz -o /tmp/just.tar.gz
-          tar -xzf /tmp/just.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
+          # Idempotent + race-free: /usr/local/bin/just is pre-provisioned on
+          # the fleet; concurrent runs extracting the same fixed /tmp path
+          # raced (the chest fleet hit the same class with cargo-deny).
+          if ! command -v just >/dev/null; then
+            curl -sSL https://github.com/casey/just/releases/download/1.55.1/just-1.55.1-x86_64-unknown-linux-musl.tar.gz -o /tmp/just.tar.gz
+            tar -xzf /tmp/just.tar.gz -C /tmp just
+            sudo mv /tmp/just /usr/local/bin/just
+          fi
 
       - name: Run tests
         run: just test


### PR DESCRIPTION
Run tests 红于 `Install just`（#420 豁免记录过）：共享 /tmp 固定路径被 16 个并发 runner 互踩。守卫幂等——/usr/local/bin/just 已在车队预装（command -v 命中即跳过下载）。同源修复参照 chest #724/#725。