### PR TITLE
🔧 Realign the npm series to 0.40.31 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.30",
+  "version": "0.40.31",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
## 版本竞态处置（0.40.26 / 0.40.12 同型，第三次）

- #433 与 #434（本系列前一个 PR，i18n 标签值 + 弹层单滚动条）几乎同时合并，双双把 packages/vue 声明为 0.40.30（同 diff 无冲突静默叠加）；#433 侧抢先打 tag v0.40.30 并已发 npm——**npm 0.40.30 = #433 的树，不含 #434 的改动**。
- #434 的改动已在 master（3fb4e57）。本 PR 仅把 master 声明改到 **0.40.31**，合并后打 tag v0.40.31 → npm-release 发布 master 树，#434 内容随之上线。
- 无代码改动；非独立版本号 PR 惯例的例外依据 = 已两次记录在案的竞态处置先例（#428→#429 同型处理）。