### PR TITLE
🐛 Accept functional icon components in the empty state and clear dead rework leftovers.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.40.35",
+  "version": "0.40.36",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkCheckbox.tsx
+++ b/packages/vue/src/components/HkCheckbox.tsx
@@ -52,7 +52,6 @@ export default defineComponent({
 
     return () => {
       const inputType = props.type === "radio" ? "radio" : "checkbox";
-      const isChecked = props.modelValue === true || props.modelValue === null;
 
       return (
         <label

--- a/packages/vue/src/components/HkEmptyState.test.tsx
+++ b/packages/vue/src/components/HkEmptyState.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp, defineComponent, h } from "vue";
 
 import HkEmptyState from "./HkEmptyState";
@@ -54,6 +54,26 @@ describe("HkEmptyState", () => {
     const btn = c.querySelector(".hk-empty-action .stub-action") as HTMLElement;
     expect(btn).not.toBeNull();
     expect(btn.textContent).toBe("Retry");
+  });
+
+  it("accepts functional icon components without a prop-type warning", () => {
+    // lucide-vue-next icons are plain functions; the Object-only runtime
+    // check rejected them with a dev warning at every chest call site
+    // (fixed 2026-09-09: [Object, Function]).
+    const warnings: string[] = [];
+    const spy = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warnings.push(args.join(" "));
+    });
+    try {
+      // Shape-mirrors a lucide icon: a functional component accepting
+      // props (size/aria) and rendering a node.
+      const lucideLike = ((_props: unknown) => h("i", { class: "fn-icon" })) as never;
+      const c = mount(h(HkEmptyState, { title: "No items", icon: lucideLike }));
+      expect(c.querySelector(".hk-empty-icon .fn-icon")).not.toBeNull();
+      expect(warnings.filter((w) => w.includes("Invalid prop"))).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("renders the icon prop component in the icon well", () => {

--- a/packages/vue/src/components/HkEmptyState.tsx
+++ b/packages/vue/src/components/HkEmptyState.tsx
@@ -11,7 +11,7 @@ export default defineComponent({
     title: { type: String, default: undefined },
     description: { type: String, default: undefined },
     /** Icon component (lucide-vue-next style); rendered via h() at size 32. */
-    icon: { type: Object as PropType<Component>, default: undefined },
+    icon: { type: [Object, Function] as PropType<Component>, default: undefined },
     /** Loading variant: only a centered spinner, exposed as a status region. */
     loading: { type: Boolean, default: false },
     /** page = bounded, centered card on desktop; fill = stretch to the host. */

--- a/packages/vue/src/components/HkRadio.tsx
+++ b/packages/vue/src/components/HkRadio.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, type PropType } from "vue";
+import { defineComponent, type PropType } from "vue";
 import HkLabel from "./HkLabel";
 import "./HkRadio.scss";
 

--- a/packages/vue/src/components/HkSwitch.tsx
+++ b/packages/vue/src/components/HkSwitch.tsx
@@ -1,4 +1,4 @@
-import { computed, defineComponent, type PropType } from "vue";
+import { defineComponent, type PropType } from "vue";
 import HkLabel from "./HkLabel";
 import "./HkSwitch.scss";
 


### PR DESCRIPTION
2026-09-08 测试审计遗留的死码/类型问题清偿:

- **HkEmptyState**: `icon` prop 的运行时校验只有 `Object`,lucide-vue-next 的函数式图标(纯函数)在全部四个 chest 调用点触发 Vue Invalid-prop 开发告警 → 改 `[Object, Function]`,并补用例钉死(函数图标渲染 + 零告警)。
- **HkCheckbox**: 删重写残留的死变量 `isChecked`。
- **HkRadio / HkSwitch**: 删未用的 `computed` 导入。
- 版本 0.40.35 → 0.40.36。

测试:全量 131 文件 / 1132 用例全绿;vue-tsc 0。