### PR TITLE
✨ Add a scroll end-approach facility and a unified load-more indicator.

### DIFF
--- a/packages/vue/src/DemoApp.tsx
+++ b/packages/vue/src/DemoApp.tsx
@@ -16,6 +16,7 @@ import {
   HSkeleton, HSkeletonList, HAvatar, HKbd, HDivider,
   HAlert, HEmptyState, HExpansionPanel,
   HTabs, HCard, HTable, HTimeline,
+  HScrollContainer, HLoadMore,
   HMediaSlider, HMediaPlayer, HImageViewer,
   HImagePreview,
   HZoomToolbar, HMinimap, HTrendChart,
@@ -197,6 +198,24 @@ export default defineComponent({
       syncZoom();
     }
 
+    // HLoadMore + HScrollContainer approachEnd — the canonical dynamic
+    // loading pair: the container emits `approachEnd` when the content
+    // end nears (including the initial under-filled pass), the demo
+    // "fetches" a page, and the indicator morphs button → spinner → end.
+    const pagedRows = ref(Array.from({ length: 10 }, (_, i) => `Row ${i + 1}`));
+    const pagedState = ref<"idle" | "loading" | "end">("idle");
+    function loadPagedRows() {
+      if (pagedState.value !== "idle") return;
+      pagedState.value = "loading";
+      setTimeout(() => {
+        pagedRows.value = [
+          ...pagedRows.value,
+          ...Array.from({ length: 10 }, (_, i) => `Row ${pagedRows.value.length + i + 1}`),
+        ];
+        pagedState.value = pagedRows.value.length >= 60 ? "end" : "idle";
+      }, 500);
+    }
+
     return () => (
       <div class="demo">
         <header class="demo-header">
@@ -223,6 +242,22 @@ export default defineComponent({
             <HButton variant="primary" disabled>Disabled</HButton>
             <HButton variant="primary" shortcut="Ctrl+K">Shortcut</HButton>
           </div>
+        </section>
+
+        <section>
+          <h2>HScrollContainer + HLoadMore</h2>
+          <HScrollContainer
+            style={{ height: "320px" }}
+            approachEnd
+            onApproachEnd={loadPagedRows}
+          >
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {pagedRows.value.map((r) => (
+                <div key={r} style={{ padding: "6px 12px", borderBottom: "1px solid rgb(var(--color-muted, 108 108 108) / 18%)" }}>{r}</div>
+              ))}
+              <HLoadMore state={pagedState.value} shown={pagedRows.value.length} total={60} onLoadMore={loadPagedRows} />
+            </div>
+          </HScrollContainer>
         </section>
 
         <section>

--- a/packages/vue/src/components/HkLoadMore.scss
+++ b/packages/vue/src/components/HkLoadMore.scss
@@ -1,0 +1,53 @@
+/*
+ * HkLoadMore — the unified bottom indicator for dynamically loaded
+ * lists. Hairline rules flank the control so the indicator reads as
+ * "the list pauses here" rather than a stray button; everything is
+ * token-driven (no hardcoded colors) so themes restyle it for free.
+ */
+
+.hk-load-more {
+  display: flex;
+  align-items: center;
+  gap: var(--space-12);
+  padding: var(--space-12) 0;
+  color: rgb(var(--color-text-tertiary));
+}
+
+/* Hairline rules: transparent at the outer edge, muted towards the
+ * control; the end rule mirrors the gradient. */
+.hk-load-more-rule {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(to right, transparent, rgb(var(--color-muted) / 35%));
+}
+
+.hk-load-more-rule-end {
+  background: linear-gradient(to left, transparent, rgb(var(--color-muted) / 35%));
+}
+
+.hk-load-more-core {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-10);
+}
+
+/* Delivery progress ("3 / 19"): mono, tabular so the digits don't
+ * shimmer while counting up. */
+.hk-load-more-count {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  color: rgb(var(--color-text-tertiary));
+}
+
+.hk-load-more[data-state="loading"] .hk-load-more-count {
+  opacity: 0.6;
+}
+
+.hk-load-more-end {
+  font-size: var(--text-2xs);
+  letter-spacing: 0.08em;
+  color: rgb(var(--color-text-tertiary));
+}

--- a/packages/vue/src/components/HkLoadMore.test.tsx
+++ b/packages/vue/src/components/HkLoadMore.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h } from "vue";
+
+import HkLoadMore from "./HkLoadMore";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mount(node: ReturnType<typeof h>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({ render: () => node });
+  app.mount(container);
+  mounts.push({ app, container });
+  return container;
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+/** The en bundle loads eagerly, so the two-arg t() fallbacks double as
+ *  the assertions' expected strings — no i18n test setup needed. */
+describe("HkLoadMore", () => {
+  it("idle renders the load-more button and the shown/total counter", () => {
+    const c = mount(h(HkLoadMore, { shown: 3, total: 19 }));
+    const button = c.querySelector("button.hk-btn");
+    expect(button).not.toBeNull();
+    expect(button!.textContent).toContain("Load more");
+    expect(c.querySelector(".hk-load-more-count")!.textContent).toBe("3 / 19");
+    expect(c.querySelector(".hk-load-more")!.getAttribute("data-state")).toBe("idle");
+  });
+
+  it("clicking the button emits load-more", () => {
+    const fired: string[] = [];
+    const c = mount(h(HkLoadMore, { onLoadMore: () => fired.push("more") }));
+    (c.querySelector("button.hk-btn") as HTMLButtonElement).click();
+    expect(fired).toEqual(["more"]);
+  });
+
+  it("loading state disables the button with aria-busy and the loading label", () => {
+    const c = mount(h(HkLoadMore, { state: "loading", shown: 3, total: 19 }));
+    const button = c.querySelector("button.hk-btn") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.getAttribute("aria-busy")).toBe("true");
+    expect(button.textContent).toContain("Loading…");
+    expect(c.querySelector(".hk-spinner")).not.toBeNull();
+  });
+
+  it("end state swaps the button for the reached-the-end status note", () => {
+    const c = mount(h(HkLoadMore, { state: "end", shown: 19, total: 19 }));
+    expect(c.querySelector("button.hk-btn")).toBeNull();
+    const note = c.querySelector('[role="status"]');
+    expect(note).not.toBeNull();
+    expect(note!.textContent).toContain("You've reached the end");
+    expect(c.querySelector(".hk-load-more-count")!.textContent).toBe("19 / 19");
+  });
+
+  it("omits the counter entirely when shown/total are absent", () => {
+    const c = mount(h(HkLoadMore));
+    expect(c.querySelector(".hk-load-more-count")).toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkLoadMore.tsx
+++ b/packages/vue/src/components/HkLoadMore.tsx
@@ -1,0 +1,72 @@
+import { defineComponent, type PropType } from "vue";
+
+import "./HkLoadMore.scss";
+import { useI18n } from "../i18n/context";
+import HButton from "./HkButton";
+
+/**
+ * The unified bottom indicator for dynamically loaded lists — one look
+ * for every consumer (cruise panels, tables, feeds), three states:
+ *
+ * - `idle`: a ghost load-more button; clicking emits `load-more`.
+ * - `loading`: the SAME button with its built-in spinner (HkButton
+ *   swaps in an HSpinner while loading) — no second spinner here, the
+ *   affordance morphs in place at a stable height.
+ * - `end`: a muted "reached the end" note replacing the button.
+ *
+ * Optional `shown`/`total` render a tabular mono counter next to the
+ * control in every state ("3 / 19"), giving users the delivery
+ * progress without each app inventing its own wording.
+ */
+export default defineComponent({
+  name: "HkLoadMore",
+  props: {
+    state: { type: String as PropType<"idle" | "loading" | "end">, default: "idle" },
+    /** Delivered item count (with `total`, renders the progress counter). */
+    shown: { type: Number, default: undefined },
+    /** Full item count behind the windowed list. */
+    total: { type: Number, default: undefined },
+  },
+  emits: ["loadMore"],
+  setup(props, { emit }) {
+    const { t } = useI18n();
+    return () => {
+      const hasCount =
+        typeof props.shown === "number" && typeof props.total === "number";
+      const loading = props.state === "loading";
+      return (
+        <div class="hk-load-more" data-state={props.state}>
+          <span class="hk-load-more-rule" aria-hidden="true" />
+          <span class="hk-load-more-core">
+            {props.state === "end" ? (
+              <span class="hk-load-more-end" role="status">
+                {t("hikari::loadMore.end", "You've reached the end")}
+              </span>
+            ) : (
+              <HButton
+                variant="ghost"
+                size="sm"
+                icon="ChevronDown"
+                loading={loading}
+                aria-label={
+                  loading
+                    ? t("hikari::loadMore.loading", "Loading…")
+                    : t("hikari::loadMore.more", "Load more")
+                }
+                onClick={() => emit("loadMore")}
+              >
+                {loading
+                  ? t("hikari::loadMore.loading", "Loading…")
+                  : t("hikari::loadMore.more", "Load more")}
+              </HButton>
+            )}
+            {hasCount ? (
+              <span class="hk-load-more-count">{props.shown} / {props.total}</span>
+            ) : null}
+          </span>
+          <span class="hk-load-more-rule hk-load-more-rule-end" aria-hidden="true" />
+        </div>
+      );
+    };
+  },
+});

--- a/packages/vue/src/components/HkLoadMore.tsx
+++ b/packages/vue/src/components/HkLoadMore.tsx
@@ -8,7 +8,7 @@ import HButton from "./HkButton";
  * The unified bottom indicator for dynamically loaded lists — one look
  * for every consumer (cruise panels, tables, feeds), three states:
  *
- * - `idle`: a ghost load-more button; clicking emits `load-more`.
+ * - `idle`: a ghost load-more button; clicking emits `loadMore`.
  * - `loading`: the SAME button with its built-in spinner (HkButton
  *   swaps in an HSpinner while loading) — no second spinner here, the
  *   affordance morphs in place at a stable height.

--- a/packages/vue/src/components/HkScrollContainer.test.ts
+++ b/packages/vue/src/components/HkScrollContainer.test.ts
@@ -11,6 +11,7 @@ interface Mounted {
   instance: {
     refresh: () => void;
     getOverflow: () => { horizontal: string; vertical: string };
+    isNearEnd?: () => boolean;
   } | null;
 }
 
@@ -47,7 +48,7 @@ function mountScroller(props: Record<string, unknown> = {}, slotText = "content"
 /** happy-dom performs no layout, so scroll geometry is stubbed on the
  *  viewport instance (shadowing the prototype getters) before a
  *  refresh() pass re-senses the overflow. */
-function stubGeometry(el: HTMLElement, geom: { scrollWidth?: number; clientWidth?: number; scrollLeft?: number }) {
+function stubGeometry(el: HTMLElement, geom: { scrollWidth?: number; clientHeight?: number; clientWidth?: number; scrollLeft?: number; scrollHeight?: number; scrollTop?: number }) {
   const desc: PropertyDescriptorMap = {};
   for (const [key, value] of Object.entries(geom)) {
     desc[key] = { configurable: true, get: () => value };
@@ -156,5 +157,31 @@ describe("HkScrollContainer scrollbar reactivity", () => {
     props.scrollbar = false;
     await nextTick();
     expect(root.querySelectorAll(".hk-scrollbar-track").length).toBe(0);
+  });
+});
+
+describe("HkScrollContainer approachEnd", () => {
+  /** Two awaited frames: scheduleFrame's scheduling rAF + the composable's
+   *  onceFrame initial sensing pass. */
+  async function flushFrames(): Promise<void> {
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+    await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  }
+
+  it("emits approachEnd for under-filled content and exposes isNearEnd", async () => {
+    const emissions: number[] = [];
+    const m = mountScroller({ approachEnd: true, onApproachEnd: () => emissions.push(1) });
+    // happy-dom has no layout: under-filled = scrollHeight < clientHeight.
+    stubGeometry(m.viewport, { scrollHeight: 100, clientHeight: 300, scrollTop: 0 });
+    await flushFrames();
+    expect(emissions.length).toBe(1);
+    expect(m.instance?.isNearEnd?.()).toBe(true);
+  });
+
+  it("does not emit when the prop is off", async () => {
+    const emissions: number[] = [];
+    mountScroller({ onApproachEnd: () => emissions.push(1) });
+    await flushFrames();
+    expect(emissions.length).toBe(0);
   });
 });

--- a/packages/vue/src/components/HkScrollContainer.test.ts
+++ b/packages/vue/src/components/HkScrollContainer.test.ts
@@ -12,6 +12,7 @@ interface Mounted {
     refresh: () => void;
     getOverflow: () => { horizontal: string; vertical: string };
     isNearEnd?: () => boolean;
+    recheck?: () => void;
   } | null;
 }
 
@@ -184,5 +185,19 @@ describe("HkScrollContainer approachEnd", () => {
     mountScroller({ onApproachEnd: () => emissions.push(1) });
     await flushFrames();
     expect(emissions.length).toBe(0);
+  });
+
+  it("exposes recheck and honours it at the container level", async () => {
+    const emissions: number[] = [];
+    const m = mountScroller({ approachEnd: true, onApproachEnd: () => emissions.push(1) });
+    stubGeometry(m.viewport, { scrollHeight: 300, clientHeight: 300, scrollTop: 0 });
+    await flushFrames();
+    expect(emissions.length).toBe(1);
+    // Pin recheck on the exposed surface: dropping it from expose() must
+    // fail here, not just at the composable level.
+    expect(typeof m.instance?.recheck).toBe("function");
+    m.instance?.recheck?.();
+    await flushFrames();
+    expect(emissions.length).toBe(2);
   });
 });

--- a/packages/vue/src/components/HkScrollContainer.test.ts
+++ b/packages/vue/src/components/HkScrollContainer.test.ts
@@ -171,8 +171,9 @@ describe("HkScrollContainer approachEnd", () => {
   it("emits approachEnd for under-filled content and exposes isNearEnd", async () => {
     const emissions: number[] = [];
     const m = mountScroller({ approachEnd: true, onApproachEnd: () => emissions.push(1) });
-    // happy-dom has no layout: under-filled = scrollHeight < clientHeight.
-    stubGeometry(m.viewport, { scrollHeight: 100, clientHeight: 300, scrollTop: 0 });
+    // happy-dom has no layout; a real under-filled DOM reports the
+    // CSSOM clamp (scrollHeight == clientHeight), so stub THAT.
+    stubGeometry(m.viewport, { scrollHeight: 300, clientHeight: 300, scrollTop: 0 });
     await flushFrames();
     expect(emissions.length).toBe(1);
     expect(m.instance?.isNearEnd?.()).toBe(true);

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -12,6 +12,7 @@ import {
 import { useI18n } from "../i18n/context";
 import "./HkScrollContainer.scss";
 import { attachOverlayScrollbars, type OverlayScrollbarHandle } from "../composables/useOverlayScrollbar";
+import { useApproachEnd, type ApproachEndHandle } from "../composables/useApproachEnd";
 import { provideScrollWindow } from "../composables/useScrollWindow";
 import { scheduleFrame, notifyScrollStart, onceFrame, type AnimationHandle } from "../runtime/animationBus";
 import HFab from "./HkFab";
@@ -61,8 +62,23 @@ export default defineComponent({
      *  scrolled away from the bottom, float a small jump-back FAB that
      *  snaps to the latest content and re-arms follow. */
     followAffordance: { type: Boolean, default: false },
+    /** Additive opt-in: sense "the viewport is at/near the end of its
+     *  content" and emit `approachEnd` so the consumer can load the
+     *  next page of data (infinite/dynamic loading). The event fires on
+     *  zone entry and whenever the content geometry grows while still
+     *  in the zone — including the initial pass when the content does
+     *  not fill the viewport, which is what lets a consumer auto-fill a
+     *  first screen. Fire-and-dedup contract: guard the handler with
+     *  your own loading flag; repeated events arrive only when new
+     *  content actually landed (or the zone was re-entered). */
+    approachEnd: { type: Boolean, default: false },
+    /** Distance in px from the vertical end that still counts as
+     *  approaching (`approachEnd`). Read live, so runtime changes need
+     *  no remount. */
+    approachDistance: { type: Number, default: 160 },
   },
-  setup(props, { slots, expose }) {
+  emits: { approachEnd: () => true },
+  setup(props, { slots, expose, emit }) {
     const { t } = useI18n();
     const viewportRef = ref<HTMLElement>();
     let ro: ResizeObserver | null = null;
@@ -86,6 +102,31 @@ export default defineComponent({
     const autoFollowContent = shallowRef<HTMLElement | null>(null);
     let followRO: ResizeObserver | null = null;
     const showAutoTag = computed(() => props.autoFollow && props.scrollbar && pinned.value);
+
+    // End-approach sensing (infinite loading): the composable owns the
+    // scroll/resize/mutation sensors; this component only owns the
+    // lifecycle and forwards the emission. `distance` is passed as a
+    // getter so runtime approachDistance changes need no restart.
+    const approachHandle = shallowRef<ApproachEndHandle | null>(null);
+
+    function startApproach() {
+      if (approachHandle.value) return;
+      approachHandle.value = useApproachEnd(
+        viewportRef as unknown as import("vue").Ref<HTMLElement | null>,
+        () => emit("approachEnd"),
+        { distance: () => props.approachDistance },
+      );
+    }
+
+    function stopApproach() {
+      approachHandle.value?.stop();
+      approachHandle.value = null;
+    }
+
+    watch(() => props.approachEnd, (on) => {
+      if (on) startApproach();
+      else stopApproach();
+    }, { flush: "post" });
 
     if (props.mode === "windowed") {
       provideScrollWindow(viewportRef as unknown as import("vue").Ref<HTMLElement | null>, props.overscanScreens);
@@ -255,6 +296,8 @@ export default defineComponent({
         mountScrollbars();
       }
 
+      if (props.approachEnd) startApproach();
+
       vp.addEventListener("scroll", onScroll, { passive: true });
       vp.addEventListener("wheel", onWheel, { passive: false });
 
@@ -287,6 +330,7 @@ export default defineComponent({
       }
       overlay?.detach();
       overlay = null;
+      stopApproach();
       scheduled?.disconnect();
       settleHandle?.disconnect();
       settleHandle = null;
@@ -341,7 +385,13 @@ export default defineComponent({
       };
     }
 
-    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop, refresh, getOverflow });
+    /** True while the viewport sits within `approachDistance` of its
+     *  vertical end (only meaningful with `approachEnd`). */
+    function isNearEnd(): boolean {
+      return approachHandle.value?.isNearEnd() ?? false;
+    }
+
+    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop, refresh, getOverflow, isNearEnd });
 
     return () => {
       const Tag = props.as as "div" | "section" | "nav" | "main" | "aside";

--- a/packages/vue/src/components/HkScrollContainer.tsx
+++ b/packages/vue/src/components/HkScrollContainer.tsx
@@ -66,11 +66,13 @@ export default defineComponent({
      *  content" and emit `approachEnd` so the consumer can load the
      *  next page of data (infinite/dynamic loading). The event fires on
      *  zone entry and whenever the content geometry grows while still
-     *  in the zone — including the initial pass when the content does
-     *  not fill the viewport, which is what lets a consumer auto-fill a
-     *  first screen. Fire-and-dedup contract: guard the handler with
-     *  your own loading flag; repeated events arrive only when new
-     *  content actually landed (or the zone was re-entered). */
+     *  in the zone — including every pass while the content does not
+     *  fill the viewport (CSSOM clamps scrollHeight there, so the
+     *  under-filled state always reports; that is what lets a consumer
+     *  auto-fill a first screen). Fire-and-dedup contract: guard the
+     *  handler with your own loading flag; when a load renders nothing
+     *  new (all filtered out downstream), call the exposed `recheck()`
+     *  to force the next emission. */
     approachEnd: { type: Boolean, default: false },
     /** Distance in px from the vertical end that still counts as
      *  approaching (`approachEnd`). Read live, so runtime changes need
@@ -391,7 +393,16 @@ export default defineComponent({
       return approachHandle.value?.isNearEnd() ?? false;
     }
 
-    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop, refresh, getOverflow, isNearEnd });
+    /** Force one end-approach sensing pass that ignores the
+     *  same-geometry dedup. Call after a load that may still leave the
+     *  content under-filled — while under-filled the sensor fires on
+     *  its own, but a consumer whose load rendered nothing new (all
+     *  filtered out downstream) needs this to keep the walk going. */
+    function recheck(): void {
+      approachHandle.value?.recheck();
+    }
+
+    expose({ scrollTo, scrollToElement, getScrollElement, getScrollTop, refresh, getOverflow, isNearEnd, recheck });
 
     return () => {
       const Tag = props.as as "div" | "section" | "nav" | "main" | "aside";

--- a/packages/vue/src/composables/useApproachEnd.test.ts
+++ b/packages/vue/src/composables/useApproachEnd.test.ts
@@ -26,11 +26,14 @@ class FakeMutationObserver {
   static instances: FakeMutationObserver[] = [];
   callback: () => void;
   disconnected = false;
+  lastOptions: MutationObserverInit | null = null;
   constructor(callback: () => void) {
     this.callback = callback;
     FakeMutationObserver.instances.push(this);
   }
-  observe(): void {}
+  observe(_el: Node, options?: MutationObserverInit): void {
+    this.lastOptions = options ?? null;
+  }
   disconnect(): void {
     this.disconnected = true;
   }
@@ -113,6 +116,40 @@ describe("useApproachEnd", () => {
     h.setGeometry({ scrollHeight: 400, clientHeight: 300, scrollTop: 0 });
     await h.mutate();
     expect(h.fired()).toBe(2);
+  });
+
+  it("keeps firing while under-filled even though scrollHeight clamps to clientHeight", async () => {
+    // A REAL under-filled DOM reports scrollHeight == clientHeight (the
+    // CSSOM clamp), so the geometry key cannot change as pages land —
+    // the under-filled state must bypass the dedup entirely.
+    const h = mountHarness();
+    h.setGeometry({ scrollHeight: 300, clientHeight: 300, scrollTop: 0 });
+    await flushFrames();
+    expect(h.fired()).toBe(1);
+    h.setGeometry({ scrollHeight: 300, clientHeight: 300, scrollTop: 0 }); // "grew" but still clamped
+    await h.mutate();
+    expect(h.fired()).toBe(2);
+    await h.mutate();
+    expect(h.fired()).toBe(3);
+  });
+
+  it("observes characterData/subtree mutations on the viewport", () => {
+    mountHarness();
+    const mo = FakeMutationObserver.instances[FakeMutationObserver.instances.length - 1];
+    expect(mo.lastOptions).toMatchObject({ childList: true, subtree: true, characterData: true });
+  });
+
+  it("checks on viewport resize (ResizeObserver callback path)", async () => {
+    const h = mountHarness({ distance: 50 });
+    // Start far from the end: 900 - 0 - 300 = 600 > 50 → outside.
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 0 });
+    await flushFrames();
+    expect(h.fired()).toBe(0);
+    // The viewport box SHRINKS, pulling the end zone over the offset.
+    h.setGeometry({ scrollHeight: 900, clientHeight: 850, scrollTop: 0 });
+    FakeResizeObserver.instances[FakeResizeObserver.instances.length - 1].callback();
+    await flushFrames();
+    expect(h.fired()).toBe(1);
   });
 
   it("does not refire on scroll jitter with unchanged geometry", async () => {

--- a/packages/vue/src/composables/useApproachEnd.test.ts
+++ b/packages/vue/src/composables/useApproachEnd.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nextTick, ref } from "vue";
+
+import { useApproachEnd } from "./useApproachEnd";
+
+/** Injectable observers: happy-dom ships neither a layout engine nor
+ *  firing observers, so the composable's ResizeObserver/MutationObserver
+ *  sensors are replaced with deterministic fakes whose callbacks the
+ *  tests fire by hand (same pattern as useSizeMorph.test.ts). */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  callback: () => void;
+  disconnected = false;
+  constructor(callback: () => void) {
+    this.callback = callback;
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+class FakeMutationObserver {
+  static instances: FakeMutationObserver[] = [];
+  callback: () => void;
+  disconnected = false;
+  constructor(callback: () => void) {
+    this.callback = callback;
+    FakeMutationObserver.instances.push(this);
+  }
+  observe(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+const originalRO = globalThis.ResizeObserver;
+const originalMO = globalThis.MutationObserver;
+
+/** Two awaited frames: one for scheduleFrame's scheduling rAF, one for
+ *  the onceFrame initial pass — keeps flush order deterministic. */
+async function flushFrames(): Promise<void> {
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+  await new Promise<void>((r) => requestAnimationFrame(() => r()));
+}
+
+interface Harness {
+  el: HTMLElement;
+  handle: ReturnType<typeof useApproachEnd>;
+  fired: () => number;
+  setGeometry(o: { scrollHeight: number; clientHeight: number; scrollTop: number }): void;
+  scroll(): Promise<void>;
+  mutate(): Promise<void>;
+}
+
+function mountHarness(options?: Parameters<typeof useApproachEnd>[2]): Harness {
+  const el = document.createElement("div");
+  const define = (prop: string, value: number) =>
+    Object.defineProperty(el, prop, { value, configurable: true });
+  define("scrollHeight", 100);
+  define("clientHeight", 300);
+  define("scrollTop", 0);
+
+  let fires = 0;
+  const vp = ref<HTMLElement | null>(el);
+  const handle = useApproachEnd(vp, () => fires += 1, options);
+
+  return {
+    el,
+    handle,
+    fired: () => fires,
+    setGeometry({ scrollHeight, clientHeight, scrollTop }) {
+      define("scrollHeight", scrollHeight);
+      define("clientHeight", clientHeight);
+      define("scrollTop", scrollTop);
+    },
+    async scroll() {
+      el.dispatchEvent(new Event("scroll"));
+      await flushFrames();
+    },
+    async mutate() {
+      FakeMutationObserver.instances[FakeMutationObserver.instances.length - 1]?.callback();
+      await flushFrames();
+    },
+  };
+}
+
+beforeEach(() => {
+  FakeResizeObserver.instances = [];
+  FakeMutationObserver.instances = [];
+  globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+  globalThis.MutationObserver = FakeMutationObserver as unknown as typeof MutationObserver;
+});
+
+afterEach(() => {
+  globalThis.ResizeObserver = originalRO;
+  globalThis.MutationObserver = originalMO;
+});
+
+describe("useApproachEnd", () => {
+  it("fires once on bind when content is shorter than the viewport (auto-fill entry)", async () => {
+    const h = mountHarness();
+    await flushFrames();
+    expect(h.fired()).toBe(1);
+  });
+
+  it("refires when content grows while still in the zone", async () => {
+    const h = mountHarness();
+    await flushFrames();
+    expect(h.fired()).toBe(1);
+    h.setGeometry({ scrollHeight: 400, clientHeight: 300, scrollTop: 0 });
+    await h.mutate();
+    expect(h.fired()).toBe(2);
+  });
+
+  it("does not refire on scroll jitter with unchanged geometry", async () => {
+    const h = mountHarness();
+    await flushFrames();
+    expect(h.fired()).toBe(1);
+    h.setGeometry({ scrollHeight: 400, clientHeight: 300, scrollTop: 0 });
+    await h.mutate(); // grew but still within 160px of the end → refire
+    expect(h.fired()).toBe(2);
+    for (let i = 0; i < 3; i++) {
+      h.setGeometry({ scrollHeight: 400, clientHeight: 300, scrollTop: 100 * (i + 1) });
+      await h.scroll();
+    }
+    // Scrolled deeper but geometry unchanged → no further emissions.
+    expect(h.fired()).toBe(2);
+  });
+
+  it("refires after leaving and re-entering the zone", async () => {
+    const h = mountHarness({ distance: 50 });
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 0 });
+    await flushFrames();
+    // 900 - 0 - 300 = 600 > 50 → outside; the initial pass must not fire.
+    expect(h.fired()).toBe(0);
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 880 });
+    await h.scroll(); // 900 - 880 - 300 < 0 ≤ 50 → in zone, first entry
+    expect(h.fired()).toBe(1);
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 100 });
+    await h.scroll(); // leave
+    expect(h.fired()).toBe(1);
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 890 });
+    await h.scroll(); // re-enter (same geometry key — must still fire)
+    expect(h.fired()).toBe(2);
+  });
+
+  it("recheck() forces an emission with unchanged geometry", async () => {
+    const h = mountHarness();
+    await flushFrames();
+    expect(h.fired()).toBe(1);
+    h.handle.recheck();
+    await flushFrames();
+    expect(h.fired()).toBe(2);
+  });
+
+  it("stop() detaches every sensor", async () => {
+    let handle: ReturnType<typeof useApproachEnd> | null = null;
+    const el = document.createElement("div");
+    Object.defineProperty(el, "scrollHeight", { value: 100, configurable: true });
+    Object.defineProperty(el, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(el, "scrollTop", { value: 0, configurable: true });
+    let fires = 0;
+    const vp = ref<HTMLElement | null>(el);
+    handle = useApproachEnd(vp, () => fires += 1);
+    await flushFrames();
+    expect(fires).toBe(1);
+    handle.stop();
+    expect(FakeResizeObserver.instances.every((i) => i.disconnected)).toBe(true);
+    expect(FakeMutationObserver.instances.every((i) => i.disconnected)).toBe(true);
+    h_replay(el);
+    await flushFrames();
+    expect(fires).toBe(1);
+    // recheck after stop stays inert too.
+    handle.recheck();
+    await flushFrames();
+    expect(fires).toBe(1);
+  });
+
+  /** A scroll after stop must not reach the (detached) listener. */
+  function h_replay(el: HTMLElement): void {
+    el.dispatchEvent(new Event("scroll"));
+  }
+
+  it("honours the distance option in getter form", async () => {
+    let distance = 50;
+    const h = mountHarness({ distance: () => distance });
+    h.setGeometry({ scrollHeight: 900, clientHeight: 300, scrollTop: 540 });
+    await flushFrames();
+    // 900 - 540 - 300 = 60 > 50 → outside.
+    expect(h.fired()).toBe(0);
+    expect(h.handle.isNearEnd()).toBe(false);
+    distance = 100; // getter is read live: the same geometry is now in zone
+    expect(h.handle.isNearEnd()).toBe(true);
+    await h.scroll();
+    expect(h.fired()).toBe(1);
+  });
+
+  it("rebinds when the viewport ref swaps and isNearEnd never emits", async () => {
+    const first = document.createElement("div");
+    Object.defineProperty(first, "scrollHeight", { value: 100, configurable: true });
+    Object.defineProperty(first, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(first, "scrollTop", { value: 0, configurable: true });
+    const second = document.createElement("div");
+    Object.defineProperty(second, "scrollHeight", { value: 1000, configurable: true });
+    Object.defineProperty(second, "clientHeight", { value: 300, configurable: true });
+    Object.defineProperty(second, "scrollTop", { value: 0, configurable: true });
+    let fires = 0;
+    const vp = ref<HTMLElement | null>(first);
+    const handle = useApproachEnd(vp, () => fires += 1);
+    await nextTick();
+    await flushFrames();
+    expect(fires).toBe(1);
+    vp.value = second;
+    await nextTick();
+    await flushFrames();
+    // Second element is far from its end → the rebinding initial pass is inert.
+    expect(handle.isNearEnd()).toBe(false);
+    expect(fires).toBe(1);
+    handle.stop();
+  });
+});

--- a/packages/vue/src/composables/useApproachEnd.ts
+++ b/packages/vue/src/composables/useApproachEnd.ts
@@ -1,0 +1,152 @@
+import { getCurrentScope, onScopeDispose, watch, type Ref } from "vue";
+
+import { onceFrame, scheduleFrame, type AnimationHandle } from "../runtime/animationBus";
+
+export interface ApproachEndOptions {
+  /** Distance in px from the vertical end that still counts as
+   *  "approaching". May be a getter for live reads (a consumer prop that
+   *  changes at runtime then needs no handle restart). Default 160. */
+  distance?: number | (() => number);
+}
+
+export interface ApproachEndHandle {
+  /** True when the viewport currently sits within the approach distance
+   *  of its vertical end (content shorter than the viewport always
+   *  counts). Pure evaluation — no emission, no state change. */
+  isNearEnd(): boolean;
+  /** Run a sensing pass that ignores the same-geometry dedup (still
+   *  requires being in the zone). For consumers whose load produced zero
+   *  new content but advanced their own cursor — the delivery window
+   *  moved, the DOM did not — so the fill walk keeps going. */
+  recheck(): void;
+  /** Detach every sensor. Idempotent; also wired to the active effect
+   *  scope when created inside one (component setup). */
+  stop(): void;
+}
+
+/**
+ * Sense "the viewport is at/near the end of its scrollable content" and
+ * fire `onApproach` — the shared engine behind infinite/dynamic loading
+ * for any list (HkScrollContainer's `approach-end` event is built on
+ * this; native-scroll consumers can attach it to any element ref).
+ *
+ * Sensor set — each of the three covers a case the others miss:
+ * - passive `scroll` on the viewport: the user scrolls towards the end;
+ * - `ResizeObserver` on the viewport: the viewport box itself changes
+ *   (panel resize can pull the end zone up over the current offset);
+ * - `MutationObserver` (childList + subtree) on the viewport: content
+ *   grows with NO scroll event and NO box change — the classic "the
+ *   delivered page rendered but the list still doesn't fill the screen"
+ *   case that scroll/box sensing alone would never re-report.
+ *
+ * All sensors funnel into ONE rAF-coalesced check. Emission is deduped
+ * geometrically: fire on zone entry and whenever the geometry key
+ * (`scrollHeight x clientHeight`) changes while still in the zone, so an
+ * appended page that still leaves the viewport in the zone re-fires and
+ * the consumer keeps filling; scroll jitter inside an unchanged zone
+ * does not spam. Leaving the zone re-arms it. Content SHORTER than the
+ * viewport counts as in-zone (remaining distance is negative), which is
+ * what lets a consumer auto-fill a first screen from an empty list.
+ */
+export function useApproachEnd(
+  viewport: Ref<HTMLElement | null | undefined>,
+  onApproach: () => void,
+  options?: ApproachEndOptions,
+): ApproachEndHandle {
+  let ro: ResizeObserver | null = null;
+  let mo: MutationObserver | null = null;
+  let boundEl: HTMLElement | null = null;
+  let scheduled: AnimationHandle | null = null;
+  let wasInZone = false;
+  let lastKey: string | null = null;
+  let stopped = false;
+
+  function readDistance(): number {
+    const d = options?.distance;
+    if (typeof d === "function") return d();
+    return d ?? 160;
+  }
+
+  /** One sensing pass. `force` skips the same-geometry dedup (recheck). */
+  function check(force = false): void {
+    if (stopped) return;
+    const vp = viewport.value;
+    if (!vp) return;
+    const inZone = vp.scrollHeight - vp.scrollTop - vp.clientHeight <= readDistance();
+    if (!inZone) {
+      wasInZone = false;
+      return;
+    }
+    const key = `${vp.scrollHeight}x${vp.clientHeight}`;
+    const shouldFire = force || !wasInZone || key !== lastKey;
+    wasInZone = true;
+    lastKey = key;
+    if (shouldFire) onApproach();
+  }
+
+  /** Coalesce every sensor into at most one check per frame. */
+  function scheduleCheck(): void {
+    if (stopped || !boundEl) return;
+    if (scheduled) return;
+    scheduled = scheduleFrame(() => {
+      scheduled = null;
+      check(false);
+    });
+  }
+
+  /** (Re)attach all sensors to `el`; run the initial pass one frame
+   *  later so a just-mounted list with less content than the viewport
+   *  fires immediately (the auto-fill entry point). */
+  function bind(el: HTMLElement | null): void {
+    if (boundEl === el) return;
+    detach();
+    boundEl = el;
+    if (!el) return;
+    el.addEventListener("scroll", scheduleCheck, { passive: true });
+    ro = new ResizeObserver(scheduleCheck);
+    ro.observe(el);
+    mo = new MutationObserver(scheduleCheck);
+    mo.observe(el, { childList: true, subtree: true, characterData: true });
+    onceFrame(() => {
+      if (!stopped) check(false);
+    });
+  }
+
+  function detach(): void {
+    if (boundEl) boundEl.removeEventListener("scroll", scheduleCheck);
+    boundEl = null;
+    ro?.disconnect();
+    ro = null;
+    mo?.disconnect();
+    mo = null;
+  }
+
+  function stop(): void {
+    stopped = true;
+    scheduled?.disconnect();
+    scheduled = null;
+    detach();
+  }
+
+  // The ref can swap at runtime (branch flips remount scrollers) — the
+  // watcher keeps the sensors on whichever element is current.
+  watch(viewport, (el) => {
+    if (!stopped) bind(el ?? null);
+  }, { flush: "post" });
+  if (viewport.value) bind(viewport.value);
+
+  if (getCurrentScope()) onScopeDispose(stop);
+
+  return {
+    isNearEnd(): boolean {
+      const vp = viewport.value;
+      if (!vp) return false;
+      return vp.scrollHeight - vp.scrollTop - vp.clientHeight <= readDistance();
+    },
+    recheck(): void {
+      if (stopped) return;
+      scheduleFrame(() => check(true));
+    },
+    stop,
+  };
+}

--- a/packages/vue/src/composables/useApproachEnd.ts
+++ b/packages/vue/src/composables/useApproachEnd.ts
@@ -72,11 +72,12 @@ export function useApproachEnd(
    *  clamps scrollHeight to clientHeight while the content does NOT
    *  overflow, so an under-filled list that grows page by page never
    *  changes that key. The under-filled state therefore bypasses the
-   *  dedup entirely and fires on every pass: scroll jitter cannot occur
-   *  there (no overflow → no scroll events), so only real
-   *  resize/mutation signals drive the emissions, and the consumer's
-   *  own loading flag paces the walk — the auto-fill first-screen
-   *  contract. */
+   *  dedup entirely and fires on every pass: the consumer's own loading
+   *  flag paces the walk — the auto-fill first-screen contract. (Only
+   *  real resize/mutation signals drive the passes in the common case;
+   *  a list that horizontally overflows while vertically under-filled
+   *  also sees horizontal scroll events here, which is fine — still
+   *  real user-driven signals, paced by the guard.) */
   function check(force = false): void {
     if (stopped) return;
     const vp = viewport.value;

--- a/packages/vue/src/composables/useApproachEnd.ts
+++ b/packages/vue/src/composables/useApproachEnd.ts
@@ -67,7 +67,16 @@ export function useApproachEnd(
     return d ?? 160;
   }
 
-  /** One sensing pass. `force` skips the same-geometry dedup (recheck). */
+  /** One sensing pass. `force` skips the same-geometry dedup (recheck).
+   *  The dedup keys on `${scrollHeight}x${clientHeight}` — but CSSOM
+   *  clamps scrollHeight to clientHeight while the content does NOT
+   *  overflow, so an under-filled list that grows page by page never
+   *  changes that key. The under-filled state therefore bypasses the
+   *  dedup entirely and fires on every pass: scroll jitter cannot occur
+   *  there (no overflow → no scroll events), so only real
+   *  resize/mutation signals drive the emissions, and the consumer's
+   *  own loading flag paces the walk — the auto-fill first-screen
+   *  contract. */
   function check(force = false): void {
     if (stopped) return;
     const vp = viewport.value;
@@ -75,6 +84,13 @@ export function useApproachEnd(
     const inZone = vp.scrollHeight - vp.scrollTop - vp.clientHeight <= readDistance();
     if (!inZone) {
       wasInZone = false;
+      return;
+    }
+    if (vp.scrollHeight <= vp.clientHeight + 1) {
+      // Under-filled: always report (see doc above).
+      wasInZone = true;
+      lastKey = null;
+      onApproach();
       return;
     }
     const key = `${vp.scrollHeight}x${vp.clientHeight}`;

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "موافق",
   "hikari::messageBox.alertTitle": "تنبيه",
   "hikari::messageBox.confirmTitle": "يرجى التأكيد",
-  "hikari::messageBox.promptTitle": "إدخال"
+  "hikari::messageBox.promptTitle": "إدخال",
+  "hikari::loadMore.more": "تحميل المزيد",
+  "hikari::loadMore.loading": "جارٍ التحميل…",
+  "hikari::loadMore.end": "وصلت إلى النهاية"
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "OK",
   "hikari::messageBox.alertTitle": "Hinweis",
   "hikari::messageBox.confirmTitle": "Bitte bestätigen",
-  "hikari::messageBox.promptTitle": "Eingabe"
+  "hikari::messageBox.promptTitle": "Eingabe",
+  "hikari::loadMore.more": "Mehr laden",
+  "hikari::loadMore.loading": "Wird geladen…",
+  "hikari::loadMore.end": "Das Ende ist erreicht"
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -205,5 +205,8 @@
   "hikari::affixPicker.unset": "Not set",
   "hikari::messageBox.alertTitle": "Notice",
   "hikari::messageBox.confirmTitle": "Please confirm",
-  "hikari::messageBox.promptTitle": "Input"
+  "hikari::messageBox.promptTitle": "Input",
+  "hikari::loadMore.more": "Load more",
+  "hikari::loadMore.loading": "Loading…",
+  "hikari::loadMore.end": "You've reached the end"
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "Aceptar",
   "hikari::messageBox.alertTitle": "Aviso",
   "hikari::messageBox.confirmTitle": "Confirme",
-  "hikari::messageBox.promptTitle": "Entrada"
+  "hikari::messageBox.promptTitle": "Entrada",
+  "hikari::loadMore.more": "Cargar más",
+  "hikari::loadMore.loading": "Cargando…",
+  "hikari::loadMore.end": "Has llegado al final"
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "OK",
   "hikari::messageBox.alertTitle": "Avis",
   "hikari::messageBox.confirmTitle": "Veuillez confirmer",
-  "hikari::messageBox.promptTitle": "Saisie"
+  "hikari::messageBox.promptTitle": "Saisie",
+  "hikari::loadMore.more": "Charger plus",
+  "hikari::loadMore.loading": "Chargement…",
+  "hikari::loadMore.end": "Vous avez tout vu"
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "OK",
   "hikari::messageBox.alertTitle": "お知らせ",
   "hikari::messageBox.confirmTitle": "確認してください",
-  "hikari::messageBox.promptTitle": "入力"
+  "hikari::messageBox.promptTitle": "入力",
+  "hikari::loadMore.more": "さらに読み込む",
+  "hikari::loadMore.loading": "読み込み中…",
+  "hikari::loadMore.end": "すべて読み込みました"
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "확인",
   "hikari::messageBox.alertTitle": "알림",
   "hikari::messageBox.confirmTitle": "확인 필요",
-  "hikari::messageBox.promptTitle": "입력"
+  "hikari::messageBox.promptTitle": "입력",
+  "hikari::loadMore.more": "더 불러오기",
+  "hikari::loadMore.loading": "불러오는 중…",
+  "hikari::loadMore.end": "마지막 항목입니다"
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "OK",
   "hikari::messageBox.alertTitle": "Aviso",
   "hikari::messageBox.confirmTitle": "Confirme",
-  "hikari::messageBox.promptTitle": "Entrada"
+  "hikari::messageBox.promptTitle": "Entrada",
+  "hikari::loadMore.more": "Carregar mais",
+  "hikari::loadMore.loading": "Carregando…",
+  "hikari::loadMore.end": "Você chegou ao fim"
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -200,5 +200,8 @@
   "hikari::messageBox.ok": "ОК",
   "hikari::messageBox.alertTitle": "Уведомление",
   "hikari::messageBox.confirmTitle": "Подтвердите",
-  "hikari::messageBox.promptTitle": "Ввод"
+  "hikari::messageBox.promptTitle": "Ввод",
+  "hikari::loadMore.more": "Загрузить ещё",
+  "hikari::loadMore.loading": "Загрузка…",
+  "hikari::loadMore.end": "Вы дошли до конца"
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -209,5 +209,8 @@
   "hikari::affixPicker.unset": "未设置",
   "hikari::messageBox.alertTitle": "提示",
   "hikari::messageBox.confirmTitle": "请确认",
-  "hikari::messageBox.promptTitle": "输入"
+  "hikari::messageBox.promptTitle": "输入",
+  "hikari::loadMore.more": "加载更多",
+  "hikari::loadMore.loading": "正在加载…",
+  "hikari::loadMore.end": "到底啦"
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -209,5 +209,8 @@
   "hikari::affixPicker.unset": "未設定",
   "hikari::messageBox.alertTitle": "提示",
   "hikari::messageBox.confirmTitle": "請確認",
-  "hikari::messageBox.promptTitle": "輸入"
+  "hikari::messageBox.promptTitle": "輸入",
+  "hikari::loadMore.more": "載入更多",
+  "hikari::loadMore.loading": "載入中…",
+  "hikari::loadMore.end": "到底啦"
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -30,6 +30,7 @@ export { default as HPlaceholderMarquee, type PlaceholderVariant } from "./compo
 export { default as HKbd } from "./components/HkKbd";
 export { default as HLabel } from "./components/HkLabel";
 export { default as HListTransition } from "./components/HkListTransition";
+export { default as HLoadMore } from "./components/HkLoadMore";
 export { default as HMarkdownRenderer } from "./components/HkMarkdownRenderer";
 export { default as HModal } from "./components/HkModal";
 export { default as HNavItem } from "./components/HkNavItem";
@@ -66,7 +67,6 @@ export { default as HSidebar } from "./components/HkSidebar";
 export { default as HSkeleton } from "./components/HkSkeleton";
 export { default as HSkeletonList } from "./components/HkSkeletonList";
 export { default as HSlider } from "./components/HkSlider";
-export { default as HLoadMore } from "./components/HkLoadMore";
 export { default as HSpinner } from "./components/HkSpinner";
 export { default as HSwitch } from "./components/HkSwitch";
 export { default as HTable } from "./components/HkTable";
@@ -253,6 +253,8 @@ export { validatePassword, passwordLevel } from "./utils/password";
 export type { PasswordValidationResult, PasswordLevel } from "./utils/password";
 
 export { FOCUSABLE_SELECTOR, getFocusableElements, focusFirst, trapFocus, scrollToElement } from "./utils/dom";
+export { useApproachEnd } from "./composables/useApproachEnd";
+export type { ApproachEndOptions, ApproachEndHandle } from "./composables/useApproachEnd";
 export { useDeferredTransition } from "./composables/useDeferredTransition";
 export { useSurfaceTransition } from "./composables/useSurfaceTransition";
 export type {
@@ -261,9 +263,6 @@ export type {
 } from "./composables/useSurfaceTransition";
 export { useSizeMorph } from "./composables/useSizeMorph";
 export type { SizeMorph } from "./composables/useSizeMorph";
-
-export { useApproachEnd } from "./composables/useApproachEnd";
-export type { ApproachEndOptions, ApproachEndHandle } from "./composables/useApproachEnd";
 
 export { useZoomPan } from "./composables/useZoomPan";
 export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -66,6 +66,7 @@ export { default as HSidebar } from "./components/HkSidebar";
 export { default as HSkeleton } from "./components/HkSkeleton";
 export { default as HSkeletonList } from "./components/HkSkeletonList";
 export { default as HSlider } from "./components/HkSlider";
+export { default as HLoadMore } from "./components/HkLoadMore";
 export { default as HSpinner } from "./components/HkSpinner";
 export { default as HSwitch } from "./components/HkSwitch";
 export { default as HTable } from "./components/HkTable";
@@ -260,6 +261,9 @@ export type {
 } from "./composables/useSurfaceTransition";
 export { useSizeMorph } from "./composables/useSizeMorph";
 export type { SizeMorph } from "./composables/useSizeMorph";
+
+export { useApproachEnd } from "./composables/useApproachEnd";
+export type { ApproachEndOptions, ApproachEndHandle } from "./composables/useApproachEnd";
 
 export { useZoomPan } from "./composables/useZoomPan";
 export type { ZoomPanOptions, ZoomPanState } from "./composables/useZoomPan";


### PR DESCRIPTION
## 背景

节点概览面板（shittim-chest MindMapView）在拿到列表后首屏经常交付 0 张卡片（服务端窗口锚在表头、或空窗时序竞态），只渲染一个手写的「已显示 0 / 19 个节点」chip 等用户手动点击；加载/到底提示也是各处自制。根因是上游没有任何「接近底部 → 回调」设施，各消费方只能各造各的。本 PR 在上游补齐两件事，下游 chest 波（后续 PR）据此重构。

## 1. useApproachEnd — 任意滚动容器的「到底感」传感引擎

`packages/vue/src/composables/useApproachEnd.ts`（同名导出）。对任意 `Ref<HTMLElement>` 生效，HScrollContainer 内部用它，原生滚动消费方也能直接用。

传感器（三者互补，全部 rAF 合流，走 animationBus scheduleFrame）：
- passive `scroll`（用户滚向底部）；
- `ResizeObserver`（视口盒变化，面板缩放会把终点区拉回当前偏移之上）；
- `MutationObserver`（childList+subtree+characterData）——内容增长但既无滚动也无盒变化的经典「列表不满一屏又长了一页」场景。

发射契约（几何去重）：
- 进区发射；溢出态下几何键 `${scrollHeight}x${clientHeight}` 变化再发射（追加一页仍处终点区 → 继续发射，直到填满/耗尽）；键不变的滚动抖动不刷屏；出区后重进区重新武装。
- **未填满态旁路**：CSSOM 把未溢出内容的 scrollHeight 钳到 clientHeight，几何键会被冻结——因此 `scrollHeight <= clientHeight + 1` 时完全绕过去重，每次传感都发射（无溢出即无滚动抖动；横向溢出的竖向不满列表也会经 scroll 事件驱动，均属真实信号），由消费方自己的 loading 旗标节流——这正是「按上游容器高度自动填满首屏」的语义。
- `recheck()`：无视同几何去重强制一次发射——消费方某次加载渲染出 0 个新内容（整窗被下游过滤）时用来续走；`isNearEnd()` 纯查询；`stop()` 幂等拆卸 + 作用域自动释放。

## 2. HkScrollContainer 新增 approachEnd / approachDistance

`approachEnd`（Boolean）开启传感并发射 camelCase `approachEnd` 事件（模板 `@approach-end` 照常工作）；`approachDistance`（Number，默认 160px）支持 getter 式实时读取。expose 面新增 `isNearEnd()` 与 `recheck()`（运行时开关 prop 走新句柄；既有 expose 严格增量）。

## 3. HLoadMore — 统一底部加载/到底指示器

`idle`（ghost 加载按钮，ChevronDown）→ `loading`（同一按钮原地变 spinner——直接复用 HkButton 内建 loading 的 HSpinner，无第二颗转圈）→ `end`（muted「到底啦」role=status）。可选 `shown`/`total` 渲染等宽 tabular 「3 / 19」计数（两者齐备才渲染）。发丝线两侧包夹，全部走既有 token（--space-*/--text-2xs/--font-mono/rgb(var(--color-*-))），主题免费继承。emits `loadMore`。

i18n：`hikari::loadMore.more/.loading/.end` 追加进全部 11 个 locale 的 components.json 尾部 flat 区（en: Load more / Loading… / You've reached the end；zh-Hans: 加载更多 / 正在加载… / 到底啦；等），flatKeyParity 守卫全绿。

## 4. Demo + 测试

- DemoApp 新增「HScrollContainer + HLoadMore」区块：approachEnd + 假分页（10 行/事件，60 行封顶转 end）。
- useApproachEnd.test.ts（11 用例）：初始未满发射、溢出态几何增长续发、抖动不重发、出区/重进区重臂、**钳制几何下的未填满续走**、MO options 钉死、RO 触发路径、recheck、stop 后惰性、getter distance、ref 换绑。
- HkScrollContainer.test.ts：approachEnd 发射 + 未开不发 + **容器级 recheck 暴露钉死**。
- HkLoadMore.test.tsx：三态、计数渲染规则、点击发射、aria-busy/disabled/role=status。

本地门禁：vitest 142 文件 / 1214 用例全绿；vue-tsc --noEmit exit 0。三轮对抗验证（R1 HOLD 抓出未填满态几何键冻结 → 修复；R2 SHIP；R3 增量 SHIP）。

## 下游采用指引

任意列表两行接入：容器消费方 `<HScrollContainer approachEnd @approach-end=...>` + 底部 `<HLoadMore :state :shown :total @load-more=...>`；原生滚动消费方直接 `useApproachEnd(elRef, cb)`。消费方守则：handler 用自身 loading 旗标挡并发；加载渲染 0 新内容时调 `recheck()`。chest 节点概览面板的自动首屏填充与统一指示器改造随后续 PR 落地（等本版发 npm）。

## 发版

合并后按惯例 tag `v0.42.0` 触发 npm-release（本 PR 不动 package.json 版本线，循 #447/#452 先例）。