### PR TITLE
✨ Promote formatRelativeTime to a localized standard with week granularity.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.42.2",
+  "version": "0.43.0",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/i18n/locales/ar/time.json
+++ b/packages/vue/src/i18n/locales/ar/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "الآن",
+    "common.time.minutesAgo": "قبل {n} دقيقة",
+    "common.time.hoursAgo": "قبل {n} ساعة",
+    "common.time.daysAgo": "قبل {n} يوم",
+    "common.time.weeksAgo": "قبل {n} أسبوع"
+  }
+}

--- a/packages/vue/src/i18n/locales/de/time.json
+++ b/packages/vue/src/i18n/locales/de/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "Gerade eben",
+    "common.time.minutesAgo": "vor {n} Min.",
+    "common.time.hoursAgo": "vor {n} Std.",
+    "common.time.daysAgo": "vor {n} Tg.",
+    "common.time.weeksAgo": "vor {n} Wo."
+  }
+}

--- a/packages/vue/src/i18n/locales/en/time.json
+++ b/packages/vue/src/i18n/locales/en/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "Just now",
+    "common.time.minutesAgo": "{n} min ago",
+    "common.time.hoursAgo": "{n} h ago",
+    "common.time.daysAgo": "{n} d ago",
+    "common.time.weeksAgo": "{n} w ago"
+  }
+}

--- a/packages/vue/src/i18n/locales/es/time.json
+++ b/packages/vue/src/i18n/locales/es/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "Ahora mismo",
+    "common.time.minutesAgo": "hace {n} min",
+    "common.time.hoursAgo": "hace {n} h",
+    "common.time.daysAgo": "hace {n} d",
+    "common.time.weeksAgo": "hace {n} sem"
+  }
+}

--- a/packages/vue/src/i18n/locales/fr/time.json
+++ b/packages/vue/src/i18n/locales/fr/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "À l'instant",
+    "common.time.minutesAgo": "il y a {n} min",
+    "common.time.hoursAgo": "il y a {n} h",
+    "common.time.daysAgo": "il y a {n} j",
+    "common.time.weeksAgo": "il y a {n} sem."
+  }
+}

--- a/packages/vue/src/i18n/locales/ja/time.json
+++ b/packages/vue/src/i18n/locales/ja/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "たった今",
+    "common.time.minutesAgo": "{n} 分前",
+    "common.time.hoursAgo": "{n} 時間前",
+    "common.time.daysAgo": "{n} 日前",
+    "common.time.weeksAgo": "{n} 週間前"
+  }
+}

--- a/packages/vue/src/i18n/locales/ko/time.json
+++ b/packages/vue/src/i18n/locales/ko/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "방금 전",
+    "common.time.minutesAgo": "{n}분 전",
+    "common.time.hoursAgo": "{n}시간 전",
+    "common.time.daysAgo": "{n}일 전",
+    "common.time.weeksAgo": "{n}주 전"
+  }
+}

--- a/packages/vue/src/i18n/locales/pt/time.json
+++ b/packages/vue/src/i18n/locales/pt/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "Agora mesmo",
+    "common.time.minutesAgo": "há {n} min",
+    "common.time.hoursAgo": "há {n} h",
+    "common.time.daysAgo": "há {n} d",
+    "common.time.weeksAgo": "há {n} sem"
+  }
+}

--- a/packages/vue/src/i18n/locales/ru/time.json
+++ b/packages/vue/src/i18n/locales/ru/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "Только что",
+    "common.time.minutesAgo": "{n} мин. назад",
+    "common.time.hoursAgo": "{n} ч. назад",
+    "common.time.daysAgo": "{n} дн. назад",
+    "common.time.weeksAgo": "{n} нед. назад"
+  }
+}

--- a/packages/vue/src/i18n/locales/zh-Hans/time.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "刚刚",
+    "common.time.minutesAgo": "{n} 分钟前",
+    "common.time.hoursAgo": "{n} 小时前",
+    "common.time.daysAgo": "{n} 天前",
+    "common.time.weeksAgo": "{n} 周前"
+  }
+}

--- a/packages/vue/src/i18n/locales/zh-Hant/time.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/time.json
@@ -1,0 +1,9 @@
+{
+  "time": {
+    "common.time.justNow": "剛剛",
+    "common.time.minutesAgo": "{n} 分鐘前",
+    "common.time.hoursAgo": "{n} 小時前",
+    "common.time.daysAgo": "{n} 天前",
+    "common.time.weeksAgo": "{n} 週前"
+  }
+}

--- a/packages/vue/src/i18n/timeKeys.test.ts
+++ b/packages/vue/src/i18n/timeKeys.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { setLocale, useI18n } from "./context";
+
+/**
+ * Locale key pack for the formatRelativeTime facility
+ * (common.time.justNow/minutesAgo/hoursAgo/daysAgo/weeksAgo, served from
+ * the new locales/<lang>/time.json bundles). The JSON keys are the literal
+ * unprefixed full names because t() resolves by exact full-name match
+ * (context.ts merges string leaves under their literal key) and the
+ * facility + its host-t consumers call t("common.time.*") unprefixed —
+ * the "hikari::" prefix convention is reserved for
+ * hikari-component-owned keys. A key missing from any locale silently
+ * falls back to English there, so every locale must define all five keys
+ * with matching {n} placeholder presence (hikari review lessons
+ * #373/#374, same shape as contextKeys.test.ts).
+ */
+const modules = import.meta.glob<{ default: Record<string, Record<string, string>> }>(
+  "./locales/*/time.json",
+  { eager: true },
+);
+
+const EXPECTED_LOCALES = [
+  "ar", "de", "en", "es", "fr", "ja", "ko", "pt", "ru", "zh-Hans", "zh-Hant",
+];
+
+const REQUIRED_KEYS = [
+  "common.time.justNow",
+  "common.time.minutesAgo",
+  "common.time.hoursAgo",
+  "common.time.daysAgo",
+  "common.time.weeksAgo",
+];
+
+describe("common.time locale keys", () => {
+  const bundles = Object.entries(modules).map(([path, mod]) => ({
+    locale: path.match(/locales\/([^/]+)\/time\.json/)?.[1] ?? "",
+    flat: mod.default.time ?? {},
+  }));
+
+  it("covers all 11 time.json locale files", () => {
+    expect(bundles.map((b) => b.locale).sort()).toEqual(EXPECTED_LOCALES);
+  });
+
+  it("defines all 5 common.time.* keys in every locale, non-empty", () => {
+    for (const { locale, flat } of bundles) {
+      for (const key of REQUIRED_KEYS) {
+        expect(typeof flat[key], `${locale} must define ${key}`).toBe("string");
+        expect((flat[key] ?? "").length, `${locale} ${key} must not be empty`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("matches the {n} placeholder pattern of en in every locale", () => {
+    const en = bundles.find((b) => b.locale === "en");
+    expect(en, "en bundle renders").toBeTruthy();
+    for (const { locale, flat } of bundles) {
+      for (const key of REQUIRED_KEYS) {
+        const wantsN = en!.flat[key].includes("{n}");
+        expect(flat[key].includes("{n}"), `${locale} ${key} {n} parity`).toBe(wantsN);
+      }
+    }
+  });
+
+  it("resolves through useI18n at runtime, per locale", async () => {
+    await setLocale("zh-Hans");
+    const zh = useI18n();
+    expect(zh.t("common.time.justNow", "Just now")).toBe("刚刚");
+    expect(zh.t("common.time.hoursAgo", "{n} h ago").replace("{n}", "3")).toBe("3 小时前");
+
+    await setLocale("de");
+    const de = useI18n();
+    expect(de.t("common.time.daysAgo", "{n} d ago").replace("{n}", "2")).toBe("vor 2 Tg.");
+
+    await setLocale("en");
+    const en = useI18n();
+    expect(en.t("common.time.weeksAgo", "{n} w ago")).toBe("{n} w ago");
+  });
+});

--- a/packages/vue/src/utils/format.test.ts
+++ b/packages/vue/src/utils/format.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeTime, type RelativeTimeT } from "./format";
+
+const MIN = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+function ago(ms: number): Date {
+  return new Date(Date.now() - ms);
+}
+
+interface CapturedCall {
+  key: string;
+  fallback: string;
+  named?: Record<string, unknown>;
+}
+
+/** Fake translator: records every lookup and renders the {n} slot so
+ *  injection can be asserted end-to-end. */
+function makeCaptureT(): { t: RelativeTimeT; calls: CapturedCall[] } {
+  const calls: CapturedCall[] = [];
+  const t: RelativeTimeT = (key, fallback, named) => {
+    calls.push({ key, fallback, named });
+    return fallback.replace("{n}", String(named?.n ?? ""));
+  };
+  return { t, calls };
+}
+
+describe("formatRelativeTime", () => {
+  it("returns an empty string for missing input", () => {
+    expect(formatRelativeTime("")).toBe("");
+    expect(formatRelativeTime(0)).toBe("");
+  });
+
+  it("returns an empty string for unparseable input", () => {
+    expect(formatRelativeTime("not-a-date")).toBe("");
+    expect(formatRelativeTime(Number.NaN)).toBe("");
+  });
+
+  it("renders the compact English fallback per tier", () => {
+    expect(formatRelativeTime(ago(59_000))).toBe("Just now");
+    expect(formatRelativeTime(ago(MIN))).toBe("1m ago");
+    expect(formatRelativeTime(ago(59 * MIN))).toBe("59m ago");
+    expect(formatRelativeTime(ago(HOUR))).toBe("1h ago");
+    expect(formatRelativeTime(ago(23 * HOUR))).toBe("23h ago");
+    expect(formatRelativeTime(ago(DAY))).toBe("1d ago");
+    expect(formatRelativeTime(ago(6 * DAY))).toBe("6d ago");
+  });
+
+  it("adds the weeks tier from 7d up to (excluding) 30d", () => {
+    expect(formatRelativeTime(ago(7 * DAY))).toBe("1w ago");
+    expect(formatRelativeTime(ago(13 * DAY))).toBe("1w ago");
+    expect(formatRelativeTime(ago(14 * DAY))).toBe("2w ago");
+    expect(formatRelativeTime(ago(29 * DAY))).toBe("4w ago");
+  });
+
+  it("falls to the absolute-date path at >= 30d", () => {
+    const d = ago(30 * DAY);
+    // Do not pin a locale-specific rendering; assert the value comes
+    // from the same Date's toLocaleDateString().
+    expect(formatRelativeTime(d)).toBe(d.toLocaleDateString());
+    expect(formatRelativeTime(d).length).toBeGreaterThan(0);
+  });
+
+  it("clamps future timestamps into the justNow tier", () => {
+    expect(formatRelativeTime(ago(-5 * MIN))).toBe("Just now");
+    expect(formatRelativeTime(ago(-2 * DAY))).toBe("Just now");
+  });
+
+  it("passes the documented keys with injected {n} to the translator", () => {
+    const { t, calls } = makeCaptureT();
+
+    expect(formatRelativeTime(ago(30_000), t)).toBe("Just now");
+    expect(calls[0]).toEqual({
+      key: "common.time.justNow",
+      fallback: "Just now",
+      named: undefined,
+    });
+
+    expect(formatRelativeTime(ago(5 * MIN), t)).toBe("5 min ago");
+    expect(calls[1]).toEqual({
+      key: "common.time.minutesAgo",
+      fallback: "{n} min ago",
+      named: { n: 5 },
+    });
+
+    expect(formatRelativeTime(ago(3 * HOUR), t)).toBe("3 h ago");
+    expect(calls[2]).toEqual({
+      key: "common.time.hoursAgo",
+      fallback: "{n} h ago",
+      named: { n: 3 },
+    });
+
+    expect(formatRelativeTime(ago(2 * DAY), t)).toBe("2 d ago");
+    expect(calls[3]).toEqual({
+      key: "common.time.daysAgo",
+      fallback: "{n} d ago",
+      named: { n: 2 },
+    });
+
+    expect(formatRelativeTime(ago(8 * DAY), t)).toBe("1 w ago");
+    expect(calls[4]).toEqual({
+      key: "common.time.weeksAgo",
+      fallback: "{n} w ago",
+      named: { n: 1 },
+    });
+  });
+
+  it("keeps absolute dates away from the translator", () => {
+    const { t, calls } = makeCaptureT();
+    const d = ago(45 * DAY);
+    expect(formatRelativeTime(d, t)).toBe(d.toLocaleDateString());
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/packages/vue/src/utils/format.ts
+++ b/packages/vue/src/utils/format.ts
@@ -37,7 +37,8 @@ export function formatPriceUsd(n: number, currency = "$"): string {
   return `${currency}${n.toFixed(2)}`;
 }
 
-/** Timestamp -> "Just now" / "5m ago" / "3h ago" / "2d ago" / locale date. */
+/** Timestamp -> "Just now" / "5m ago" / "3h ago" / "2d ago" / "2w ago" /
+ *  locale date. */
 export type RelativeTimeT = (
   key: string,
   fallback: string,
@@ -46,7 +47,12 @@ export type RelativeTimeT = (
 
 /** Relative-time formatting ("just now / {n} min ago / …").
  *  Pass an optional translator for localized variants; defaults to
- *  compact English text. */
+ *  compact English text. Tiers: <1min justNow, <60min minutes,
+ *  <24h hours, <7d days, <30d weeks, otherwise an absolute
+ *  locale-rendered date (browser locale, like formatDateTime).
+ *  The translator owns {n} interpolation — hikari's own useI18n().t
+ *  does NOT interpolate named params, so wrap it (the canonical key
+ *  set lives in the per-locale i18n time bundles). */
 export function formatRelativeTime(
   input: string | number | Date,
   t?: RelativeTimeT,
@@ -54,7 +60,8 @@ export function formatRelativeTime(
   if (!input) return "";
   const d = input instanceof Date ? input : new Date(input);
   if (isNaN(d.getTime())) return "";
-  const diff = Date.now() - d.getTime();
+  // Clamp future timestamps to "just now" — no negative weeks/days.
+  const diff = Math.max(0, Date.now() - d.getTime());
   const mins = Math.floor(diff / 60000);
   const hours = Math.floor(diff / 3600000);
   const days = Math.floor(diff / 86400000);
@@ -62,6 +69,12 @@ export function formatRelativeTime(
   if (mins < 60) return t?.("common.time.minutesAgo", "{n} min ago", { n: mins }) ?? `${mins}m ago`;
   if (hours < 24) return t?.("common.time.hoursAgo", "{n} h ago", { n: hours }) ?? `${hours}h ago`;
   if (days < 7) return t?.("common.time.daysAgo", "{n} d ago", { n: days }) ?? `${days}d ago`;
+  if (days < 30) {
+    const weeks = Math.floor(days / 7);
+    return (
+      t?.("common.time.weeksAgo", "{n} w ago", { n: weeks }) ?? `${weeks}w ago`
+    );
+  }
   return d.toLocaleDateString();
 }
 


### PR DESCRIPTION
## 背景

formatRelativeTime 早已存在,但其解析的 `common.time.{justNow,minutesAgo,hoursAgo,daysAgo}` 键**在任何 locale bundle 里都没有定义**——所有消费方(含 chest WorkspaceModal)一直在静默回退英文紧凑文案。本 PR 把它升级为标准 i18n 设施。

## 改动
- **11 语言官方键包**:`locales/<lang>/time.json` 提供 `common.time.{justNow,minutesAgo,hoursAgo,daysAgo,weeksAgo}` 官方译文(bucket 形态,经 buildLocaleMessages 一层 assign 后为字面整名,与 t() 整名查找精确吻合——runtime 测试 setLocale 实测 zh-Hans「刚刚」/de「vor 2 Tg.」)。
- **weeks 档**:7d≤diff<30d 新增 `weeksAgo`;≥30d 维持绝对日期(浏览器 locale,与 formatDateTime 一致)。
- **未来时间戳钳制**:diff≤0 → justNow(不再产生负数档位)。
- **JSDoc**:注明 translator 自持 {n} 插值(hikari 自家 useI18n().t 不做插值),键包位置。
- **测试**:format.test.ts 8 用例(档位边界/钳制/translator 键与 {n} 捕获/45d 零调用);timeKeys.test.ts 4 用例(11 locale 齐平/{n} parity/runtime 解析)。
- 版本 0.42.2 → **0.43.0**(minor 新功能;0.42.3 已由 select-panel 在飞波占号并已协调改道 0.43.1,见 PLAN)。

## 验证
- 独立验证代理全项 PASS(键解析链 runtime 实证、档位边界逐一、11 语言全读真翻译、契约兼容——旧 4 键名与 fallback 逐字未变,chest WorkspaceModal 透传不崩)。
- vitest 150 文件/1291 用例全绿;vue-tsc 0 错。
- 兼容性:旧 4 键未改名,chest WorkspaceModal 零破坏;chest 消费侧(用户页相对时间列)在后续 PR 落地。