### PR TITLE
♻️ Declare GuardRouter hooks with method syntax so real routers assign cast-free.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.41.7",
+  "version": "0.41.8",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/runtime/createAuthGuard.ts
+++ b/packages/vue/src/runtime/createAuthGuard.ts
@@ -56,9 +56,12 @@ interface GuardRouter {
   // Accepts any guard signature (vue-router's NavigationGuard takes extra
   // args; slimmer routers take fewer) — the callback just inspects `to`.
   // The guard callback receives the route; vue-router also passes from/next
-  // which we ignore. `never`-parameter variance keeps both sides assignable.
-  beforeEach: (fn: (to: GuardRoute, ...rest: unknown[]) => unknown) => void;
-  onError?: (fn: (error: unknown, to: GuardRoute) => void) => void;
+  // which we ignore. METHOD syntax keeps both sides assignable cast-free:
+  // property-function syntax would fall under strictFunctionTypes' strict
+  // contravariance and reject a real vue-router Router (field report e.cw
+  // #84).
+  beforeEach(fn: (to: GuardRoute, ...rest: unknown[]) => unknown): void;
+  onError?(fn: (error: unknown, to: GuardRoute) => void): void;
 }
 
 export function createAuthGuard(router: GuardRouter, opts: AuthGuardOptions) {

--- a/packages/vue/src/runtime/guardRouterInterop.test.ts
+++ b/packages/vue/src/runtime/guardRouterInterop.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPoisonedLocationGuard, type GuardRouter } from "./navigationGuard";
+import { createAuthGuard } from "./createAuthGuard";
+
+/**
+ * Cast-free interoperability with a REAL vue-router Router shape.
+ *
+ * Field report e.cw #84: with GuardRouter.beforeEach declared as a
+ * PROPERTY function, strictFunctionTypes applies strict parameter
+ * contravariance and vue-router's Router (whose beforeEach is
+ * method-typed, taking a NavigationGuard with a full RouteNormalized
+ * `to`) can never satisfy GuardRouter — every consumer needed an
+ * `as GuardRouter` cast. Method syntax (bivariant parameters) is the
+ * contract under test here: the assignments below must compile with NO
+ * casts, which vue-tsc (the package gate) enforces on every run.
+ */
+
+/** Minimal structural mimic of vue-router's method-typed Router —
+ *  deliberately NOT GuardRouter-shaped (extra params, richer `to`,
+ *  non-void return) so a variance regression fails compilation. */
+interface VueRouterLike {
+  beforeEach(
+    guard: (
+      to: { path: string; fullPath: string; name?: string | symbol | null; meta?: Record<string, unknown> },
+      from: unknown,
+      next: unknown,
+    ) => unknown,
+  ): () => void;
+  onError?(handler: (error: unknown, to: { fullPath: string }) => void): () => void;
+}
+
+function makeVueRouterLike(): VueRouterLike {
+  type Guard = Parameters<VueRouterLike["beforeEach"]>[0];
+  const guards: Guard[] = [];
+  return {
+    beforeEach(guard: Guard) {
+      guards.push(guard);
+      return () => { const i = guards.indexOf(guard); if (i >= 0) guards.splice(i, 1); };
+    },
+    onError() { return () => undefined; },
+  };
+}
+
+// The contract: both assignments must be cast-free. If GuardRouter ever
+// regresses to property-function syntax, vue-tsc rejects these lines.
+const routerForGuard: GuardRouter = makeVueRouterLike();
+const routerForAuth: Parameters<typeof createAuthGuard>[0] = makeVueRouterLike();
+
+describe("GuardRouter cast-free interop", () => {
+  it("registers the poisoned-location guard on a vue-router-shaped router", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    createPoisonedLocationGuard(routerForGuard);
+    expect(routerForGuard).toBeDefined();
+    warn.mockRestore();
+  });
+
+  it("createAuthGuard accepts a vue-router-shaped router cast-free", () => {
+    const auth = {
+      isAuthenticated: false,
+      user: null,
+      tryRestoreSession: () => Promise.resolve(),
+      checkSetup: () => Promise.resolve({ needs_setup: false }),
+      fetchUser: () => Promise.resolve({}),
+    };
+    createAuthGuard(routerForAuth, {
+      loginRoute: "login",
+      homeRoute: "home",
+      setupRoute: "setup",
+      useAuthStore: () => auth,
+    });
+    expect(routerForAuth).toBeDefined();
+  });
+});

--- a/packages/vue/src/runtime/navigationGuard.ts
+++ b/packages/vue/src/runtime/navigationGuard.ts
@@ -21,7 +21,13 @@ const POISONED_LITERALS = new Set(["undefined", "null", "nan"]);
  *  beforeEach, so any router-shaped object works (no vue-router dep:
  *  hikari stays UI-library-scoped). */
 export interface GuardRouter {
-  beforeEach: (fn: (to: GuardRoute, ...rest: unknown[]) => unknown) => void;
+  // METHOD syntax on purpose: property-function syntax falls under
+  // strictFunctionTypes' strict contravariance, which makes a real
+  // vue-router Router (whose beforeEach is itself method-typed with a
+  // NavigationGuard parameter) unassignable — consumers then need
+  // `as GuardRouter` casts (field report e.cw #84). Method parameters
+  // are bivariant, so both shapes interoperate cast-free.
+  beforeEach(fn: (to: GuardRoute, ...rest: unknown[]) => unknown): void;
 }
 
 export interface GuardRoute {


### PR DESCRIPTION
Field report e.cw #84: GuardRouter.beforeEach/onError as PROPERTY functions fall under strictFunctionTypes' strict contravariance — a real vue-router Router (method-typed beforeEach with a NavigationGuard parameter) can never satisfy them, forcing `as GuardRouter` casts at every consumer. Method syntax is bivariant, so consumers drop the casts. Adds guardRouterInterop.test.ts: a vue-router-shaped router double (richer `to`, extra from/next params, non-void return) assigned to GuardRouter and to createAuthGuard's router parameter with NO casts — vue-tsc pins the contract on every run (the exact regression 0.41.7 shipped). Gates: vitest runtime 15 files / 114 tests, vue-tsc clean. Version 0.41.8.