### PR TITLE
🐛 Cap the theme menu inside the mobile sheet at its designed measure.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.22",
+  "version": "0.40.23",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -62,7 +62,15 @@
  * width never derives from content.
  */
 .hk-popover-panel.hk-is-sheet .s-theme-menu {
-  max-width: none;
+  /* User report 09-07 22:53 (mobile sheet, 412px viewport): the exclusion
+   * below let the host slot's long prose (chest DPI hint, ~870px ideal)
+   * keep driving the sheet's max-content contribution — clamped to
+   * 100vw-16px and left-anchored it left a mysterious right gap plus
+   * full-bleed stretched rows. The sheet content is capped to the same
+   * designed measure, centered within the viewport-wide sheet. */
+  max-width: min(22rem, 100%);
+  margin-inline: auto;
+  width: 100%;
 }
 
 .s-theme-menu-label {


### PR DESCRIPTION
## Summary

Follow-up to #422 (user report, mobile sheet screenshot 09-07 22:53): #422 capped the ANCHORED theme menu at 22rem but deliberately excluded the mobile sheet — "stretches to the viewport by design". The user's screenshot shows why the exclusion misfires: with the chest DPI hint prose in `mode-extra`, the sheet's max-content contribution (~870px ideal) clamps to `100vw - 16px` and left-anchors, leaving a mysterious ~16px gap on the RIGHT plus full-bleed stretched rows/mode group.

Fix: the sheet menu is capped at the same designed measure — `max-width: min(22rem, 100%)` with `margin-inline: auto` — turning the inset into a symmetric, intentional form column inside the viewport-wide sheet. Static repro (deployed CSS, 390px) verified the pre-cap layout; post-fix the column centers symmetrically.

Version 0.40.22 → 0.40.23.