### PR TITLE
🐛 Fix the collapsed lightbox stage, keep its zoom controls and close button visible, and regroup on-brand content colors.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@celestia-island/hikari",
+<<<<<<< HEAD
   "version": "0.42.1",
+=======
+  "version": "0.42.2",
+>>>>>>> ee1d16c (🐛 Fix the collapsed lightbox stage, keep its zoom controls and close button visible, and regroup on-brand content colors.)
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-<<<<<<< HEAD
-  "version": "0.42.1",
-=======
   "version": "0.42.2",
->>>>>>> ee1d16c (🐛 Fix the collapsed lightbox stage, keep its zoom controls and close button visible, and regroup on-brand content colors.)
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkColorSchemeDialog.test.ts
+++ b/packages/vue/src/components/HkColorSchemeDialog.test.ts
@@ -84,22 +84,28 @@ describe("HkColorSchemeDialog extension groups", () => {
   it("renders the extension section reactively when a group is registered after mount", async () => {
     mountDialog();
     await nextTick();
-    // Zero-cost for consumers that register nothing.
-    expect(document.body.querySelector(".s-scheme-groups")).toBeNull();
+    // The section always renders now (the on-brand content group lives
+    // here); before any registration it holds exactly that one panel.
+    const before = document.body.querySelector(".s-scheme-groups");
+    expect(before).toBeTruthy();
+    expect(before!.querySelectorAll(".hk-expansion-panel")).toHaveLength(1);
 
     // Late registration (after the dialog is already rendered): the
     // registry's reactive version invalidates the computed and the
-    // section appears without a remount.
+    // group's panel appears without a remount.
     registerTokenGroup(DIALOG_GROUP);
     await nextTick();
 
     const section = document.body.querySelector(".s-scheme-groups");
     expect(section).toBeTruthy();
-    // Un-sectioned group: one expansion panel, all slots on its grid.
-    expect(section!.querySelectorAll(".hk-expansion-panel")).toHaveLength(1);
-    const grid = section!.querySelector(".s-scheme-group-grid");
-    expect(grid).toBeTruthy();
-    expect(grid!.querySelectorAll(".hk-color-picker")).toHaveLength(2);
+    // The late group's panel lands after the on-brand content panel.
+    expect(section!.querySelectorAll(".hk-expansion-panel")).toHaveLength(2);
+    // The late group's own grid: scoped by its panel title, 2 slots.
+    const groupPanel = [...section!.querySelectorAll<HTMLElement>(".hk-expansion-panel")].find(
+      (p) => p.querySelector(".hk-expansion-panel-title")?.textContent === "Dialog wires",
+    );
+    expect(groupPanel).toBeTruthy();
+    expect(groupPanel!.querySelectorAll(".hk-color-picker")).toHaveLength(2);
   });
 
   it("renders one expansion panel per section of a sectioned group", async () => {

--- a/packages/vue/src/components/HkColorSchemeEditor.test.ts
+++ b/packages/vue/src/components/HkColorSchemeEditor.test.ts
@@ -143,6 +143,23 @@ async function setSwatchHex(swatchIndex: number, hex: string): Promise<void> {
   await nextTick();
 }
 
+/** Set an on-brand content slot (0 = onSolidText, 1 = onSolidIcon) of the
+ *  active mode to a hex color — the pair edits inside the extended-colors
+ *  section's first group panel, not the accent row. */
+async function setOnSolidHex(slotIndex: number, hex: string): Promise<void> {
+  const swatches = document.body.querySelectorAll(
+    ".s-scheme-groups .s-scheme-group-grid .hk-color-picker-swatch-btn",
+  );
+  (swatches[slotIndex] as HTMLButtonElement).click();
+  await settle();
+  const input = document.body.querySelector(
+    ".hk-color-picker-hex-row input.hk-input-element",
+  ) as HTMLInputElement | null;
+  input!.value = hex;
+  input!.dispatchEvent(new Event("input", { bubbles: true }));
+  await nextTick();
+}
+
 beforeEach(() => {
   // Pin the effective mode so edits deterministically target the dark side.
   useTheme().setMode("dark");
@@ -156,14 +173,21 @@ afterEach(() => {
 });
 
 describe("HkColorSchemeEditor", () => {
-  it("renders the seven accent pickers plus the two on-solid content pickers", async () => {
+  it("renders seven accent pickers and moves the on-solid pair into the extended section", async () => {
     const { container } = mountEditor();
     await nextTick();
 
     const pickers = container.querySelectorAll(".s-scheme-colors .hk-color-picker");
-    expect(pickers).toHaveLength(9); // 7 accents + onSolidText + onSolidIcon
-    // No groups registered in this file yet: the extension section is absent.
-    expect(container.querySelector(".s-scheme-groups")).toBeNull();
+    expect(pickers).toHaveLength(7); // accents only — the on-solid pair moved out
+    // The extended section is always rendered: the on-brand content group
+    // lives there even with no extension token group registered.
+    const groups = container.querySelector(".s-scheme-groups");
+    expect(groups).not.toBeNull();
+    expect(groups!.querySelector(".s-scheme-groups-title")).not.toBeNull();
+    const onSolidPickers = groups!.querySelectorAll(
+      ".s-scheme-group-grid .hk-color-picker",
+    );
+    expect(onSolidPickers).toHaveLength(2); // onSolidText + onSolidIcon
   });
 
   it("editing a token updates getDraft() with the edited RGB", async () => {
@@ -175,15 +199,15 @@ describe("HkColorSchemeEditor", () => {
     expect(draft.dark.primary).toEqual({ r: 255, g: 0, b: 0 });
   });
 
-  it("editing an on-solid content color updates getDraft()", async () => {
+  it("editing an on-brand content color updates getDraft()", async () => {
     const { ref } = mountEditor();
     await nextTick();
 
-    // 9th picker in the grid = onSolidIcon (7 accents, then text, then icon).
+    // 2nd picker in the on-brand group grid = onSolidIcon (text first).
     const swatches = document.body.querySelectorAll(
-      ".s-scheme-colors .hk-color-picker-swatch-btn",
+      ".s-scheme-groups .s-scheme-group-grid .hk-color-picker-swatch-btn",
     );
-    (swatches[8] as HTMLButtonElement).click();
+    (swatches[1] as HTMLButtonElement).click();
     await settle();
     const input = document.body.querySelector(
       ".hk-color-picker-hex-row input.hk-input-element",
@@ -237,8 +261,8 @@ describe("HkColorSchemeEditor", () => {
     const { ref } = mountEditor({ initialDark: legacyDark });
     await nextTick();
 
-    // 8th picker in the grid = onSolidText (7 accents, then text, then icon).
-    await setSwatchHex(7, "00ff00");
+    // 1st picker in the on-brand group grid = onSolidText.
+    await setOnSolidHex(0, "00ff00");
     expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 0, g: 255, b: 0 });
 
     ref.value!.reset();
@@ -259,7 +283,7 @@ describe("HkColorSchemeEditor", () => {
     });
     await nextTick();
 
-    await setSwatchHex(7, "00ff00");
+    await setOnSolidHex(0, "00ff00");
     expect(ref.value!.getDraft().dark.onSolidText).toEqual({ r: 0, g: 255, b: 0 });
 
     ref.value!.reset();

--- a/packages/vue/src/components/HkColorSchemeEditor.tsx
+++ b/packages/vue/src/components/HkColorSchemeEditor.tsx
@@ -123,14 +123,16 @@ export interface HCustomTheme {
  * their own surface (tabs, drawers, panels) instead of the built-in modal.
  *
  * Edits the seven accent tokens (primary/secondary/accent/success/error/
- * warning/info) plus the on-solid content colors (onSolidText — text on
- * brand fills, onSolidIcon — icons/shapes such as the switch thumb) per
- * mode (dark/light); the remaining surface tokens are derived. When
- * extension token groups are registered (`registerTokenGroup` /
- * `registerTokenGroupConfig`), the "Extended colors" section renders one
- * Material expansion panel per group — sub-sectioned groups get one panel
- * per section — with the slots laid out on a 2–3 column grid of
- * hue-clamped pickers showing full localized color names.
+ * warning/info) per mode (dark/light); the remaining surface tokens are
+ * derived. The on-solid content colors (onSolidText — text on brand
+ * fills, onSolidIcon — icons/shapes such as the switch thumb) are
+ * user-choosable too and edit as the FIRST group of the "Extended
+ * colors" section (2026-09-11 user direction: moved out of the accent
+ * row). When extension token groups are registered
+ * (`registerTokenGroup` / `registerTokenGroupConfig`), the section
+ * renders one Material expansion panel per group — sub-sectioned groups
+ * get one panel per section — with the slots laid out on a 2–3 column
+ * grid of hue-clamped pickers showing full localized color names.
  *
  * Exposes `reset()` (re-seed from props + current effective mode) and
  * `getDraft()` (snapshot the current edits as a `HCustomTheme`) for the
@@ -365,6 +367,40 @@ export const HkColorSchemeEditor = defineComponent({
       return panels;
     }
 
+    // ── On-brand content colors as their own extended group ──────────
+    // The two content tokens (text / icons on solid brand fills) USED to
+    // sit in the top accent row (2026-09-11 user direction: they are
+    // niche, rarely-tuned colors — they belong with the other extension
+    // palettes, as the section's FIRST group). Editing them here writes
+    // the exact same draft slots as before; only the location moved.
+    function renderOnSolidGroup() {
+      return (
+        <HExpansionPanel
+          key="on-solid-content"
+          title={t("hikari::theme.onSolidGroupTitle", "On-brand content")}
+          subtitle={countLabel(contentTokens.length)}
+        >
+          <div class="s-scheme-group-grid">
+            {contentTokens.map((key) => {
+              // Optional slots: an older prefilled custom theme may omit them.
+              const rgb = currentTokens.value[key] ?? WHITE;
+              return (
+                <HColorPicker
+                  key={key}
+                  r={rgb.r}
+                  g={rgb.g}
+                  b={rgb.b}
+                  label={t(`hikari::theme.tokens.${key}`)}
+                  layout="row"
+                  onChange={(next: { r: number; g: number; b: number }) => updateToken(key, next)}
+                />
+              );
+            })}
+          </div>
+        </HExpansionPanel>
+      );
+    }
+
     return () => (
       <div class="s-scheme-dialog">
         {props.showName && (
@@ -393,31 +429,18 @@ export const HkColorSchemeEditor = defineComponent({
               onChange={(rgb: { r: number; g: number; b: number }) => updateToken(key, rgb)}
             />
           ))}
-          {contentTokens.map((key) => {
-            // Optional slots: an older prefilled custom theme may omit them.
-            const rgb = currentTokens.value[key] ?? WHITE;
-            return (
-              <HColorPicker
-                key={key}
-                r={rgb.r}
-                g={rgb.g}
-                b={rgb.b}
-                label={t(`hikari::theme.tokens.${key}`)}
-                onChange={(next: { r: number; g: number; b: number }) => updateToken(key, next)}
-              />
-            );
-          })}
         </div>
-        {registeredGroups.value.length > 0 && (
-          <div class="s-scheme-groups">
-            <div class="s-scheme-groups-title">
-              {t("hikari::theme.extendedColors", "Extended colors")}
-            </div>
-            <div class="s-scheme-group-panels">
-              {registeredGroups.value.map((group) => renderGroup(group))}
-            </div>
+        {/* Always rendered now: the on-brand content group lives here even
+            when no extension token group is registered. */}
+        <div class="s-scheme-groups">
+          <div class="s-scheme-groups-title">
+            {t("hikari::theme.extendedColors", "Extended colors")}
           </div>
-        )}
+          <div class="s-scheme-group-panels">
+            {renderOnSolidGroup()}
+            {registeredGroups.value.map((group) => renderGroup(group))}
+          </div>
+        </div>
       </div>
     );
   },

--- a/packages/vue/src/components/HkImageLightbox.contract.test.ts
+++ b/packages/vue/src/components/HkImageLightbox.contract.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Source contract for the immersive lightbox layout (2026-09-11 field
+ * report wave). Pinned as scss-text assertions because the failure class
+ * is invisible to DOM tests: happy-dom has no layout engine, so a
+ * collapsed flex chain (the "white lightbox" — viewer 0px tall inside a
+ * full-size modal frame) and a cascade-losing hover state (the floating
+ * close button melting into the page) both pass every render test.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (f: string): string => readFileSync(join(here, f), "utf-8");
+
+describe("HkImageLightbox layout contract", () => {
+  it("makes the modal scroll region a flex container so the body chain can fill the frame", () => {
+    const css = read("HkImageLightbox.scss");
+    // The lightbox override block must carry the display itself: the inner
+    // only carries flex: 1, which is inert inside a block parent — without
+    // this the stage collapses to its padding and the viewer renders 0px
+    // tall (white canvas, dead gestures).
+    const block = css.slice(
+      css.indexOf(".hk-modal-content.hk-image-lightbox"),
+      css.indexOf(".hk-image-lightbox-stage"),
+    );
+    expect(block).toContain(".hk-modal-body-scroll");
+    expect(block).toMatch(/\.hk-modal-body-scroll\s*\{[^}]*display:\s*flex/);
+  });
+
+  it("re-asserts the dark chip on hover/focus above the window-close cascade", () => {
+    const css = read("HkImageLightbox.scss");
+    // window-close.scss's :hover paints the light theme tint and loses to
+    // nothing here — the lightbox hover must re-assert the real background
+    // (not just the custom properties) at higher specificity, and push the
+    // color into the glyph span (which keeps its own white declaration).
+    expect(css).toContain("&.hk-window-close:hover");
+    expect(css).toContain("&.hk-window-close:focus-visible");
+    const hoverBlock = css.slice(css.indexOf("&.hk-window-close:hover"));
+    expect(hoverBlock.indexOf("background:")).toBeGreaterThan(-1);
+    expect(hoverBlock).toContain(".hk-icon-button-icon");
+  });
+});

--- a/packages/vue/src/components/HkImageLightbox.scss
+++ b/packages/vue/src/components/HkImageLightbox.scss
@@ -103,7 +103,8 @@
     --hi-icon-button-icon-color: #fff;
   }
 
-  // (0,4,0)+pseudo — beats `.hk-icon-button.hk-window-close:hover`.
+  // (0,4,0) with the pseudo-class counted — beats
+  // `.hk-icon-button.hk-window-close:hover` at (0,3,0).
   &.hk-window-close:hover,
   &.hk-window-close:focus-visible {
     background: var(--hi-icon-button-bg);

--- a/packages/vue/src/components/HkImageLightbox.scss
+++ b/packages/vue/src/components/HkImageLightbox.scss
@@ -8,6 +8,13 @@
 // The frame is a fixed-size stage; the body chain (body → scroll →
 // inner) is flattened to pure flex so the HImageViewer fills it, and the
 // floating close button rides on top of the stage.
+//
+// The scroll link MUST become a flex container itself: the inner below it
+// only carries `flex: 1`, which does nothing inside a block parent —
+// without `display: flex` here the chain collapses to the stage's own
+// padding and the viewer renders 0px tall (the 2026-09-11 "white
+// lightbox" field report: full-size modal frame, invisible canvas, and
+// every wheel/pointer gesture dead because their surface had no area).
 // ------
 
 .hk-modal-content.hk-image-lightbox {
@@ -28,6 +35,8 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
   }
 
   .hk-modal-body-inner {
@@ -61,6 +70,17 @@
 // Floating close button — legible on any image: translucent dark chip
 // with a blur, light glyph. Colors ride HIconButton's variable layer
 // (--hi-icon-button-*) so the icon span picks them up too.
+//
+// The hover/focus state must RE-ASSERT the real `background`/`color`
+// properties, not just the custom properties: the shared window-close
+// grammar (imported after this sheet, equal specificity on :hover) wins
+// the cascade tie and paints the near-transparent light-theme tint over
+// the dark chip, while the glyph span keeps its own
+// `color: var(--hi-icon-button-icon-color)` (white) — white glyph on the
+// white modal, the button visibly vanished (2026-09-11 field report).
+// The selectors carry the extra `.hk-window-close` class the lightbox
+// button always wears, so the pair here outranks window-close's
+// `&:hover` regardless of bundle order.
 // ------
 
 .hk-image-lightbox-close.hk-icon-button {
@@ -77,9 +97,21 @@
   color: var(--hi-icon-button-icon-color);
   backdrop-filter: blur(6px);
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     --hi-icon-button-bg: rgb(0 0 0 / 65%);
     --hi-icon-button-icon-color: #fff;
+  }
+
+  // (0,4,0)+pseudo — beats `.hk-icon-button.hk-window-close:hover`.
+  &.hk-window-close:hover,
+  &.hk-window-close:focus-visible {
+    background: var(--hi-icon-button-bg);
+    color: var(--hi-icon-button-icon-color);
+
+    .hk-icon-button-icon {
+      color: var(--hi-icon-button-icon-color);
+    }
   }
 
   &:focus-visible {

--- a/packages/vue/src/components/HkImageViewer.tsx
+++ b/packages/vue/src/components/HkImageViewer.tsx
@@ -327,7 +327,13 @@ export default defineComponent({
           </div>
         )}
 
-        {loaded.value && isZoomed.value && (
+        {/* The controls are visible for the WHOLE session, not only once
+            zoomed past fit (2026-09-11 user report: at fit the viewer
+            offered no affordance at all — no buttons, no percent, no hint
+            that wheel/pinch/drag exist). At fit the viewport rect says
+            nothing worth drawing, so the minimap runs toolbar-only and
+            grows the overview map back the moment zooming starts. */}
+        {loaded.value && (
           <HMinimap
             imageSrc={props.src}
             imageBounds={contentBounds.value}
@@ -344,6 +350,7 @@ export default defineComponent({
             minZoomPercent={Math.max(1, Math.round(fit.value * 100))}
             maxZoomPercent={Math.round(MAX_ZOOM * 100)}
             showReset
+            toolbarOnly={!isZoomed.value}
             onZoomTo={(percent: number) => setZoom(percent / 100)}
             onReset={resetView}
             onPanDelta={onPanDelta}

--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -41,6 +41,16 @@
   pointer-events: auto;
 }
 
+// Toolbar-only form (no overview map): shrink-wrap the card around the
+// zoom bar and drop the map's separator — the bar IS the whole surface.
+.hk-minimap[data-toolbar-only] {
+  width: auto;
+
+  .hk-mm-zoom-bar {
+    border-top: none;
+  }
+}
+
 .hk-mm-zoom-btn {
   display: flex;
   align-items: center;

--- a/packages/vue/src/components/HkMinimap.toolbarOnly.test.tsx
+++ b/packages/vue/src/components/HkMinimap.toolbarOnly.test.tsx
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h } from "vue";
+
+import HkMinimap from "./HkMinimap";
+
+const mounts: ReturnType<typeof createApp>[] = [];
+const containers: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const app of mounts.splice(0)) app.unmount();
+  for (const el of containers.splice(0)) el.remove();
+});
+
+function mountMinimap(props: Record<string, unknown>): HTMLElement {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  containers.push(container);
+
+  const Host = defineComponent({
+    setup() {
+      return () => h("div", [h(HkMinimap, props)]);
+    },
+  });
+  const app = createApp(Host);
+  mounts.push(app);
+  app.mount(container);
+  return container;
+}
+
+describe("HkMinimap toolbar-only form", () => {
+  it("renders nothing without boxes, an image, or the toolbar-only flag", () => {
+    const c = mountMinimap({ zoomPercent: 100 });
+    expect(c.querySelector(".hk-minimap")).toBeNull();
+  });
+
+  it("renders only the zoom bar under toolbarOnly (no overview map)", () => {
+    const c = mountMinimap({ zoomPercent: 100, toolbarOnly: true });
+    const root = c.querySelector<HTMLElement>(".hk-minimap");
+    expect(root).not.toBeNull();
+    expect(root!.hasAttribute("data-toolbar-only")).toBe(true);
+    expect(root!.querySelector(".hk-minimap-svg")).toBeNull();
+    expect(root!.querySelector(".hk-mm-zoom-bar")).not.toBeNull();
+    expect(root!.querySelectorAll(".hk-mm-zoom-btn").length).toBe(2);
+  });
+
+  it("keeps the overview map when toolbarOnly is not set and an image is given", () => {
+    const c = mountMinimap({ imageSrc: "data:image/gif;base64,", toolbarOnly: false });
+    const root = c.querySelector<HTMLElement>(".hk-minimap");
+    expect(root).not.toBeNull();
+    expect(root!.hasAttribute("data-toolbar-only")).toBe(false);
+    expect(root!.querySelector(".hk-minimap-svg")).not.toBeNull();
+    expect(root!.querySelector(".hk-mm-zoom-bar")).not.toBeNull();
+  });
+});

--- a/packages/vue/src/components/HkMinimap.tsx
+++ b/packages/vue/src/components/HkMinimap.tsx
@@ -65,6 +65,12 @@ export default defineComponent({
     /** Show the reset/fit button in the zoom bar (chest only rendered it
      *  when a reset handler was wired up). */
     showReset: { type: Boolean, default: false },
+    /** Toolbar-only form: render just the zoom bar, no overview map. For
+     *  hosts whose viewport rect is uninformative at rest (e.g. the image
+     *  lightbox at fit zoom) but that still want the zoom controls
+     *  visible; the map is expected to reappear once it has something to
+     *  say (the viewer switches this off when zoomed past fit). */
+    toolbarOnly: { type: Boolean, default: false },
     /** Optional prop-callback surface (alternative to the emits). */
     onZoomTo: { type: Function as PropType<(percent: number) => void>, default: undefined },
     onReset: { type: Function as PropType<() => void>, default: undefined },
@@ -180,7 +186,7 @@ export default defineComponent({
     });
 
     return () => {
-      if (props.boxes.length === 0 && !props.imageSrc) return null;
+      if (props.boxes.length === 0 && !props.imageSrc && !props.toolbarOnly) return null;
 
       const s = scale.value;
       const vr = viewportRect.value;
@@ -213,42 +219,45 @@ export default defineComponent({
           ref={rootRef}
           class="hk-minimap"
           data-dragging={dragging.value ? "" : undefined}
+          data-toolbar-only={props.toolbarOnly ? "" : undefined}
         >
-          <svg viewBox={`0 0 ${svgW} ${svgH}`} width={svgW} height={svgH} class="hk-minimap-svg">
-            {imgPos && (
-              <image
-                href={props.imageSrc}
-                x={imgPos[0]}
-                y={imgPos[1]}
-                width={ib.w * s}
-                height={ib.h * s}
-                preserveAspectRatio="none"
-                class="hk-mm-image"
+          {!props.toolbarOnly && (
+            <svg viewBox={`0 0 ${svgW} ${svgH}`} width={svgW} height={svgH} class="hk-minimap-svg">
+              {imgPos && (
+                <image
+                  href={props.imageSrc}
+                  x={imgPos[0]}
+                  y={imgPos[1]}
+                  width={ib.w * s}
+                  height={ib.h * s}
+                  preserveAspectRatio="none"
+                  class="hk-mm-image"
+                />
+              )}
+              {boxRects}
+              {hubP && (
+                <circle
+                  cx={hubP[0]}
+                  cy={hubP[1]}
+                  r={3}
+                  fill="rgb(var(--color-primary))"
+                  filter="drop-shadow(0 0 2px rgb(var(--color-primary) / 0.6))"
+                />
+              )}
+              <rect
+                x={vr.x}
+                y={vr.y}
+                width={Math.max(1, vr.w)}
+                height={Math.max(1, vr.h)}
+                fill="none"
+                stroke="rgb(var(--color-primary))"
+                stroke-width="1"
+                stroke-dasharray="3 2"
+                rx="2"
+                opacity="0.85"
               />
-            )}
-            {boxRects}
-            {hubP && (
-              <circle
-                cx={hubP[0]}
-                cy={hubP[1]}
-                r={3}
-                fill="rgb(var(--color-primary))"
-                filter="drop-shadow(0 0 2px rgb(var(--color-primary) / 0.6))"
-              />
-            )}
-            <rect
-              x={vr.x}
-              y={vr.y}
-              width={Math.max(1, vr.w)}
-              height={Math.max(1, vr.h)}
-              fill="none"
-              stroke="rgb(var(--color-primary))"
-              stroke-width="1"
-              stroke-dasharray="3 2"
-              rx="2"
-              opacity="0.85"
-            />
-          </svg>
+            </svg>
+          )}
           <div class="hk-mm-zoom-bar">
             <button
               class="hk-mm-zoom-btn"

--- a/packages/vue/src/components/HkThemeToggle.contract.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.contract.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Source contract for the theme-row leading cell sizing (2026-09-11
+ * field report: chest's 28px three-dot palette swatch overflowed its
+ * 16px generic icon cell and bled into the row gap — at fractional zoom
+ * rounding the dots visually overlapped the row name). happy-dom has no
+ * layout engine, so the geometry contract is pinned as an scss-text
+ * assertion: the theme-row lead cell must carry an explicit size that
+ * fits the widest host lead mark, not just the mixin's generic box.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (f: string): string => readFileSync(join(here, f), "utf-8");
+
+describe("HkThemeToggle row lead-cell contract", () => {
+  it("sizes the theme-row lead cell to fit a 28px swatch mark", () => {
+    const css = read("HkThemeToggle.scss");
+    const block = css.match(
+      /\.s-theme-item-btn \.hk-menu-item-icon\s*\{[^}]*\}/,
+    );
+    expect(block).not.toBeNull();
+    expect(block![0]).toContain("width: 28px");
+    expect(block![0]).toContain("height: 28px");
+  });
+});

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -188,9 +188,19 @@
   @include mi.label;
 }
 
-/* Leading check / customize glyphs share the spec's fixed icon cell. */
+/* Leading check / customize glyphs share the spec's fixed icon cell —
+ * sized for the WIDEST lead mark hosts render there, not the generic
+ * 16px box: chest's three-dot palette swatch is 28px (3×8px dots + 2px
+ * gaps), and a mark wider than its cell bleeds symmetrically out of the
+ * cell into the row gap — at fractional zoom rounding the dots visually
+ * overlap the name (2026-09-11 field report). A uniform 28px cell keeps
+ * every row's name starting at the same x (swatch rows and icon rows
+ * stay aligned) and leaves the bleed zero room at any zoom. */
 .s-theme-item-btn .hk-menu-item-icon {
   @include mi.icon;
+
+  width: 28px;
+  height: 28px;
 }
 
 /* Custom rows keep the name clear of the overlaid delete button. */

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "أيقونات على لون العلامة",
     "hikari::theme.groupCount": "{count} ألوان",
     "hikari::theme.extendedColors": "ألوان موسعة",
+    "hikari::theme.onSolidGroupTitle": "المحتوى على لون العلامة",
     "hikari::secret.title": "سر",
     "hikari::secret.notice": "يُعرض هذا السر مرة واحدة فقط. انسخه واحفظه قبل الإغلاق.",
     "hikari::secret.copy": "نسخ",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Symbole auf Markenfarbe",
     "hikari::theme.groupCount": "{count} Farben",
     "hikari::theme.extendedColors": "Erweiterte Farben",
+    "hikari::theme.onSolidGroupTitle": "Inhalte auf Brandfarben",
     "hikari::secret.title": "Geheimnis",
     "hikari::secret.notice": "Dieses Geheimnis wird nur einmal angezeigt. Kopieren und speichern Sie es vor dem Schließen.",
     "hikari::secret.copy": "Kopieren",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Icons on brand fill",
     "hikari::theme.groupCount": "{count} colors",
     "hikari::theme.extendedColors": "Extended colors",
+    "hikari::theme.onSolidGroupTitle": "On-brand content",
     "hikari::secret.title": "Secret",
     "hikari::secret.notice": "This secret is shown only once. Copy and store it before closing.",
     "hikari::secret.copy": "Copy",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Iconos sobre color de marca",
     "hikari::theme.groupCount": "{count} colores",
     "hikari::theme.extendedColors": "Colores extendidos",
+    "hikari::theme.onSolidGroupTitle": "Contenido sobre el color de marca",
     "hikari::secret.title": "Secreto",
     "hikari::secret.notice": "Este secreto se muestra solo una vez. Cópielo y guárdelo antes de cerrar.",
     "hikari::secret.copy": "Copiar",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Icônes sur la couleur de marque",
     "hikari::theme.groupCount": "{count} couleurs",
     "hikari::theme.extendedColors": "Couleurs étendues",
+    "hikari::theme.onSolidGroupTitle": "Contenu sur la couleur de marque",
     "hikari::secret.title": "Secret",
     "hikari::secret.notice": "Ce secret n'est affiché qu'une seule fois. Copiez-le et conservez-le avant de fermer.",
     "hikari::secret.copy": "Copier",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "ブランド色上のアイコン",
     "hikari::theme.groupCount": "{count} 色",
     "hikari::theme.extendedColors": "拡張カラー",
+    "hikari::theme.onSolidGroupTitle": "ブランドカラー上のコンテンツ",
     "hikari::secret.title": "シークレット",
     "hikari::secret.notice": "このシークレットは一度だけ表示されます。閉じる前にコピーして保存してください。",
     "hikari::secret.copy": "コピー",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "브랜드 색 위의 아이콘",
     "hikari::theme.groupCount": "색상 {count}개",
     "hikari::theme.extendedColors": "확장 색상",
+    "hikari::theme.onSolidGroupTitle": "브랜드 색상 콘텐츠",
     "hikari::secret.title": "비밀",
     "hikari::secret.notice": "이 비밀은 한 번만 표시됩니다. 닫기 전에 복사하여 저장하세요.",
     "hikari::secret.copy": "복사",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Ícones sobre a cor da marca",
     "hikari::theme.groupCount": "{count} cores",
     "hikari::theme.extendedColors": "Cores estendidas",
+    "hikari::theme.onSolidGroupTitle": "Conteúdo sobre a cor da marca",
     "hikari::secret.title": "Segredo",
     "hikari::secret.notice": "Este segredo é mostrado apenas uma vez. Copie e guarde antes de fechar.",
     "hikari::secret.copy": "Copiar",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "Значки на фирменном цвете",
     "hikari::theme.groupCount": "Цветов: {count}",
     "hikari::theme.extendedColors": "Расширенные цвета",
+    "hikari::theme.onSolidGroupTitle": "Контент на фирменном цвете",
     "hikari::secret.title": "Секрет",
     "hikari::secret.notice": "Этот секрет показывается только один раз. Скопируйте и сохраните его до закрытия.",
     "hikari::secret.copy": "Копировать",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "品牌色上的图标",
     "hikari::theme.groupCount": "{count} 种颜色",
     "hikari::theme.extendedColors": "扩展配色",
+    "hikari::theme.onSolidGroupTitle": "品牌色内容",
     "hikari::secret.title": "密钥",
     "hikari::secret.notice": "此密钥仅显示一次，请先复制并妥善保存。",
     "hikari::secret.copy": "复制",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -41,6 +41,7 @@
     "hikari::theme.tokens.onSolidIcon": "品牌色上的圖示",
     "hikari::theme.groupCount": "{count} 種顏色",
     "hikari::theme.extendedColors": "擴充配色",
+    "hikari::theme.onSolidGroupTitle": "品牌色內容",
     "hikari::secret.title": "金鑰",
     "hikari::secret.notice": "此金鑰僅顯示一次，請先複製並妥善保存。",
     "hikari::secret.copy": "複製",


### PR DESCRIPTION
## What

Three user-visible fixes to the image lightbox / viewer and one color-editor regroup, driven by the 2026-09-11 field reports (chest webui theme-customize wallpaper preview):

### 1. White lightbox (点开莫名白屏) — root cause: collapsed flex chain
Reproduced in headless Chrome against the deployed CSS: `.hk-modal-body-scroll` stayed `display: block`, so the inner's `flex: 1` was inert (its parent was not a flex container). The stage collapsed to its own padding (24px) and `.hk-image-viewer` — whose base `height: 60vh` / `min-height: 18rem` floor is deliberately overridden to `auto` / `0` by the lightbox rule — collapsed to **0px tall**. The dark canvas was invisible (white modal everywhere) and every wheel/pointer gesture was dead because their surface had no area. Measured before: viewer `h=0`; after adding `display: flex; flex-direction: column` to the scroll link: viewer `h=516`.

### 2. Zoom controls always visible (放大缩小操纵按钮 + 响应能力)
`HkImageViewer` only rendered `HkMinimap` once zoomed past fit — at fit the viewer offered zero affordance. The minimap now renders for the whole session with a new `toolbarOnly` prop: at fit it shows the zoom bar (− / percent / + / reset); the overview map reappears the moment zooming starts. Wheel, double-click, drag-pan and pinch gestures are unchanged (and work again, per fix 1).

### 3. Close button vanishing on hover/focus (右上角关闭按钮凭空消失)
`window-close.scss`'s `:hover` paints the light-theme tint over the dark chip (it wins the cascade tie against the lightbox override) while the glyph span keeps its own `color: var(--hi-icon-button-icon-color)` (white) — a white glyph on the white modal with no chip = the button visibly disappears. The lightbox hover/focus state now re-asserts the real `background`/`color` at higher specificity (`.hk-image-lightbox-close.hk-icon-button.hk-window-close:hover`), pushing the color into the glyph span too. CSSOM-verified: the winning hover rule is now the dark chip.

### 4. On-brand content colors regrouped (品牌色收到扩展配色)
`onSolidText` (品牌色上的文字) and `onSolidIcon` (品牌色上的图标) move out of the top accent row into the **Extended colors** section as its first expansion panel (title i18n key `hikari::theme.onSolidGroupTitle`, all 11 locales). The section now renders even when no extension token group is registered. `getDraft()` structure is unchanged — only the editing location moved.

## Verification
- Full suite: **1200/1200 vitest green**, `vue-tsc --noEmit` clean.
- New: `HkImageLightbox.contract.test.ts` (scss source contracts for fixes 1–3 — DOM tests cannot see layout collapse in happy-dom) and `HkMinimap.toolbarOnly.test.tsx`.
- Headless Chrome measurement against the deployed CSS confirms the stage chain fills the frame and the hover cascade resolves to the dark chip.
- Version bump: `0.41.11` (0.41.10 is claimed by fix/root-zoom-popover, v0.42.0 by #455).