### PR TITLE
🐛 Drop the index signature from GuardRoute so real routers stay assignable.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.41.6",
+  "version": "0.41.7",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/runtime/navigationGuard.ts
+++ b/packages/vue/src/runtime/navigationGuard.ts
@@ -27,7 +27,6 @@ export interface GuardRouter {
 export interface GuardRoute {
   path?: string | null;
   fullPath?: string;
-  [k: string]: unknown;
 }
 
 export interface NavigationSafetyNetOptions extends HistorySafetyNetOptions {


### PR DESCRIPTION
Follow-up to #450: the `[k: string]: unknown` index signature on GuardRoute kills the structural overlap between vue-router's Router and GuardRouter — every consumer passing a real router to createPoisonedLocationGuard / installNavigationSafetyNet needs an unsafe double cast. Chest's createAuthGuard GuardRoute (the proven shape) carries no index signature and real routers assign through Parameters<> casts fine. Gates: vitest runtime suite 112/112, vue-tsc clean. Version 0.41.7.