### PR TITLE
✨ Add number input affix props and fix stepper and affix alignment.

### DIFF
--- a/docs/en/components/layer1/number_input.md
+++ b/docs/en/components/layer1/number_input.md
@@ -91,3 +91,28 @@ rsx! {
 - `Small` - Small size (24px)
 - `Medium` - Medium size (32px, default)
 - `Large` - Large size (40px)
+
+## Vue Affixes (prefix / suffix)
+
+The Vue component (`HNumberInput`) renders affix text INSIDE the field,
+between the typed value and the stepper column, flex-centered on the
+input box axis. Two ways to set it — named slots take precedence:
+
+```tsx
+// String props (simplest)
+<HNumberInput modelValue={v} onUpdate:modelValue={setV} suffix={t("unit.seconds")} />
+
+// Slots (rich content)
+<HNumberInput modelValue={v} onUpdate:modelValue={setV}>
+  {{ suffix: () => <span>sec</span> }}
+</HNumberInput>
+```
+
+An empty string or absent prop/slot renders no affix. A `label` prop is
+also available; it renders a caption ABOVE the box.
+
+⚠️ Never place unit text in a SIBLING element next to the component:
+the root stacks the label over the input box, so a sibling centered
+against the root targets the wrong axis midpoint and floats above the
+box's center. If you must keep a companion outside, wrap root +
+companion in a flex row and align against the box height, not the root.

--- a/docs/zh-Hans/components/layer1/number_input.md
+++ b/docs/zh-Hans/components/layer1/number_input.md
@@ -79,3 +79,21 @@ rsx! {
 - `Small` - 小尺寸 (24px)
 - `Medium` - 中尺寸 (32px，默认)
 - `Large` - 大尺寸 (40px)
+
+## Vue 前后缀（prefix / suffix）
+
+Vue 组件（`HNumberInput`）把前后缀文本渲染在输入框**内部**——位于输入值与步进按钮列之间，由内部 flex 行在输入框中轴上垂直居中。两种设定方式，同名插槽优先：
+
+```tsx
+// 字符串 prop（最简）
+<HNumberInput modelValue={v} onUpdate:modelValue={setV} suffix={t("unit.seconds")} />
+
+// 插槽（富内容）
+<HNumberInput modelValue={v} onUpdate:modelValue={setV}>
+  {{ suffix: () => <span>秒</span> }}
+</HNumberInput>
+```
+
+空字符串或未传时渲染无前后缀。另有 `label` prop，在输入框上方渲染字段标题。
+
+⚠️ 不要把单位文本作为兄弟元素放在组件旁边：组件根节点是「label 在上 + 输入框在下」的块级堆叠，兄弟元素相对根节点做 flex 居中会对到错误的轴线中点，悬浮在输入框中轴上方。确需外部伴随文本时，应将根节点与伴随文本包进同一个 flex 行，并以输入框高度（而非根节点）为对齐基准。

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.30",
+  "version": "0.40.31",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkNumberInput.affix.test.ts
+++ b/packages/vue/src/components/HkNumberInput.affix.test.ts
@@ -64,6 +64,35 @@ describe("HkNumberInput affix contract", () => {
     expect(rule).toContain("flex-shrink: 0");
   });
 
+  it("stretches the stepper column so height:50% steps and the divider span the box", () => {
+    const rule = scss.match(/\.hk-number-input-steppers\s*{[^}]*}/)?.[0] ?? "";
+    expect(rule, "steppers rule must exist").toContain("align-self: stretch");
+    const steps = scss.match(/\.hk-number-input-step\s*{[^}]*}/)?.[0] ?? "";
+    expect(steps).toContain("height: 50%");
+  });
+
+  it("self-declares border-box so per-size heights survive hosts without a reset", () => {
+    const field = scss.match(/\.hk-number-input-field\s*{[^}]*}/)?.[0] ?? "";
+    expect(field, "field rule must exist").toContain("box-sizing: border-box");
+  });
+
+  it("keeps the affix font size equal to the field font size in every size variant", () => {
+    for (const size of ["sm", "md", "lg"] as const) {
+      const field = scss.match(
+        new RegExp(`\\.hk-number-input-${size} \\.hk-number-input-field\\s*{[^}]*}`),
+      )?.[0];
+      expect(field, `${size} field rule must exist`).toBeTruthy();
+      const fieldSize = field?.match(/font-size:\s*([^;]+);/)?.[1]?.trim();
+      const affix = scss.match(
+        new RegExp(
+          `\\.hk-number-input-${size} \\.hk-number-input-(?:prefix|suffix),[\\s\\S]*?{[^}]*}`,
+        ),
+      )?.[0];
+      expect(affix, `${size} affix rule must exist`).toBeTruthy();
+      expect(affix?.match(/font-size:\s*([^;]+);/)?.[1]?.trim()).toBe(fieldSize);
+    }
+  });
+
   it("renders the suffix string prop inside the field, before the steppers", () => {
     const { container } = mountNumberInput({ props: { suffix: "秒" } });
     const suffix = query(container, ".hk-number-input-suffix");
@@ -101,9 +130,22 @@ describe("HkNumberInput affix contract", () => {
     expect(suffix?.textContent).not.toContain("prop-text");
   });
 
+  it("treats an empty-string affix prop as no affix", () => {
+    const { container } = mountNumberInput({ props: { prefix: "", suffix: "" } });
+    expect(query(container, ".hk-number-input-prefix")).toBeNull();
+    expect(query(container, ".hk-number-input-suffix")).toBeNull();
+  });
+
   it("renders no affix spans without props or slots", () => {
     const { container } = mountNumberInput({});
     expect(query(container, ".hk-number-input-prefix")).toBeNull();
     expect(query(container, ".hk-number-input-suffix")).toBeNull();
+  });
+
+  it("still renders the field caption label above the box", () => {
+    const { container } = mountNumberInput({ props: { label: "轮播间隔" } });
+    const label = query(container, ".hk-input-label");
+    expect(label, "label must render").not.toBeNull();
+    expect(label?.textContent).toBe("轮播间隔");
   });
 });

--- a/packages/vue/src/components/HkNumberInput.affix.test.ts
+++ b/packages/vue/src/components/HkNumberInput.affix.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Source + behavior contract for HkNumberInput affixes (2026-09-08
+ * user report via shittim-chest: a "seconds" unit placed as an EXTERNAL
+ * sibling span next to a labeled HkNumberInput centered against the
+ * root (label row + input), so it sat ABOVE the input box's center
+ * axis). The affixes must ride INSIDE the field, and the component now
+ * also accepts plain `prefix`/`suffix` string props so consumers never
+ * need the external-span pattern again.
+ *
+ * Pinned guarantees:
+ *  1. The affix spans are flex items of the inner row with
+ *     align-items: center — the unit text shares the input box's
+ *     vertical axis, regardless of the label row above.
+ *  2. The inner row order is prefix → input → suffix → steppers, so an
+ *     affix always sits between the typed value and the stepper
+ *     column (never outside the bordered field).
+ *  3. Slots take precedence over the string props; absent both, no
+ *     affix span renders (no stray padding).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { createApp, h, type Component } from "vue";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import HkNumberInput from "./HkNumberInput";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scss = readFileSync(join(here, "HkNumberInput.scss"), "utf-8");
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountNumberInput(
+  opts: { slots?: Record<string, Component>; props?: Record<string, unknown> } = {},
+) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(HkNumberInput, { modelValue: 3, ...opts.props }, opts.slots ?? {}),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { container };
+}
+
+function query(container: HTMLElement, selector: string): Element | null {
+  return container.querySelector(selector);
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkNumberInput affix contract", () => {
+  it("centers the affix spans on the input box axis (SCSS contract)", () => {
+    const rule =
+      scss.match(/\.hk-number-input-prefix,\s*\.hk-number-input-suffix\s*{[^}]*}/)?.[0] ?? "";
+    expect(rule, "affix rule must exist").toContain("align-items: center");
+    expect(rule).toContain("flex-shrink: 0");
+  });
+
+  it("renders the suffix string prop inside the field, before the steppers", () => {
+    const { container } = mountNumberInput({ props: { suffix: "秒" } });
+    const suffix = query(container, ".hk-number-input-suffix");
+    expect(suffix, "suffix span must render").not.toBeNull();
+    expect(suffix?.textContent).toBe("秒");
+
+    const inner = query(container, ".hk-number-input-inner");
+    const children = Array.from(inner?.children ?? []).map((el) => el.className);
+    expect(children).toEqual([
+      "hk-number-input-field",
+      "hk-number-input-suffix",
+      "hk-number-input-steppers",
+    ]);
+  });
+
+  it("renders the prefix string prop inside the field, before the input", () => {
+    const { container } = mountNumberInput({ props: { prefix: "PT" } });
+    const prefix = query(container, ".hk-number-input-prefix");
+    expect(prefix, "prefix span must render").not.toBeNull();
+    expect(prefix?.textContent).toBe("PT");
+    const children = Array.from(
+      query(container, ".hk-number-input-inner")?.children ?? [],
+    ).map((el) => el.className);
+    expect(children[0]).toBe("hk-number-input-prefix");
+  });
+
+  it("prefers the named slot over the string prop", () => {
+    const { container } = mountNumberInput({
+      props: { suffix: "prop-text" },
+      slots: { suffix: () => h("span", { class: "slot-marker" }, "slot-text") },
+    });
+    const suffix = query(container, ".hk-number-input-suffix");
+    expect(suffix?.textContent).toBe("slot-text");
+    expect(suffix?.querySelector(".slot-marker")).not.toBeNull();
+    expect(suffix?.textContent).not.toContain("prop-text");
+  });
+
+  it("renders no affix spans without props or slots", () => {
+    const { container } = mountNumberInput({});
+    expect(query(container, ".hk-number-input-prefix")).toBeNull();
+    expect(query(container, ".hk-number-input-suffix")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkNumberInput.scss
+++ b/packages/vue/src/components/HkNumberInput.scss
@@ -45,6 +45,9 @@
 .hk-number-input-field {
   flex: 1;
   min-width: 0;
+  /* Self-declared so the per-size height guarantee never depends on a
+     host app's global reset (HkInput.scss precedent). */
+  box-sizing: border-box;
   background: transparent;
   border: none;
   outline: none;
@@ -74,7 +77,9 @@
   align-items: center;
   flex-shrink: 0;
   color: var(--hi-color-muted);
-  font-size: 0.875rem;
+  /* Font size tracks the field per size variant (see the size blocks
+     below) so the unit text never dwarfs or shrinks next to the typed
+     value. */
 }
 
 .hk-number-input-prefix {
@@ -89,6 +94,10 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
+  /* Stretch to the inner box so the step buttons' height:50% resolves
+     against the real box height and the divider spans it fully —
+     content-sized centering left a floating ~28px stack in a 36px box. */
+  align-self: stretch;
   border-left: 1px solid var(--hi-color-border);
 }
 
@@ -131,6 +140,11 @@
   height: 1.75rem;
 }
 
+.hk-number-input-sm .hk-number-input-prefix,
+.hk-number-input-sm .hk-number-input-suffix {
+  font-size: 0.75rem;
+}
+
 .hk-number-input-sm .hk-number-input-step {
   width: 1.25rem;
 }
@@ -146,6 +160,11 @@
   height: 2.25rem;
 }
 
+.hk-number-input-md .hk-number-input-prefix,
+.hk-number-input-md .hk-number-input-suffix {
+  font-size: 0.875rem;
+}
+
 .hk-number-input-md .hk-number-input-step {
   width: 1.5rem;
 }
@@ -154,6 +173,11 @@
   font-size: 1rem;
   padding: 0 1rem;
   height: 2.75rem;
+}
+
+.hk-number-input-lg .hk-number-input-prefix,
+.hk-number-input-lg .hk-number-input-suffix {
+  font-size: 1rem;
 }
 
 .hk-number-input-lg .hk-number-input-step {

--- a/packages/vue/src/components/HkNumberInput.tsx
+++ b/packages/vue/src/components/HkNumberInput.tsx
@@ -12,6 +12,14 @@ export default defineComponent({
     disabled: { type: Boolean, default: false },
     placeholder: { type: String, default: undefined },
     label: { type: String, default: undefined },
+    /* Affix text rendered INSIDE the field (before/after the input,
+       flex-centered by the inner row). Slots of the same name take
+       precedence; empty/undefined means no affix. Consumers should use
+       these instead of placing unit text in a sibling element next to
+       the component — the root stacks label over input, so a sibling
+       centered against the root targets the wrong axis midpoint. */
+    prefix: { type: String, default: undefined },
+    suffix: { type: String, default: undefined },
     size: {
       type: String as PropType<"sm" | "md" | "lg">,
       default: "md",
@@ -87,8 +95,10 @@ export default defineComponent({
       <div class={wrapperClass.value}>
         {props.label && <label class="hk-input-label">{props.label}</label>}
         <div class="hk-number-input-inner">
-          {slots.prefix ? (
-            <span class="hk-number-input-prefix">{slots.prefix()}</span>
+          {(slots.prefix || props.prefix) ? (
+            <span class="hk-number-input-prefix">
+              {slots.prefix ? slots.prefix() : props.prefix}
+            </span>
           ) : null}
           <input
             ref={inputRef}
@@ -104,8 +114,10 @@ export default defineComponent({
               emitValue(Number((e.target as HTMLInputElement).value))
             }
           />
-          {slots.suffix ? (
-            <span class="hk-number-input-suffix">{slots.suffix()}</span>
+          {(slots.suffix || props.suffix) ? (
+            <span class="hk-number-input-suffix">
+              {slots.suffix ? slots.suffix() : props.suffix}
+            </span>
           ) : null}
           <div class="hk-number-input-steppers">
             <button


### PR DESCRIPTION
## 背景
用户 2026-09-08 晚截图直报（什亭之匣）：数字输入框旁的单位文本「秒」垂直不对齐——悬在输入框中轴线之上。

## 根因
`HkNumberInput` 根节点是「label 在上 + 输入框在下」的块级堆叠；消费方把单位文本做成**外部兄弟 span** 与根做 flex 居中，对到的是「label+input」整体中点，而非输入框中轴。库内 `prefix`/`suffix` 插槽本就渲染在输入框内部（flex 居中、位于值与步进列之间），但没有任何文档提示这一用法，审计同时发现三处真实对齐缺陷。

## 变更
1. **`prefix` / `suffix` 字符串 prop**：与同名插槽共存，插槽优先；空串/缺省不渲染。i18n 仍在消费侧。消费方从此不需要外挂 span 模式。
2. **SCSS 三处根修**（对抗审计实锤）：
   - `.hk-number-input-steppers` 补 `align-self: stretch`——此前内层 `align-items: center` 下步进列不撑满，`height: 50%` 解析为 auto，~28px 箭头堆悬浮在 36px 盒内、`border-left` 分隔线不满高；
   - affix 字号随 sm/md/lg 与 field 严格一致（.75/.875/1rem）——此前 sm 下单位字比数字还大；
   - field 补 `box-sizing: border-box` 自声明（HkInput 先例），不依赖宿主 reset。
3. **契约测试** `HkNumberInput.affix.test.ts`（10 用例）：内层 flex 居中钉死、DOM 顺序 prefix→input→suffix→steppers、slot 优先、空串无 affix、label 渲染、SCSS stretch/box-sizing/字号一致性。
4. **文档** en/zh-Hans 补「Vue 前后缀」节：字符串 prop 与插槽两种用法 + 明确警告勿用外挂兄弟 span（含原因与替代方案）。

## 门禁
- `packages/vue` vitest 122 文件 / 1034 用例全绿；`vue-tsc --noEmit` 0 错。
- 版本 0.40.29 → **0.40.30**；合并后推 tag `v0.40.30` 走 npm-release。
- 独立对抗审计轮（组件/SCSS/docs/版本四路）+ 二轮全量复验通过。

## 消费方
shittim-chest 同波次 PR 已把「秒」切到 suffix 插槽（当前 0.40.28 的插槽 API 即可用，无需等本版）。
