### PR TITLE
✨ Polish the error landing with tone badges and a fixed scrollable details pane.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.29",
+  "version": "0.40.30",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkErrorBoundary.tsx
+++ b/packages/vue/src/components/HkErrorBoundary.tsx
@@ -30,8 +30,9 @@ function formatError(err: CapturedError): string {
  * Captures descendant errors via `onErrorCaptured` and stops propagation.
  * The built-in fallback is the same HkErrorLanding card the family's
  * full-page takeovers use (inline variant): tone icon, headline, the error
- * name as the code chip, the message as the description, the raw
- * name/message/stack in a collapsible JSON tree, plus retry / copy actions.
+ * name as the tone-matched HkBadge chip, the message as the description,
+ * the raw name/message/stack in the fixed-height JSON tree pane, plus
+ * retry / copy actions.
  */
 export default defineComponent({
   name: "HkErrorBoundary",

--- a/packages/vue/src/components/HkErrorLanding.scss
+++ b/packages/vue/src/components/HkErrorLanding.scss
@@ -36,16 +36,38 @@
 }
 
 .hk-error-landing__card {
-  width: min(430px, 100%);
+  position: relative;
+  overflow: hidden;
+  width: min(440px, 100%);
   background: rgb(var(--hel-surface));
   border: 1px solid rgb(var(--hel-border) / 70%);
-  border-radius: var(--radius-lg, 16px);
+  border-radius: var(--radius-xl, 20px);
   box-shadow: var(--shadow-lg, 0 18px 48px rgb(0 0 0 / 8%));
-  padding: 2rem 1.75rem;
+  padding: 2.25rem 1.75rem 1.75rem;
   text-align: center;
+
+  // Tone wash bleeding down from the top edge behind the icon — gives the
+  // upper half the designed depth the plain white card used to lack.
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 150px;
+    background: radial-gradient(58% 100% at 50% 0%, rgb(var(--hel-error) / 8%), transparent 72%);
+    pointer-events: none;
+  }
+}
+
+.hk-error-landing.is-warning .hk-error-landing__card::before {
+  background: radial-gradient(58% 100% at 50% 0%, rgb(var(--hel-warning) / 10%), transparent 72%);
+}
+
+.hk-error-landing.is-info .hk-error-landing__card::before {
+  background: radial-gradient(58% 100% at 50% 0%, rgb(var(--hel-primary) / 7%), transparent 72%);
 }
 
 .hk-error-landing__brand {
+  position: relative;
   display: flex;
   justify-content: center;
   margin-bottom: var(--space-16, 1rem);
@@ -56,9 +78,10 @@
 }
 
 .hk-error-landing__icon {
-  width: 58px;
-  height: 58px;
-  margin: 0 auto var(--space-16, 1rem);
+  position: relative;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto var(--space-14, 0.875rem);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -69,8 +92,13 @@
     color: rgb(var(--hel-error));
   }
 
-  background: rgb(var(--hel-error) / 12%);
-  border: 1px solid rgb(var(--hel-error) / 22%);
+  background: linear-gradient(145deg, rgb(var(--hel-error) / 18%), rgb(var(--hel-error) / 6%));
+  border: 1px solid rgb(var(--hel-error) / 26%);
+  // Layered halo: a soft tone ring hugging the disc plus a long, faint
+  // drop shadow — reads as a designed badge instead of a flat circle.
+  box-shadow:
+    0 0 0 8px rgb(var(--hel-error) / 5%),
+    0 10px 28px -12px rgb(var(--hel-error) / 45%);
 }
 
 .hk-error-landing.is-warning .hk-error-landing__icon {
@@ -79,8 +107,11 @@
     color: rgb(var(--hel-warning));
   }
 
-  background: rgb(var(--hel-warning) / 12%);
-  border-color: rgb(var(--hel-warning) / 24%);
+  background: linear-gradient(145deg, rgb(var(--hel-warning) / 20%), rgb(var(--hel-warning) / 7%));
+  border-color: rgb(var(--hel-warning) / 28%);
+  box-shadow:
+    0 0 0 8px rgb(var(--hel-warning) / 6%),
+    0 10px 28px -12px rgb(var(--hel-warning) / 45%);
 }
 
 .hk-error-landing.is-info .hk-error-landing__icon {
@@ -89,19 +120,63 @@
     color: rgb(var(--hel-primary));
   }
 
-  background: rgb(var(--hel-primary) / 10%);
-  border-color: rgb(var(--hel-primary) / 20%);
+  background: linear-gradient(145deg, rgb(var(--hel-primary) / 16%), rgb(var(--hel-primary) / 5%));
+  border-color: rgb(var(--hel-primary) / 24%);
+  box-shadow:
+    0 0 0 8px rgb(var(--hel-primary) / 5%),
+    0 10px 28px -12px rgb(var(--hel-primary) / 40%);
+}
+
+// Code / status chips ride on the canonical HkBadge (mono, small). The
+// channels are re-resolved through the landing's --hel-* fallbacks so a
+// theme-less standalone render paints them exactly like the themed one,
+// and the code chip follows the landing tone like the icon does.
+.hk-error-landing__meta {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-6, 0.375rem);
+  margin-bottom: var(--space-8, 0.5rem);
+}
+
+.hk-error-landing__meta .hk-badge:not(.hk-badge-muted) {
+  --hk-badge-text: rgb(var(--hel-error));
+  --hk-badge-bg: rgb(var(--hel-error) / 10%);
+  --hk-badge-border: rgb(var(--hel-error) / 22%);
+}
+
+.hk-error-landing.is-warning .hk-error-landing__meta .hk-badge:not(.hk-badge-muted) {
+  --hk-badge-text: rgb(var(--hel-warning));
+  --hk-badge-bg: rgb(var(--hel-warning) / 12%);
+  --hk-badge-border: rgb(var(--hel-warning) / 24%);
+}
+
+.hk-error-landing.is-info .hk-error-landing__meta .hk-badge:not(.hk-badge-muted) {
+  --hk-badge-text: rgb(var(--hel-primary));
+  --hk-badge-bg: rgb(var(--hel-primary) / 10%);
+  --hk-badge-border: rgb(var(--hel-primary) / 20%);
+}
+
+.hk-error-landing__meta .hk-badge-muted {
+  --hk-badge-text: rgb(var(--hel-muted));
+  --hk-badge-bg: rgb(var(--hel-muted) / 8%);
+  --hk-badge-border: rgb(var(--hel-border) / 80%);
 }
 
 .hk-error-landing__title {
+  position: relative;
   margin: 0;
-  font-size: var(--text-lg, 1.125rem);
-  font-weight: 600;
+  font-size: var(--text-xl, 1.25rem);
+  font-weight: 650;
+  letter-spacing: -0.01em;
   line-height: 1.35;
   color: rgb(var(--hel-text));
 }
 
 .hk-error-landing__desc {
+  position: relative;
   margin: var(--space-8, 0.5rem) 0 0;
   font-size: var(--text-sm, 0.8125rem);
   line-height: 1.6;
@@ -110,69 +185,71 @@
   overflow-wrap: anywhere;
 }
 
-.hk-error-landing__meta {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: var(--space-6, 0.375rem);
-  margin-top: var(--space-10, 0.625rem);
-}
-
-.hk-error-landing__code {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: var(--text-xs, 0.75rem);
-  color: rgb(var(--hel-muted));
-  background: rgb(var(--hel-muted) / 8%);
-  border: 1px solid rgb(var(--hel-border) / 80%);
-  border-radius: var(--radius-sm, 4px);
-  padding: 0.1em 0.55em;
-  overflow-wrap: anywhere;
-}
-
-.hk-error-landing__status {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: var(--text-xs, 0.75rem);
-  color: rgb(var(--hel-muted));
-  border: 1px dashed rgb(var(--hel-border));
-  border-radius: var(--radius-sm, 4px);
-  padding: 0.1em 0.55em;
-}
-
 .hk-error-landing__details {
+  position: relative;
   margin-top: var(--space-16, 1rem);
   text-align: left;
 }
 
-.hk-error-landing__details-toggle {
-  display: inline-flex;
+.hk-error-landing__details-label {
+  display: flex;
   align-items: center;
   gap: 4px;
-  border: none;
-  background: transparent;
-  padding: 2px 4px;
-  font: inherit;
+  padding: 0 2px;
   font-size: var(--text-xs, 0.75rem);
+  font-weight: 500;
+  letter-spacing: 0.02em;
   color: rgb(var(--hel-muted));
-  cursor: pointer;
-  border-radius: var(--radius-xs, 4px);
+  user-select: none;
+}
 
-  &:hover {
-    color: rgb(var(--hel-text));
-    background: rgb(var(--hel-muted) / 8%);
-  }
-
-  &:focus-visible {
-    outline: 2px solid rgb(var(--hel-primary) / 60%);
-    outline-offset: 1px;
-  }
+// Fixed-height details pane: the raw payload keeps a stable ~20vh
+// footprint. Folding every JSON node still leaves the pane standing at
+// the same height, and a long stack trace can never stretch the card —
+// the family overlay scrollbar (attachOverlayScrollbars) carries the
+// overflow inside the frame. The pane div is the track's positioning
+// context and wraps EXACTLY the scrolling body (useOverlayScrollbar
+// host contract).
+.hk-error-landing__details-pane {
+  position: relative;
+  margin-top: var(--space-6, 0.375rem);
+  height: max(9rem, 20vh);
+  height: max(9rem, 20dvh);
+  border: 1px solid rgb(var(--hel-border) / 70%);
+  border-radius: var(--radius-md, 10px);
+  background: rgb(var(--hel-muted) / 4%);
 }
 
 .hk-error-landing__details-body {
-  margin-top: var(--space-6, 0.375rem);
+  height: 100%;
+  overflow: auto;
+  border-radius: inherit;
+  padding: var(--space-4, 0.25rem);
+
+  // The overlay scrollbar is the only chrome — hide the native bar.
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+// A nested HkJsonTree fills the pane instead of stacking its own frame
+// and 320px cap — the pane above owns the chrome now (overflow included:
+// the tree must never engage its own scroller).
+.hk-error-landing__details-body .s-tool-json-tree {
+  max-height: none;
+  height: auto;
+  overflow: visible;
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: transparent;
 }
 
 .hk-error-landing__actions {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -192,6 +269,6 @@
 
 @media (max-width: 480px) {
   .hk-error-landing__card {
-    padding: 1.5rem 1.125rem;
+    padding: 1.75rem 1.125rem 1.5rem;
   }
 }

--- a/packages/vue/src/components/HkErrorLanding.test.tsx
+++ b/packages/vue/src/components/HkErrorLanding.test.tsx
@@ -1,8 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { createApp, h, nextTick } from "vue";
+import { createApp, h } from "vue";
 
 import { HkErrorLanding } from "./HkErrorLanding";
-
 const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
 
 interface MountOptions {
@@ -12,7 +11,6 @@ interface MountOptions {
   status?: number;
   tone?: "error" | "warning" | "info";
   variant?: "page" | "inline";
-  detailsOpen?: boolean;
   details?: () => ReturnType<typeof h>;
   actions?: () => ReturnType<typeof h>;
   brand?: () => ReturnType<typeof h>;
@@ -30,7 +28,6 @@ function mountLanding(opts: MountOptions = {}) {
         status: opts.status,
         tone: opts.tone ?? "error",
         variant: opts.variant ?? "page",
-        detailsOpen: opts.detailsOpen ?? true,
       }, {
         ...(opts.details ? { default: opts.details } : {}),
         ...(opts.actions ? { actions: opts.actions } : {}),
@@ -59,7 +56,12 @@ describe("HkErrorLanding", () => {
   it("renders the given title, description, and meta chips", () => {
     const el = mountLanding({ title: "OAuth failed", description: "line1\nline2", code: "unknown_provider", status: 400 });
     expect(el.querySelector(".hk-error-landing__title")!.textContent).toBe("OAuth failed");
+    // Chips ride on the canonical HkBadge (class fallthrough keeps the
+    // landing-level selectors testable).
+    expect(el.querySelector(".hk-error-landing__code")!.classList.contains("hk-badge")).toBe(true);
+    expect(el.querySelector(".hk-error-landing__code")!.classList.contains("hk-badge-warning")).toBe(false);
     expect(el.querySelector(".hk-error-landing__code")!.textContent).toBe("unknown_provider");
+    expect(el.querySelector(".hk-error-landing__status")!.classList.contains("hk-badge-muted")).toBe(true);
     expect(el.querySelector(".hk-error-landing__status")!.textContent).toBe("HTTP 400");
   });
 
@@ -68,22 +70,55 @@ describe("HkErrorLanding", () => {
     expect(el.querySelector(".hk-error-landing__meta")).toBeNull();
   });
 
-  it("renders the details slot with the raw JSON tree pane and toggles it", async () => {
+  it("renders the details pane always open with a tone-following code chip", () => {
     const el = mountLanding({
       details: () => h("pre", { class: "s-tool-json-tree" }, "raw"),
     });
-    const toggle = el.querySelector<HTMLButtonElement>(".hk-error-landing__details-toggle")!;
-    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    // No collapse affordance anymore — the pane is a fixed region.
+    expect(el.querySelector(".hk-error-landing__details-toggle")).toBeNull();
+    expect(el.querySelector(".hk-error-landing__details-label")!.textContent).toContain("Raw error details");
+    expect(el.querySelector(".hk-error-landing__details-pane")).not.toBeNull();
     expect(el.querySelector(".hk-error-landing__details-body")).not.toBeNull();
-    toggle.click();
-    await nextTick();
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-    expect(el.querySelector(".hk-error-landing__details-body")).toBeNull();
   });
 
-  it("keeps details collapsed when detailsOpen is false", () => {
-    const el = mountLanding({ detailsOpen: false, details: () => h("pre", {}, "raw") });
-    expect(el.querySelector(".hk-error-landing__details-body")).toBeNull();
+  it("keeps the code chip on the tone variant and the status chip muted", () => {
+    const el = mountLanding({ code: "rate_limited", status: 429, tone: "warning" });
+    expect(el.querySelector(".hk-error-landing__code")!.classList.contains("hk-badge-warning")).toBe(true);
+    expect(el.querySelector(".hk-error-landing__status")!.classList.contains("hk-badge-muted")).toBe(true);
+  });
+
+  it("maps the info tone onto the info chip variant", () => {
+    const el = mountLanding({ code: "maintenance", tone: "info" });
+    expect(el.querySelector(".hk-error-landing__code")!.classList.contains("hk-badge-info")).toBe(true);
+  });
+
+  it("renders the description text", () => {
+    const el = mountLanding({ description: "line1\nline2" });
+    expect(el.querySelector(".hk-error-landing__desc")!.textContent).toBe("line1\nline2");
+  });
+
+  it("attaches the overlay scrollbar chrome inside the details pane", () => {
+    const el = mountLanding({ details: () => h("pre", { class: "s-tool-json-tree" }, "raw") });
+    expect(el.querySelector(".hk-error-landing__details-pane .hk-scrollbar-track")).not.toBeNull();
+    expect(el.querySelector(".hk-error-landing__details-pane .hk-scrollbar-thumb")).not.toBeNull();
+  });
+
+  it("renders no scrollbar chrome without a details pane", () => {
+    const el = mountLanding({});
+    expect(el.querySelector(".hk-scrollbar-track")).toBeNull();
+  });
+
+  it("detaches the scrollbar chrome on unmount", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () => h(HkErrorLanding, { title: "Boom" }, { default: () => h("pre", "raw") }),
+    });
+    app.mount(container);
+    expect(container.querySelector(".hk-scrollbar-track")).not.toBeNull();
+    app.unmount();
+    container.remove();
+    expect(container.querySelector(".hk-scrollbar-track")).toBeNull();
   });
 
   it("renders no details section without a default slot", () => {

--- a/packages/vue/src/components/HkErrorLanding.tsx
+++ b/packages/vue/src/components/HkErrorLanding.tsx
@@ -1,6 +1,17 @@
-import { computed, defineComponent, ref, type PropType } from "vue";
-import { ChevronDown, ChevronRight, Info, TriangleAlert } from "lucide-vue-next";
+import { Braces, Info, TriangleAlert } from "lucide-vue-next";
+import {
+  computed,
+  defineComponent,
+  onBeforeUnmount,
+  onMounted,
+  onUpdated,
+  ref,
+  type PropType,
+} from "vue";
+
+import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
 import { useI18n } from "../i18n/context";
+import HkBadge from "./HkBadge";
 
 import "./HkErrorLanding.scss";
 
@@ -21,14 +32,20 @@ export type HErrorLandingVariant = "page" | "inline";
  *
  * Login-page-like layout: a centered card over a full-viewport backdrop,
  * carrying a tone icon, a (pre-translated) title and description, the wire
- * error code / HTTP status as meta chips, a collapsible raw-details section
- * (the default slot — hosts render HkJsonTree there) and an actions slot.
+ * error code / HTTP status as HkBadge chips above the headline, an
+ * always-open raw-details pane (the default slot — hosts render HkJsonTree
+ * there) with a FIXED ~20vh footprint carried by the family overlay
+ * scrollbar, and an actions slot.
+ *
+ * The details pane deliberately never collapses and never grows past its
+ * frame: folding every JSON node still leaves the pane standing, and a
+ * long stack trace scrolls inside it instead of stretching the card.
  *
  * The component is presentation-only and route-agnostic: it never touches
  * the router and can be mounted by an SPA overlay, a modal, or a standalone
  * server-rendered error page alike. All host-facing copy (`title`,
  * `description`, action buttons) arrives pre-translated; the component only
- * translates its own two labels via `hikari::errors.*`.
+ * translates its own labels via `hikari::errors.*`.
  */
 export const HkErrorLanding = defineComponent({
   name: "HkErrorLanding",
@@ -44,19 +61,73 @@ export const HkErrorLanding = defineComponent({
     tone: { type: String as PropType<HErrorTone>, default: "error" },
     /** Layout variant: `page` (viewport backdrop) or `inline` (in-flow card). */
     variant: { type: String as PropType<HErrorLandingVariant>, default: "page" },
-    /** Initial expansion of the raw-details section. */
-    detailsOpen: { type: Boolean, default: true },
   },
   setup(props, { slots }) {
     const { t } = useI18n();
-    const detailsExpanded = ref(props.detailsOpen);
 
     const titleText = computed(() => props.title || t("hikari::errors.defaultTitle", "Something went wrong"));
     const hasDetails = computed(() => slots.default != null);
 
-    function toggleDetails() {
-      detailsExpanded.value = !detailsExpanded.value;
+    // Badge variant follows the landing tone so the chip, the icon and the
+    // card wash always speak the same severity language.
+    const codeBadgeVariant = computed(() =>
+      props.tone === "warning" ? "warning" : props.tone === "info" ? "info" : "error",
+    );
+
+    const detailsBodyRef = ref<HTMLElement | null>(null);
+    let detailsScrollbars: OverlayScrollbarHandle | null = null;
+    // The pane's viewport box is fixed, so the composable's own viewport
+    // ResizeObserver never fires when the slot content changes size — and
+    // folding a JSON node re-renders HkJsonTree internally, so the landing
+    // itself does not re-render either. Observe the CONTENT element (the
+    // tree root) so every fold/expand re-reads the thumb geometry.
+    let contentResizeObserver: ResizeObserver | null = null;
+    let observedContent: Element | null = null;
+
+    function observeDetailsContent() {
+      const content = detailsBodyRef.value?.firstElementChild ?? null;
+      if (content === observedContent) return;
+      if (observedContent) contentResizeObserver?.unobserve(observedContent);
+      observedContent = content;
+      if (content) contentResizeObserver?.observe(content);
     }
+
+    function ensureDetailsScrollbars() {
+      if (detailsScrollbars || !detailsBodyRef.value) return;
+      detailsScrollbars = attachOverlayScrollbars(detailsBodyRef.value);
+      contentResizeObserver = new ResizeObserver(() => detailsScrollbars?.update());
+      observeDetailsContent();
+    }
+
+    function releaseDetailsScrollbars() {
+      detailsScrollbars?.detach();
+      detailsScrollbars = null;
+      contentResizeObserver?.disconnect();
+      contentResizeObserver = null;
+      observedContent = null;
+    }
+
+    onMounted(() => {
+      ensureDetailsScrollbars();
+    });
+
+    // Covers landing rerenders (thumb geometry re-read) plus the rare
+    // dynamic-slot cases: a slot appearing after mount attaches the
+    // chrome, a slot removed at runtime tears it down (element-identity
+    // check, not the frozen hasDetails computed).
+    onUpdated(() => {
+      if (detailsBodyRef.value) {
+        ensureDetailsScrollbars();
+        observeDetailsContent();
+        detailsScrollbars?.update();
+      } else if (detailsScrollbars) {
+        releaseDetailsScrollbars();
+      }
+    });
+
+    onBeforeUnmount(() => {
+      releaseDetailsScrollbars();
+    });
 
     return () => (
       <div class={`hk-error-landing is-${props.tone}${props.variant === "inline" ? " is-inline" : ""}`}>
@@ -64,34 +135,43 @@ export const HkErrorLanding = defineComponent({
           {slots.brand?.()}
 
           <div class="hk-error-landing__icon" aria-hidden="true">
-            {props.tone === "info" ? <Info size={26} /> : <TriangleAlert size={26} />}
+            {props.tone === "info" ? <Info size={28} /> : <TriangleAlert size={28} />}
           </div>
+
+          {(props.code || props.status != null) && (
+            <div class="hk-error-landing__meta">
+              {/* The landing-scoped selectors (.hk-error-landing__code/
+                  __status) and family tests rely on the class falling
+                  through onto the badge root — HkBadge must stay
+                  single-rooted for that contract to hold. */}
+              {props.code && (
+                <HkBadge class="hk-error-landing__code" variant={codeBadgeVariant.value} size="sm" mono>
+                  {props.code}
+                </HkBadge>
+              )}
+              {props.status != null && (
+                <HkBadge class="hk-error-landing__status" variant="muted" size="sm" mono>
+                  HTTP {props.status}
+                </HkBadge>
+              )}
+            </div>
+          )}
 
           <h1 class="hk-error-landing__title">{titleText.value}</h1>
 
           {props.description && <p class="hk-error-landing__desc">{props.description}</p>}
 
-          {(props.code || props.status != null) && (
-            <div class="hk-error-landing__meta">
-              {props.code && <code class="hk-error-landing__code">{props.code}</code>}
-              {props.status != null && <span class="hk-error-landing__status">HTTP {props.status}</span>}
-            </div>
-          )}
-
           {hasDetails.value && (
             <div class="hk-error-landing__details">
-              <button
-                type="button"
-                class="hk-error-landing__details-toggle"
-                aria-expanded={detailsExpanded.value}
-                onClick={toggleDetails}
-              >
-                {detailsExpanded.value ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              <div class="hk-error-landing__details-label" aria-hidden="true">
+                <Braces size={11} />
                 <span>{t("hikari::errors.rawDetails", "Raw error details")}</span>
-              </button>
-              {detailsExpanded.value && (
-                <div class="hk-error-landing__details-body">{slots.default?.()}</div>
-              )}
+              </div>
+              <div class="hk-error-landing__details-pane">
+                <div ref={detailsBodyRef} class="hk-error-landing__details-body">
+                  {slots.default?.()}
+                </div>
+              </div>
             </div>
           )}
 

--- a/packages/vue/src/errorReporting/HkErrorReportingOverlay.tsx
+++ b/packages/vue/src/errorReporting/HkErrorReportingOverlay.tsx
@@ -17,8 +17,8 @@ import "./HkErrorReportingOverlay.scss";
  * Renders nothing until the error-reporting state is raised. The card is
  * the family-wide HkErrorLanding (same design language as every unified
  * error surface): tone icon, headline, the error name as the code chip,
- * the message as the description, the raw error record in a collapsible
- * JSON tree, and Home / Retry actions.
+ * the message as the description, the raw error record in the fixed-height
+ * raw-details pane, and Home / Retry actions.
  *
  * Mounted by `createErrorReporting` on a dedicated root appended to
  * `document.body` via its own tiny app instance, so it keeps working even


### PR DESCRIPTION
## Summary

User-reported polish on the family-wide unified error landing (screenshot from shittim-chest AppShell HkErrorBoundary capture, `demo.dev.celestia.world`).

**Top half redesign**
- Code / status chips now ride on the canonical `HkBadge` (mono, `sm`), placed as an eyebrow above the headline; the code chip follows the landing tone (`error`/`warning`/`info`), the HTTP status chip stays muted.
- Tone icon upgraded to a layered badge: gradient disc, tone ring halo (`box-shadow` ring + long soft shadow).
- Card gains a tone-tinted radial wash bleeding from the top edge; title bumped to `text-xl` / weight 650 / tight tracking.
- All new colors resolve through the landing's `--hel-*` fallback triplets, so dark themes and theme-less standalone renders (server error page) behave identically.

**Details pane: fixed height + family overlay scrollbar**
- The raw-details section is now a FIXED ~20vh pane (`max(9rem, 20vh)`, `20dvh` fallback): always open, never collapsible (toggle + `detailsOpen` prop removed), never grows past the frame.
- Folding every JSON node keeps the pane standing; a long stack trace scrolls inside it.
- Scroll chrome is the family overlay scrollbar (`attachOverlayScrollbars`) anchored to the pane (host contract: pane wraps exactly the scrolling body); the nested `HkJsonTree` is reset to a fill-host (`max-height:none; overflow:visible`) so the body is the sole scroll host — no nested scrollbar.
- A content ResizeObserver (element-identity tracked) keeps the thumb geometry fresh across JSON folds, which neither the landing's `onUpdated` nor the composable's viewport RO could see.

**Compatibility**
- `HkBadge` class fallthrough keeps the landing-scoped `.hk-error-landing__code` / `.hk-error-landing__status` selectors (and shittim-chest's `ErrorLandingCard` tests) working unchanged; contract documented at the usage site.
- No family consumer passes `detailsOpen` (grep: hikari, chest, plana, noa, arona, e.celestia.world, celestia.ac.cn, erp).

## Verification

- Full package suite: `vitest run` → **121 files / 1029 tests passed**; `vue-tsc --noEmit` clean; SCSS compiles standalone.
- New tests: always-open pane (no toggle), tone-following chip + muted status under all three tones, badge fallthrough, overlay chrome attached inside the pane / absent without details / detached on unmount, info tone, description text.
- Light + dark static renders screenshot-checked at 412×915 (card fits, fixed pane scrolls, wash/halo/badges adapt).
- Two independent review rounds (no blockers; both should-fix findings addressed: stale-thumb-on-fold fixed via content RO; unreachable re-attach branch replaced by element-identity lifecycle).

## Release note

shittim-chest picks this up via registry (`^*`) once `@celestia-island/hikari@0.40.30` publishes, then a chest lockfile refresh.