### PR TITLE
🔧 Realign the npm series to 0.40.35 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.34",
+  "version": "0.40.35",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Same class as #436/#437: the v0.40.34 tag raced ahead with #439's tree while #438's merge had also picked 0.40.34, so npm latest (0.40.34) carries content WITHOUT #438's component-test tier. Bump master to 0.40.35 and tag after merge so the next tarball's content matches its version again.