### PR TITLE
✨ Add the reusable tag editor field component.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.41.8",
+  "version": "0.42.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTag.test.tsx
+++ b/packages/vue/src/components/HkTag.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, type VNode } from "vue";
+
+import HkTag from "./HkTag";
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+function mountTag(props: Record<string, unknown> = {}, children?: () => VNode) {
+  const events = { close: 0 };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(
+        HkTag,
+        {
+          ...props,
+          onClose: () => {
+            events.close++;
+          },
+        },
+        children ? { default: children } : undefined,
+      ),
+  });
+  app.mount(container);
+  mounts.push({ app, container });
+  return { events, container };
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkTag", () => {
+  it("renders slot content without a close button by default", () => {
+    const { container } = mountTag({}, () => h("span", "Default"));
+    const tag = container.querySelector(".hk-tag")!;
+    expect(tag.textContent).toBe("Default");
+    expect(tag.querySelector(".hk-tag-close")).toBeNull();
+  });
+
+  it("closable renders the × which emits close", () => {
+    const { events, container } = mountTag({ closable: true }, () => h("span", "Closable"));
+    const close = container.querySelector<HTMLButtonElement>(".hk-tag-close")!;
+    expect(close).toBeTruthy();
+    // The pre-prop markup: an unlabeled button, exactly as before.
+    expect(close.hasAttribute("aria-label")).toBe(false);
+    close.click();
+    expect(events.close).toBe(1);
+  });
+
+  it("closeLabel names the close button for screen readers", () => {
+    const { events, container } = mountTag(
+      { closable: true, closeLabel: "Remove — News" },
+      () => h("span", "News"),
+    );
+    const close = container.querySelector<HTMLButtonElement>(".hk-tag-close")!;
+    expect(close.getAttribute("aria-label")).toBe("Remove — News");
+    close.click();
+    expect(events.close).toBe(1);
+  });
+
+  it("keeps the variant and size classes untouched", () => {
+    const { container } = mountTag(
+      { variant: "success", size: "sm", closable: true, closeLabel: "Remove" },
+      () => h("span", "Done"),
+    );
+    const tag = container.querySelector(".hk-tag")!;
+    expect(tag.classList.contains("hk-tag-success")).toBe(true);
+    expect(tag.classList.contains("hk-tag-sm")).toBe(true);
+  });
+});

--- a/packages/vue/src/components/HkTag.tsx
+++ b/packages/vue/src/components/HkTag.tsx
@@ -11,6 +11,13 @@ export default defineComponent({
     variant: { type: String as PropType<TagVariant>, default: "default" },
     size: { type: String as PropType<"sm" | "md">, default: "md" },
     closable: { type: Boolean, default: false },
+    /**
+     * Accessible name of the close button, rendered as its `aria-label`.
+     * Undefined (the default) renders exactly the pre-prop markup, so
+     * existing consumers are untouched; tag fields that can carry several
+     * chips side by side set it to name the entry each × removes.
+     */
+    closeLabel: { type: String, default: undefined },
   },
   emits: {
     close: () => true,
@@ -34,6 +41,7 @@ export default defineComponent({
           <button
             type="button"
             class="hk-tag-close"
+            aria-label={props.closeLabel}
             onClick={() => emit("close")}
           >
             <X size={12} />

--- a/packages/vue/src/components/HkTagInput.scss
+++ b/packages/vue/src/components/HkTagInput.scss
@@ -1,0 +1,299 @@
+/* HkTagInput — the tag editor field: chips inside the field, one
+ * searchable catalog panel behind the chevron. Field chrome mirrors
+ * HkInput's box (border, radius, rhythm, focus ring) so a tag field sits
+ * flush beside plain inputs in the same form; the panel chrome mirrors
+ * HkAffixPicker's popup (search on top, rows below, NO inner scroll
+ * region — the HkSelectPanel window owns the single scrollbar). */
+
+.hk-tag-input-wrapper {
+  display: block;
+  width: 100%;
+}
+
+.hk-tag-input-label {
+  display: block;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: var(--space-4);
+  /* Same caption hierarchy as HkInput's label, dark-theme survivable. */
+  color: rgb(var(--color-text) / var(--hk-field-label-alpha, 72%));
+}
+
+/* ── the field ────────────────────────────────────────────────────── */
+.hk-tag-input-box {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+  row-gap: var(--space-6);
+  /* Inline inset matches HkInput's element padding, so a tag field and a
+   * plain input line up in the same form; the block inset is tighter to
+   * leave wrapped chip rows room inside the same height rhythm. */
+  padding: var(--space-6) var(--space-12);
+  min-height: 2.5rem;
+  background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
+  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
+  border-radius: var(--radius-sm);
+  color: rgb(var(--color-text));
+  cursor: text;
+  transition:
+    background-color var(--duration-normal) var(--ease-standard),
+    border-color var(--duration-normal) var(--ease-standard),
+    box-shadow var(--duration-normal) var(--ease-standard),
+    opacity var(--duration-normal) var(--ease-standard);
+
+  &:hover:not([data-disabled]) {
+    border-color: var(--c-primary-strong);
+  }
+
+  &:focus-within,
+  &.hk-tag-input-box-open {
+    border-color: rgb(var(--color-focused-border));
+    box-shadow: var(--shadow-focus);
+    background: rgb(var(--color-surface));
+  }
+
+  &[data-disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+/* Size rhythm matches HkInput's field heights. */
+.hk-tag-input-box-sm {
+  min-height: 2rem;
+  padding: var(--space-4) var(--space-8);
+}
+
+.hk-tag-input-box-md {
+  min-height: 2.5rem;
+}
+
+.hk-tag-input-box-lg {
+  min-height: 3rem;
+  padding: var(--space-8) var(--space-12);
+}
+
+.hk-tag-input-tag {
+  max-width: 100%;
+}
+
+.hk-tag-input-tag-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── inline typing input / placeholder ────────────────────────────── */
+.hk-tag-input-element {
+  /* Auto-growing: the element's width is published inline in `ch`
+   * units, so it must not stretch on the main axis. */
+  flex: 0 1 auto;
+  min-width: 2rem;
+  max-width: 100%;
+  padding: var(--space-2) 0;
+  border: none;
+  outline: none;
+  border-radius: 0;
+  background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
+  font-family: inherit;
+  font-size: var(--text-base);
+  line-height: 1.5;
+  color: rgb(var(--color-text));
+
+  /* The shell owns the focus affordance (`:focus-within`); an
+   * element-level focus ring would double it. */
+  &:focus,
+  &:focus-visible {
+    border: none;
+    outline: none;
+    box-shadow: none;
+  }
+
+  &::placeholder {
+    color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
+  }
+}
+
+.hk-tag-input-placeholder {
+  flex: 1 1 4rem;
+  min-width: 0;
+  padding: var(--space-2) 0;
+  font-size: var(--text-base);
+  line-height: 1.5;
+  color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-tag-input-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
+  /* Pins to the field's trailing edge. */
+  margin-inline-start: auto;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: rgb(var(--color-muted));
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: rgb(var(--color-primary) / 12%);
+    color: rgb(var(--color-text));
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+}
+
+.hk-tag-input-hint {
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
+  color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
+}
+
+/* ── the panel ────────────────────────────────────────────────────── */
+.hk-tag-input-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 13rem;
+  max-width: min(19rem, calc(100vw - 2rem));
+}
+
+/* Mobile sheet context (the HkAffixPicker #424 pattern): inside the
+ * full-width select sheet the popup's designed measure becomes a
+ * centered cap instead of a left-glued clamp, so the search + rows read
+ * as one designed block in the viewport-wide sheet. */
+.hk-select-sheet-panel .hk-tag-input-panel {
+  width: 100%;
+  max-width: min(19rem, 100%);
+  margin-inline: auto;
+}
+
+.hk-tag-input-search {
+  padding: 8px 10px 6px;
+}
+
+/* NOT a scroll region: the window surface (popout / sheet) owns THE one
+ * scrollbar and scrolls the search field with the rows. */
+.hk-tag-input-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px 6px 8px;
+}
+
+.hk-tag-input-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 2.25rem;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  color: rgb(var(--color-text));
+  font-size: var(--text-sm, 14px);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.1s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(var(--color-primary) / 10%);
+    outline: none;
+  }
+
+  /* Selected = the tag is in use; the check glyph carries the state and
+   * the row stays clickable so it can be toggled back off. */
+  &[data-selected] {
+    font-weight: 600;
+
+    &:hover {
+      background: rgb(var(--color-primary) / 16%);
+    }
+  }
+
+  &[data-disabled] {
+    opacity: 0.5;
+    cursor: default;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+
+  /* The "Use “<query>”" free-text row reads as an add affordance. */
+  &[data-custom="true"] {
+    color: rgb(var(--color-primary));
+
+    .hk-tag-input-row-label {
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+.hk-tag-input-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 1rem;
+  height: 1rem;
+  color: rgb(var(--color-primary));
+}
+
+.hk-tag-input-row-flag {
+  flex: none;
+  font-size: calc(var(--text-base, 15px) * 1.05);
+  line-height: 1;
+  font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
+    sans-serif;
+}
+
+.hk-tag-input-row-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hk-tag-input-row-meta {
+  flex: none;
+  color: rgb(var(--color-muted));
+  font-size: calc(var(--text-sm, 14px) * 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+.hk-tag-input-empty {
+  padding: 14px 12px;
+  color: rgb(var(--color-muted));
+  font-size: var(--text-sm, 14px);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-tag-input-box,
+  .hk-tag-input-chevron,
+  .hk-tag-input-row {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkTagInput.scss
+++ b/packages/vue/src/components/HkTagInput.scss
@@ -228,6 +228,14 @@
     }
   }
 
+  /* Keyboard cursor (`aria-activedescendant`): the field's own focus-ring
+   * language, inset so the highlight never shifts the row's metrics and
+   * never clips at the list edge. Focus itself stays in the field. */
+  &[data-active] {
+    background: rgb(var(--color-primary) / 12%);
+    box-shadow: inset 0 0 0 1px rgb(var(--color-focused-border));
+  }
+
   &[data-disabled] {
     opacity: 0.5;
     cursor: default;

--- a/packages/vue/src/components/HkTagInput.singleScroll.contract.test.ts
+++ b/packages/vue/src/components/HkTagInput.singleScroll.contract.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Source contract: ONE SCROLLBAR PER WINDOW (the HkAffixPicker contract,
+ * 2026-09-08 user report — the language sheet showed two nested
+ * scrollbars). HkTagInput's panel lists EVERY option with an always-open
+ * toggling list, so it is exactly the shape that invites a second
+ * `max-height: 17rem; overflow: auto` row region. It has none: the
+ * HkSelectPanel window surface (desktop popout / mobile sheet) owns THE
+ * single scrollbar and scrolls the search field with the rows as one.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scss = readFileSync(join(here, "HkTagInput.scss"), "utf-8");
+const tsx = readFileSync(join(here, "HkTagInput.tsx"), "utf-8");
+
+/** Extract ONE balanced `{...}` declaration block following the given
+ *  selector — a naive `[^}]*` would stop at the first nested `}` and let
+ *  properties appended after a future nested block evade the pin. */
+function cssBlock(src: string, selector: string): string {
+  const at = src.indexOf(selector);
+  expect(at, `${selector} block exists`).toBeGreaterThanOrEqual(0);
+  const open = src.indexOf("{", at);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  return "";
+}
+
+function expectNoScroll(block: string, what: string): void {
+  expect(block, `${what} block exists`).toBeTruthy();
+  expect(block).not.toMatch(/max-height/);
+  expect(block).not.toMatch(/overflow/);
+  expect(block).not.toMatch(/scrollbar-width/);
+}
+
+describe("HkTagInput single-scrollbar-per-window contract", () => {
+  it("the row list carries no max-height and no overflow of its own", () => {
+    expectNoScroll(cssBlock(scss, ".hk-tag-input-list"), ".hk-tag-input-list");
+  });
+
+  it("the panel is a width container, not a scroll region", () => {
+    const block = cssBlock(scss, ".hk-tag-input-panel");
+    expectNoScroll(block, ".hk-tag-input-panel");
+    expect(block).not.toMatch(/position\s*:/);
+  });
+
+  it("the mobile sheet centers the designed measure instead of gluing it left", () => {
+    const block =
+      scss.match(/\.hk-select-sheet-panel \.hk-tag-input-panel\s*{[^}]*}/)?.[0] ?? "";
+    expect(block, "sheet descendant block exists").toBeTruthy();
+    expect(block).toContain("max-width: min(19rem, 100%)");
+    expect(block).toContain("margin-inline: auto");
+    expectNoScroll(block, ".hk-select-sheet-panel .hk-tag-input-panel");
+  });
+
+  it("the component mounts no overlay scrollbar machinery", () => {
+    expect(tsx).not.toContain("attachOverlayScrollbars");
+    expect(tsx).not.toContain("OverlayScrollbarHandle");
+    // No inline clamp on the row list either (the prose in the file
+    // mentions `max-height` in the contract comment, so this pins the
+    // style property spelling instead of the words).
+    expect(tsx).not.toContain("maxHeight");
+    expect(tsx).not.toContain("overflowY");
+  });
+});

--- a/packages/vue/src/components/HkTagInput.test.tsx
+++ b/packages/vue/src/components/HkTagInput.test.tsx
@@ -1,0 +1,764 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+
+import HkModal from "./HkModal";
+import HkTagInput, { type HkTagOption } from "./HkTagInput";
+
+/** Regional-indicator flag pair for an ISO 3166-1 alpha-2 code, built
+ * from code points (same derivation as data/dialCodes flagEmoji) so the
+ * fixture source itself carries no literal emoji. */
+const flagOf = (iso: string): string =>
+  String.fromCodePoint(
+    ...Array.from(iso.toUpperCase(), (c) => 0x1f1e6 + c.charCodeAt(0) - 65),
+  );
+
+const OPTIONS: HkTagOption[] = [
+  { key: "news", label: "News", meta: "feed", keywords: "press 新闻" },
+  { key: "cn-main", label: "中华人民共和国", meta: "cn" },
+  { key: "tech", label: "Technology", meta: "tech", keywords: "dev 技术" },
+  { key: "de", label: "Germany", meta: "de", flag: flagOf("de") },
+  { key: "retired", label: "Retired", meta: "old", disabled: true },
+];
+
+interface MountOptions {
+  modelValue?: readonly string[];
+  options?: readonly HkTagOption[];
+  allowCustom?: boolean;
+  label?: string;
+  placeholder?: string;
+  hint?: string;
+  disabled?: boolean;
+  size?: "sm" | "md" | "lg";
+  maxTags?: number;
+  searchPlaceholder?: string;
+  emptyText?: string;
+}
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+/** Reactive harness — a REAL v-model parent: `update:modelValue` flows
+ * back into the prop, so toggling a row re-renders the tag list exactly
+ * as it does in an application (the component owns no selection state of
+ * its own). Every emitted payload is recorded verbatim. */
+function mountTagInput(opts: MountOptions = {}) {
+  const events = {
+    modelValue: [] as string[][],
+    add: [] as string[],
+    remove: [] as string[],
+    open: [] as boolean[],
+  };
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const Host = defineComponent({
+    name: "HkTagInputHost",
+    setup() {
+      const value = ref<readonly string[]>(opts.modelValue ?? []);
+      return () =>
+        h(HkTagInput, {
+          modelValue: value.value,
+          options: opts.options ?? OPTIONS,
+          allowCustom: opts.allowCustom ?? false,
+          label: opts.label,
+          placeholder: opts.placeholder,
+          hint: opts.hint,
+          disabled: opts.disabled ?? false,
+          size: opts.size ?? "md",
+          maxTags: opts.maxTags,
+          searchPlaceholder: opts.searchPlaceholder,
+          emptyText: opts.emptyText,
+          "onUpdate:modelValue": (keys: string[]) => {
+            events.modelValue.push(keys);
+            value.value = keys;
+          },
+          onAdd: (key: string) => events.add.push(key),
+          onRemove: (key: string) => events.remove.push(key),
+          "onUpdate:open": (open: boolean) => events.open.push(open),
+        });
+    },
+  });
+  const app = createApp(Host);
+  app.mount(container);
+  mounts.push({ app, container });
+  return { events, container };
+}
+
+async function settle(): Promise<void> {
+  await nextTick();
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
+/** Wait out a leave transition (the panel stays mounted while it folds). */
+async function untilSettled(check: () => number): Promise<void> {
+  const deadline = Date.now() + 800;
+  while (check() > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await nextTick();
+  }
+}
+
+function field(container: HTMLElement): HTMLElement {
+  const box = container.querySelector<HTMLElement>(".hk-tag-input-box");
+  expect(box, "field box renders").toBeTruthy();
+  return box!;
+}
+
+function chevron(container: HTMLElement): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(".hk-tag-input-chevron");
+  expect(button, "chevron renders").toBeTruthy();
+  return button!;
+}
+
+function inlineInput(container: HTMLElement): HTMLInputElement | null {
+  return container.querySelector<HTMLInputElement>(".hk-tag-input-element");
+}
+
+function tags(container: HTMLElement): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(".hk-tag")];
+}
+
+function tagTexts(container: HTMLElement): string[] {
+  return tags(container).map(
+    (tag) => tag.querySelector(".hk-tag-input-tag-text")?.textContent ?? "",
+  );
+}
+
+function closeButtons(container: HTMLElement): HTMLButtonElement[] {
+  return [...container.querySelectorAll<HTMLButtonElement>(".hk-tag-close")];
+}
+
+/** Rows live in the teleported panel, so they are queried on body. */
+function rows(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>(".hk-tag-input-row")];
+}
+
+function rowLabels(): string[] {
+  return rows().map(
+    (row) => row.querySelector(".hk-tag-input-row-label")?.textContent ?? "",
+  );
+}
+
+function rowByLabel(label: string): HTMLElement {
+  const row = rows().find(
+    (r) => (r.querySelector(".hk-tag-input-row-label")?.textContent ?? "") === label,
+  );
+  expect(row, `row "${label}" renders`).toBeTruthy();
+  return row!;
+}
+
+function customRow(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('.hk-tag-input-row[data-custom="true"]');
+}
+
+function searchInput(): HTMLInputElement {
+  const input = document.querySelector<HTMLInputElement>(".hk-tag-input-search input");
+  expect(input, "panel search field renders").toBeTruthy();
+  return input!;
+}
+
+async function openPanel(container: HTMLElement): Promise<void> {
+  chevron(container).click();
+  await settle();
+}
+
+async function typeInto(input: HTMLInputElement, value: string): Promise<void> {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  await settle();
+}
+
+async function typeInline(container: HTMLElement, value: string): Promise<void> {
+  const input = inlineInput(container);
+  expect(input, "inline input renders").toBeTruthy();
+  await typeInto(input!, value);
+}
+
+async function typeSearch(value: string): Promise<void> {
+  await typeInto(searchInput(), value);
+}
+
+function pressKey(el: Element, key: string): void {
+  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
+afterEach(async () => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+  document.body.innerHTML = "";
+});
+
+describe("HkTagInput", () => {
+  it("renders the tags in modelValue order and degrades unknown keys to the raw key", () => {
+    const { container } = mountTagInput({
+      modelValue: ["tech", "legacy-flag", "news"],
+    });
+    expect(tagTexts(container)).toEqual(["Technology", "legacy-flag", "News"]);
+    expect(tags(container)).toHaveLength(3);
+    // Every tag is closable, and each × names the entry it removes.
+    expect(closeButtons(container)).toHaveLength(3);
+    expect(closeButtons(container)[0].getAttribute("aria-label")).toBe(
+      "Remove — Technology",
+    );
+  });
+
+  it("maps the field size onto the box and the tags", () => {
+    const small = mountTagInput({ modelValue: ["news"], size: "sm" });
+    expect(field(small.container).classList.contains("hk-tag-input-box-sm")).toBe(true);
+    expect(tags(small.container)[0].classList.contains("hk-tag-sm")).toBe(true);
+    // HkTag only knows sm/md — the field's lg maps down to a md chip while
+    // the box itself takes the tall rhythm.
+    const large = mountTagInput({ modelValue: ["news"], size: "lg" });
+    expect(field(large.container).classList.contains("hk-tag-input-box-lg")).toBe(true);
+    expect(tags(large.container)[0].classList.contains("hk-tag-md")).toBe(true);
+    expect(inlineInput(large.container), "lg still types").not.toBeNull();
+  });
+
+  it("opens the panel from the chevron and from a click inside the field", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"] });
+
+    await openPanel(container);
+    expect(rows().length).toBe(OPTIONS.length);
+    expect(events.open).toEqual([true]);
+
+    // Fold it again through the panel's own Escape, then reopen by
+    // clicking anywhere in the field.
+    pressKey(searchInput(), "Escape");
+    await untilSettled(() => rows().length);
+    expect(rows()).toHaveLength(0);
+    expect(events.open.at(-1)).toBe(false);
+
+    field(container).click();
+    await settle();
+    expect(rows().length).toBe(OPTIONS.length);
+  });
+
+  it("opens the panel with ArrowDown from the inline input", async () => {
+    const { container } = mountTagInput();
+    const input = inlineInput(container)!;
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    pressKey(input, "ArrowDown");
+    await settle();
+    expect(rows().length).toBe(OPTIONS.length);
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("exposes combobox / listbox semantics with aria-selected on every row", async () => {
+    const { container } = mountTagInput({ modelValue: ["news"] });
+    const input = inlineInput(container)!;
+    expect(input.getAttribute("role")).toBe("combobox");
+    expect(input.getAttribute("aria-autocomplete")).toBe("list");
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+
+    await openPanel(container);
+    const list = document.querySelector<HTMLElement>(".hk-tag-input-list");
+    expect(list).toBeTruthy();
+    expect(list!.getAttribute("role")).toBe("listbox");
+    expect(list!.getAttribute("aria-multiselectable")).toBe("true");
+    expect(input.getAttribute("aria-controls")).toBe(list!.id);
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+
+    expect(rowByLabel("News").getAttribute("role")).toBe("option");
+    expect(rowByLabel("News").getAttribute("aria-selected")).toBe("true");
+    expect(rowByLabel("Technology").getAttribute("aria-selected")).toBe("false");
+    // The chevron and the search field carry accessible names.
+    expect(chevron(container).getAttribute("aria-label")).toBe("Tags");
+    expect(searchInput().getAttribute("aria-label")).toBe("Search");
+  });
+
+  it("lists EVERY option — selected ones stay visible with a check glyph", async () => {
+    const { container } = mountTagInput({ modelValue: ["news", "tech"] });
+    await openPanel(container);
+    expect(rowLabels()).toEqual([
+      "News",
+      "中华人民共和国",
+      "Technology",
+      "Germany",
+      "Retired",
+    ]);
+    expect(rowByLabel("News").hasAttribute("data-selected")).toBe(true);
+    expect(rowByLabel("Technology").hasAttribute("data-selected")).toBe(true);
+    expect(rowByLabel("Germany").hasAttribute("data-selected")).toBe(false);
+    // The check glyph marks the selected rows.
+    expect(rowByLabel("News").querySelector(".hk-tag-input-check svg")).toBeTruthy();
+    expect(rowByLabel("Germany").querySelector(".hk-tag-input-check svg")).toBeNull();
+  });
+
+  it("toggling a row appends to the END, keeps the panel open, and emits exact payloads", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["tech"] });
+    await openPanel(container);
+
+    rowByLabel("News").click();
+    await settle();
+    // "news" is FIRST in the catalog but lands LAST in the host order.
+    expect(events.add).toEqual(["news"]);
+    expect(events.remove).toEqual([]);
+    expect(events.modelValue).toEqual([["tech", "news"]]);
+    expect(tagTexts(container)).toEqual(["Technology", "News"]);
+    expect(rowByLabel("News").getAttribute("aria-selected")).toBe("true");
+    // Batch editing: the panel is still there.
+    expect(rows().length).toBe(OPTIONS.length);
+
+    rowByLabel("News").click();
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.modelValue.at(-1)).toEqual(["tech"]);
+    expect(tagTexts(container)).toEqual(["Technology"]);
+    expect(rows().length).toBe(OPTIONS.length);
+  });
+
+  it("never toggles a disabled option on", async () => {
+    const { events, container } = mountTagInput();
+    await openPanel(container);
+    const retired = rowByLabel("Retired");
+    expect(retired.hasAttribute("data-disabled")).toBe(true);
+    expect(retired.getAttribute("aria-disabled")).toBe("true");
+    retired.click();
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(tagTexts(container)).toEqual([]);
+  });
+
+  it("lets a disabled option that is already set be toggled back off", async () => {
+    // `disabled` means "cannot be toggled ON": a catalog edit must never
+    // strand a key the host already carries.
+    const { events, container } = mountTagInput({ modelValue: ["retired"] });
+    await openPanel(container);
+    const retired = rowByLabel("Retired");
+    expect(retired.getAttribute("aria-selected")).toBe("true");
+    expect(retired.hasAttribute("data-disabled")).toBe(false);
+    retired.click();
+    await settle();
+    expect(events.remove).toEqual(["retired"]);
+    expect(events.modelValue).toEqual([[]]);
+    expect(tagTexts(container)).toEqual([]);
+  });
+
+  it("removes a tag immediately on ×, with no confirm dialog", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"] });
+    await openPanel(container);
+    const close = closeButtons(container)[0];
+    expect(close.getAttribute("aria-label")).toBe("Remove — News");
+    close.click();
+    // One click, one synchronous commit: no dialog stands between the ×
+    // and the model (HkAffixPicker's confirmRemove does — deliberately not
+    // here), and the open panel survives for the next edit.
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.modelValue).toEqual([["tech"]]);
+    expect(tagTexts(container)).toEqual(["Technology"]);
+    expect(rows()).toHaveLength(OPTIONS.length);
+    expect(document.querySelector(".hk-message-box-confirm")).toBeNull();
+    expect(document.querySelector(".hk-message-box-text")).toBeNull();
+    expect(document.querySelector(".hk-modal-root")).toBeNull();
+  });
+
+  it("removing a tag from the closed field never opens the panel", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"] });
+    closeButtons(container)[0].click();
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.open).toEqual([]);
+    expect(rows()).toHaveLength(0);
+  });
+
+  it("emits a fresh ordered array and never mutates the host's array", async () => {
+    const host = ["tech", "news"];
+    const { events, container } = mountTagInput({ modelValue: host });
+    closeButtons(container)[0].click();
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["news"]);
+    // The host's own array is untouched, and the emitted value is a copy
+    // the host can keep, reorder or discard freely.
+    expect(host).toEqual(["tech", "news"]);
+    expect(events.modelValue.at(-1)).not.toBe(host);
+    expect(tagTexts(container)).toEqual(["News"]);
+  });
+
+  it("falls back to the raw key when a catalog label is blank", async () => {
+    const blank: HkTagOption[] = [
+      { key: "news", label: "News" },
+      { key: "ghost", label: "" },
+    ];
+    const { container } = mountTagInput({ modelValue: ["ghost", "news"], options: blank });
+    // An empty chip would be invisible and unnameable — the key carries it.
+    expect(tagTexts(container)).toEqual(["ghost", "News"]);
+    await openPanel(container);
+    expect(rowLabels()).toContain("ghost");
+  });
+
+  it("filters rows by substring and by in-order subsequence", async () => {
+    const { container } = mountTagInput();
+    await openPanel(container);
+
+    await typeSearch("Technology");
+    expect(rowLabels()).toEqual(["Technology"]);
+
+    await typeSearch("feed");
+    expect(rowLabels()).toEqual(["News"]);
+
+    // Subsequence: 中国 is NOT a substring of 中华人民共和国.
+    await typeSearch("中国");
+    expect(rowLabels()).toEqual(["中华人民共和国"]);
+
+    // Order-violating query must not fuzzy-match it.
+    await typeSearch("国民");
+    expect(rows()).toHaveLength(0);
+    expect(document.querySelector(".hk-tag-input-empty")?.textContent).toContain(
+      "No matches",
+    );
+  });
+
+  it("shows emptyText when nothing matches, and offers no custom row without allowCustom", async () => {
+    const { container } = mountTagInput({ emptyText: "Nothing here" });
+    await openPanel(container);
+    await typeSearch("zzz-nothing");
+    expect(rows()).toHaveLength(0);
+    expect(customRow()).toBeNull();
+    expect(document.querySelector(".hk-tag-input-empty")?.textContent).toBe(
+      "Nothing here",
+    );
+  });
+
+  it("allowCustom: Enter in the inline input adds the raw query at the end", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news"],
+      allowCustom: true,
+    });
+    await typeInline(container, "gitee.com");
+    pressKey(inlineInput(container)!, "Enter");
+    await settle();
+    expect(events.add).toEqual(["gitee.com"]);
+    expect(events.modelValue).toEqual([["news", "gitee.com"]]);
+    expect(tagTexts(container)).toEqual(["News", "gitee.com"]);
+  });
+
+  it("allowCustom: the trailing row adds the query and clears it afterwards", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    await typeSearch("brand-new");
+    expect(rowLabels()).toEqual(["Use “brand-new”"]);
+    customRow()!.click();
+    await settle();
+    expect(events.add).toEqual(["brand-new"]);
+    expect(events.modelValue).toEqual([["brand-new"]]);
+    expect(tagTexts(container)).toEqual(["brand-new"]);
+    // The query is consumed, so the custom row is gone and the panel
+    // (still open) lists the whole catalog again.
+    expect(customRow()).toBeNull();
+    expect(searchInput().value).toBe("");
+    expect(rows().length).toBe(OPTIONS.length);
+  });
+
+  it("allowCustom: an exact option key or label suppresses the custom row", async () => {
+    const { container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+
+    await typeSearch("Technology");
+    expect(customRow()).toBeNull();
+    expect(rowLabels()).toEqual(["Technology"]);
+
+    await typeSearch("tech");
+    expect(customRow()).toBeNull();
+
+    await typeSearch("technology");
+    expect(customRow()).toBeNull();
+
+    await typeSearch("Technology two");
+    expect(customRow()).not.toBeNull();
+  });
+
+  it("allowCustom: a query that repeats an existing custom tag offers no duplicate row", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["gitee.com"],
+      allowCustom: true,
+    });
+    await openPanel(container);
+    await typeSearch("gitee.com");
+    // Already a tag — there is nothing to add, so no row pretends there is.
+    expect(customRow()).toBeNull();
+    expect(rows()).toHaveLength(0);
+    expect(document.querySelector(".hk-tag-input-empty")).toBeTruthy();
+    // Case-insensitive too, and Enter is inert instead of a silent no-op
+    // that also swallowed the query.
+    await typeSearch("GITEE.com");
+    expect(customRow()).toBeNull();
+    pressKey(searchInput(), "Enter");
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(searchInput().value).toBe("GITEE.com");
+    expect(tagTexts(container)).toEqual(["gitee.com"]);
+  });
+
+  it("Enter toggles the first matching option instead of adding a custom tag", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    await typeSearch("tech");
+    pressKey(searchInput(), "Enter");
+    await settle();
+    expect(events.add).toEqual(["tech"]);
+    expect(events.modelValue).toEqual([["tech"]]);
+    // Panel stayed open, the query survived, and no custom entry was made
+    // (the query now names a selected key, so its custom row is gone).
+    expect(rows()).toHaveLength(1);
+    expect(rowByLabel("Technology").getAttribute("aria-selected")).toBe("true");
+    expect(customRow()).toBeNull();
+  });
+
+  it("Enter falls through a disabled top row to the custom row", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    // Only the disabled "Retired" row matches — the typed text becomes
+    // the tag instead of being swallowed by an unpickable row.
+    await typeSearch("retir");
+    expect(rowLabels()).toEqual(["Retired", "Use “retir”"]);
+    pressKey(searchInput(), "Enter");
+    await settle();
+    expect(events.add).toEqual(["retir"]);
+    expect(tagTexts(container)).toEqual(["retir"]);
+  });
+
+  it("Enter on an empty query picks nothing", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    pressKey(searchInput(), "Enter");
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(tagTexts(container)).toEqual([]);
+  });
+
+  it("ArrowDown while the panel is already open changes nothing", async () => {
+    const { events, container } = mountTagInput();
+    const input = inlineInput(container)!;
+    pressKey(input, "ArrowDown");
+    await settle();
+    pressKey(input, "ArrowDown");
+    await settle();
+    expect(events.open).toEqual([true]);
+    expect(rows().length).toBe(OPTIONS.length);
+  });
+
+  it("Backspace with no tags to remove is inert", async () => {
+    const { events, container } = mountTagInput();
+    pressKey(inlineInput(container)!, "Backspace");
+    await settle();
+    expect(events.remove).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+  });
+
+  it("Backspace on an empty input removes the last tag", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "tech"],
+      allowCustom: true,
+    });
+    pressKey(inlineInput(container)!, "Backspace");
+    await settle();
+    expect(events.remove).toEqual(["tech"]);
+    expect(events.modelValue).toEqual([["news"]]);
+    expect(tagTexts(container)).toEqual(["News"]);
+  });
+
+  it("Backspace with text in the input only edits the text", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news"],
+      allowCustom: true,
+    });
+    await typeInline(container, "gi");
+    pressKey(inlineInput(container)!, "Backspace");
+    await settle();
+    expect(events.remove).toEqual([]);
+    expect(tagTexts(container)).toEqual(["News"]);
+  });
+
+  it("Escape closes the panel and clears the query but never the tags", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"], allowCustom: true });
+    await openPanel(container);
+    await typeSearch("tech");
+    expect(rows()).toHaveLength(1);
+
+    pressKey(searchInput(), "Escape");
+    await settle();
+    expect(events.open.at(-1)).toBe(false);
+    expect(inlineInput(container)!.getAttribute("aria-expanded")).toBe("false");
+    await untilSettled(() => rows().length);
+    expect(rows()).toHaveLength(0);
+    expect(tagTexts(container)).toEqual(["News"]);
+
+    // Second Escape: the panel is closed, the tags stay committed.
+    pressKey(inlineInput(container)!, "Escape");
+    await settle();
+    expect(tagTexts(container)).toEqual(["News"]);
+    expect(events.remove).toEqual([]);
+
+    // Reopening starts from a calm, empty query.
+    await openPanel(container);
+    expect(searchInput().value).toBe("");
+  });
+
+  it("disabled: no inline input, disabled chevron, unremovable tags", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"], disabled: true });
+    expect(inlineInput(container)).toBeNull();
+    expect(chevron(container).disabled).toBe(true);
+    expect(closeButtons(container)).toHaveLength(0);
+    expect(field(container).hasAttribute("data-disabled")).toBe(true);
+
+    chevron(container).click();
+    field(container).click();
+    await settle();
+    expect(rows()).toHaveLength(0);
+    expect(events.open).toEqual([]);
+  });
+
+  it("maxTags: the inline input gives way to the placeholder and adds stop", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "tech"],
+      maxTags: 2,
+      placeholder: "Add a tag…",
+    });
+    expect(inlineInput(container)).toBeNull();
+    expect(
+      container.querySelector(".hk-tag-input-placeholder")?.textContent,
+    ).toBe("Add a tag…");
+    expect(field(container).hasAttribute("data-full")).toBe(true);
+
+    await openPanel(container);
+    for (const row of rows()) {
+      expect(row.hasAttribute("data-disabled")).toBe(true);
+    }
+    rowByLabel("Germany").click();
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(tagTexts(container)).toEqual(["News", "Technology"]);
+
+    // Removal stays available through the tag ×.
+    closeButtons(container)[0].click();
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.modelValue).toEqual([["tech"]]);
+  });
+
+  it("maxTags: a field with room left still types and adds", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"], maxTags: 2 });
+    expect(inlineInput(container)).not.toBeNull();
+    await openPanel(container);
+    rowByLabel("Technology").click();
+    await settle();
+    expect(events.modelValue).toEqual([["news", "tech"]]);
+  });
+
+  it("maxTags: 1 caps the field at one tag, 0 and undefined stay unlimited", async () => {
+    const unlimited = mountTagInput({ modelValue: ["news", "tech"], maxTags: 0 });
+    expect(inlineInput(unlimited.container), "0 means unlimited").not.toBeNull();
+    expect(field(unlimited.container).hasAttribute("data-full")).toBe(false);
+    const full = mountTagInput({ modelValue: ["news"], maxTags: 1 });
+    expect(inlineInput(full.container)).toBeNull();
+    expect(field(full.container).hasAttribute("data-full")).toBe(true);
+    const empty = mountTagInput({ maxTags: 1 });
+    expect(inlineInput(empty.container), "a capped but empty field types").not.toBeNull();
+    expect(field(empty.container).hasAttribute("data-full")).toBe(false);
+    await openPanel(empty.container);
+    rowByLabel("News").click();
+    await settle();
+    expect(empty.events.modelValue).toEqual([["news"]]);
+    // Second add is refused at the cap.
+    await settle();
+    expect(inlineInput(empty.container)).toBeNull();
+  });
+
+  it("renders the label, the hint and the placeholder", () => {
+    const { container } = mountTagInput({
+      label: "Interests",
+      hint: "Pick a few topics",
+      placeholder: "Type to search",
+    });
+    expect(container.querySelector(".hk-tag-input-label")?.textContent).toBe("Interests");
+    expect(container.querySelector(".hk-tag-input-hint")?.textContent).toBe(
+      "Pick a few topics",
+    );
+    expect(inlineInput(container)!.getAttribute("placeholder")).toBe("Type to search");
+  });
+
+  it("keeps host order when a middle tag is removed", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["tech", "news", "de"],
+    });
+    closeButtons(container)[1].click();
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.modelValue).toEqual([["tech", "de"]]);
+    expect(tagTexts(container)).toEqual(["Technology", "Germany"]);
+  });
+
+  it("mounts NO inner scroll region — the window owns the one scrollbar", async () => {
+    const { container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    expect(document.querySelector(".hk-tag-input-list"), "row list renders").toBeTruthy();
+    expect(document.querySelector(".hk-tag-input-list .hk-scrollbar-track")).toBeNull();
+  });
+
+  it("opens its panel above a modal and toggles rows there", async () => {
+    // The first consumer is an admin settings page, which is usually a
+    // modal: the panel must stack through the popup manager, not the page.
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const Host = defineComponent({
+      name: "HkTagInputModalHost",
+      setup() {
+        const open = ref(true);
+        const value = ref<readonly string[]>(["news"]);
+        return () =>
+          h(
+            HkModal,
+            {
+              modelValue: open.value,
+              title: "Settings",
+              "onUpdate:modelValue": (v: boolean) => {
+                open.value = v;
+              },
+            },
+            {
+              default: () =>
+                h(HkTagInput, {
+                  modelValue: value.value,
+                  options: OPTIONS,
+                  label: "Interests",
+                  "onUpdate:modelValue": (keys: string[]) => {
+                    value.value = keys;
+                  },
+                }),
+            },
+          );
+      },
+    });
+    const app = createApp(Host);
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+
+    // Modal content is teleported to body.
+    const chevron = document.querySelector<HTMLButtonElement>(".hk-tag-input-chevron");
+    expect(chevron, "the field renders inside the modal").toBeTruthy();
+    chevron!.click();
+    await settle();
+    expect(rows().length).toBe(OPTIONS.length);
+
+    const host = document.querySelector<HTMLElement>(".hk-select-popout-host");
+    const modal = document.querySelector<HTMLElement>(".hk-modal-root");
+    const z = (el: HTMLElement | null) => Number(el?.style.zIndex || 0);
+    expect(host, "panel host exists").toBeTruthy();
+    expect(z(modal)).toBeGreaterThan(0);
+    expect(z(host)).toBeGreaterThan(z(modal));
+
+    rowByLabel("Technology").click();
+    await settle();
+    expect(
+      [...document.querySelectorAll(".hk-tag-input-tag-text")].map((n) => n.textContent),
+    ).toEqual(["News", "Technology"]);
+  });
+});

--- a/packages/vue/src/components/HkTagInput.test.tsx
+++ b/packages/vue/src/components/HkTagInput.test.tsx
@@ -295,13 +295,20 @@ describe("HkTagInput", () => {
     expect(rows()).toHaveLength(0);
 
     // The reference is not allowed to dangle: the listbox element stays
-    // mounted while the panel is open, with the empty state inside it.
+    // mounted while the panel is open, even with nothing to list.
     const id = inlineInput(container)!.getAttribute("aria-controls");
     expect(id, "the input names a listbox id").toBeTruthy();
     const list = document.getElementById(id!);
     expect(list, "the referenced element exists").toBeTruthy();
     expect(list!.getAttribute("role")).toBe("listbox");
-    expect(list!.querySelector(".hk-tag-input-empty")?.textContent).toBe("Nothing here");
+    expect(list!.children).toHaveLength(0);
+
+    // …and the message itself is NOT owned by the listbox: a listbox may
+    // only own options/groups (aria-required-children), so it sits beside.
+    const empty = document.querySelector(".hk-tag-input-empty")!;
+    expect(empty.textContent).toBe("Nothing here");
+    expect(list!.contains(empty)).toBe(false);
+    expect(empty.parentElement?.contains(list!)).toBe(true);
   });
 
   it("lists EVERY option — selected ones stay visible with a check glyph", async () => {

--- a/packages/vue/src/components/HkTagInput.test.tsx
+++ b/packages/vue/src/components/HkTagInput.test.tsx
@@ -147,6 +147,11 @@ function rowByLabel(label: string): HTMLElement {
   return row!;
 }
 
+/** The row the keyboard cursor currently sits on (none = null). */
+function activeRow(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".hk-tag-input-row[data-active]");
+}
+
 function customRow(): HTMLElement | null {
   return document.querySelector<HTMLElement>('.hk-tag-input-row[data-custom="true"]');
 }
@@ -243,6 +248,21 @@ describe("HkTagInput", () => {
     await settle();
     expect(rows().length).toBe(OPTIONS.length);
     expect(input.getAttribute("aria-expanded")).toBe("true");
+    // Opening is the whole job of that first press: the cursor is not
+    // placed on a row until the next arrow (the APG combobox step).
+    expect(activeRow()).toBeNull();
+  });
+
+  it("ArrowUp on the closed field opens the panel as well", async () => {
+    const { events, container } = mountTagInput();
+    const input = inlineInput(container)!;
+    pressKey(input, "ArrowUp");
+    await settle();
+    expect(events.open).toEqual([true]);
+    expect(activeRow()).toBeNull();
+    pressKey(input, "ArrowUp");
+    await settle();
+    expect(activeRow()).toBe(rows().at(-1));
   });
 
   it("exposes combobox / listbox semantics with aria-selected on every row", async () => {
@@ -266,6 +286,22 @@ describe("HkTagInput", () => {
     // The chevron and the search field carry accessible names.
     expect(chevron(container).getAttribute("aria-label")).toBe("Tags");
     expect(searchInput().getAttribute("aria-label")).toBe("Search");
+  });
+
+  it("aria-controls resolves even when the filter matches nothing", async () => {
+    const { container } = mountTagInput({ emptyText: "Nothing here" });
+    await openPanel(container);
+    await typeSearch("zzz-nothing");
+    expect(rows()).toHaveLength(0);
+
+    // The reference is not allowed to dangle: the listbox element stays
+    // mounted while the panel is open, with the empty state inside it.
+    const id = inlineInput(container)!.getAttribute("aria-controls");
+    expect(id, "the input names a listbox id").toBeTruthy();
+    const list = document.getElementById(id!);
+    expect(list, "the referenced element exists").toBeTruthy();
+    expect(list!.getAttribute("role")).toBe("listbox");
+    expect(list!.querySelector(".hk-tag-input-empty")?.textContent).toBe("Nothing here");
   });
 
   it("lists EVERY option — selected ones stay visible with a check glyph", async () => {
@@ -532,7 +568,7 @@ describe("HkTagInput", () => {
     expect(tagTexts(container)).toEqual([]);
   });
 
-  it("ArrowDown while the panel is already open changes nothing", async () => {
+  it("ArrowDown opens the panel once and then walks the rows", async () => {
     const { events, container } = mountTagInput();
     const input = inlineInput(container)!;
     pressKey(input, "ArrowDown");
@@ -541,6 +577,163 @@ describe("HkTagInput", () => {
     await settle();
     expect(events.open).toEqual([true]);
     expect(rows().length).toBe(OPTIONS.length);
+    // The second press moved the cursor instead of reopening anything.
+    expect(activeRow()).toBe(rows()[0]);
+  });
+
+  it("ArrowDown / ArrowUp walk the rows, wrap at both ends, and publish aria-activedescendant", async () => {
+    const { container } = mountTagInput();
+    const input = inlineInput(container)!;
+    input.focus();
+    await openPanel(container);
+    expect(input.getAttribute("aria-activedescendant"), "nothing active on open").toBeNull();
+
+    // From nothing active, ArrowDown lands on the FIRST row.
+    pressKey(input, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rows()[0]);
+    expect(rows()[0].id, "the active row is addressable").toBeTruthy();
+    expect(input.getAttribute("aria-activedescendant")).toBe(rows()[0].id);
+
+    // One step down, then wrapping off both ends.
+    pressKey(input, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rows()[1]);
+    expect(rows()[0].hasAttribute("data-active")).toBe(false);
+    pressKey(input, "ArrowUp");
+    await settle();
+    expect(activeRow()).toBe(rows()[0]);
+    pressKey(input, "ArrowUp");
+    await settle();
+    expect(activeRow()).toBe(rows().at(-1));
+    expect(input.getAttribute("aria-activedescendant")).toBe(rows().at(-1)!.id);
+    pressKey(input, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rows()[0]);
+
+    // The activedescendant pattern: focus never left the field.
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("the panel search field drives the same cursor and keeps its focus", async () => {
+    const { container } = mountTagInput();
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(rows()[0].hasAttribute("data-active")).toBe(true);
+    expect(search.getAttribute("aria-activedescendant")).toBe(rows()[0].id);
+    expect(document.activeElement, "focus stays in the search field").toBe(search);
+
+    // A query edit re-filters the list, so the cursor is dropped with it.
+    await typeSearch("Technology");
+    expect(rows()).toHaveLength(1);
+    expect(activeRow()).toBeNull();
+    expect(search.getAttribute("aria-activedescendant")).toBeNull();
+  });
+
+  it("arrow keys pressed on a row itself still walk the cursor", async () => {
+    // Clicking a row leaves focus on it (rows are tabindex="-1"), so the
+    // panel surface forwards those arrows too — handled once, not twice.
+    const { container } = mountTagInput();
+    await openPanel(container);
+    const row = rowByLabel("News");
+    row.focus();
+    expect(document.activeElement).toBe(row);
+
+    pressKey(row, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rows()[0]);
+    expect(document.activeElement, "the row keeps its own focus").toBe(row);
+  });
+
+  it("Enter activates the ACTIVE row instead of the first match", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    // "e" matches four rows: News, Technology, Germany, Retired.
+    await typeSearch("e");
+    expect(rowLabels()).toEqual(["News", "Technology", "Germany", "Retired", "Use “e”"]);
+
+    pressKey(search, "ArrowDown");
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+    pressKey(search, "Enter");
+    await settle();
+    // The SECOND row was activated — not the top one, which is what the
+    // no-cursor fallback would have picked.
+    expect(events.add).toEqual(["tech"]);
+    expect(events.modelValue).toEqual([["tech"]]);
+  });
+
+  it("the custom row is the LAST stop and wraps back to the first row", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    await typeSearch("e");
+    expect(customRow()).not.toBeNull();
+
+    // ArrowUp from nothing active walks to the LAST stop — the custom row.
+    pressKey(search, "ArrowUp");
+    await settle();
+    expect(activeRow()).toBe(customRow());
+    pressKey(search, "ArrowUp");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Retired"));
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(customRow());
+
+    pressKey(search, "Enter");
+    await settle();
+    expect(events.add).toEqual(["e"]);
+    expect(events.modelValue).toEqual([["e"]]);
+    // The query was consumed, so the custom row is gone and the cursor
+    // has nothing left to sit on.
+    expect(customRow()).toBeNull();
+    expect(search.value).toBe("");
+    expect(activeRow()).toBeNull();
+  });
+
+  it("Enter on an INERT active row is a no-op, not a fall-through", async () => {
+    const { events, container } = mountTagInput({ allowCustom: true });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    await typeSearch("retir");
+    // "Retired" cannot be toggled on, and with no cursor the same Enter
+    // falls through to the custom row (the test above). Once the user has
+    // explicitly parked the cursor on it, the key must not silently act on
+    // a DIFFERENT row than the highlighted one.
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Retired"));
+
+    pressKey(search, "Enter");
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(search.value).toBe("retir");
+  });
+
+  it("closing clears the cursor and reopening starts with none", async () => {
+    const { container } = mountTagInput();
+    await openPanel(container);
+    pressKey(inlineInput(container)!, "ArrowDown");
+    await settle();
+    expect(activeRow()).not.toBeNull();
+
+    pressKey(searchInput(), "Escape");
+    await settle();
+    await untilSettled(() => rows().length);
+    await openPanel(container);
+    expect(activeRow()).toBeNull();
+    expect(inlineInput(container)!.getAttribute("aria-activedescendant")).toBeNull();
   });
 
   it("Backspace with no tags to remove is inert", async () => {
@@ -614,16 +807,89 @@ describe("HkTagInput", () => {
     expect(events.open).toEqual([]);
   });
 
-  it("maxTags: the inline input gives way to the placeholder and adds stop", async () => {
+  it("disabled: no label dangles and the field box carries the caption", () => {
+    const { container } = mountTagInput({ label: "Interests", disabled: true });
+    const label = container.querySelector<HTMLLabelElement>(".hk-tag-input-label")!;
+    // A `for` with nothing behind it is worse than none: the caption moves
+    // onto the box as the group's name instead.
+    expect(label.getAttribute("for")).toBeNull();
+    expect(inlineInput(container)).toBeNull();
+    expect(field(container).getAttribute("aria-label")).toBe("Interests");
+    expect(field(container).getAttribute("role")).toBe("group");
+  });
+
+  it("disabled without a label: the box still carries the default caption", () => {
+    const { container } = mountTagInput({ disabled: true });
+    expect(field(container).getAttribute("aria-label")).toBe("Tags");
+  });
+
+  it("disabled while the panel is open marks the custom row inert like the option rows", async () => {
+    // A live `disabled` flip — the panel is already open with a query typed.
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const value = ref<readonly string[]>([]);
+    const disabled = ref(false);
+    const added: string[] = [];
+    const Host = defineComponent({
+      name: "HkTagInputDisabledFlipHost",
+      setup() {
+        return () =>
+          h(HkTagInput, {
+            modelValue: value.value,
+            options: OPTIONS,
+            allowCustom: true,
+            disabled: disabled.value,
+            "onUpdate:modelValue": (keys: string[]) => {
+              value.value = keys;
+            },
+            onAdd: (key: string) => added.push(key),
+          });
+      },
+    });
+    const app = createApp(Host);
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+
+    chevron(container).click();
+    await settle();
+    await typeSearch("Tec");
+    const custom = customRow()!;
+    expect(custom, "the custom row is offered").toBeTruthy();
+    expect(custom.hasAttribute("data-disabled")).toBe(false);
+
+    disabled.value = true;
+    await settle();
+
+    // The custom row reads inert on exactly the same flag as the option
+    // rows — same ARIA, same visual hook — instead of being a silent no-op.
+    const option = rowByLabel("Technology");
+    expect(option.getAttribute("aria-disabled")).toBe("true");
+    expect(custom.getAttribute("aria-disabled")).toBe(
+      option.getAttribute("aria-disabled"),
+    );
+    expect(custom.hasAttribute("data-disabled")).toBe(option.hasAttribute("data-disabled"));
+    expect(custom.hasAttribute("data-disabled")).toBe(true);
+
+    custom.click();
+    await settle();
+    expect(added).toEqual([]);
+    expect(value.value).toEqual([]);
+  });
+
+  it("maxTags: the inline input stays put as a readOnly field and adds stop", async () => {
     const { events, container } = mountTagInput({
       modelValue: ["news", "tech"],
       maxTags: 2,
       placeholder: "Add a tag…",
     });
-    expect(inlineInput(container)).toBeNull();
-    expect(
-      container.querySelector(".hk-tag-input-placeholder")?.textContent,
-    ).toBe("Add a tag…");
+    // The element is not swapped for placeholder text: it is the same
+    // field, readOnly, and the placeholder is its own.
+    const capped = inlineInput(container);
+    expect(capped).not.toBeNull();
+    expect(capped!.readOnly).toBe(true);
+    expect(capped!.placeholder).toBe("Add a tag…");
+    expect(container.querySelector(".hk-tag-input-placeholder")).toBeNull();
     expect(field(container).hasAttribute("data-full")).toBe(true);
 
     await openPanel(container);
@@ -641,6 +907,90 @@ describe("HkTagInput", () => {
     await settle();
     expect(events.remove).toEqual(["news"]);
     expect(events.modelValue).toEqual([["tech"]]);
+    // Back under the cap the same element types again.
+    expect(inlineInput(container)!.readOnly).toBe(false);
+  });
+
+  it("maxTags: reaching the cap keeps the FOCUSED field focused", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news"],
+      maxTags: 2,
+      placeholder: "Add a tag…",
+    });
+    const input = inlineInput(container)!;
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    // The real keyboard path to the cap: type, commit with Enter. (A row
+    // `.click()` would not prove much — jsdom never moves focus on click,
+    // while a browser focuses the row and the field would lose it anyway.)
+    await typeInto(input, "tech");
+    pressKey(input, "Enter");
+    await settle();
+
+    expect(events.modelValue).toEqual([["news", "tech"]]);
+    expect(field(container).hasAttribute("data-full")).toBe(true);
+    // Same element, still focused: reaching the cap used to unmount it and
+    // drop activeElement back to <body>.
+    const capped = inlineInput(container);
+    expect(capped).toBe(input);
+    expect(capped!.readOnly).toBe(true);
+    expect(document.activeElement).toBe(capped);
+    expect(container.querySelector(".hk-tag-input-placeholder")).toBeNull();
+  });
+
+  it("maxTags: Backspace on the readOnly capped field frees a slot", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "tech"],
+      maxTags: 2,
+    });
+    // Backspace-on-empty is the same code path an editable field uses;
+    // at the cap it is the keyboard route to a free slot.
+    pressKey(inlineInput(container)!, "Backspace");
+    await settle();
+    expect(events.remove).toEqual(["tech"]);
+    expect(events.modelValue).toEqual([["news"]]);
+    // Back under the cap, the very same element edits text again.
+    expect(inlineInput(container)!.readOnly).toBe(false);
+  });
+
+  it("maxTags: Enter and the custom row stay inert for a readOnly capped field", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news"],
+      maxTags: 1,
+      allowCustom: true,
+    });
+    const input = inlineInput(container)!;
+    expect(input.readOnly).toBe(true);
+
+    await openPanel(container);
+    await typeSearch("brand-new");
+    const custom = customRow()!;
+    expect(custom, "the custom row is offered").toBeTruthy();
+    expect(custom.getAttribute("aria-disabled")).toBe("true");
+    custom.click();
+    pressKey(input, "Enter");
+    await settle();
+    expect(events.add).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(tagTexts(container)).toEqual(["News"]);
+  });
+
+  it("associates the label with a field that exists at the cap", () => {
+    const { container } = mountTagInput({
+      label: "Interests",
+      modelValue: ["news"],
+      maxTags: 1,
+    });
+    const label = container.querySelector<HTMLLabelElement>(".hk-tag-input-label")!;
+    const id = label.getAttribute("for");
+    expect(id, "the capped field is still named by the label").toBeTruthy();
+    // There IS an element behind that `for` — the capped (readOnly) input,
+    // not a dangling reference to the unmounted element of the old shape.
+    const capped = inlineInput(container);
+    expect(capped, "the capped field still renders an input").not.toBeNull();
+    expect(document.getElementById(id!)).toBe(capped);
+    expect(label.control).toBe(capped);
   });
 
   it("maxTags: a field with room left still types and adds", async () => {
@@ -657,7 +1007,7 @@ describe("HkTagInput", () => {
     expect(inlineInput(unlimited.container), "0 means unlimited").not.toBeNull();
     expect(field(unlimited.container).hasAttribute("data-full")).toBe(false);
     const full = mountTagInput({ modelValue: ["news"], maxTags: 1 });
-    expect(inlineInput(full.container)).toBeNull();
+    expect(inlineInput(full.container)?.readOnly, "capped, not gone").toBe(true);
     expect(field(full.container).hasAttribute("data-full")).toBe(true);
     const empty = mountTagInput({ maxTags: 1 });
     expect(inlineInput(empty.container), "a capped but empty field types").not.toBeNull();
@@ -666,9 +1016,10 @@ describe("HkTagInput", () => {
     rowByLabel("News").click();
     await settle();
     expect(empty.events.modelValue).toEqual([["news"]]);
-    // Second add is refused at the cap.
+    // Second add is refused at the cap — the field is still there, inert.
     await settle();
-    expect(inlineInput(empty.container)).toBeNull();
+    expect(inlineInput(empty.container)?.readOnly).toBe(true);
+    expect(field(empty.container).hasAttribute("data-full")).toBe(true);
   });
 
   it("renders the label, the hint and the placeholder", () => {

--- a/packages/vue/src/components/HkTagInput.tsx
+++ b/packages/vue/src/components/HkTagInput.tsx
@@ -51,6 +51,12 @@ function isSubsequence(query: string, text: string): boolean {
 const WIDE_GLYPH =
   /[\u1100-\u115f\u2e80-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe30-\ufe6f\uff00-\uff60\uffe0-\uffe6]/;
 
+/** One keyboard stop of the panel: a visible catalog row, or the
+ *  trailing custom row when `allowCustom` offers one (always last). */
+type HkTagStop =
+  | { id: string; kind: "option"; option: HkTagOption }
+  | { id: string; kind: "custom" };
+
 /**
  * HkTagInput — the tag editor field: selected tags live IN the field as
  * closable chips, and one searchable panel toggles catalog membership.
@@ -59,7 +65,13 @@ const WIDE_GLYPH =
  *     language: tags left to right in host order, then a bare
  *     auto-growing input for typing, then the chevron that opens the
  *     panel. Chips wrap onto as many lines as they need and the box
- *     grows with them;
+ *     grows with them. At `maxTags` that input is NOT unmounted — it
+ *     stays in place and goes `readOnly`, so the field keeps its focus,
+ *     its caret and its accessible name while every ADD affordance is
+ *     inert; the browser shows the placeholder (or the surviving query)
+ *     as the field's text. Only `disabled` removes the element — a
+ *     disabled control must not be focusable — and the placeholder text
+ *     stands in for it;
  *   - the PANEL (chevron, any click inside the field, ArrowDown) is the
  *     shared HkSelectPanel surface — same popup-manager stacking, mobile
  *     bottom sheet, outside-click/Escape closing and ONE SCROLLBAR PER
@@ -81,14 +93,33 @@ const WIDE_GLYPH =
  *     with no confirm dialog. This is a deliberate divergence from
  *     HkAffixPicker's `confirmRemove` two-step — a tag field is edited
  *     in bulk, and a modal per chip would dominate the flow;
- *   - with `allowCustom` the trimmed query that matches no option key or
- *     label offers a trailing "Use “<query>”" row, so the search box can
- *     also CREATE a value (the CORS-origin/admin-keyword case).
+ *   - with `allowCustom` a NON-EMPTY trimmed query offers a trailing
+ *     "Use “<query>”" row, so the search box can also CREATE a value (the
+ *     CORS-origin/admin-keyword case) — but only while that query names
+ *     nothing the field already carries. An exact, case-folded match on
+ *     an option key, on an option label, or on an ALREADY-SELECTED key
+ *     suppresses the row: in all three cases there is nothing left to add.
  *
  * The field is a combobox-style control: the inline input carries
  * `role="combobox"`, `aria-expanded`, `aria-controls` (the listbox id)
  * and `aria-autocomplete="list"`; rows are `role="option"` with
- * `aria-selected`.
+ * `aria-selected`. ArrowDown / ArrowUp walk an ACTIVE row through the
+ * visible rows — the custom row, when offered, is the LAST stop and both
+ * ends wrap — and publish it as `aria-activedescendant` on the inline
+ * input and on the panel's search field. That is the activedescendant
+ * pattern: focus never moves to a row, the row is only highlighted, and
+ * Enter activates the active row (falling back to today's first
+ * togglable row / custom row when nothing is active). Every open and
+ * every query edit starts again with no active row.
+ *
+ * CONTROLLED: the component owns no selected state — `add` / `remove`
+ * fire with the key and `update:modelValue` with the full next array, and
+ * the host writes the prop back. Two synthetic clicks dispatched in the
+ * SAME tick therefore both resolve against the same stale prop and
+ * collapse to the last emitted state — a real pair of user clicks cannot
+ * hit this, because the second lands after the host has re-rendered the
+ * first — so a host must not write back asynchronously expecting both
+ * edits to land.
  */
 export const HkTagInput = defineComponent({
   name: "HkTagInput",
@@ -115,8 +146,9 @@ export const HkTagInput = defineComponent({
     disabled: { type: Boolean, default: false },
     size: { type: String as PropType<"sm" | "md" | "lg">, default: "md" },
     /** Capacity cap; 0 / undefined means unlimited. At the cap the
-     *  inline input gives way to the placeholder text and the panel's
-     *  add affordances go disabled (the tags' × still removes). */
+     *  inline input stays mounted but `readOnly` (focus and the field's
+     *  accessible name survive) and the panel's add affordances go
+     *  disabled (the tags' × still removes). */
     maxTags: { type: Number, default: undefined },
     /** Search field placeholder; defaulted from the i18n bundle. */
     searchPlaceholder: { type: String, default: undefined },
@@ -136,6 +168,9 @@ export const HkTagInput = defineComponent({
 
     const open = ref(false);
     const query = ref("");
+    /** The keyboard cursor: an index into the stops list, -1 for "nothing
+     *  active" — the state every open and every query edit starts from. */
+    const activeIndex = ref(-1);
     const fieldRef = ref<HTMLElement | null>(null);
     const inputRef = ref<HTMLInputElement | null>(null);
 
@@ -145,11 +180,24 @@ export const HkTagInput = defineComponent({
     const listboxId = `${generatedId}-listbox`;
 
     /** A fresh close drops the filter — a reopened panel starts calm
-     *  (the HkAffixPicker convention). */
+     *  (the HkAffixPicker convention) — and the cursor is cleared on BOTH
+     *  edges: a reopened panel must not remember a row. */
     watch(open, (v) => {
       if (!v) query.value = "";
+      activeIndex.value = -1;
       emit("update:open", v);
     });
+
+    /** Any query edit re-filters the list under the cursor, so the cursor
+     *  goes with it — synchronously, so a key pressed in the same tick as
+     *  the input event can never address a row that is already gone. */
+    watch(
+      query,
+      () => {
+        activeIndex.value = -1;
+      },
+      { flush: "sync" },
+    );
 
     const selectedKeys = computed<readonly string[]>(() =>
       Array.isArray(props.modelValue) ? props.modelValue : [],
@@ -224,6 +272,49 @@ export const HkTagInput = defineComponent({
     /** Rows and the custom row are inert while the field is disabled or
      *  already at capacity. */
     const rowsDisabled = computed(() => props.disabled || atMax.value);
+
+    /** DOM id of one stop: the single spelling the ROW renders and
+     *  `aria-activedescendant` publishes, so the two can never drift. */
+    function stopId(kind: "option" | "custom", index = 0): string {
+      return kind === "custom" ? `${generatedId}-custom` : `${generatedId}-option-${index}`;
+    }
+
+    /** The stops ArrowDown / ArrowUp walk, in the panel's reading order:
+     *  the visible rows, then the custom row as the LAST stop.
+     *
+     *  Indexed by position, not by key — the filter rebuilds the list on
+     *  every query edit (which clears the cursor) and an index can never
+     *  collide the way a host-supplied key could inside a DOM id. */
+    const stops = computed<readonly HkTagStop[]>(() => {
+      const list: HkTagStop[] = filteredRows.value.map((option, index) => ({
+        id: stopId("option", index),
+        kind: "option" as const,
+        option,
+      }));
+      if (customVisible.value) list.push({ id: stopId("custom"), kind: "custom" });
+      return list;
+    });
+
+    /** The active stop, or null when nothing is active — also when the
+     *  list shrank under a stale index (a cursor past the end is no
+     *  cursor, never a neighbouring row). */
+    const activeStop = computed<HkTagStop | null>(
+      () => stops.value[activeIndex.value] ?? null,
+    );
+
+    /** Walk the cursor one stop. From "nothing active" ArrowDown lands on
+     *  the FIRST stop and ArrowUp on the last; from either end it wraps
+     *  around. An empty list leaves nothing active. */
+    function moveActive(delta: 1 | -1): void {
+      const count = stops.value.length;
+      if (count === 0) {
+        activeIndex.value = -1;
+        return;
+      }
+      const from = activeIndex.value;
+      if (from < 0 || from >= count) activeIndex.value = delta > 0 ? 0 : count - 1;
+      else activeIndex.value = (from + delta + count) % count;
+    }
 
     /** Rows that carry the raw key when the catalog's label is blank. */
     function labelOf(option: HkTagOption): string {
@@ -315,12 +406,20 @@ export const HkTagInput = defineComponent({
       query.value = "";
     }
 
-    /** Enter resolves the typed query: the first togglable row when one
-     *  matches, otherwise the custom row (the HkAffixPicker order — an
-     *  inert top row falls through instead of swallowing the key).
+    /** Enter resolves the typed query. With an active row that row wins —
+     *  the keyboard cursor must be able to reach a row other than the top
+     *  one. With nothing active it stays the HkAffixPicker order: the
+     *  first togglable row, otherwise the custom row (an inert top row
+     *  falls through instead of swallowing the key).
      *  An empty query is a no-op: Enter on a blank field must not pick
      *  the top of the catalog. */
     function commitQuery(): void {
+      const stop = activeStop.value;
+      if (stop) {
+        if (stop.kind === "custom") addCustom();
+        else toggleRow(stop.option);
+        return;
+      }
       const q = customText.value;
       if (!q) return;
       const rows = filteredRows.value;
@@ -358,9 +457,13 @@ export const HkTagInput = defineComponent({
         }
         return;
       }
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
-        openPanel();
+        // Closed: the arrow only opens the panel — the canonical combobox
+        // step, and opening starts with nothing active. Open: it walks
+        // the cursor; focus stays where it is (activedescendant).
+        if (!open.value) openPanel();
+        else moveActive(e.key === "ArrowDown" ? 1 : -1);
         return;
       }
       if (e.key === "Escape") {
@@ -383,9 +486,28 @@ export const HkTagInput = defineComponent({
         commitQuery();
         return;
       }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        moveActive(e.key === "ArrowDown" ? 1 : -1);
+        return;
+      }
       if (e.key === "Escape") {
         e.preventDefault();
         open.value = false;
+      }
+    }
+
+    /** Arrows pressed on the panel SURFACE itself (a row keeps focus
+     *  after a click, since rows carry tabindex="-1") walk the cursor
+     *  too. Keydowns that bubbled out of a field are that field's own
+     *  business — handled once, never twice. */
+    function onPanelKeydown(e: KeyboardEvent): void {
+      if (e.isComposing) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.closest?.("input, textarea, select")) return;
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        moveActive(e.key === "ArrowDown" ? 1 : -1);
       }
     }
 
@@ -399,13 +521,24 @@ export const HkTagInput = defineComponent({
         t("hikari::tagInput.addCustom", "Use “{q}”"),
         { q: customText.value },
       );
-      // The inline input is absent while disabled or at capacity; the
-      // placeholder text keeps the field readable in its place.
-      const typingEnabled = !props.disabled && !atMax.value;
+      // The inline input is unmounted ONLY while disabled — a disabled
+      // control must not be focusable, and the placeholder text keeps the
+      // field readable. At capacity it stays mounted and goes readOnly:
+      // the field keeps its focus, its caret and its accessible name, the
+      // browser shows the placeholder (or the surviving query) as the
+      // field's text, and every add affordance is inert anyway.
+      const inputRendered = !props.disabled;
+      const activeId = activeStop.value?.id;
       return (
         <div class="hk-tag-input-wrapper">
           {props.label && (
-            <label class="hk-tag-input-label" for={generatedId}>
+            <label
+              class="hk-tag-input-label"
+              // A `for` must name an element that exists. While disabled
+              // there is no input to point at, and the box carries the
+              // caption itself (role="group" + aria-label).
+              for={inputRendered ? generatedId : undefined}
+            >
               {props.label}
             </label>
           )}
@@ -420,6 +553,8 @@ export const HkTagInput = defineComponent({
             ]}
             data-disabled={props.disabled || undefined}
             data-full={atMax.value || undefined}
+            role={inputRendered ? undefined : "group"}
+            aria-label={inputRendered ? undefined : title.value}
             onClick={onFieldClick}
           >
             {tagEntries.value.map((entry) => (
@@ -434,7 +569,7 @@ export const HkTagInput = defineComponent({
                 <span class="hk-tag-input-tag-text">{entry.label}</span>
               </HkTag>
             ))}
-            {typingEnabled ? (
+            {inputRendered ? (
               <input
                 ref={inputRef}
                 id={generatedId}
@@ -447,7 +582,17 @@ export const HkTagInput = defineComponent({
                 aria-controls={listboxId}
                 aria-autocomplete="list"
                 aria-haspopup="listbox"
+                aria-activedescendant={activeId}
                 aria-label={props.label ? undefined : title.value}
+                // At the cap the field stays focusable and readable, but
+                // takes no text; nothing could be added with it anyway.
+                // (Lowercase `readonly`: Vue's JSX types spell the DOM
+                // ATTRIBUTE, and the runtime sets the boolean attribute.)
+                // Backspace on the empty readOnly field still removes the
+                // last tag — the very code path an editable field uses,
+                // and at the cap the keyboard way to free a slot, exactly
+                // like the chip's ×.
+                readonly={atMax.value || undefined}
                 placeholder={placeholder.value}
                 autocomplete="off"
                 spellcheck={false}
@@ -492,6 +637,7 @@ export const HkTagInput = defineComponent({
             onUpdate:open={(v: boolean) => {
               open.value = v;
             }}
+            onKeydown={onPanelKeydown}
           >
             {{
               default: () => (
@@ -509,6 +655,10 @@ export const HkTagInput = defineComponent({
                       size="sm"
                       placeholder={searchPlaceholder}
                       aria-label={searchPlaceholder}
+                      // The search field is the second combobox surface:
+                      // arrows pressed here move the SAME cursor, and the
+                      // row is published the same way.
+                      aria-activedescendant={activeId}
                       autocomplete="off"
                       onKeydown={onSearchKeydown}
                     >
@@ -517,71 +667,83 @@ export const HkTagInput = defineComponent({
                       }}
                     </HkInput>
                   </div>
-                  {rows.length > 0 || customVisible.value ? (
-                    <div
-                      id={listboxId}
-                      class="hk-tag-input-list"
-                      role="listbox"
-                      aria-multiselectable="true"
-                      aria-label={title.value}
-                    >
-                      {rows.map((option) => {
-                        const selected = selectedKeys.value.includes(option.key);
-                        const inert = rowInert(option);
-                        return (
-                          <div
-                            key={option.key}
-                            role="option"
-                            tabindex={-1}
-                            class="hk-tag-input-row"
-                            aria-selected={selected}
-                            aria-disabled={inert || undefined}
-                            data-selected={selected || undefined}
-                            data-disabled={inert || undefined}
-                            onClick={(e: MouseEvent) => {
-                              e.stopPropagation();
-                              toggleRow(option);
-                            }}
-                          >
-                            <span class="hk-tag-input-check" aria-hidden="true">
-                              {selected && <Check size={14} />}
-                            </span>
-                            {option.flag && (
-                              <span class="hk-tag-input-row-flag" aria-hidden="true">
-                                {option.flag}
-                              </span>
-                            )}
-                            <span class="hk-tag-input-row-label">{labelOf(option)}</span>
-                            {option.meta && (
-                              <span class="hk-tag-input-row-meta">{option.meta}</span>
-                            )}
-                          </div>
-                        );
-                      })}
-                      {customVisible.value && (
+                  {/* The listbox element exists for as long as the panel is
+                    * open — including when the filter matches nothing — so
+                    * the input's `aria-controls` always resolves; the empty
+                    * state is its only child in that case. */}
+                  <div
+                    id={listboxId}
+                    class="hk-tag-input-list"
+                    role="listbox"
+                    aria-multiselectable="true"
+                    aria-label={title.value}
+                  >
+                    {rows.map((option, index) => {
+                      const selected = selectedKeys.value.includes(option.key);
+                      const inert = rowInert(option);
+                      const stop = stops.value[index];
+                      return (
                         <div
+                          key={option.key}
+                          id={stop.id}
                           role="option"
                           tabindex={-1}
                           class="hk-tag-input-row"
-                          aria-selected={false}
-                          aria-disabled={atMax.value || undefined}
-                          data-custom="true"
-                          data-disabled={atMax.value || undefined}
+                          aria-selected={selected}
+                          aria-disabled={inert || undefined}
+                          data-selected={selected || undefined}
+                          data-disabled={inert || undefined}
+                          data-active={activeId === stop.id || undefined}
                           onClick={(e: MouseEvent) => {
                             e.stopPropagation();
-                            addCustom();
+                            toggleRow(option);
                           }}
                         >
                           <span class="hk-tag-input-check" aria-hidden="true">
-                            <Plus size={14} />
+                            {selected && <Check size={14} />}
                           </span>
-                          <span class="hk-tag-input-row-label">{customLabel}</span>
+                          {option.flag && (
+                            <span class="hk-tag-input-row-flag" aria-hidden="true">
+                              {option.flag}
+                            </span>
+                          )}
+                          <span class="hk-tag-input-row-label">{labelOf(option)}</span>
+                          {option.meta && (
+                            <span class="hk-tag-input-row-meta">{option.meta}</span>
+                          )}
                         </div>
-                      )}
-                    </div>
-                  ) : (
-                    <div class="hk-tag-input-empty">{emptyText}</div>
-                  )}
+                      );
+                    })}
+                    {customVisible.value && (
+                      <div
+                        id={stopId("custom")}
+                        role="option"
+                        tabindex={-1}
+                        class="hk-tag-input-row"
+                        aria-selected={false}
+                        // The custom row is inert on exactly the same flag
+                        // as the option rows — the whole list (custom row
+                        // included) freezes when the field is disabled or
+                        // full, and reads inert to AT while it does.
+                        aria-disabled={rowsDisabled.value || undefined}
+                        data-custom="true"
+                        data-disabled={rowsDisabled.value || undefined}
+                        data-active={activeId === stopId("custom") || undefined}
+                        onClick={(e: MouseEvent) => {
+                          e.stopPropagation();
+                          addCustom();
+                        }}
+                      >
+                        <span class="hk-tag-input-check" aria-hidden="true">
+                          <Plus size={14} />
+                        </span>
+                        <span class="hk-tag-input-row-label">{customLabel}</span>
+                      </div>
+                    )}
+                    {rows.length === 0 && !customVisible.value && (
+                      <div class="hk-tag-input-empty">{emptyText}</div>
+                    )}
+                  </div>
                 </div>
               ),
             }}

--- a/packages/vue/src/components/HkTagInput.tsx
+++ b/packages/vue/src/components/HkTagInput.tsx
@@ -1,0 +1,595 @@
+import {
+  computed,
+  defineComponent,
+  ref,
+  useId,
+  watch,
+  type PropType,
+} from "vue";
+
+import { Check, ChevronDown, Plus, Search } from "lucide-vue-next";
+
+import { useI18n } from "../i18n/context";
+
+import HkInput from "./HkInput";
+import HkSelectPanel from "./HkSelectPanel";
+import HkTag from "./HkTag";
+import "./HkTagInput.scss";
+
+/** One entry of the tag catalog the field picks from. */
+export interface HkTagOption {
+  /** Stable identity — the value emitted back to the host. */
+  key: string;
+  /** Primary row AND tag text. */
+  label: string;
+  /** Secondary muted text (code suffix, hint). */
+  meta?: string;
+  /** Optional leading glyph (flag emoji or any short symbol). */
+  flag?: string;
+  /** Extra haystack for the search filter (aliases, codes, digits). */
+  keywords?: string;
+  /** Cannot be toggled on (still renders its check when it is set). */
+  disabled?: boolean;
+}
+
+/** True when every character of `query` appears in `text` in the same
+ *  order — gaps allowed ("中国" finds 中华人民共和国). Callers lowercase
+ *  both sides first, matching the substring pass. Local copy of the
+ *  helper HkAffixPicker uses (its internals are not exported; the rule
+ *  is shared, the code deliberately is not). */
+function isSubsequence(query: string, text: string): boolean {
+  let i = 0;
+  for (const ch of text) {
+    if (ch === query[i]) i++;
+    if (i === query.length) return true;
+  }
+  return false;
+}
+
+/** East-Asian wide glyphs occupy two `ch` units — approximating them
+ *  keeps an auto-grown inline input from clipping CJK queries. */
+const WIDE_GLYPH =
+  /[\u1100-\u115f\u2e80-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe30-\ufe6f\uff00-\uff60\uffe0-\uffe6]/;
+
+/**
+ * HkTagInput — the tag editor field: selected tags live IN the field as
+ * closable chips, and one searchable panel toggles catalog membership.
+ *
+ *   - the FIELD is a bordered, focus-ringed box in HkInput's visual
+ *     language: tags left to right in host order, then a bare
+ *     auto-growing input for typing, then the chevron that opens the
+ *     panel. Chips wrap onto as many lines as they need and the box
+ *     grows with them;
+ *   - the PANEL (chevron, any click inside the field, ArrowDown) is the
+ *     shared HkSelectPanel surface — same popup-manager stacking, mobile
+ *     bottom sheet, outside-click/Escape closing and ONE SCROLLBAR PER
+ *     WINDOW contract as every other picker. It deliberately mounts no
+ *     scroll region of its own: the window surface scrolls the search
+ *     field and the rows as one;
+ *   - ALL options are listed, each with a check glyph when selected —
+ *     unlike HkAffixPicker's multi mode, which hides the selected keys,
+ *     "is this tag used or not" must stay visible and togglable in one
+ *     pass. Toggling never closes the panel (batch editing);
+ *   - ORDER IS HOST STATE: a newly added key is APPENDED to the end of
+ *     `modelValue` ("first tag = primary" for hosts that care), an
+ *     existing key is removed in place, and the emitted array is always
+ *     a copy of the host's order with that one edit applied;
+ *   - a key in `modelValue` that the catalog does not carry (a custom
+ *     tag, or an option deleted since) degrades to its raw key as the
+ *     tag label — the same rule as HkAffixPicker.tagEntries;
+ *   - removal is IMMEDIATE: a tag's × emits `remove` + `update:modelValue`
+ *     with no confirm dialog. This is a deliberate divergence from
+ *     HkAffixPicker's `confirmRemove` two-step — a tag field is edited
+ *     in bulk, and a modal per chip would dominate the flow;
+ *   - with `allowCustom` the trimmed query that matches no option key or
+ *     label offers a trailing "Use “<query>”" row, so the search box can
+ *     also CREATE a value (the CORS-origin/admin-keyword case).
+ *
+ * The field is a combobox-style control: the inline input carries
+ * `role="combobox"`, `aria-expanded`, `aria-controls` (the listbox id)
+ * and `aria-autocomplete="list"`; rows are `role="option"` with
+ * `aria-selected`.
+ */
+export const HkTagInput = defineComponent({
+  name: "HkTagInput",
+  props: {
+    /** Selected keys, IN HOST ORDER (order is meaningful to hosts). */
+    modelValue: {
+      type: Array as PropType<readonly string[]>,
+      default: () => [] as readonly string[],
+    },
+    /** The catalog the panel lists. */
+    options: {
+      type: Array as PropType<readonly HkTagOption[]>,
+      default: () => [] as readonly HkTagOption[],
+    },
+    /** Free-text tags typed into the field / search box. */
+    allowCustom: { type: Boolean, default: false },
+    /** Field caption; also names the panel and the control. */
+    label: { type: String, default: undefined },
+    /** Shown inside the field while no tag & query — the inline input's
+     *  placeholder. */
+    placeholder: { type: String, default: undefined },
+    /** Muted helper line under the field. */
+    hint: { type: String, default: undefined },
+    disabled: { type: Boolean, default: false },
+    size: { type: String as PropType<"sm" | "md" | "lg">, default: "md" },
+    /** Capacity cap; 0 / undefined means unlimited. At the cap the
+     *  inline input gives way to the placeholder text and the panel's
+     *  add affordances go disabled (the tags' × still removes). */
+    maxTags: { type: Number, default: undefined },
+    /** Search field placeholder; defaulted from the i18n bundle. */
+    searchPlaceholder: { type: String, default: undefined },
+    /** "No matches" row text; defaulted from the i18n bundle. */
+    emptyText: { type: String, default: undefined },
+  },
+  emits: {
+    "update:modelValue": (_keys: string[]) => true,
+    /** A key was toggled on (fires before `update:modelValue`). */
+    add: (_key: string) => true,
+    /** A key was toggled off — tag × or a selected row. */
+    remove: (_key: string) => true,
+    "update:open": (_open: boolean) => true,
+  },
+  setup(props, { emit }) {
+    const { t } = useI18n();
+
+    const open = ref(false);
+    const query = ref("");
+    const fieldRef = ref<HTMLElement | null>(null);
+    const inputRef = ref<HTMLInputElement | null>(null);
+
+    // Field identity for the label association, plus the listbox id the
+    // inline input points at with aria-controls.
+    const generatedId = useId();
+    const listboxId = `${generatedId}-listbox`;
+
+    /** A fresh close drops the filter — a reopened panel starts calm
+     *  (the HkAffixPicker convention). */
+    watch(open, (v) => {
+      if (!v) query.value = "";
+      emit("update:open", v);
+    });
+
+    const selectedKeys = computed<readonly string[]>(() =>
+      Array.isArray(props.modelValue) ? props.modelValue : [],
+    );
+
+    const atMax = computed(
+      () => (props.maxTags ?? 0) > 0 && selectedKeys.value.length >= (props.maxTags ?? 0),
+    );
+
+    /** Tags in host order; a key the catalog does not carry renders the
+     *  raw key as its label (custom tags survive edits of the catalog),
+     *  and so does a catalog entry whose label is blank — an empty chip
+     *  would be invisible and unnameable. */
+    const tagEntries = computed<readonly HkTagOption[]>(() =>
+      selectedKeys.value.map((key) => {
+        const option = props.options.find((o) => o.key === key);
+        if (option && option.label.trim()) return option;
+        return { key, label: key };
+      }),
+    );
+
+    /** Rows of the panel: EVERY option, filtered — never pruned by
+     *  selection (that is what makes "used / not used" visible).
+     *
+     *  Filtering is TWO-PASS over a single field at a time (never across
+     *  concatenated fields, which produces noise):
+     *    1. an exact substring match for precision (label / meta / key /
+     *       keywords, case-folded);
+     *    2. an in-order character subsequence fallback (gaps allowed) —
+     *       so a renamed or CJK-composed label like "中华人民共和国" is
+     *       still found by its short form "中国".
+     */
+    const filteredRows = computed<readonly HkTagOption[]>(() => {
+      const q = query.value.trim().toLowerCase();
+      if (!q) return props.options;
+      return props.options.filter((o) => {
+        if (o.label.toLowerCase().includes(q)) return true;
+        if (o.meta && o.meta.toLowerCase().includes(q)) return true;
+        if (o.key.toLowerCase().includes(q)) return true;
+        if (o.keywords && o.keywords.toLowerCase().includes(q)) return true;
+        // Fuzzy fallback — per field, in-order subsequence, gaps allowed.
+        if (isSubsequence(q, o.label.toLowerCase())) return true;
+        if (o.meta && isSubsequence(q, o.meta.toLowerCase())) return true;
+        if (isSubsequence(q, o.key.toLowerCase())) return true;
+        return !!o.keywords && isSubsequence(q, o.keywords.toLowerCase());
+      });
+    });
+
+    const customText = computed(() => query.value.trim());
+
+    /** An exact key OR label match means the query is naming an entry the
+     *  catalog already carries; a key already selected (a custom tag from
+     *  an earlier edit) has nothing left to add either — in both cases no
+     *  duplicate custom row is offered. */
+    const exactMatch = computed(() => {
+      const q = customText.value.toLowerCase();
+      if (!q) return false;
+      if (
+        props.options.some(
+          (o) => o.key.toLowerCase() === q || o.label.toLowerCase() === q,
+        )
+      ) {
+        return true;
+      }
+      return selectedKeys.value.some((key) => key.toLowerCase() === q);
+    });
+
+    const customVisible = computed(
+      () => props.allowCustom && !!customText.value && !exactMatch.value,
+    );
+
+    /** Rows and the custom row are inert while the field is disabled or
+     *  already at capacity. */
+    const rowsDisabled = computed(() => props.disabled || atMax.value);
+
+    /** Rows that carry the raw key when the catalog's label is blank. */
+    function labelOf(option: HkTagOption): string {
+      return option.label.trim() ? option.label : option.key;
+    }
+
+    /** Is this row inert? The field being disabled or full freezes the
+     *  whole list (there is nothing to add); `disabled` on an option only
+     *  forbids toggling it ON, so an already-set disabled option stays
+     *  removable — a catalog edit must never strand a tag forever. */
+    function rowInert(option: HkTagOption): boolean {
+      if (rowsDisabled.value) return true;
+      return !!option.disabled && !selectedKeys.value.includes(option.key);
+    }
+
+    const title = computed(() => props.label ?? t("hikari::tagInput.title", "Tags"));
+    const placeholder = computed(() => props.placeholder ?? "");
+
+    const tagSize = computed<"sm" | "md">(() => (props.size === "sm" ? "sm" : "md"));
+
+    /** The inline input grows with its content (plus one caret unit);
+     *  the placeholder drives the width while the query is empty. */
+    const inlineWidth = computed(() => {
+      const text = query.value || placeholder.value;
+      let units = 0;
+      for (const ch of text) units += WIDE_GLYPH.test(ch) ? 2 : 1;
+      return `${Math.max(2, units + 1)}ch`;
+    });
+
+    function interpolate(template: string, vars: Record<string, string>): string {
+      return Object.entries(vars).reduce(
+        (acc, [k, v]) => acc.split(`{${k}}`).join(v),
+        template,
+      );
+    }
+
+    function openPanel(): void {
+      if (props.disabled) return;
+      open.value = true;
+    }
+
+    /** Commit one edit to the host's ordered key list. `add` / `remove`
+     *  fire first (the key), `update:modelValue` second (the full new
+     *  array) — the same "specific event, then the model" order the
+     *  neighbours use. */
+    function commit(next: string[], key: string, kind: "add" | "remove"): void {
+      if (kind === "add") emit("add", key);
+      else emit("remove", key);
+      emit("update:modelValue", next);
+    }
+
+    /** Appends to the END of the host order — never re-sorts, so
+     *  "first tag = primary" stays under the host's control. Returns
+     *  whether the key was actually added. */
+    function addKey(key: string): boolean {
+      if (props.disabled || atMax.value) return false;
+      if (selectedKeys.value.includes(key)) return false;
+      commit([...selectedKeys.value, key], key, "add");
+      return true;
+    }
+
+    function removeKey(key: string): void {
+      if (props.disabled) return;
+      const index = selectedKeys.value.indexOf(key);
+      if (index < 0) return;
+      const next = selectedKeys.value.slice();
+      next.splice(index, 1);
+      commit(next, key, "remove");
+    }
+
+    function toggle(key: string): void {
+      if (props.disabled) return;
+      if (selectedKeys.value.includes(key)) removeKey(key);
+      else addKey(key);
+    }
+
+    function toggleRow(option: HkTagOption): void {
+      if (rowInert(option)) return;
+      toggle(option.key);
+    }
+
+    /** The "Use “<query>”" row — the raw typed text becomes the tag. The
+     *  query is consumed only when the tag was really added, so a no-op
+     *  can never look like an accepted edit. */
+    function addCustom(): void {
+      const q = customText.value;
+      if (!q || rowsDisabled.value) return;
+      if (!addKey(q)) return;
+      query.value = "";
+    }
+
+    /** Enter resolves the typed query: the first togglable row when one
+     *  matches, otherwise the custom row (the HkAffixPicker order — an
+     *  inert top row falls through instead of swallowing the key).
+     *  An empty query is a no-op: Enter on a blank field must not pick
+     *  the top of the catalog. */
+    function commitQuery(): void {
+      const q = customText.value;
+      if (!q) return;
+      const rows = filteredRows.value;
+      if (rows.length > 0 && !rowInert(rows[0])) {
+        toggleRow(rows[0]);
+        return;
+      }
+      if (customVisible.value) addCustom();
+    }
+
+    function onFieldClick(e: MouseEvent): void {
+      if (props.disabled) return;
+      const target = e.target as HTMLElement | null;
+      // The chevron drives its own toggle, and a tag × must only remove:
+      // an already-open panel is left as it is, but the press never
+      // OPENS one behind the pointer.
+      if (target?.closest?.(".hk-tag-input-chevron")) return;
+      if (target?.closest?.(".hk-tag-close")) return;
+      openPanel();
+      inputRef.value?.focus();
+    }
+
+    function onInlineKeydown(e: KeyboardEvent): void {
+      if (e.isComposing) return;
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitQuery();
+        return;
+      }
+      if (e.key === "Backspace" && !query.value) {
+        const last = selectedKeys.value.at(-1);
+        if (last !== undefined && !props.disabled) {
+          e.preventDefault();
+          removeKey(last);
+        }
+        return;
+      }
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        openPanel();
+        return;
+      }
+      if (e.key === "Escape") {
+        // First Escape folds the panel (and drops the query); a second
+        // one has nothing left to clear — committed tags are never
+        // discarded by a keystroke.
+        if (open.value) {
+          e.preventDefault();
+          e.stopPropagation();
+          open.value = false;
+        }
+        return;
+      }
+    }
+
+    function onSearchKeydown(e: KeyboardEvent): void {
+      if (e.isComposing) return;
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitQuery();
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        open.value = false;
+      }
+    }
+
+    return () => {
+      const rows = filteredRows.value;
+      const searchPlaceholder =
+        props.searchPlaceholder ?? t("hikari::tagInput.search", "Search");
+      const emptyText = props.emptyText ?? t("hikari::tagInput.empty", "No matches");
+      const removeLabel = t("hikari::tagInput.remove", "Remove");
+      const customLabel = interpolate(
+        t("hikari::tagInput.addCustom", "Use “{q}”"),
+        { q: customText.value },
+      );
+      // The inline input is absent while disabled or at capacity; the
+      // placeholder text keeps the field readable in its place.
+      const typingEnabled = !props.disabled && !atMax.value;
+      return (
+        <div class="hk-tag-input-wrapper">
+          {props.label && (
+            <label class="hk-tag-input-label" for={generatedId}>
+              {props.label}
+            </label>
+          )}
+          <div
+            ref={(el: unknown) => {
+              fieldRef.value = (el as HTMLElement) ?? null;
+            }}
+            class={[
+              "hk-tag-input-box",
+              `hk-tag-input-box-${props.size}`,
+              open.value ? "hk-tag-input-box-open" : "",
+            ]}
+            data-disabled={props.disabled || undefined}
+            data-full={atMax.value || undefined}
+            onClick={onFieldClick}
+          >
+            {tagEntries.value.map((entry) => (
+              <HkTag
+                key={entry.key}
+                class="hk-tag-input-tag"
+                size={tagSize.value}
+                closable={!props.disabled}
+                closeLabel={`${removeLabel} — ${entry.label}`}
+                onClose={() => removeKey(entry.key)}
+              >
+                <span class="hk-tag-input-tag-text">{entry.label}</span>
+              </HkTag>
+            ))}
+            {typingEnabled ? (
+              <input
+                ref={inputRef}
+                id={generatedId}
+                type="text"
+                class="hk-tag-input-element"
+                style={{ width: inlineWidth.value }}
+                value={query.value}
+                role="combobox"
+                aria-expanded={open.value}
+                aria-controls={listboxId}
+                aria-autocomplete="list"
+                aria-haspopup="listbox"
+                aria-label={props.label ? undefined : title.value}
+                placeholder={placeholder.value}
+                autocomplete="off"
+                spellcheck={false}
+                data-1p-ignore
+                data-lpignore="true"
+                onInput={(e: Event) => {
+                  query.value = (e.target as HTMLInputElement).value;
+                }}
+                onKeydown={onInlineKeydown}
+              />
+            ) : placeholder.value ? (
+              <span class="hk-tag-input-placeholder">{placeholder.value}</span>
+            ) : null}
+            <button
+              type="button"
+              class="hk-tag-input-chevron"
+              disabled={props.disabled}
+              aria-haspopup="listbox"
+              aria-expanded={open.value}
+              aria-label={title.value}
+              title={title.value}
+              // Keep the inline input's focus (and its caret) on the
+              // chevron press — the panel opens without a blur flicker.
+              onMousedown={(e: MouseEvent) => e.preventDefault()}
+              onClick={(e: MouseEvent) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (props.disabled) return;
+                open.value = !open.value;
+              }}
+            >
+              <ChevronDown size={16} aria-hidden="true" />
+            </button>
+          </div>
+          {props.hint && <p class="hk-tag-input-hint">{props.hint}</p>}
+          <HkSelectPanel
+            open={open.value}
+            anchorRef={fieldRef.value}
+            title={title.value}
+            placement="bottom-start"
+            matchAnchorWidth
+            onUpdate:open={(v: boolean) => {
+              open.value = v;
+            }}
+          >
+            {{
+              default: () => (
+                /* Width container only — the window surface (HkSelectPanel
+                 * popout / sheet) owns THE single scrollbar and scrolls the
+                 * search field with the rows; no inner max-height/overflow
+                 * here, ever. */
+                <div class="hk-tag-input-panel">
+                  <div class="hk-tag-input-search" role="search">
+                    <HkInput
+                      modelValue={query.value}
+                      onUpdate:modelValue={(v: string) => {
+                        query.value = v;
+                      }}
+                      size="sm"
+                      placeholder={searchPlaceholder}
+                      aria-label={searchPlaceholder}
+                      autocomplete="off"
+                      onKeydown={onSearchKeydown}
+                    >
+                      {{
+                        prefixIcon: () => <Search size={13} aria-hidden="true" />,
+                      }}
+                    </HkInput>
+                  </div>
+                  {rows.length > 0 || customVisible.value ? (
+                    <div
+                      id={listboxId}
+                      class="hk-tag-input-list"
+                      role="listbox"
+                      aria-multiselectable="true"
+                      aria-label={title.value}
+                    >
+                      {rows.map((option) => {
+                        const selected = selectedKeys.value.includes(option.key);
+                        const inert = rowInert(option);
+                        return (
+                          <div
+                            key={option.key}
+                            role="option"
+                            tabindex={-1}
+                            class="hk-tag-input-row"
+                            aria-selected={selected}
+                            aria-disabled={inert || undefined}
+                            data-selected={selected || undefined}
+                            data-disabled={inert || undefined}
+                            onClick={(e: MouseEvent) => {
+                              e.stopPropagation();
+                              toggleRow(option);
+                            }}
+                          >
+                            <span class="hk-tag-input-check" aria-hidden="true">
+                              {selected && <Check size={14} />}
+                            </span>
+                            {option.flag && (
+                              <span class="hk-tag-input-row-flag" aria-hidden="true">
+                                {option.flag}
+                              </span>
+                            )}
+                            <span class="hk-tag-input-row-label">{labelOf(option)}</span>
+                            {option.meta && (
+                              <span class="hk-tag-input-row-meta">{option.meta}</span>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {customVisible.value && (
+                        <div
+                          role="option"
+                          tabindex={-1}
+                          class="hk-tag-input-row"
+                          aria-selected={false}
+                          aria-disabled={atMax.value || undefined}
+                          data-custom="true"
+                          data-disabled={atMax.value || undefined}
+                          onClick={(e: MouseEvent) => {
+                            e.stopPropagation();
+                            addCustom();
+                          }}
+                        >
+                          <span class="hk-tag-input-check" aria-hidden="true">
+                            <Plus size={14} />
+                          </span>
+                          <span class="hk-tag-input-row-label">{customLabel}</span>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div class="hk-tag-input-empty">{emptyText}</div>
+                  )}
+                </div>
+              ),
+            }}
+          </HkSelectPanel>
+        </div>
+      );
+    };
+  },
+});
+
+export default HkTagInput;

--- a/packages/vue/src/components/HkTagInput.tsx
+++ b/packages/vue/src/components/HkTagInput.tsx
@@ -740,10 +740,14 @@ export const HkTagInput = defineComponent({
                         <span class="hk-tag-input-row-label">{customLabel}</span>
                       </div>
                     )}
-                    {rows.length === 0 && !customVisible.value && (
-                      <div class="hk-tag-input-empty">{emptyText}</div>
-                    )}
                   </div>
+                  {/* The empty message lives OUTSIDE the listbox: a listbox
+                    * may only own options/groups (aria-required-children),
+                    * and the element it hangs off must still exist while the
+                    * panel is open for `aria-controls` to resolve. */}
+                  {rows.length === 0 && !customVisible.value && (
+                    <div class="hk-tag-input-empty">{emptyText}</div>
+                  )}
                 </div>
               ),
             }}

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "إدخال",
   "hikari::loadMore.more": "تحميل المزيد",
   "hikari::loadMore.loading": "جارٍ التحميل…",
-  "hikari::loadMore.end": "وصلت إلى النهاية"
+  "hikari::loadMore.end": "وصلت إلى النهاية",
+  "hikari::tagInput.title": "الوسوم",
+  "hikari::tagInput.search": "بحث",
+  "hikari::tagInput.empty": "لا تطابقات",
+  "hikari::tagInput.remove": "إزالة",
+  "hikari::tagInput.addCustom": "استخدام \"{q}\""
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "Eingabe",
   "hikari::loadMore.more": "Mehr laden",
   "hikari::loadMore.loading": "Wird geladen…",
-  "hikari::loadMore.end": "Das Ende ist erreicht"
+  "hikari::loadMore.end": "Das Ende ist erreicht",
+  "hikari::tagInput.title": "Tags",
+  "hikari::tagInput.search": "Suchen",
+  "hikari::tagInput.empty": "Keine Treffer",
+  "hikari::tagInput.remove": "Entfernen",
+  "hikari::tagInput.addCustom": "„{q}“ verwenden"
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -208,5 +208,10 @@
   "hikari::messageBox.promptTitle": "Input",
   "hikari::loadMore.more": "Load more",
   "hikari::loadMore.loading": "Loading…",
-  "hikari::loadMore.end": "You've reached the end"
+  "hikari::loadMore.end": "You've reached the end",
+  "hikari::tagInput.title": "Tags",
+  "hikari::tagInput.search": "Search",
+  "hikari::tagInput.empty": "No matches",
+  "hikari::tagInput.remove": "Remove",
+  "hikari::tagInput.addCustom": "Use “{q}”"
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "Entrada",
   "hikari::loadMore.more": "Cargar más",
   "hikari::loadMore.loading": "Cargando…",
-  "hikari::loadMore.end": "Has llegado al final"
+  "hikari::loadMore.end": "Has llegado al final",
+  "hikari::tagInput.title": "Etiquetas",
+  "hikari::tagInput.search": "Buscar",
+  "hikari::tagInput.empty": "Sin coincidencias",
+  "hikari::tagInput.remove": "Quitar",
+  "hikari::tagInput.addCustom": "Usar «{q}»"
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "Saisie",
   "hikari::loadMore.more": "Charger plus",
   "hikari::loadMore.loading": "Chargement…",
-  "hikari::loadMore.end": "Vous avez tout vu"
+  "hikari::loadMore.end": "Vous avez tout vu",
+  "hikari::tagInput.title": "Étiquettes",
+  "hikari::tagInput.search": "Rechercher",
+  "hikari::tagInput.empty": "Aucun résultat",
+  "hikari::tagInput.remove": "Retirer",
+  "hikari::tagInput.addCustom": "Utiliser « {q} »"
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "入力",
   "hikari::loadMore.more": "さらに読み込む",
   "hikari::loadMore.loading": "読み込み中…",
-  "hikari::loadMore.end": "すべて読み込みました"
+  "hikari::loadMore.end": "すべて読み込みました",
+  "hikari::tagInput.title": "タグ",
+  "hikari::tagInput.search": "検索",
+  "hikari::tagInput.empty": "一致なし",
+  "hikari::tagInput.remove": "削除",
+  "hikari::tagInput.addCustom": "「{q}」を使用"
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "입력",
   "hikari::loadMore.more": "더 불러오기",
   "hikari::loadMore.loading": "불러오는 중…",
-  "hikari::loadMore.end": "마지막 항목입니다"
+  "hikari::loadMore.end": "마지막 항목입니다",
+  "hikari::tagInput.title": "태그",
+  "hikari::tagInput.search": "검색",
+  "hikari::tagInput.empty": "일치 항목 없음",
+  "hikari::tagInput.remove": "제거",
+  "hikari::tagInput.addCustom": "\"{q}\" 사용"
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "Entrada",
   "hikari::loadMore.more": "Carregar mais",
   "hikari::loadMore.loading": "Carregando…",
-  "hikari::loadMore.end": "Você chegou ao fim"
+  "hikari::loadMore.end": "Você chegou ao fim",
+  "hikari::tagInput.title": "Etiquetas",
+  "hikari::tagInput.search": "Pesquisar",
+  "hikari::tagInput.empty": "Sem correspondências",
+  "hikari::tagInput.remove": "Remover",
+  "hikari::tagInput.addCustom": "Usar \"{q}\""
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -203,5 +203,10 @@
   "hikari::messageBox.promptTitle": "Ввод",
   "hikari::loadMore.more": "Загрузить ещё",
   "hikari::loadMore.loading": "Загрузка…",
-  "hikari::loadMore.end": "Вы дошли до конца"
+  "hikari::loadMore.end": "Вы дошли до конца",
+  "hikari::tagInput.title": "Теги",
+  "hikari::tagInput.search": "Поиск",
+  "hikari::tagInput.empty": "Нет совпадений",
+  "hikari::tagInput.remove": "Удалить",
+  "hikari::tagInput.addCustom": "Использовать «{q}»"
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -212,5 +212,10 @@
   "hikari::messageBox.promptTitle": "输入",
   "hikari::loadMore.more": "加载更多",
   "hikari::loadMore.loading": "正在加载…",
-  "hikari::loadMore.end": "到底啦"
+  "hikari::loadMore.end": "到底啦",
+  "hikari::tagInput.title": "标签",
+  "hikari::tagInput.search": "搜索",
+  "hikari::tagInput.empty": "没有匹配项",
+  "hikari::tagInput.remove": "移除",
+  "hikari::tagInput.addCustom": "使用「{q}」"
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -212,5 +212,10 @@
   "hikari::messageBox.promptTitle": "輸入",
   "hikari::loadMore.more": "載入更多",
   "hikari::loadMore.loading": "載入中…",
-  "hikari::loadMore.end": "到底啦"
+  "hikari::loadMore.end": "到底啦",
+  "hikari::tagInput.title": "標籤",
+  "hikari::tagInput.search": "搜尋",
+  "hikari::tagInput.empty": "沒有符合項目",
+  "hikari::tagInput.remove": "移除",
+  "hikari::tagInput.addCustom": "使用「{q}」"
 }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -72,6 +72,7 @@ export { default as HSwitch } from "./components/HkSwitch";
 export { default as HTable } from "./components/HkTable";
 export { default as HTabs } from "./components/HkTabs";
 export { default as HTag } from "./components/HkTag";
+export { HkTagInput as HTagInput, type HkTagOption } from "./components/HkTagInput";
 export { default as HTextarea } from "./components/HkTextarea";
 export { default as HFileField } from "./components/HkFileField";
 export { default as HFileBrowserDialog } from "./components/HkFileBrowserDialog";


### PR DESCRIPTION
## What

Adds **`HkTagInput`** (exported as **`HTagInput`**) — the reusable *tag editor field*: a form control whose value is an ordered list of tags rendered as chips **inside** the field, with a searchable dropdown that toggles which entries are used.

Nothing upstream covered this shape:

| control | why it does not fit |
|---|---|
| `HkTag` | display-only chip (no field, no picker) |
| `HkAffixPicker` | the field carries ONE affix chip; its tag list lives *inside* the popup, and multi mode hides already-selected rows — the opposite of "toggle whether this tag is used" |
| `HkSelect` / `HkSelectPanel` | single-value select, no tag rendering |

First consumer: shittim-chest's admin *System Settings* page (interface languages + CORS origins), where the field also has to accept **free-typed** entries.

## Contract

```ts
interface HkTagOption { key: string; label: string; meta?: string; flag?: string; keywords?: string; disabled?: boolean }

props:  modelValue: readonly string[]   // HOST ORDER — hosts read "first tag = primary"
        options: readonly HkTagOption[] // full catalog (the panel lists ALL of them)
        allowCustom?, label?, placeholder?, hint?, disabled?, size?, maxTags?, searchPlaceholder?, emptyText?
emits:  "update:modelValue"(string[])   // always a fresh array
        add(key) / remove(key)          // fire first, same tick, with the specific key
        "update:open"(boolean)          // notification only (open state is internal)
```

Guarantees the consumer relies on:

* **Order is the host's.** Adds append to the END, removals keep the relative order of the rest, the prop array is never mutated. No sorting, ever.
* **Removal is immediate** — the tag × erases without a dialog (deliberately unlike `HkAffixPicker.confirmRemove`): in a settings form the edit is cheap and reversible, and a confirm box per keystroke-scale action is noise.
* **Toggling keeps the panel open** and lists every option with a check glyph (`role="option"` + `aria-selected`), because "which of these are on?" is the whole question.
* **`allowCustom`** offers a trailing `Use “<query>”` row (and Enter support) so a value outside the catalog can be created from the same search box — the CORS-origin case.
* **One scrollbar per window**: the popup mounts no scroll region of its own; `HkSelectPanel` (desktop popout / mobile bottom sheet, popup-manager stacking, back-gesture) owns the single scrollbar. A source-contract test pins it next to the neighbours' equivalents.
* Accessible combobox/listbox wiring; the chevron and every tag × are named (the latter needed one **additive** `HkTag.closeLabel` prop — undefined renders the previous markup byte-for-byte).

## Verification

* `npx vitest run` → **143 files / 1238 tests green** (baseline 140 / 1195: +43 tests, 0 regressions).
* `npx vue-tsc --noEmit` → 0 errors.
* New tests cover: order/degradation, open paths (chevron / field click / ArrowDown), aria state, panel stays open + exact payloads, disabled rows, immediate ×, filter (substring + subsequence), empty state, custom add (Enter + row), duplicate/exact-match suppression, Enter fall-through, Backspace, Escape, `disabled`, `maxTags`, label/hint/placeholder, the no-inner-scrollbar contract, and use inside `HkModal`.


## Adversarial verification (independent agents)

**Round 1 — 53 probe tests by a verifier that did not write the code.** Verdict SHIP with 9 minor findings. Five were fixed in `3713628` (the a11y commit):

| finding | fix |
|---|---|
| focus destroyed when the field reached `maxTags` (the focused input was unmounted) | the inline input stays mounted and goes `readOnly` at the cap — focus, caret and accessible name survive; only `disabled` unmounts it |
| dangling `<label for>` / unnamed field at cap and disabled | `for` is emitted only when the input exists; the disabled box carries `role="group"` + `aria-label` |
| the custom row was not marked inert when `disabled` flipped while the panel was open | it now uses the same `rowsDisabled` flag as the option rows |
| `aria-controls` could point at a listbox that was not rendered | the `role="listbox"` element exists for as long as the panel is open (empty state inside it), with no new scroll region |
| no keyboard navigation in the listbox | activedescendant cursor: ArrowDown/ArrowUp walk the rows (custom row last, wrapping), `aria-activedescendant` on both the field and the search box, Enter activates the active row, cursor resets on open and on every query edit, focus never moves |

The two tests that pinned the old at-cap shape were updated; everything else stayed green (143 files / 1254 tests, `vue-tsc` 0).

**Round 2 — a second independent verifier re-probed the fixed revision** (focus survival across all three paths to the cap, `aria-activedescendant` target existence in every state, wrapping with 1/2/0 stops, IME guards, Enter on an inert active row, label association in all states, `aria-controls` with an empty filter, the single-scrollbar contract, no prop/emit surface change) and re-ran the full suite and typecheck.

## Version

`packages/vue/package.json` → **0.42.1**, chosen to clear the three version claims currently held by in-flight waves (`0.41.10` #456 root-zoom popover, `0.41.11` #457 image-lightbox/theme, `0.42.0` #455 load-more facility) rather than racing them. First consumer: celestia-island/shittim-chest (its lockfile picks this up).
