### PR TITLE
✨ Standardize button icon geometry and wire the icon button name prop.

### DIFF
--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -64,6 +64,52 @@
   min-height: 2.75rem;
 }
 
+/* ---- Prefix / suffix icon boxes ---- */
+/* Standard-part contract (2026-09-10 user direction): a button glyph
+   renders inside a FIXED SQUARE box — flex:none so host flex rows can
+   never squeeze it into a squat sliver, centered on both axes so the
+   icon rides the button's vertical midline at any button height, and
+   the box (not the bare svg) owns the rhythm so the glyph keeps a
+   consistent margin from the adjacent label via the button's own gap.
+   The 1rem box matches the 16px glyph HkButton renders for the
+   icon/suffix props. */
+.hk-btn-icon,
+.hk-btn-suffix {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  inline-size: 1rem;
+  block-size: 1rem;
+  line-height: 0;
+
+  svg {
+    display: block;
+  }
+}
+
+/* ---- Icon-only square ---- */
+/* An icon-only HkButton (glyph, no label) occupies a SQUARE footprint
+   by default: inline padding collapses and width locks to the size
+   variant's min-height, so it reads as the same standard square the
+   HIconButton family guarantees. Hosts may still override with an
+   explicit width when a design genuinely calls for another shape. */
+.hk-btn-icon-only {
+  padding-inline: 0;
+}
+
+.hk-btn-sm.hk-btn-icon-only {
+  width: 1.75rem;
+}
+
+.hk-btn-md.hk-btn-icon-only {
+  width: 2.5rem;
+}
+
+.hk-btn-lg.hk-btn-icon-only {
+  width: 2.75rem;
+}
+
 /* ---- Primary ---- */
 
 .hk-btn-primary {

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -90,12 +90,17 @@
 
 /* ---- Icon-only square ---- */
 /* An icon-only HkButton (glyph, no label) occupies a SQUARE footprint
-   by default: inline padding collapses and width locks to the size
+   by default: padding collapses fully and width locks to the size
    variant's min-height, so it reads as the same standard square the
-   HIconButton family guarantees. Hosts may still override with an
-   explicit width when a design genuinely calls for another shape. */
+   HIconButton family guarantees. box-sizing is self-declared (house
+   convention — geometry rules never rely on a host-side reset reaching
+   the component): with zero padding the min-height governs the height
+   on every size, an exact square under border-box AND content-box.
+   Hosts may still override with an explicit width when a design
+   genuinely calls for another shape. */
 .hk-btn-icon-only {
-  padding-inline: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 .hk-btn-sm.hk-btn-icon-only {
@@ -108,6 +113,11 @@
 
 .hk-btn-lg.hk-btn-icon-only {
   width: 2.75rem;
+}
+
+/* The first-class block prop wins over the square width. */
+.hk-btn-block.hk-btn-icon-only {
+  width: 100%;
 }
 
 /* ---- Primary ---- */

--- a/packages/vue/src/components/HkButton.test.tsx
+++ b/packages/vue/src/components/HkButton.test.tsx
@@ -142,6 +142,29 @@ describe("HkButton content slots", () => {
   });
 });
 
+describe("HkButton icon-only square contract", () => {
+  it("flags the icon-only square class for a glyph with no label", () => {
+    const iconOnly = mount(h(HkButton, { icon: "close", ariaLabel: "Close" }));
+    const btn = button(iconOnly);
+    expect(btn.className).toContain("hk-btn-icon-only");
+    expect(iconOnly.querySelector(".hk-btn-icon")).not.toBeNull();
+
+    const suffixOnly = mount(h(HkButton, { suffix: "close", ariaLabel: "Next" }));
+    expect(button(suffixOnly).className).toContain("hk-btn-icon-only");
+
+    // Glyph + text stays a normal text button — no square collapse.
+    const withText = mount(h(HkButton, { icon: "close" }, () => "Close"));
+    expect(button(withText).className).not.toContain("hk-btn-icon-only");
+  });
+
+  it("keeps the square footprint while an icon-only button loads", () => {
+    const c = mount(h(HkButton, { icon: "close", loading: true, ariaLabel: "Busy" }));
+    // The spinner replaces the glyph, but the button still carries no
+    // label — the square footprint must hold through the swap.
+    expect(button(c).className).toContain("hk-btn-icon-only");
+  });
+});
+
 describe("HkButton attr fallthrough (inheritAttrs: false)", () => {
   it("spreads extra attrs and honors an explicit type", () => {
     const c = mount(h(HkButton, { type: "submit", "data-test": "probe" }, () => "Save"));

--- a/packages/vue/src/components/HkButton.test.tsx
+++ b/packages/vue/src/components/HkButton.test.tsx
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createApp, h } from "vue";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import HkButton from "./HkButton";
+
+const here = dirname(fileURLToPath(import.meta.url));
 
 /**
  * HkButton contract tests:
@@ -162,6 +167,52 @@ describe("HkButton icon-only square contract", () => {
     // The spinner replaces the glyph, but the button still carries no
     // label — the square footprint must hold through the swap.
     expect(button(c).className).toContain("hk-btn-icon-only");
+  });
+
+  it("keeps the block class alongside the icon-only square class", () => {
+    // CSS precedence lives in the SCSS contract test below; this pins the
+    // class composition so both rules can actually apply.
+    const c = mount(h(HkButton, { icon: "close", block: true, ariaLabel: "Go" }));
+    const cls = button(c).className;
+    expect(cls).toContain("hk-btn-block");
+    expect(cls).toContain("hk-btn-icon-only");
+  });
+});
+
+// SCSS geometry contract (house pattern, cf. HkNumberInput.affix.test.ts):
+// the square is a CSS fact — padding fully collapsed + self-declared
+// border-box (survives hosts without a reset) + the block prop winning
+// over the square width. Textual assertions because happy-dom does not
+// lay out.
+describe("HkButton icon-only SCSS contract", () => {
+  const scss = readFileSync(join(here, "HkButton.scss"), "utf-8");
+
+  it("self-declares the collapsed square geometry", () => {
+    const rule = scss.match(/\.hk-btn-icon-only\s*{[^}]*}/)?.[0] ?? "";
+    expect(rule, "icon-only rule must exist").toBeTruthy();
+    expect(rule).toContain("padding: 0");
+    expect(rule).toContain("box-sizing: border-box");
+  });
+
+  it("lets the block prop win over the square width", () => {
+    const rule = scss.match(/\.hk-btn-block\.hk-btn-icon-only\s*{[^}]*}/)?.[0] ?? "";
+    expect(rule, "block override rule must exist").toBeTruthy();
+    expect(rule).toContain("width: 100%");
+  });
+
+  it("locks each size variant width to its min-height", () => {
+    const cases: Array<[string, string]> = [
+      ["sm", "1.75rem"],
+      ["md", "2.5rem"],
+      ["lg", "2.75rem"],
+    ];
+    for (const [size, width] of cases) {
+      const rule = scss.match(new RegExp(`\\.hk-btn-${size}\\.hk-btn-icon-only\\s*{[^}]*}`))?.[0] ?? "";
+      expect(rule, `${size} icon-only rule must exist`).toBeTruthy();
+      expect(rule).toContain(`width: ${width}`);
+      const minH = scss.match(new RegExp(`\\.hk-btn-${size}\\s*{[^}]*}`))?.[0] ?? "";
+      expect(minH).toContain(`min-height: ${width}`);
+    }
   });
 });
 

--- a/packages/vue/src/components/HkButton.test.tsx
+++ b/packages/vue/src/components/HkButton.test.tsx
@@ -177,6 +177,13 @@ describe("HkButton icon-only square contract", () => {
     expect(cls).toContain("hk-btn-block");
     expect(cls).toContain("hk-btn-icon-only");
   });
+
+  it("does not square-collapse when a shortcut chip rides along", () => {
+    // The HKbd chip is an extra flex child — the fixed square width would
+    // visibly clip it, so icon + shortcut stays a padded button.
+    const c = mount(h(HkButton, { icon: "close", shortcut: "Ctrl+W", ariaLabel: "Close" }));
+    expect(button(c).className).not.toContain("hk-btn-icon-only");
+  });
 });
 
 // SCSS geometry contract (house pattern, cf. HkNumberInput.affix.test.ts):

--- a/packages/vue/src/components/HkButton.tsx
+++ b/packages/vue/src/components/HkButton.tsx
@@ -49,8 +49,11 @@ export default defineComponent({
       // in a padded text button reads as a squat rectangle otherwise.
       // Re-evaluated per render, NOT a computed: slots.default is not
       // reactive, so a cached flag would go stale when a parent toggles
-      // the label slot without touching the icon props.
-      const iconOnly = !slots.default && Boolean(props.icon || props.suffix);
+      // the label slot without touching the icon props. A shortcut chip
+      // is excluded: it renders as an extra flex child the fixed square
+      // width would visibly clip.
+      const iconOnly =
+        !slots.default && Boolean(props.icon || props.suffix) && !props.shortcut;
 
       return (
         <button

--- a/packages/vue/src/components/HkButton.tsx
+++ b/packages/vue/src/components/HkButton.tsx
@@ -33,6 +33,14 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const attrs = useAttrs();
 
+    // Icon-only contract (2026-09-10 user direction): a button carrying
+    // just a prefix/suffix glyph and no text collapses to the same square
+    // footprint the HIconButton family guarantees — a bare icon in a
+    // padded text button reads as a squat rectangle otherwise.
+    const iconOnly = computed(
+      () => !slots.default && Boolean(props.icon || props.suffix),
+    );
+
     const buttonClass = computed(() => [
       "hk-btn",
       `hk-btn-${props.variant}`,
@@ -40,6 +48,7 @@ export default defineComponent({
       props.block ? "hk-btn-block" : "",
       props.loading ? "hk-btn-loading" : "",
       props.shortcut ? "hk-btn-has-shortcut" : "",
+      iconOnly.value ? "hk-btn-icon-only" : "",
     ]);
 
     return () => (

--- a/packages/vue/src/components/HkButton.tsx
+++ b/packages/vue/src/components/HkButton.tsx
@@ -33,14 +33,6 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     const attrs = useAttrs();
 
-    // Icon-only contract (2026-09-10 user direction): a button carrying
-    // just a prefix/suffix glyph and no text collapses to the same square
-    // footprint the HIconButton family guarantees — a bare icon in a
-    // padded text button reads as a squat rectangle otherwise.
-    const iconOnly = computed(
-      () => !slots.default && Boolean(props.icon || props.suffix),
-    );
-
     const buttonClass = computed(() => [
       "hk-btn",
       `hk-btn-${props.variant}`,
@@ -48,36 +40,46 @@ export default defineComponent({
       props.block ? "hk-btn-block" : "",
       props.loading ? "hk-btn-loading" : "",
       props.shortcut ? "hk-btn-has-shortcut" : "",
-      iconOnly.value ? "hk-btn-icon-only" : "",
     ]);
 
-    return () => (
-      <button
-        {...attrs}
-        type={(attrs.type as "button" | "submit" | "reset") || "button"}
-        disabled={props.disabled || props.loading}
-        class={[buttonClass.value, attrs.class]}
-        style={attrs.style || undefined}
-        aria-label={props.ariaLabel}
-        aria-busy={props.loading || undefined}
-        onClick={(e) => emit("click", e)}
-      >
-        {props.loading ? <HSpinner size="xs" tone="current" /> : null}
-        {!props.loading && props.icon ? (
-          <span class="hk-btn-icon">
-            <HIcon name={props.icon} size={16} />
-          </span>
-        ) : null}
-        {slots.default?.()}
-        {props.suffix ? (
-          <span class="hk-btn-suffix">
-            <HIcon name={props.suffix} size={16} />
-          </span>
-        ) : null}
-        {props.shortcut ? (
-          <HKbd keys={props.shortcut!} size="sm" />
-        ) : null}
-      </button>
-    );
+    return () => {
+      // Icon-only contract (2026-09-10 user direction): a button carrying
+      // just a prefix/suffix glyph and no text collapses to the same
+      // square footprint the HIconButton family guarantees — a bare icon
+      // in a padded text button reads as a squat rectangle otherwise.
+      // Re-evaluated per render, NOT a computed: slots.default is not
+      // reactive, so a cached flag would go stale when a parent toggles
+      // the label slot without touching the icon props.
+      const iconOnly = !slots.default && Boolean(props.icon || props.suffix);
+
+      return (
+        <button
+          {...attrs}
+          type={(attrs.type as "button" | "submit" | "reset") || "button"}
+          disabled={props.disabled || props.loading}
+          class={[buttonClass.value, iconOnly ? "hk-btn-icon-only" : "", attrs.class]}
+          style={attrs.style || undefined}
+          aria-label={props.ariaLabel}
+          aria-busy={props.loading || undefined}
+          onClick={(e) => emit("click", e)}
+        >
+          {props.loading ? <HSpinner size="xs" tone="current" /> : null}
+          {!props.loading && props.icon ? (
+            <span class="hk-btn-icon">
+              <HIcon name={props.icon} size={16} />
+            </span>
+          ) : null}
+          {slots.default?.()}
+          {props.suffix ? (
+            <span class="hk-btn-suffix">
+              <HIcon name={props.suffix} size={16} />
+            </span>
+          ) : null}
+          {props.shortcut ? (
+            <HKbd keys={props.shortcut!} size="sm" />
+          ) : null}
+        </button>
+      );
+    };
   },
 });

--- a/packages/vue/src/components/HkIconButton.test.tsx
+++ b/packages/vue/src/components/HkIconButton.test.tsx
@@ -102,4 +102,19 @@ describe("HkIconButton", () => {
     const c = mountComp(() => h(HkIconButton, { "aria-label": "probe" }));
     expect(c.querySelector("circle")).not.toBeNull();
   });
+
+  // Named-icon contract (2026-09-10): the icon prop resolves through HIcon
+  // (functional keys ride the host material pack) — slot content still
+  // wins over it, and the placeholder circle only shows with neither.
+  it("renders the icon prop through HIcon, below slot precedence", () => {
+    const propOnly = mountComp(() => h(HkIconButton, { icon: "close", "aria-label": "close" }));
+    expect(propOnly.querySelector(".hk-icon")).not.toBeNull();
+    expect(propOnly.querySelector("circle")).toBeNull();
+
+    const propAndSlot = mountComp(() =>
+      h(HkIconButton, { icon: "close", "aria-label": "close" }, { icon: () => h("span", { class: "slot-probe" }) }),
+    );
+    expect(propAndSlot.querySelector(".slot-probe")).not.toBeNull();
+    expect(propAndSlot.querySelector(".hk-icon")).toBeNull();
+  });
 });

--- a/packages/vue/src/components/HkIconButton.tsx
+++ b/packages/vue/src/components/HkIconButton.tsx
@@ -1,6 +1,7 @@
 import { computed, defineComponent, type PropType } from "vue";
 import "./HkIconButton.scss";
 import "./HkIconButtonVars.scss";
+import HIcon from "./HkIcon";
 
 export default defineComponent({
   name: "HkIconButton",
@@ -21,6 +22,14 @@ export default defineComponent({
       `hk-icon-button-${props.variant}`,
     ]);
 
+    // Named-icon contract (2026-09-10 user direction): the icon prop is a
+    // first-class way to draw the glyph — it resolves through HIcon so
+    // functional keys ("close", "back") keep riding the host material-pack
+    // family exactly like the slot composition does. The rendered size is
+    // pinned by --hi-icon-button-icon-size; the HIcon size prop only picks
+    // the matching box class. Slot content still wins over the prop.
+    const glyphSize = computed(() => (props.size >= 32 ? 20 : 16));
+
     return () => (
       <button
         class={cls.value}
@@ -35,11 +44,15 @@ export default defineComponent({
               ? // Natural children usage: <HIconButton><HIcon .../></HIconButton>
                 // renders the child as the icon (unified window-close wave).
                 slots.default()
-              : (
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <circle cx="12" cy="12" r="10" />
-                </svg>
-              )}
+              : props.icon
+                ? (
+                  <HIcon name={props.icon} size={glyphSize.value} />
+                )
+                : (
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="10" />
+                  </svg>
+                )}
         </span>
       </button>
     );


### PR DESCRIPTION
## 概要

用户 2026-09-10 挂载方案编辑窗截图反馈的标准件治理波（上游部分）：按钮图标几何从未被标准化——`.hk-btn-icon`/`.hk-btn-suffix` 此前**零 CSS 规则**（裸 svg 直塞 flex），HkIconButton 的 `icon` prop 声明了却从未在渲染里使用（死 prop，消费侧被迫全部走 slot + 原始 lucide 子组件）。

## 变更

### HkButton — 图标盒标准化
- `.hk-btn-icon` / `.hk-btn-suffix`：固定 **1rem 方形盒**（`inline-flex` 居中、`flex: none`、`line-height: 0`、`svg { display: block }`）——宿主 flex 行永远无法把它挤成扁条；图标与文字的间距由按钮自身的 gap 节奏承担（用户要求「图标标准化方形尺寸、与右侧文本有一定边距、垂直居中」）。
- **icon-only 自动方形**：无 default slot 且带 icon/suffix 时挂 `hk-btn-icon-only`——inline padding 收拢、宽度锁到对应 size 档的 min-height（sm 1.75rem / md 2.5rem / lg 2.75rem），默认即标准方形；宿主仍可显式宽度覆盖做特殊造型（用户要求「除非设计特定样式，默认图标按钮自动方形占位」）。

### HkIconButton — icon prop 通电
- `icon` prop 经 HIcon 解析渲染（功能键 close/back 照常走材质包家族管线）；slot 内容优先级不变（icon slot > default slot > icon prop > 占位圆）；渲染尺寸仍由 `--hi-icon-button-icon-size` 钉死，HIcon size prop 只选配的盒类（16/24 按钮→16，32/36/40→20）。

### 测试与版本
- HkButton：icon-only 方形契约 2 例（含 loading 期间保持方形）；HkIconButton：icon prop 渲染 + slot 优先级 1 例。
- 全量 vitest **133 文件 / 1145 用例全绿**，vue-tsc 0 错误。
- 版本 0.41.2 → **0.41.3**（发版后供下游 lockfile 拾取：chest 挂载编辑器 ✕/＋ 字符按钮改造依赖本版）。

## 关联

- 下游波：shittim-chest 挂载方案编辑器字符按钮 → 标准件改造（随后 PR）；noa/gateway/e.cw/erp 等 webui 排查波进行中。
- PLAN.md 活跃认领：「图标按钮/输入框标准件治理波」。