### PR TITLE
🐛 Localize the unset placeholder and stop the locale loader dropping flat keys.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAffixPicker.scss
+++ b/packages/vue/src/components/HkAffixPicker.scss
@@ -134,6 +134,11 @@
   &[data-unset] {
     font-style: italic;
     color: rgb(var(--color-muted));
+    /* Italic final strokes lean past the glyph advance; overflow:hidden
+     * (the ellipsis pair above) shaves them at the content edge. The
+     * inline-end cushion is clipping room, and because it sits INSIDE
+     * the padding box it never triggers the ellipsis for fitting text. */
+    padding-inline-end: 0.2em;
   }
 }
 

--- a/packages/vue/src/i18n/context.flatKeys.test.ts
+++ b/packages/vue/src/i18n/context.flatKeys.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { setLocale, useI18n } from "./context";
+
+/**
+ * Regression (2026-09-08 user report): the language tag's "Not set"
+ * placeholder stayed ENGLISH on a Chinese UI. Root cause —
+ * buildLocaleMessages only merged nested domain sections and silently
+ * DROPPED every top-level flat key ("hikari::x.y": "…"), so all
+ * post-0.3 flat additions (affixPicker.*, messageBox.*,
+ * localizedInput.noMatches, …) fell back to the inline English default
+ * at runtime on every locale. These tests pin flat-key loading.
+ */
+describe("i18n flat-key loading", () => {
+  it("serves top-level flat keys from the locale bundle", async () => {
+    await setLocale("zh-Hans");
+    const { t } = useI18n();
+    expect(t("hikari::affixPicker.unset", "Not set")).toBe("未设置");
+    expect(t("hikari::affixPicker.remove", "Remove")).toBe("移除");
+    expect(t("hikari::affixPicker.removeConfirmTitle", "Remove entry")).toBe("移除条目");
+    expect(t("hikari::messageBox.confirm", "Confirm")).toBe("确认");
+  });
+
+  it("keeps nested legacy sections loading beside the flat keys", async () => {
+    await setLocale("zh-Hans");
+    const { t } = useI18n();
+    expect(t("hikari::localizedInput.chooseLanguage", "Choose editing language")).toBe(
+      "选择编辑语言",
+    );
+    expect(t("hikari::modal.close", "Close")).toBe("关闭");
+  });
+
+  it("other locales serve their own flat translations, not English", async () => {
+    await setLocale("ja");
+    const { t } = useI18n();
+    expect(t("hikari::affixPicker.unset", "Not set")).toBe("未設定");
+    await setLocale("ko");
+    expect(t("hikari::affixPicker.unset", "Not set")).toBe("미설정");
+  });
+});

--- a/packages/vue/src/i18n/context.ts
+++ b/packages/vue/src/i18n/context.ts
@@ -3,7 +3,7 @@ import { reactive } from "vue";
 type Messages = Record<string, string>;
 
 interface LocaleModule {
-  default: Record<string, Messages>;
+  default: Record<string, unknown>;
 }
 
 const localeModules = import.meta.glob<LocaleModule>(
@@ -18,9 +18,18 @@ function buildLocaleMessages(locale: string): Messages {
   for (const [path, mod] of Object.entries(localeModules)) {
     if (!path.startsWith(prefix)) continue;
     const domain = mod.default;
-    for (const [_section, keys] of Object.entries(domain)) {
-      if (typeof keys === "object" && keys !== null) {
-        Object.assign(merged, keys);
+    for (const [key, value] of Object.entries(domain)) {
+      if (typeof value === "string") {
+        // Flat leaf — the appended-at-the-bottom style
+        // ("hikari::x.y": "…") every post-0.3 locale addition uses
+        // (affixPicker.*, messageBox.*, localizedInput.noMatches, …).
+        // The old object-only merge SILENTLY DROPPED these, so every
+        // flat key fell back to English at runtime no matter the
+        // locale (2026-09-08 user report: "Not set" stayed English).
+        merged[key] = value;
+      } else if (value !== null && typeof value === "object") {
+        // Legacy nested domain section ("components", "chat", …).
+        Object.assign(merged, value as Messages);
       }
     }
   }

--- a/packages/vue/src/i18n/flatKeyParity.test.ts
+++ b/packages/vue/src/i18n/flatKeyParity.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Flat-key parity guard (2026-09-10, follow-up to the flat-loader fix):
+ * buildLocaleMessages now serves top-level flat keys ("hikari::x.y": "…")
+ * beside the legacy nested sections — but a key missing from a locale's
+ * components.json still silently falls back to English for that locale.
+ * Every flat key in the en bundle must therefore exist in ALL 11 locale
+ * bundles. (This is the guard that would have caught the affixPicker/
+ * messageBox flat family missing from 8 locales for months.)
+ */
+const modules = import.meta.glob<{ default: Record<string, unknown> }>(
+  "./locales/*/components.json",
+  { eager: true },
+);
+
+const EXPECTED_LOCALES = [
+  "ar", "de", "en", "es", "fr", "ja", "ko", "pt", "ru", "zh-Hans", "zh-Hant",
+];
+
+describe("components.json flat-key parity", () => {
+  const bundles = Object.entries(modules).map(([path, mod]) => ({
+    locale: path.match(/locales\/([^/]+)\/components\.json/)?.[1] ?? "",
+    flat: Object.fromEntries(
+      Object.entries(mod.default).filter(([, v]) => typeof v === "string"),
+    ) as Record<string, string>,
+  }));
+
+  it("covers all 11 locales", () => {
+    expect(bundles.map((b) => b.locale).sort()).toEqual(EXPECTED_LOCALES);
+  });
+
+  it("defines every en flat key in every locale, non-empty", () => {
+    const en = bundles.find((b) => b.locale === "en");
+    expect(en, "en bundle renders").toBeTruthy();
+    const keys = Object.keys(en!.flat);
+    expect(keys.length, "en has flat keys").toBeGreaterThan(0);
+    for (const { locale, flat } of bundles) {
+      for (const key of keys) {
+        expect(typeof flat[key], `${locale} must define ${key}`).toBe("string");
+        expect((flat[key] ?? "").length, `${locale} ${key} must not be empty`).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "إعادة تعيين التكبير",
     "hikari::zoomToolbar.zoomIn": "تكبير",
     "hikari::zoomToolbar.zoomOut": "تصغير"
-  }
+  },
+  "hikari::affixPicker.unset": "غير محدد",
+  "hikari::affixPicker.title": "الخيارات",
+  "hikari::affixPicker.search": "بحث",
+  "hikari::affixPicker.empty": "لا تطابقات",
+  "hikari::affixPicker.selected": "المحدد",
+  "hikari::affixPicker.selectedCount": "تم اختيار {count}",
+  "hikari::affixPicker.switchTo": "التبديل إلى",
+  "hikari::affixPicker.remove": "إزالة",
+  "hikari::affixPicker.useCustom": "استخدام \"{query}\"",
+  "hikari::affixPicker.removeConfirmTitle": "إزالة العنصر",
+  "hikari::affixPicker.removeConfirm": "إزالة \"{label}\"؟ لا يمكن التراجع عن هذا الإجراء.",
+  "hikari::localizedInput.noMatches": "لا توجد لغة مطابقة",
+  "hikari::messageBox.confirm": "تأكيد",
+  "hikari::messageBox.cancel": "إلغاء",
+  "hikari::messageBox.ok": "موافق",
+  "hikari::messageBox.alertTitle": "تنبيه",
+  "hikari::messageBox.confirmTitle": "يرجى التأكيد",
+  "hikari::messageBox.promptTitle": "إدخال"
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "Zoom zurücksetzen",
     "hikari::zoomToolbar.zoomIn": "Vergrößern",
     "hikari::zoomToolbar.zoomOut": "Verkleinern"
-  }
+  },
+  "hikari::affixPicker.unset": "Nicht festgelegt",
+  "hikari::affixPicker.title": "Optionen",
+  "hikari::affixPicker.search": "Suchen",
+  "hikari::affixPicker.empty": "Keine Treffer",
+  "hikari::affixPicker.selected": "Ausgewählt",
+  "hikari::affixPicker.selectedCount": "{count} ausgewählt",
+  "hikari::affixPicker.switchTo": "Wechseln zu",
+  "hikari::affixPicker.remove": "Entfernen",
+  "hikari::affixPicker.useCustom": "„{query}“ verwenden",
+  "hikari::affixPicker.removeConfirmTitle": "Eintrag entfernen",
+  "hikari::affixPicker.removeConfirm": "„{label}“ entfernen? Dies kann nicht rückgängig gemacht werden.",
+  "hikari::localizedInput.noMatches": "Keine passende Sprache",
+  "hikari::messageBox.confirm": "Bestätigen",
+  "hikari::messageBox.cancel": "Abbrechen",
+  "hikari::messageBox.ok": "OK",
+  "hikari::messageBox.alertTitle": "Hinweis",
+  "hikari::messageBox.confirmTitle": "Bitte bestätigen",
+  "hikari::messageBox.promptTitle": "Eingabe"
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "Restablecer zoom",
     "hikari::zoomToolbar.zoomIn": "Acercar",
     "hikari::zoomToolbar.zoomOut": "Alejar"
-  }
+  },
+  "hikari::affixPicker.unset": "Sin establecer",
+  "hikari::affixPicker.title": "Opciones",
+  "hikari::affixPicker.search": "Buscar",
+  "hikari::affixPicker.empty": "Sin coincidencias",
+  "hikari::affixPicker.selected": "Seleccionados",
+  "hikari::affixPicker.selectedCount": "{count} seleccionados",
+  "hikari::affixPicker.switchTo": "Cambiar a",
+  "hikari::affixPicker.remove": "Quitar",
+  "hikari::affixPicker.useCustom": "Usar «{query}»",
+  "hikari::affixPicker.removeConfirmTitle": "Quitar elemento",
+  "hikari::affixPicker.removeConfirm": "¿Quitar «{label}»? Esto no se puede deshacer.",
+  "hikari::localizedInput.noMatches": "Ningún idioma coincidente",
+  "hikari::messageBox.confirm": "Confirmar",
+  "hikari::messageBox.cancel": "Cancelar",
+  "hikari::messageBox.ok": "Aceptar",
+  "hikari::messageBox.alertTitle": "Aviso",
+  "hikari::messageBox.confirmTitle": "Confirme",
+  "hikari::messageBox.promptTitle": "Entrada"
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "Réinitialiser le zoom",
     "hikari::zoomToolbar.zoomIn": "Agrandir",
     "hikari::zoomToolbar.zoomOut": "Réduire"
-  }
+  },
+  "hikari::affixPicker.unset": "Non défini",
+  "hikari::affixPicker.title": "Options",
+  "hikari::affixPicker.search": "Rechercher",
+  "hikari::affixPicker.empty": "Aucun résultat",
+  "hikari::affixPicker.selected": "Sélectionnés",
+  "hikari::affixPicker.selectedCount": "{count} sélectionnés",
+  "hikari::affixPicker.switchTo": "Passer à",
+  "hikari::affixPicker.remove": "Retirer",
+  "hikari::affixPicker.useCustom": "Utiliser « {query} »",
+  "hikari::affixPicker.removeConfirmTitle": "Retirer l’entrée",
+  "hikari::affixPicker.removeConfirm": "Retirer « {label} » ? Cette action est irréversible.",
+  "hikari::localizedInput.noMatches": "Aucune langue correspondante",
+  "hikari::messageBox.confirm": "Confirmer",
+  "hikari::messageBox.cancel": "Annuler",
+  "hikari::messageBox.ok": "OK",
+  "hikari::messageBox.alertTitle": "Avis",
+  "hikari::messageBox.confirmTitle": "Veuillez confirmer",
+  "hikari::messageBox.promptTitle": "Saisie"
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "ズームをリセット",
     "hikari::zoomToolbar.zoomIn": "拡大",
     "hikari::zoomToolbar.zoomOut": "縮小"
-  }
+  },
+  "hikari::affixPicker.unset": "未設定",
+  "hikari::affixPicker.title": "オプション",
+  "hikari::affixPicker.search": "検索",
+  "hikari::affixPicker.empty": "一致なし",
+  "hikari::affixPicker.selected": "選択中",
+  "hikari::affixPicker.selectedCount": "{count} 件選択中",
+  "hikari::affixPicker.switchTo": "切り替え",
+  "hikari::affixPicker.remove": "削除",
+  "hikari::affixPicker.useCustom": "「{query}」を使用",
+  "hikari::affixPicker.removeConfirmTitle": "項目を削除",
+  "hikari::affixPicker.removeConfirm": "「{label}」を削除しますか？この操作は元に戻せません。",
+  "hikari::localizedInput.noMatches": "一致する言語がありません",
+  "hikari::messageBox.confirm": "確認",
+  "hikari::messageBox.cancel": "キャンセル",
+  "hikari::messageBox.ok": "OK",
+  "hikari::messageBox.alertTitle": "お知らせ",
+  "hikari::messageBox.confirmTitle": "確認してください",
+  "hikari::messageBox.promptTitle": "入力"
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "줌 초기화",
     "hikari::zoomToolbar.zoomIn": "확대",
     "hikari::zoomToolbar.zoomOut": "축소"
-  }
+  },
+  "hikari::affixPicker.unset": "미설정",
+  "hikari::affixPicker.title": "옵션",
+  "hikari::affixPicker.search": "검색",
+  "hikari::affixPicker.empty": "일치 항목 없음",
+  "hikari::affixPicker.selected": "선택됨",
+  "hikari::affixPicker.selectedCount": "{count}개 선택됨",
+  "hikari::affixPicker.switchTo": "전환",
+  "hikari::affixPicker.remove": "제거",
+  "hikari::affixPicker.useCustom": "\"{query}\" 사용",
+  "hikari::affixPicker.removeConfirmTitle": "항목 제거",
+  "hikari::affixPicker.removeConfirm": "\"{label}\"을(를) 제거할까요? 이 작업은 되돌릴 수 없습니다.",
+  "hikari::localizedInput.noMatches": "일치하는 언어가 없습니다",
+  "hikari::messageBox.confirm": "확인",
+  "hikari::messageBox.cancel": "취소",
+  "hikari::messageBox.ok": "확인",
+  "hikari::messageBox.alertTitle": "알림",
+  "hikari::messageBox.confirmTitle": "확인 필요",
+  "hikari::messageBox.promptTitle": "입력"
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "Redefinir zoom",
     "hikari::zoomToolbar.zoomIn": "Ampliar",
     "hikari::zoomToolbar.zoomOut": "Reduzir"
-  }
+  },
+  "hikari::affixPicker.unset": "Não definido",
+  "hikari::affixPicker.title": "Opções",
+  "hikari::affixPicker.search": "Pesquisar",
+  "hikari::affixPicker.empty": "Sem correspondências",
+  "hikari::affixPicker.selected": "Selecionados",
+  "hikari::affixPicker.selectedCount": "{count} selecionados",
+  "hikari::affixPicker.switchTo": "Mudar para",
+  "hikari::affixPicker.remove": "Remover",
+  "hikari::affixPicker.useCustom": "Usar \"{query}\"",
+  "hikari::affixPicker.removeConfirmTitle": "Remover item",
+  "hikari::affixPicker.removeConfirm": "Remover \"{label}\"? Isso não pode ser desfeito.",
+  "hikari::localizedInput.noMatches": "Nenhum idioma correspondente",
+  "hikari::messageBox.confirm": "Confirmar",
+  "hikari::messageBox.cancel": "Cancelar",
+  "hikari::messageBox.ok": "OK",
+  "hikari::messageBox.alertTitle": "Aviso",
+  "hikari::messageBox.confirmTitle": "Confirme",
+  "hikari::messageBox.promptTitle": "Entrada"
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -182,5 +182,23 @@
     "hikari::zoomToolbar.reset": "Сбросить масштаб",
     "hikari::zoomToolbar.zoomIn": "Увеличить",
     "hikari::zoomToolbar.zoomOut": "Уменьшить"
-  }
+  },
+  "hikari::affixPicker.unset": "Не задано",
+  "hikari::affixPicker.title": "Параметры",
+  "hikari::affixPicker.search": "Поиск",
+  "hikari::affixPicker.empty": "Нет совпадений",
+  "hikari::affixPicker.selected": "Выбрано",
+  "hikari::affixPicker.selectedCount": "Выбрано: {count}",
+  "hikari::affixPicker.switchTo": "Переключиться на",
+  "hikari::affixPicker.remove": "Удалить",
+  "hikari::affixPicker.useCustom": "Использовать «{query}»",
+  "hikari::affixPicker.removeConfirmTitle": "Удалить запись",
+  "hikari::affixPicker.removeConfirm": "Удалить «{label}»? Это действие нельзя отменить.",
+  "hikari::localizedInput.noMatches": "Нет подходящего языка",
+  "hikari::messageBox.confirm": "Подтвердить",
+  "hikari::messageBox.cancel": "Отмена",
+  "hikari::messageBox.ok": "ОК",
+  "hikari::messageBox.alertTitle": "Уведомление",
+  "hikari::messageBox.confirmTitle": "Подтвердите",
+  "hikari::messageBox.promptTitle": "Ввод"
 }


### PR DESCRIPTION
## 背景（用户 22:36 截图复检 #434 效果时直报两点）

①斜体占位文本右侧被强制裁切；②占位文本显示英文 "Not set"，未跟随界面语言（中文应显示「未设置」）。

## 根因（比表象深一层）

**`buildLocaleMessages` 只合并嵌套 section（object 值），顶层平铺键（`"hikari::x.y": "…"` 字符串值）被静默丢弃**——0.3 之后追加的全部平铺键族（affixPicker.\*、messageBox.\*、localizedInput.noMatches…）在运行时从来就是死的，任何界面语言下都落英文 inline fallback。unset 键也加在平铺区，故设备上无论部署哪个版本都显示英文。这不是发版问题，是 loader bug。

## 改动

1. **loader 修复**（src/i18n/context.ts）：字符串叶子直接并入，嵌套 section 照旧 Object.assign；优先级链（enFallback < locale bundle < mergedMessages）不变。
2. **平铺键补全至全 11 locale**：ar/de/es/fr/ja/ko/pt/ru 此前完全没有平铺区——18 个平铺键全部补齐（unset 与 affixPicker/messageBox 对话框文案全家），占位文本与选择器/消息框文案在所有界面语言下正确显示。
3. **斜体裁切修复**（HkAffixPicker.scss）：`.hk-affix-tag-text[data-unset]` 加 `padding-inline-end: 0.2em`——斜体末笔越过字形 advance，`overflow:hidden` 在内容边削字；cushion 在 padding-box 内，不会误触发省略号。
4. **测试**：`context.flatKeys.test.ts`（平铺键装载回归：zh-Hans/ja/ko 断言）+ `flatKeyParity.test.ts`（守卫：en 平铺键必须在全部 11 locale 非空存在——本可提前数月发现 8 locale 缺 18 键的缺口）。
5. 版本 0.41.0 → **0.41.1**（master 已被 #441-#444 波推进到 0.41.0，npm dist-tags.latest=0.41.0）。

## 验证（本地门禁，§7）

- 全量 vitest **133 文件 / 1140 用例全绿**（rebase 到 #442 后连续两轮）+ vue-tsc 0 错。
- 一轮对抗审查 PASS：44 份 locale JSON 全量形态核查（无数组/null 叶子）、18 平铺键 en==inline fallback 逐键对账（en 用户零文案变化）、8 语言译文语义/占位符/引号风格逐条核验、斜体 padding 机制推导（clip 在 padding-box 边、不会自触发省略号）。
- 审查发现的 rebase 竞态（fetch 与 rebase 同秒赛跑）已按其指引二次 rebase 到 1472264 并复验。