### PR TITLE
🐛 Ignore cross-origin-masked window errors in the global error landing.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.41.1",
+  "version": "0.41.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/errorReporting/index.test.tsx
+++ b/packages/vue/src/errorReporting/index.test.tsx
@@ -125,6 +125,48 @@ describe("createErrorReporting", () => {
     expect(overlayHost()).toBeNull();
   });
 
+  it("stays up for cross-origin-masked window errors", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Earlier tests in this file spy the same methods without restoring;
+    // clear the accumulated calls so the assertions see only this test's.
+    warn.mockClear();
+    error.mockClear();
+    installPlugin();
+
+    // The masking signature: details withheld (error == null) because the
+    // thrower is foreign-origin code (extension / userscript), message
+    // pinned to "Script error." by every Chromium/Gecko/WebKit build.
+    window.dispatchEvent(new ErrorEvent("error", { message: "Script error.", error: null }));
+    await nextTick();
+    expect(overlayHost()).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+
+    // The bare-spelling variant is masked the same way.
+    window.dispatchEvent(new ErrorEvent("error", { message: "Script error", error: null }));
+    await nextTick();
+    expect(overlayHost()).toBeNull();
+
+    clearGlobalError();
+    warn.mockRestore();
+    error.mockRestore();
+  });
+
+  it("still reports detail-less window errors that are not masked", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    installPlugin();
+
+    // error == null with a real message is a script error the browser DID
+    // describe — that stays reportable.
+    window.dispatchEvent(
+      new ErrorEvent("error", { message: "Uncaught SyntaxError: unexpected token", error: null }),
+    );
+    await nextTick();
+    expect(overlayHost()!.querySelector(".hk-error-landing__desc")!.textContent)
+      .toBe("Uncaught SyntaxError: unexpected token");
+  });
+
   it("chains a pre-existing app errorHandler", () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     const previous = vi.fn();

--- a/packages/vue/src/errorReporting/index.ts
+++ b/packages/vue/src/errorReporting/index.ts
@@ -87,6 +87,21 @@ function installWindowHooks(options: HkErrorReportingOptions): void {
     const onError = (event: ErrorEvent) => {
       // Resource-load failures never reach here (no capture phase); script
       // errors always carry `error` or at least a `message`.
+      //
+      // Cross-origin-masked script errors arrive as `message: "Script
+      // error."` with a null `error` object: the browser withholds the
+      // details precisely because the thrower is NOT this origin's code
+      // (browser extensions / userscripts are the usual sources). A
+      // synthetic record for one would carry zero actionable detail and a
+      // stack pointing at this very handler, while the takeover rips the
+      // host app away from the user for noise it did not produce — log
+      // and stay up instead (chest demo report 2026-09-10: tapping the
+      // wallpaper preview in a userscript-capable mobile browser nuked
+      // the session with such a masked event).
+      if (event.error == null && /^script error\.?$/i.test(event.message)) {
+        console.warn("[hikari:error-reporting] ignored a cross-origin-masked script error");
+        return;
+      }
       const err = event.error ?? new Error(event.message || "Unknown script error");
       if (reportError(err, "window")) ensureOverlayMounted();
     };


### PR DESCRIPTION
## Problem

On the chest demo (2026-09-10, user report with screenshot): tapping the theme-wallpaper preview in a mobile browser replaced the whole app with the full-screen error landing showing

```
{ name: "Error", message: "Script error.", source: "window", stack: "Error: Script error.\n at e (…/assets/src-*.js:5:4391)" }
```

The stack frame is the window hook itself (`oa(e.error ?? Error(e.message …), "window")`): the ErrorEvent arrived with `error == null` and the message pinned to `Script error.` — the browser's cross-origin masking signature. The thrower was NOT the page's code (every script on the page is same-origin; userscript-capable mobile browsers are the usual source of such noise), but `createErrorReporting`'s window hook escalated it into a full-viewport takeover anyway.

A masked event carries zero actionable detail by construction, and the synthetic `new Error(message)` record even points its stack at our own handler. Taking the app down for it is pure harm.

## Change

- In `installWindowHooks`'s `onError`, events with `error == null` and `message` matching `/^script error\.?$/i` are now logged via `console.warn` and ignored (no landing, no `onError` telemetry) — the masking signature is narrow, so real same-origin errors (which always carry an `error` object) are unaffected.
- Two tests: masked events (both spellings) leave the overlay down and only warn; a detail-less event with a real message stays reportable.

## Verification

- `vitest run`: 133 files / 1142 tests green (two pre-existing HkDateTimePicker flake-under-load instances pass in isolation and on rerun).
- `vue-tsc --noEmit`: clean.
- Version bump 0.41.1 → 0.41.2 in the same PR (chest lockfile pickup rides the consumer wave).