### PR TITLE
🔧 Realign the npm series to 0.40.32 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.31",
+  "version": "0.40.32",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
## 背景
#435（输入框前后缀 prop 与对齐修复）合并时与 #436 的 0.40.31 发布撞号：npm 0.40.31 已由 999ad40（#436 对齐提交）发布，#435 的实现内容尚未进任何已发布版本。本 PR 将 packages/vue 版本对齐到 0.40.32，随后以 tag v0.40.32 发布（包含 #435 全部内容）。

同型事故先例：0.40.12（#411 对齐）、0.40.26（#429 cherry-pick 对齐）。