### PR TITLE
🔧 Realign the npm series to 0.40.36 after the file-picker merge.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.35",
+  "version": "0.40.36",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
Version-series realign following #441 (the HFilePickerField merge): packages/vue moves 0.40.35 → 0.40.36 so the v0.40.36 tag's tarball content matches its version, per the post-race realign convention. No other files change.