### PR TITLE
✨ Add the missing functional glyph names to the icon registry.

### DIFF
--- a/packages/vue/src/composables/iconRegistry.test.ts
+++ b/packages/vue/src/composables/iconRegistry.test.ts
@@ -6,19 +6,20 @@ import { iconByName } from "./iconRegistry";
 // Glyph-expansion contract (2026-09-10): downstream audits (chest / e.cw /
 // erp.cw icon waves) found these icon-prop names silently rendering the
 // `Info` fallback because the lucide exports were missing from the
-// tree-shakeable registry. Each entry must resolve to its real glyph —
-// asserted against the unknown-name fallback, not just against `Info`,
-// so a future fallback swap cannot silently pass this suite.
+// tree-shakeable registry. `minus` and `copy` are chest adversarial-verifier
+// finds that shipped as Info-fallback regressions. Each entry must resolve
+// to its real glyph — asserted against the unknown-name fallback, not just
+// against `Info`, so a future fallback swap cannot silently pass this suite.
 const NEW_GLYPH_KEBAB = [
   "log-out", "sparkles", "upload", "camera", "flag", "download", "image",
   "video", "save", "braces", "history", "rotate-cw", "key-round",
-  "scan-search", "ban", "filter",
+  "scan-search", "ban", "filter", "minus", "copy",
 ] as const;
 
 const NEW_GLYPH_PASCAL = [
   "LogOut", "Sparkles", "Upload", "Camera", "Flag", "Download", "Image",
   "Video", "Save", "Braces", "History", "RotateCw", "KeyRound",
-  "ScanSearch", "Ban", "Filter",
+  "ScanSearch", "Ban", "Filter", "Minus", "Copy",
 ] as const;
 
 describe("icon registry glyph expansion", () => {

--- a/packages/vue/src/composables/iconRegistry.test.ts
+++ b/packages/vue/src/composables/iconRegistry.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { Info } from "lucide-vue-next";
+
+import { iconByName } from "./iconRegistry";
+
+// Glyph-expansion contract (2026-09-10): downstream audits (chest / e.cw /
+// erp.cw icon waves) found these icon-prop names silently rendering the
+// `Info` fallback because the lucide exports were missing from the
+// tree-shakeable registry. Each entry must resolve to its real glyph —
+// asserted against the unknown-name fallback, not just against `Info`,
+// so a future fallback swap cannot silently pass this suite.
+const NEW_GLYPH_KEBAB = [
+  "log-out", "sparkles", "upload", "camera", "flag", "download", "image",
+  "video", "save", "braces", "history", "rotate-cw", "key-round",
+  "scan-search", "ban", "filter",
+] as const;
+
+const NEW_GLYPH_PASCAL = [
+  "LogOut", "Sparkles", "Upload", "Camera", "Flag", "Download", "Image",
+  "Video", "Save", "Braces", "History", "RotateCw", "KeyRound",
+  "ScanSearch", "Ban", "Filter",
+] as const;
+
+describe("icon registry glyph expansion", () => {
+  const fallback = iconByName("totally-unknown-name");
+
+  it("resolves unknown names to the Info fallback", () => {
+    expect(fallback).toBe(Info);
+  });
+
+  it("keeps the kebab-case lookup distinct from the fallback for every new glyph", () => {
+    for (const kebab of NEW_GLYPH_KEBAB) {
+      const resolved = iconByName(kebab);
+      expect(resolved, `iconByName(${kebab}) hit the fallback`).not.toBe(fallback);
+      expect(resolved).not.toBe(Info);
+    }
+  });
+
+  it("resolves the PascalCase export names directly", () => {
+    for (const pascal of NEW_GLYPH_PASCAL) {
+      const resolved = iconByName(pascal);
+      expect(resolved, `iconByName(${pascal}) hit the fallback`).not.toBe(fallback);
+      expect(resolved).not.toBe(Info);
+    }
+  });
+
+  it("maps kebab-case and PascalCase spellings to the same glyph", () => {
+    for (const [kebab, pascal] of NEW_GLYPH_KEBAB.map((k, i) => [k, NEW_GLYPH_PASCAL[i]] as const)) {
+      expect(iconByName(kebab)).toBe(iconByName(pascal));
+    }
+  });
+
+  it("still resolves the Info fallback for unknown names after the expansion", () => {
+    expect(iconByName("no-such-glyph-at-all")).toBe(fallback);
+  });
+});

--- a/packages/vue/src/composables/iconRegistry.ts
+++ b/packages/vue/src/composables/iconRegistry.ts
@@ -8,7 +8,7 @@
 // badges, nav tags) resolve without the wildcard import. Unknown names fall
 // back to `Info`, matching the previous `|| LucideIcons.Info` behavior.
 
-import { Activity, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Battery, Bell, Bot, Box, Brain, Cable, Calendar, ChartBarBig as BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Circle, CircleAlert as AlertCircle, CircleCheck as CheckCircle, CircleCheckBig as CheckCircle2, CircleDot, Clock, Cpu, Database, Dot, Ellipsis as MoreHorizontal, ExternalLink, Eye, FileArchive, FileCode, FileImage, FileText, Flame, FolderOpen, Gauge, Globe, HardDrive, Info, Kanban, Key, Layers, LayoutDashboard, LoaderCircle as Loader2, Lock, Maximize, Maximize2, MessageSquare, Mic, MicOff, Minimize, Monitor, Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, Search, Send, Server, Settings, Share2, Shield, Star, Table, Tag, Thermometer, Trash2, TriangleAlert as AlertTriangle, Volume2, VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut } from "lucide-vue-next";
+import { Activity, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Ban, Battery, Bell, Bot, Box, Braces, Brain, Cable, Calendar, Camera, ChartBarBig as BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Circle, CircleAlert as AlertCircle, CircleCheck as CheckCircle, CircleCheckBig as CheckCircle2, CircleDot, Clock, Cpu, Database, Dot, Download, Ellipsis as MoreHorizontal, ExternalLink, Eye, FileArchive, FileCode, FileImage, FileText, Filter, Flag, Flame, FolderOpen, Gauge, Globe, HardDrive, History, Image, Info, Kanban, Key, KeyRound, Layers, LayoutDashboard, LoaderCircle as Loader2, LogOut, Lock, Maximize, Maximize2, MessageSquare, Mic, MicOff, Minimize, Monitor, Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, RotateCw, ScanSearch, Save, Search, Send, Server, Settings, Share2, Shield, Sparkles, Star, Table, Tag, Thermometer, Trash2, TriangleAlert as AlertTriangle, Upload, Video, Volume2, VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut } from "lucide-vue-next";
 import type { Component } from "vue";
 
 
@@ -98,16 +98,18 @@ import type { Component } from "vue";
 
 const REGISTRY: Record<string, Component> = {
   Activity, AlertCircle, AlertTriangle, ArrowDown, ArrowLeft, ArrowRight,
-  ArrowUp, BarChart3, Battery, Bell, Bot, Box, Brain, Cable, Calendar,
-  Check, CheckCircle, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight,
-  ChevronUp, Circle, CircleDot, Clock, Cpu, Database, Dot, ExternalLink, Eye,
-  FileArchive, FileCode, FileImage, FileText, Flame,
-  FolderOpen, Gauge, Globe, HardDrive, Info, Kanban, Key, Layers,
-  LayoutDashboard, Loader2, Lock, Maximize, Maximize2, MessageSquare, Mic,
-  MicOff, Minimize, Monitor, MoreHorizontal, Network, Package, Pause, Pencil,
-  Play, Plug, Plus, Radio, RefreshCw, Search, Send, Server, Settings, Share2,
-  Shield, Star, Table, Tag, Thermometer, Trash2, Volume2, VolumeX, Webhook,
-  Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut,
+  ArrowUp, Ban, BarChart3, Battery, Bell, Bot, Box, Braces, Brain, Cable,
+  Calendar, Camera, Check, CheckCircle, CheckCircle2, ChevronDown,
+  ChevronLeft, ChevronRight, ChevronUp, Circle, CircleDot, Clock, Cpu,
+  Database, Dot, Download, ExternalLink, Eye, FileArchive, FileCode,
+  FileImage, FileText, Filter, Flag, Flame, FolderOpen, Gauge, Globe,
+  HardDrive, History, Image, Info, Kanban, Key, KeyRound, Layers,
+  LayoutDashboard, Loader2, LogOut, Lock, Maximize, Maximize2,
+  MessageSquare, Mic, MicOff, Minimize, Monitor, MoreHorizontal, Network,
+  Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, RotateCw,
+  ScanSearch, Save, Search, Send, Server, Settings, Share2, Shield,
+  Sparkles, Star, Table, Tag, Thermometer, Trash2, Upload, Video, Volume2,
+  VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut,
 };
 
 /**

--- a/packages/vue/src/composables/iconRegistry.ts
+++ b/packages/vue/src/composables/iconRegistry.ts
@@ -8,7 +8,7 @@
 // badges, nav tags) resolve without the wildcard import. Unknown names fall
 // back to `Info`, matching the previous `|| LucideIcons.Info` behavior.
 
-import { Activity, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Ban, Battery, Bell, Bot, Box, Braces, Brain, Cable, Calendar, Camera, ChartBarBig as BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Circle, CircleAlert as AlertCircle, CircleCheck as CheckCircle, CircleCheckBig as CheckCircle2, CircleDot, Clock, Cpu, Database, Dot, Download, Ellipsis as MoreHorizontal, ExternalLink, Eye, FileArchive, FileCode, FileImage, FileText, Filter, Flag, Flame, FolderOpen, Gauge, Globe, HardDrive, History, Image, Info, Kanban, Key, KeyRound, Layers, LayoutDashboard, LoaderCircle as Loader2, LogOut, Lock, Maximize, Maximize2, MessageSquare, Mic, MicOff, Minimize, Monitor, Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, RotateCw, ScanSearch, Save, Search, Send, Server, Settings, Share2, Shield, Sparkles, Star, Table, Tag, Thermometer, Trash2, TriangleAlert as AlertTriangle, Upload, Video, Volume2, VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut } from "lucide-vue-next";
+import { Activity, ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Ban, Battery, Bell, Bot, Box, Braces, Brain, Cable, Calendar, Camera, ChartBarBig as BarChart3, Check, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Circle, CircleAlert as AlertCircle, CircleCheck as CheckCircle, CircleCheckBig as CheckCircle2, CircleDot, Clock, Copy, Cpu, Database, Dot, Download, Ellipsis as MoreHorizontal, ExternalLink, Eye, FileArchive, FileCode, FileImage, FileText, Filter, Flag, Flame, FolderOpen, Gauge, Globe, HardDrive, History, Image, Info, Kanban, Key, KeyRound, Layers, LayoutDashboard, LoaderCircle as Loader2, LogOut, Lock, Maximize, Maximize2, MessageSquare, Mic, MicOff, Minimize, Minus, Monitor, Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, RotateCw, ScanSearch, Save, Search, Send, Server, Settings, Share2, Shield, Sparkles, Star, Table, Tag, Thermometer, Trash2, TriangleAlert as AlertTriangle, Upload, Video, Volume2, VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut } from "lucide-vue-next";
 import type { Component } from "vue";
 
 
@@ -100,13 +100,14 @@ const REGISTRY: Record<string, Component> = {
   Activity, AlertCircle, AlertTriangle, ArrowDown, ArrowLeft, ArrowRight,
   ArrowUp, Ban, BarChart3, Battery, Bell, Bot, Box, Braces, Brain, Cable,
   Calendar, Camera, Check, CheckCircle, CheckCircle2, ChevronDown,
-  ChevronLeft, ChevronRight, ChevronUp, Circle, CircleDot, Clock, Cpu,
+  ChevronLeft, ChevronRight, ChevronUp, Circle, CircleDot, Clock, Copy, Cpu,
   Database, Dot, Download, ExternalLink, Eye, FileArchive, FileCode,
   FileImage, FileText, Filter, Flag, Flame, FolderOpen, Gauge, Globe,
   HardDrive, History, Image, Info, Kanban, Key, KeyRound, Layers,
   LayoutDashboard, Loader2, LogOut, Lock, Maximize, Maximize2,
-  MessageSquare, Mic, MicOff, Minimize, Monitor, MoreHorizontal, Network,
-  Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw, RotateCw,
+  MessageSquare, Mic, MicOff, Minimize, Minus, Monitor, MoreHorizontal,
+  Network, Package, Pause, Pencil, Play, Plug, Plus, Radio, RefreshCw,
+  RotateCw,
   ScanSearch, Save, Search, Send, Server, Settings, Share2, Shield,
   Sparkles, Star, Table, Tag, Thermometer, Trash2, Upload, Video, Volume2,
   VolumeX, Webhook, Wind, Workflow, Wrench, X, Zap, ZoomIn, ZoomOut,


### PR DESCRIPTION
## Summary

Downstream icon-prop audits found glyph names that silently rendered the `Info` fallback because the exports were absent from the tree-shakeable lucide registry (`packages/vue/src/composables/iconRegistry.ts`). This PR adds 18 missing lucide exports to the import list and `REGISTRY`, keeping the alphabetical order.

## New glyph names (18)

`LogOut` `Sparkles` `Upload` `Camera` `Flag` `Download` `Image` `Video` `Save` `Braces` `History` `RotateCw` `KeyRound` `ScanSearch` `Ban` `Filter` `Minus` `Copy`

## Downstream consumers needing them

- **shittim-chest** — icon wave using log-out / upload / camera / save / history / image / video glyphs; adversarial verification additionally caught `Minus` ("minus", MediaPipelineWidget zoom-out — registry had Minimize, not Minus) and `Copy` ("copy", SecurityFactorsModal copy-secret; pre-image rendered real lucide Copy) as shipped Info-fallback regressions
- **e.celestia.world (e.cw)** — icon wave using sparkles / braces / download / key-round / scan-search / rotate-cw
- **easy-hydro-erp (erp.cw)** — three 筛选 filter buttons were on the interim `icon="search"` and need `Filter` (kebab `filter`), plus `Flag` / `Ban` for status rails

## Kebab → Pascal lookup

`iconByName`'s camelize (`/(^|[-_])(.) /` uppercase) already maps every kebab form correctly — `log-out → LogOut`, `rotate-cw → RotateCw`, `key-round → KeyRound`, `scan-search → ScanSearch`, `filter → Filter`, `minus → Minus`, `copy → Copy` — verified programmatically for all 18; no special alias entries needed.

## Contract test

New `src/composables/iconRegistry.test.ts` (house pattern, colocated): each of the 18 names must resolve via `iconByName` (kebab and Pascal spellings) to a component distinct from the unknown-name `Info` fallback, and kebab/Pascal spellings must map to the same glyph.

## Version

`0.41.5 → 0.41.6` — 0.41.5 was published upstream today (2026-09-10T11:22Z) by PR #448, so the next free patch is taken.

## Verification

- `vitest run`: **1156 passed (1156)** — includes the 5 contract tests (extended loops cover all 18 kebab + 18 Pascal names; file-scoped verbose run green)
- `vue-tsc --noEmit`: **TSC-OK**
- No component changes; scope limited to the registry, its test, and the version bump.
