### PR TITLE
✨ Give modal bodies a default vertical rhythm and make preset shadowing coherent.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.29",
+  "version": "0.40.30",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkModal.bodyrhythm.test.ts
+++ b/packages/vue/src/components/HkModal.bodyrhythm.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Source contract for the modal body's default vertical rhythm (2026-09-08
+ * user direction: window bodies keep a little distance between their
+ * elements without every consumer hand-rolling a gap).
+ *
+ * `.hk-modal-body-inner` spaces its bare stacked children with a
+ * host-tunable custom property:
+ *   --hk-modal-body-gap  margin between adjacent direct children
+ *                        (block layout collapses it with the children's
+ *                        own margins, so it never doubles spacing)
+ *
+ * Pinned here so a refactor cannot silently regress to the
+ * padding-only body that left every unstyled window glued together —
+ * the same class of "looks fixed but never shipped" failure as the
+ * overflow-poll incident.
+ */
+import { beforeAll, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "HkModal.scss"), "utf-8");
+
+describe("HkModal body rhythm contract", () => {
+  let inner = "";
+  beforeAll(() => {
+    inner = src.match(/\.hk-modal-body-inner\s*{[\s\S]*?\n}/)?.[0] ?? "";
+  });
+
+  it("spaces bare stacked children with --hk-modal-body-gap", () => {
+    expect(inner).toContain("& > * + *");
+    expect(inner).toMatch(/--hk-modal-body-gap,\s*0\.75rem/);
+    expect(inner).toContain("margin-top: var(--hk-modal-body-gap");
+  });
+
+  it("keeps the body padding hook unchanged", () => {
+    expect(inner).toContain("padding: var(--hk-modal-padding-body");
+  });
+});

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -228,6 +228,17 @@
 
 .hk-modal-body-inner {
   padding: var(--hk-modal-padding-body, 1.5rem);
+
+  // Default vertical rhythm between bare stacked children (user direction
+  // 2026-09-08: window bodies keep a little distance between their elements
+  // without every consumer hand-rolling a gap). Block layout collapses
+  // adjacent vertical margins, so this composes with — never doubles — a
+  // consumer's own sibling margins; windows that manage their own rhythm
+  // through a single root wrapper are unaffected, and hosts can flatten it
+  // per window with `--hk-modal-body-gap: 0`.
+  & > * + * {
+    margin-top: var(--hk-modal-body-gap, 0.75rem);
+  }
 }
 
 // ------

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -88,12 +88,16 @@ export const HkThemeToggle = defineComponent({
     const { t } = useI18n();
     const { currentTheme, currentMode, effectiveMode, geo, setTheme, setMode, toggleMode, allThemeList, addCustomTheme, removeCustomTheme, customThemes } = useTheme();
 
-    /** Resolve a row's full definition for the item slots: the live
-     *  preset table first (stock + registered brand themes), then the
-     *  user's stored custom schemes. */
+    /** Resolve a row's full definition for the item slots: the user's
+     *  stored custom schemes first, then the live preset table — the SAME
+     *  precedence getAllThemePresets applies at apply time, so a row that
+     *  shadows a builtin id (in-place preset override) shows the anatomy
+     *  of the scheme that actually renders, not the shadowed factory. */
     function presetOf(id: ThemeId): ThemePreset | CustomThemePreset | undefined {
+      const custom = customThemes.value.find((c) => c.id === id);
+      if (custom) return custom;
       if (id in themePresets) return themePresets[id as keyof typeof themePresets];
-      return customThemes.value.find((c) => c.id === id);
+      return undefined;
     }
 
     const menuOpen = ref(false);

--- a/packages/vue/src/theme/useTheme.test.ts
+++ b/packages/vue/src/theme/useTheme.test.ts
@@ -137,3 +137,92 @@ describe("useTheme lean cssvar injection", () => {
     expect(blocks[0].textContent).not.toBe(before);
   });
 });
+
+describe("useTheme preset/custom shadowing", () => {
+  let theme: ThemeModule;
+  let presetModule: typeof import("./presets");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    localStorage.clear();
+    document.documentElement.style.cssText = "";
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-mode");
+    document.head.querySelectorAll("style[data-hikari-theme-vars]").forEach((el) => el.remove());
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("offline");
+    }));
+    // Same import context as useTheme so both share one presets instance.
+    presetModule = await import("./presets");
+    theme = await import("./useTheme");
+  });
+
+  afterEach(() => {
+    theme.stopThemeClock();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // A custom whose id equals a builtin shadows it at apply time
+  // (getAllThemePresets). The picker list must agree: ONE row per id,
+  // flagged custom — the in-place preset override grammar. The primary
+  // shifts so an applied override is distinguishable from the factory.
+  function override(id: string) {
+    const nord = presetModule.themePresets.nord;
+    return {
+      id,
+      name: `${id} (edited)`,
+      dark: { ...nord.dark, primary: { r: 1, g: 2, b: 3 } },
+      light: { ...nord.light },
+    };
+  }
+
+  it("allThemeList dedupes a builtin id shadowed by a custom, flagging it custom", () => {
+    theme.initTheme();
+    const th = theme.useTheme();
+    th.addCustomTheme(override("nord"));
+    const rows = th.allThemeList.value.filter((r) => r.id === "nord");
+    expect(rows).toHaveLength(1);
+    expect(rows[0].isCustom).toBe(true);
+    expect(rows[0].name).toBe("nord (edited)");
+    // Pure custom ids stay listed as customs; untouched builtins stay builtin.
+    expect(th.allThemeList.value.some((r) => r.id === "gruvbox" && !r.isCustom)).toBe(true);
+  });
+
+  it("applyTheme renders the shadowing custom's tokens", () => {
+    theme.initTheme();
+    const th = theme.useTheme();
+    th.setTheme("nord");
+    const before = document.head.querySelector("style[data-hikari-theme-vars]")!.textContent;
+    th.addCustomTheme(override("nord"));
+    th.setTheme("nord");
+    const after = document.head.querySelector("style[data-hikari-theme-vars]")!.textContent;
+    expect(after).not.toBe(before);
+  });
+
+  it("removing a shadowed builtin id restores the factory preset selection", () => {
+    theme.initTheme();
+    const th = theme.useTheme();
+    th.addCustomTheme(override("nord"));
+    th.setTheme("nord");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("nord");
+    th.removeCustomTheme("nord");
+    // Still on the id — now backed by the factory preset again.
+    expect(th.currentTheme.value).toBe("nord");
+    expect(th.allThemeList.value.find((r) => r.id === "nord")?.isCustom).toBe(false);
+    expect(th.customThemes.value.some((c) => c.id === "nord")).toBe(false);
+  });
+
+  it("removing a pure custom id resets the selection to the default theme", () => {
+    theme.initTheme();
+    const th = theme.useTheme();
+    th.setTheme("nord");
+    th.addCustomTheme({ ...override("nord"), id: "my-own" });
+    th.setTheme("my-own");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("my-own");
+    th.removeCustomTheme("my-own");
+    expect(th.currentTheme.value).not.toBe("my-own");
+    expect(th.allThemeList.value.some((r) => r.id === "my-own")).toBe(false);
+  });
+});

--- a/packages/vue/src/theme/useTheme.ts
+++ b/packages/vue/src/theme/useTheme.ts
@@ -281,16 +281,24 @@ export function useTheme() {
   const effectiveMode = computed(() => resolveEffectiveMode(currentMode.value));
 
   const allThemeList = computed(() => {
-    const builtIn = (Object.keys(themePresets) as string[]).map((id) => ({
-      id,
-      name: themePresets[id as keyof typeof themePresets].name,
-      isCustom: false,
-    }));
     const custom = customThemes.value.map((ct: CustomThemePreset) => ({
       id: ct.id,
       name: ct.name,
       isCustom: true,
     }));
+    // A custom overriding a builtin id SHADOWS it — the same rule
+    // getAllThemePresets applies at apply time — so the picker shows ONE
+    // row per id (a duplicate key row would be unselectable dead chrome),
+    // flagged custom so the delete affordance doubles as "restore the
+    // factory preset".
+    const customIds = new Set(custom.map((c) => c.id));
+    const builtIn = (Object.keys(themePresets) as string[])
+      .filter((id) => !customIds.has(id))
+      .map((id) => ({
+        id,
+        name: themePresets[id as keyof typeof themePresets].name,
+        isCustom: false,
+      }));
     return [...builtIn, ...custom];
   });
 
@@ -319,7 +327,15 @@ export function useTheme() {
     removeCustomThemeFromStorage(id);
     customThemes.value = loadCustomThemes();
     if (currentTheme.value === id) {
-      setTheme(resolveDefaultTheme());
+      // A deleted custom whose id still resolves as a builtin preset falls
+      // back to the FACTORY preset (an in-place preset override restoring
+      // its shipped look); a truly custom id would no longer resolve, so
+      // the selection resets to the default theme.
+      if (themePresets[id as keyof typeof themePresets]) {
+        setTheme(id);
+      } else {
+        setTheme(resolveDefaultTheme());
+      }
     }
   }
 


### PR DESCRIPTION
## What

Two upstream fixes driving the chest 2026-09-08 five-point WebUI feedback wave:

**1. HkModal body rhythm (issue 1 — window body elements had no vertical spacing)**

`.hk-modal-body-inner` previously provided ONLY padding; any window that dropped bare stacked children rendered them glued together (chest's DPI window shipped with no consumer-side spacing either — every element sat flush). The body now spaces adjacent direct children with a host-tunable hook:

```
& > * + * { margin-top: var(--hk-modal-body-gap, 0.75rem); }
```

Block-layout margin collapsing means it composes with (never doubles) consumer margins; single-root-wrapper windows are structurally unaffected; hosts flatten per window with `--hk-modal-body-gap: 0`. Source-contract test `HkModal.bodyrhythm.test.ts` pins it (same pattern as `sheetgap.test.ts`).

**2. Coherent preset/custom shadowing (groundwork for chest issue 4 — editing a theme forked a copy)**

The engine already let a custom theme SHADOW a preset by id at apply time (`getAllThemePresets`), but the rest of the theme surface disagreed:

- `allThemeList` rendered BOTH rows (duplicate Vue keys, one of them dead chrome).
- `HkThemeToggle.presetOf` resolved presets FIRST — a row's slot anatomy showed factory colors while the applied scheme was the custom.
- `removeCustomTheme` of a shadowed id reset the selection to the DEFAULT theme instead of the factory preset now un-shadowed.

Now: the list dedupes (custom wins, flagged `isCustom` so the delete affordance doubles as "restore factory"), `presetOf` matches apply precedence, and removal falls back to the factory preset when the id still resolves. Together these make "edit a brand preset in place" expressible as a local custom with the same id — which chest's companion PR uses to kill the fork-a-copy flow.

## Verification

- Full vue suite: 122 files / 1034 tests green (incl. new `HkModal.bodyrhythm.test.ts` and 4 new useTheme shadowing tests).
- `useTheme.test.ts` new cases: list dedupe + flag, shadow tokens actually applied, removal-to-factory, removal-to-default for pure customs.
- Version bump 0.40.29 → 0.40.30.

## Consumers

chest picks this up in the companion wave PR (lockfile → 0.40.30, specifier stays `^*`).
