### PR TITLE
🐛 Standardize the theme toggle trigger on ghost chrome and stop the popover width clamp from narrowing mobile sheets.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.23",
+  "version": "0.40.24",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -109,6 +109,16 @@
    * rule's max-content width would over-constrain it (left+right+width
    * drops `right` in LTR) and dock it at content width instead. */
   width: auto;
+  /* The base .hk-popover-panel max-width clamp (calc(100vw - 16px), the
+   * anchored panel's ratchet guard) must NOT leak into the sheet: with
+   * the inline left:0 + right:0 docking the clamp over-constrains the
+   * used width and LTR drops the `right` constraint — the sheet docks
+   * flush left but stops 16px short of the right viewport edge (2026-09-08
+   * user report: a mysterious right-hand gap on the secondary windows,
+   * present on every popover-family sheet and never on the HkModal /
+   * HkSelectPanel sheets, hence "some have it, some don't"). The inline
+   * left/right pair alone owns the sheet's horizontal geometry. */
+  max-width: none;
   border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
                  var(--hk-modal-radius, var(--hi-radius-lg, 12px))
                  0 0;

--- a/packages/vue/src/components/HkPopover.sheet-maxwidth.test.ts
+++ b/packages/vue/src/components/HkPopover.sheet-maxwidth.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Source contract for the popover sheet viewport width (2026-09-08 user
+ * report: the mobile bottom sheets showed a mysterious right-hand gap —
+ * the sheet docked flush left but stopped 16px short of the right
+ * viewport edge, on every popover-family sheet and never on the HkModal
+ * / HkSelectPanel sheets, hence "some have it, some don't").
+ *
+ * Root cause: the base `.hk-popover-panel` rule sets
+ * `max-width: calc(100vw - 2 * 8px)` (the anchored panel's
+ * anti-ratchet clamp, #421). The mobile sheet branch overrides
+ * `width: auto` but inherited the max-width, over-constraining the
+ * inline `left: 0; right: 0` docking — the used width resolved to
+ * 100vw - 16px and LTR dropped the `right` constraint. Pinned here so
+ * a refactor cannot silently reintroduce the leak.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scss = readFileSync(join(here, "HkPopover.scss"), "utf-8");
+
+describe("HkPopover sheet viewport width contract", () => {
+  let block = "";
+  beforeAll(() => {
+    block = scss.match(/\.hk-popover-panel\.hk-is-sheet\s*{[\s\S]*?^\}/m)?.[0] ?? "";
+  });
+
+  it("neutralizes the base max-width clamp inside the sheet block", () => {
+    expect(block).toContain("max-width: none;");
+  });
+
+  it("keeps the sheet width content-independent (width: auto)", () => {
+    expect(block).toContain("width: auto;");
+  });
+
+  it("declares max-width: none after the width override (ordering sanity)", () => {
+    expect(block.indexOf("max-width: none")).toBeGreaterThan(block.indexOf("width: auto"));
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.ghost-chrome.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.ghost-chrome.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Source contract for the theme-toggle trigger chrome (2026-09-08 user
+ * report: the bordered surface box read as a mystery outline in the
+ * header and fought the host themes — the faint border, the host
+ * override layer and the `--hk-theme-toggle-btn-border` var never
+ * agreed). The trigger is now the STANDARD ghost icon-button chrome
+ * (same as `.hk-btn-ghost` / the HkIconButton ghost variant beside it):
+ * transparent at rest, primary wash on hover, no border, no surface,
+ * no shadow. Pinned here so the bordered-box chrome cannot silently
+ * return.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkThemeToggle.scss"), "utf-8");
+
+describe("HkThemeToggle ghost trigger chrome contract", () => {
+  let block = "";
+  beforeAll(() => {
+    block = src.match(/\.s-theme-toggle-btn\s*{[^}]*}/)?.[0] ?? "";
+  });
+
+  it("paints no border on the trigger (border: none)", () => {
+    expect(block).toContain("border: none;");
+  });
+
+  it("keeps the rest state transparent (no surface box)", () => {
+    expect(block).toContain("background: transparent;");
+  });
+
+  it("removes the per-theme border var entirely", () => {
+    expect(src).not.toContain("--hk-theme-toggle-btn-border");
+  });
+
+  it("retains a visible focus ring via :focus-visible", () => {
+    expect(src).toMatch(/\.s-theme-toggle-btn:focus-visible\s*{[^}]*}/);
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -13,13 +13,24 @@
   height: 1.75rem;
   min-width: 1.75rem;
   padding: 0 var(--space-6, 0.375rem);
-  /* Host/theme-tunable: borderless chrome sets --hk-theme-toggle-btn-border:
-   * transparent (e.g. the BA brand look). */
-  border: 1px solid var(--hk-theme-toggle-btn-border, var(--border-faint, rgb(var(--color-border) / 12%)));
-  background: rgb(var(--color-surface));
-  color: rgb(var(--color-text-secondary, var(--color-muted)));
+  /* Standard ghost icon-button chrome (2026-09-08 user report: the
+   * bordered surface box read as a mystery outline in the header and
+   * fought the host themes — the faint border, the host override layer
+   * and the border-var never agreed). The trigger now matches the
+   * standard ghost buttons beside it (same chrome as .hk-btn-ghost and
+   * the HkIconButton ghost variant): transparent at rest, primary wash
+   * on hover, no border, no surface, no shadow, no per-theme border var. */
+  border: none;
+  border-radius: var(--radius-sm, 6px);
+  background: transparent;
+  color: rgb(var(--color-text, var(--color-text-secondary, var(--color-muted))));
   cursor: pointer;
   transition: background 0.15s ease, color 0.15s ease;
+}
+
+.s-theme-toggle-btn:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: 1px;
 }
 
 /* Host strip under the mode group (mode-extra slot). */
@@ -31,15 +42,6 @@
 .s-theme-toggle-btn:hover {
   background: rgb(var(--color-primary) / 12%);
   color: rgb(var(--color-text));
-}
-
-.s-theme-toggle-btn[data-variant="main"] {
-  border-radius: var(--radius-sm, 6px) 0 0 var(--radius-sm, 6px);
-  border-right: none;
-}
-
-.s-theme-toggle-btn[data-variant="arrow"] {
-  border-radius: 0 var(--radius-sm, 6px) var(--radius-sm, 6px) 0;
 }
 
 .s-theme-menu {


### PR DESCRIPTION
## User report (2026-09-08, phone screenshots, Via browser ≈412px viewport)

Two visual bugs in the chest webui header / secondary windows:

1. **Right-hand gap on the secondary windows — and inconsistently so ("有的有，有的没有").** The bottom sheets (theme menu 配色主题, the popup-select node picker 已注册节点, …) docked flush against the LEFT screen edge but stopped ~16 CSS px short of the RIGHT edge, leaving a gray sliver of the dimmed page visible. Pixel-measuring the screenshots: the sheet's white area ends at 95.85% of the viewport width — exactly `100vw − 16px`. The HkModal-based sheets (添加工作区) and HkSelectPanel sheets were flush — only the **popover-family** sheets gapped, which is why it looked nondeterministic.
2. **A mystery border around the top-right theme toggle trigger** that seemed to follow no theme. Three layers fought over it: hikari's faint bordered surface box (`--hk-theme-toggle-btn-border` default, #416), chest's own override (hardcoded border + gradient + shadow, added 2026-09-04), and chest's `html[data-theme="sc"]` transparent-border var (2026-09-07) — the chest override ignored the var it was supposed to consume, so the outline changed shape depending on which layer won the cascade.

## Root cause

1. `.hk-popover-panel` base rule sets `width: max-content; max-width: calc(100vw − 2·8px)` — the anti-ratchet clamp for the **desktop anchored** panel (#421). The mobile sheet branch `.hk-popover-panel.hk-is-sheet` overrides `width: auto` but **not** `max-width`. The sheet panel is `position: fixed` with inline `left: 0; right: 0`, so the inherited clamp over-constrains the box: the used width resolves to `100vw − 16px` and LTR drops the `right` constraint → flush left, 16px gap right. #424 already capped the theme **menu content** (`min(22rem, 100%)`, centered) inside the sheet but the **panel itself** stayed clamped.
2. The trigger chrome was never standardized; each host patched the last patch.

## Fix

- **HkPopover.scss**: the sheet branch sets `max-width: none` — the inline left/right pair alone owns the sheet's horizontal geometry. The anchored branch keeps `max-content` + the viewport clamp (ratchet guard intact, `VIEWPORT_PAD = 8` untouched).
- **HkThemeToggle.scss**: `.s-theme-toggle-btn` becomes the **standard ghost icon-button chrome** — transparent at rest, no border, no surface, no shadow, primary wash on hover, `:focus-visible` ring retained, uniform radius on both halves — the same chrome as the neighboring `.hk-btn-ghost` header buttons (the search button beside it). `--hk-theme-toggle-btn-border` is removed; its sole consumer was chest's override layer, retired in the companion chest PR. The `data-variant="main"/"arrow"` attributes stay on the elements (chest's HeaderThemeToggle.test.ts uses `[data-variant="arrow"]` as a structural query) but no longer carry bespoke CSS.
- Source-contract tests pin both behaviors (mirroring the HkModal.sheetgap / HkPopover.sheetdock pattern): sheet branch `max-width: none` ordering; ghost chrome + border-var absence + focus ring.
- Version 0.40.23 → 0.40.24.

## Verification

- Implementation round: 8 test files / 43 tests green (incl. HkPopoverSheet, HkSelectSheet, both sheetdock contracts, HkThemeToggle) — exit 0, no pre-existing failures.
- Independent adversarial cross-check (round 2): all items PASS — anchored clamp + VIEWPORT_PAD untouched; every `.hk-is-sheet` consumer audited (theme menu / popup select / color picker / context ring / locale pickers — all document full-viewport sheet width as the designed contract, none relied on the narrower box); `--hk-theme-toggle-btn-border` has zero remaining consumers across the family (arona / e.cw / noa / easy-hydro-erp / celestia.ac.cn swept); chest theme.scss seams coherent. Verdict SHIP.

## Deployment notes

- Requires the npm release (tag `v0.40.24`) before chest can pick it up (registry-first, lockfile-only bump in the companion chest PR).
- No build/deploy from this branch (§7.2 compile discipline) — malkuth picks it up in the next wave.