### PR TITLE
🐛 Register the vendored theme-mixin keyframes so the CSS animation parity holds.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.27",
+  "version": "0.40.28",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/animation/registerAnimations.ts
+++ b/packages/vue/src/animation/registerAnimations.ts
@@ -103,3 +103,20 @@ registerCssAnimation("s-voice-wave-bounce", { infinite: true });
 // components/HkPlaceholderMarquee.scss — overflowing placeholder sweep
 // (loops forever; pure CSS, loop geometry on inline custom properties).
 registerCssAnimation("hk-placeholder-marquee-scroll", { infinite: true });
+// styles/theme/mixins.scss — ambient/glow pulses (loop forever) and the
+// one-shot entrance/exit grammar, vendored byte-identical from
+// packages/theme. #353 brought the file under src/ without registering
+// its keyframes — the parity test caught the gap 6 days later.
+registerCssAnimation("pulse", { infinite: true });
+registerCssAnimation("ambient-move", { infinite: true });
+registerCssAnimation("pulse-glow-animation", { infinite: true });
+registerCssAnimation("expand-horizontal");
+registerCssAnimation("collapse-vertical");
+registerCssAnimation("slide-in-left");
+registerCssAnimation("slide-in-right");
+registerCssAnimation("slide-in-top");
+registerCssAnimation("slide-in-bottom");
+registerCssAnimation("fade-in-scale");
+registerCssAnimation("fade-out-scale");
+registerCssAnimation("blur-in");
+registerCssAnimation("bounce-in");

--- a/packages/vue/src/components/HkAffixPicker.test.tsx
+++ b/packages/vue/src/components/HkAffixPicker.test.tsx
@@ -281,7 +281,6 @@ describe("HkAffixPicker", () => {
       .find((b) => !b.classList.contains("hk-message-box-confirm"))!
       .click();
     await flush();
-    console.log("DBG-cancel openEvents", JSON.stringify(events.open), "tags", tags().length, "box", !!document.body.querySelector(".hk-message-box-text"));
     expect(events.remove).toHaveLength(0);
     expect(tag("China")).toBeTruthy();
     // Second pass: the dialog's Confirm is what erases.


### PR DESCRIPTION
## 背景

2026-09-08 全量测试审计(193 个测试文件逐一与现行源码对账)确诊了 master 上唯一真红:`registerAnimations.test.ts` 的奇偶检查自 **#353(09-02)起失败 6 天**——该 PR 把 `styles/theme/mixins.scss`(packages/theme 的字节级拷贝)带进 `src/`,其 13 个 keyframes 未登记,违反注册商自己的契约(「hikari 发行的每个 keyframes 动画都在此登记」)。

## 修复

- 补登记 13 个:3 个循环 pulse(`pulse`/`ambient-move`/`pulse-glow-animation`,infinite)+ 10 个一次性入场/退场(expand/collapse/slide×4/fade×2/blur/bounce,forwards)——暂停开关(`html[data-css-animations=0]`)自此真正覆盖 vendored 集合。
- 顺带删掉 `HkAffixPicker.test.tsx:284` 遗留的 DBG console.log。
- 版本 0.40.27 → 0.40.28。

## 审计上下文

本次审计结论:hikari 104 个测试文件 STALE=0、MOCK 漂移=0、HOLLOW=0(仅 1 边缘),测试策略以真实挂载为主,质量健康;本 PR 是唯一的源码侧实锤缺口。chest 侧 5 个空洞用例另开 PR 修。

## 测试

全量 vue 套件 **120 文件 / 1020 用例全绿**(此前为 1019/1020 带一红)。