### PR TITLE
✨ Rework the tag editor panel geometry and add drag-to-reorder.

### DIFF
--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -177,9 +177,24 @@
   /* Menu/switcher panels overflow a bare 240px cap even on tall viewports
      (user feedback 2026-08-30: identity header + rows ≈ 320px+). Keep 240px
      as the floor for select lists on short viewports, otherwise let the
-     panel size to its content up to a viewport-relative ceiling. */
+     panel size to its content up to a viewport-relative ceiling — plain-vh
+     first, dvh second, so an engine without dvh drops the dvh twin at PARSE
+     time and keeps the vh cap (the HkModal/HkDrawer/HkImageLightbox rule).
+     A consumer that needs a tighter surface (HkTagInput's catalog) publishes
+     --hk-select-panel-max-height through HkSelectPanel's `maxHeight` prop;
+     that hook rides the dvh-capable branch below, because a dvh value
+     reaching a dvh-less engine through var() would not be parse-dropped but
+     invalid at COMPUTED-value time — which resolves to `max-height: none`,
+     losing the cap entirely. Such an engine keeps the plain-vh ceiling
+     instead, exactly as it does today. */
   max-height: max(240px, min(36rem, calc(100vh - 32px)));
   max-height: max(240px, min(36rem, calc(100dvh - 32px)));
+  @supports (height: 1dvh) {
+    max-height: var(
+      --hk-select-panel-max-height,
+      max(240px, min(36rem, calc(100dvh - 32px)))
+    );
+  }
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -371,6 +386,17 @@
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
+  /* The same consumer-tunable cap the popout reads, applied to the band
+     that actually scrolls: the sheet header keeps its place and the
+     catalog scrolls inside it. `none` (the fallback) is exactly today's
+     behaviour, so an untouched consumer's sheet is unchanged.
+     DELIBERATELY not wrapped in the popout's `@supports (height: 1dvh)`
+     guard: this band's fallback already IS the property's initial value,
+     so a value the engine cannot use resolves to the same `none` the
+     guard would produce — the asymmetry is a no-op, not an oversight.
+     The sheet PANEL above keeps its own plain-vh/dvh family cap either
+     way, so a hidden cap can never leave the sheet unbounded. */
+  max-height: var(--hk-select-panel-max-height, none);
   /* Side insets so the option blocks (full-row hover pills) read as
      cards inside the sheet instead of an edge-to-edge strip glued to
      both screen sides — matching the popover family's breathing room.

--- a/packages/vue/src/components/HkSelectPanel.tsx
+++ b/packages/vue/src/components/HkSelectPanel.tsx
@@ -47,6 +47,15 @@ import "./HkSelect.scss";
  * events on the panel surface are forwarded (`keydown`) so owners that own
  * an option model (like HkSelect) can run their own arrow/enter navigation.
  *
+ * Geometry is the surface's to decide: `matchAnchorWidth` (default true,
+ * select parity) ties the popout's minimum width to the trigger, and the
+ * optional `maxHeight` caps whichever element scrolls (the desktop popout,
+ * the mobile sheet's list band). Both are opt-outs — a consumer that passes
+ * neither gets the historic panel, which is what every existing caller
+ * does; a consumer whose content should scroll inside a hugged surface
+ * (a tag catalog, a long filter list) sets them and relies on the panel's
+ * ONE scrollbar.
+ *
  * Mobile sheets also run a duplicate-title filter: content that opens with
  * a non-interactive heading exactly repeating the panel `title` is hidden
  * (`.hk-sheet-dup-title`) — the sheet header already names the sheet, and
@@ -85,6 +94,23 @@ export default defineComponent({
     offset: { type: Number, default: 4 },
     /** Popout min-width follows the anchor width (select parity). */
     matchAnchorWidth: { type: Boolean, default: true },
+    /** Cap for the surface that scrolls — the desktop popout or the
+     *  mobile sheet's list band — as ANY CSS length (`min(18rem, 45dvh)`,
+     *  `24rem`, `calc(50vh - 3rem)`).
+     *
+     *  Undefined (the default) keeps the stylesheet's own ceilings, so
+     *  every existing consumer is untouched; a consumer whose content
+     *  should scroll instead of stretching the panel to the viewport sets
+     *  it, and the panel's ONE scrollbar (never a second region) does the
+     *  rest. Applied through the `--hk-select-panel-max-height` hook
+     *  HkSelect.scss reads, inside its `@supports (height: 1dvh)` branch —
+     *  a value an engine cannot use is therefore IGNORED rather than
+     *  clamped: the popout keeps the plain-vh ceiling it has today.
+     *  A MALFORMED value (a typo, a bare number) is likewise not sanitized:
+     *  the substituted declaration becomes invalid at computed-value time
+     *  and resolves to `max-height: none`, i.e. the surface is UNCAPPED —
+     *  the type gate is a CSS length, the value gate is the consumer's. */
+    maxHeight: { type: String, default: undefined },
     /** Dock as a bottom sheet on phone-width viewports. */
     sheetOnMobile: { type: Boolean, default: true },
   },
@@ -319,6 +345,14 @@ export default defineComponent({
     // the sheet panel also carries the grabber + title bands.
     const sheetBodyRef = ref<HTMLElement>();
     const coords = ref<{ top?: string; left?: string; minWidth?: string }>({});
+
+    /** Host-tunable surface cap (the `maxHeight` prop): published as the
+     *  custom property HkSelect.scss reads on whichever element scrolls,
+     *  so the stylesheet keeps today's ceiling as its fallback and a
+     *  consumer that passes nothing renders exactly as before. */
+    const surfaceCap = computed<Record<string, string> | undefined>(() =>
+      props.maxHeight ? { "--hk-select-panel-max-height": props.maxHeight } : undefined,
+    );
 
     // ── overlay scrollbar (shared chrome) ─────────────────────────
     // Attached per open on whichever surface scrolls — the desktop
@@ -632,7 +666,11 @@ export default defineComponent({
                     </HIconButton>
                   </div>
                   <div class="hk-select-sheet-body" ref={sheetBodyRef}>
-                    <div class="hk-select-sheet-list" ref={sheetListRef}>
+                    <div
+                      class="hk-select-sheet-list"
+                      ref={sheetListRef}
+                      style={surfaceCap.value}
+                    >
                       <div class="hk-select-sheet-content" ref={sheetContentRef}>
                         {slots.default?.()}
                       </div>
@@ -663,6 +701,7 @@ export default defineComponent({
                 <div
                   ref={panelRef}
                   class="hk-select-popout"
+                  style={surfaceCap.value}
                   aria-label={props.title || undefined}
                   onKeydown={forwardKeydown}
                 >

--- a/packages/vue/src/components/HkTagInput.scss
+++ b/packages/vue/src/components/HkTagInput.scss
@@ -3,7 +3,10 @@
  * HkInput's box (border, radius, rhythm, focus ring) so a tag field sits
  * flush beside plain inputs in the same form; the panel chrome mirrors
  * HkAffixPicker's popup (search on top, rows below, NO inner scroll
- * region — the HkSelectPanel window owns the single scrollbar). */
+ * region — the HkSelectPanel window owns the single scrollbar, capped by
+ * the component's `maxHeight` so a long catalog scrolls there instead of
+ * stretching the panel). Chips and selected rows are reorderable; the
+ * drag states (`data-dragging` / `data-drop`) live at the bottom. */
 
 .hk-tag-input-wrapper {
   display: block;
@@ -78,6 +81,15 @@
 
 .hk-tag-input-tag {
   max-width: 100%;
+  /* Reorder affordance: the chip BODY is the handle. */
+  cursor: grab;
+  /* A press that becomes a drag must not paint a text selection, and a
+   * touch that starts scrolling vertically belongs to the page (the
+   * browser takes the gesture back with a pointercancel; a horizontal
+   * drag is ours — see usePointerReorder). */
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: pan-y;
 }
 
 .hk-tag-input-tag-text {
@@ -85,6 +97,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* A disabled field reorders nothing: the chips drop the grab affordance
+ * (and the gesture reservation with it) — the box's own not-allowed
+ * cursor takes over. */
+.hk-tag-input-box[data-disabled] .hk-tag-input-tag {
+  cursor: default;
+  touch-action: auto;
 }
 
 /* ── inline typing input / placeholder ────────────────────────────── */
@@ -171,6 +191,12 @@
 .hk-tag-input-panel {
   display: flex;
   flex-direction: column;
+  /* A FIXED measure, not a content-driven one: the popout is positioned
+   * once when it opens, so a panel that grew with its content would shift
+   * its own left edge mid-interaction — toggling a row adds a check glyph,
+   * and a query changes which rows (and how much meta text) survive.
+   * min/max stay as the bounds a narrow viewport imposes on that width. */
+  width: min(19rem, calc(100vw - 2rem));
   min-width: 13rem;
   max-width: min(19rem, calc(100vw - 2rem));
 }
@@ -291,6 +317,62 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* ── reordering ───────────────────────────────────────────────────── */
+/* Live drag (both lists): the item being moved dims, the slot it would
+ * land in is ringed. Chips carry the state as classes (HkTag takes no
+ * arbitrary attributes), panel rows as data attributes — both are
+ * assertable hooks that never collide with the pointer/hover faces. */
+.hk-tag-input-tag-dragging,
+.hk-tag-input-row[data-dragging] {
+  opacity: 0.55;
+  cursor: grabbing;
+}
+
+.hk-tag-input-tag-drop {
+  outline: 1px dashed rgb(var(--color-focused-border));
+  outline-offset: 1px;
+}
+
+.hk-tag-input-row[data-drop] {
+  box-shadow: inset 0 0 0 1px rgb(var(--color-focused-border));
+}
+
+/* Drag handle of a SELECTED panel row — the one element that claims the
+ * touch gesture outright, so the sheet keeps scrolling under the rest of
+ * the row. Only selected rows render one: an unselected row is not
+ * draggable and is never a drop target. */
+.hk-tag-input-grip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  /* The largest target the row rhythm allows: the row's content box is the
+     2.25rem row minus its 4px block padding, so the handle grows to that
+     without changing the option rows' height (the 44px touch guidance
+     cannot fit in a list row — the sheet scrolls through them instead). */
+  width: 1.5rem;
+  height: 1.75rem;
+  margin-inline-end: -4px;
+  color: rgb(var(--color-muted));
+  opacity: 0.6;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  transition: opacity 0.12s ease, color 0.12s ease;
+
+  &:active {
+    cursor: grabbing;
+  }
+}
+
+.hk-tag-input-row:hover .hk-tag-input-grip,
+.hk-tag-input-row[data-dragging] .hk-tag-input-grip,
+.hk-tag-input-grip:focus-visible {
+  opacity: 1;
+  color: rgb(var(--color-text));
+}
+
 .hk-tag-input-empty {
   padding: 14px 12px;
   color: rgb(var(--color-muted));
@@ -301,6 +383,7 @@
 @media (prefers-reduced-motion: reduce) {
   .hk-tag-input-box,
   .hk-tag-input-chevron,
+  .hk-tag-input-grip,
   .hk-tag-input-row {
     transition: none;
   }

--- a/packages/vue/src/components/HkTagInput.singleScroll.contract.test.ts
+++ b/packages/vue/src/components/HkTagInput.singleScroll.contract.test.ts
@@ -6,6 +6,14 @@
  * `max-height: 17rem; overflow: auto` row region. It has none: the
  * HkSelectPanel window surface (desktop popout / mobile sheet) owns THE
  * single scrollbar and scrolls the search field with the rows as one.
+ *
+ * The 2026-09-11 geometry wave leans on the same contract from the other
+ * side: the field used to hand the panel its own width (`matchAnchorWidth`,
+ * a full-width settings column) while the catalog caps at 19rem, leaving an
+ * empty band and a scrollbar parked far from the rows. The panel now hugs
+ * its own measure, and the catalog scrolls because the SURFACE is capped
+ * (`maxHeight` → the --hk-select-panel-max-height hook) — never because the
+ * row list grew a scroll region of its own.
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -32,6 +40,14 @@ function cssBlock(src: string, selector: string): string {
     }
   }
   return "";
+}
+
+/** The JSX opening tag that carries `marker` (attributes only, no
+ *  children) — the pin below is about what ONE element declares. */
+function jsxOpeningTag(src: string, marker: string): string {
+  const at = src.indexOf(marker);
+  expect(at, `${marker} is rendered`).toBeGreaterThanOrEqual(0);
+  return src.slice(src.lastIndexOf("<", at), src.indexOf(">", at) + 1);
 }
 
 function expectNoScroll(block: string, what: string): void {
@@ -61,13 +77,70 @@ describe("HkTagInput single-scrollbar-per-window contract", () => {
     expectNoScroll(block, ".hk-select-sheet-panel .hk-tag-input-panel");
   });
 
-  it("the component mounts no overlay scrollbar machinery", () => {
+  it("the component mounts no overlay scrollbar machinery and clamps no row region", () => {
     expect(tsx).not.toContain("attachOverlayScrollbars");
     expect(tsx).not.toContain("OverlayScrollbarHandle");
-    // No inline clamp on the row list either (the prose in the file
-    // mentions `max-height` in the contract comment, so this pins the
-    // style property spelling instead of the words).
-    expect(tsx).not.toContain("maxHeight");
     expect(tsx).not.toContain("overflowY");
+    // The ONLY max-height in the file belongs to the panel SURFACE prop
+    // (the very next test): the listbox element itself stays unpinned, so
+    // the window keeps the one scroll region.
+    const listEl = jsxOpeningTag(tsx, 'class="hk-tag-input-list"');
+    expect(listEl.startsWith("<div")).toBe(true);
+    expect(listEl).not.toMatch(/style=/);
+    expect(listEl).not.toMatch(/maxHeight|max-height|overflow/);
+  });
+
+  it("hugs its own measure, and scrolls by capping the SURFACE (an additive prop)", () => {
+    const panel = jsxOpeningTag(tsx, "<HkSelectPanel");
+    // The field's width is not the panel's width any more…
+    expect(panel).toContain("matchAnchorWidth={false}");
+    // …and the catalog scrolls inside a capped surface instead of growing
+    // to the stylesheet ceiling.
+    expect(panel).toContain('maxHeight="min(18rem, 45dvh)"');
+    // The cap is the shared panel's own hook, and it is ADDITIVE: the
+    // historic ceiling stays the fallback, so every other consumer of
+    // HkSelectPanel renders exactly as before.
+    const panelScss = readFileSync(join(here, "HkSelect.scss"), "utf-8");
+    // The hook rides the dvh-capable branch: on an engine without dvh the
+    // plain-vh ceiling above it stays the cap — a var()-substituted dvh
+    // value would be invalid at computed-value time and mean "no cap".
+    const popout = panelScss.slice(
+      panelScss.indexOf(".hk-select-popout {"),
+      panelScss.indexOf(".hk-select-option"),
+    );
+    // …and the block's POSITION is load-bearing: the hook must come after
+    // both literal ceilings, or the dvh-capable branch would override them
+    // with its own fallback and the consumer cap would never apply.
+    expect(popout).toContain("@supports (height: 1dvh)");
+    expect(popout.indexOf("@supports")).toBeGreaterThan(
+      popout.indexOf("max-height: max(240px, min(36rem, calc(100vh - 32px)));"),
+    );
+    expect(popout.indexOf("@supports")).toBeGreaterThan(
+      popout.lastIndexOf("max-height: max(240px, min(36rem, calc(100dvh - 32px)));"),
+    );
+    expect(popout).toMatch(
+      /max-height:\s*var\(\s*--hk-select-panel-max-height,\s*max\(240px, min\(36rem, calc\(100dvh - 32px\)\)\)\s*\)/,
+    );
+    expect(popout).toContain("max-height: max(240px, min(36rem, calc(100vh - 32px)));");
+    // The sheet band the same prop caps falls back to being uncapped — the
+    // property's own initial value, i.e. today's behaviour.
+    expect(panelScss).toMatch(
+      /max-height:\s*var\(--hk-select-panel-max-height,\s*none\)/,
+    );
+    const panelTsx = readFileSync(join(here, "HkSelectPanel.tsx"), "utf-8");
+    expect(panelTsx).toContain("maxHeight: { type: String, default: undefined }");
+  });
+
+  it("animates both lists through the shared list transition (FLIP move)", () => {
+    const groups = [...tsx.matchAll(/<HkListTransition\b[^>]*>/g)].map((m) => m[0]);
+    expect(groups, "the chips and the rows are both transition groups").toHaveLength(2);
+    for (const group of groups) {
+      expect(group).toContain('variant="reveal"');
+      expect(group).toMatch(/\bmove\b/);
+      // A fragment tag: the group adds no wrapper element, so the chips
+      // stay the field's own flex items and the rows stay the listbox's
+      // own children.
+      expect(group).toContain('tag=""');
+    }
   });
 });

--- a/packages/vue/src/components/HkTagInput.test.tsx
+++ b/packages/vue/src/components/HkTagInput.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { createApp, defineComponent, h, nextTick, ref } from "vue";
 
 import HkModal from "./HkModal";
+import HkSelectPanel from "./HkSelectPanel";
 import HkTagInput, { type HkTagOption } from "./HkTagInput";
 
 /** Regional-indicator flag pair for an ISO 3166-1 alpha-2 code, built
@@ -114,8 +115,19 @@ function inlineInput(container: HTMLElement): HTMLInputElement | null {
   return container.querySelector<HTMLInputElement>(".hk-tag-input-element");
 }
 
+/** HkListTransition keeps a leaving element mounted until its squeeze-out
+ *  ends (`variant="reveal"`), and happy-dom never signals that end — so a
+ *  node on its way out is still in the DOM. It is no longer part of the
+ *  list (the CSS even takes its pointer events away), so every list query
+ *  here reads the LIVING elements only. */
+function isLeaving(el: Element): boolean {
+  return el.classList.contains("hk-list-reveal-leave-active");
+}
+
 function tags(container: HTMLElement): HTMLElement[] {
-  return [...container.querySelectorAll<HTMLElement>(".hk-tag")];
+  return [...container.querySelectorAll<HTMLElement>(".hk-tag")].filter(
+    (tag) => !isLeaving(tag),
+  );
 }
 
 function tagTexts(container: HTMLElement): string[] {
@@ -125,12 +137,22 @@ function tagTexts(container: HTMLElement): string[] {
 }
 
 function closeButtons(container: HTMLElement): HTMLButtonElement[] {
-  return [...container.querySelectorAll<HTMLButtonElement>(".hk-tag-close")];
+  return tags(container)
+    .map((tag) => tag.querySelector<HTMLButtonElement>(".hk-tag-close"))
+    .filter((button): button is HTMLButtonElement => button != null);
 }
 
 /** Rows live in the teleported panel, so they are queried on body. */
 function rows(): HTMLElement[] {
-  return [...document.querySelectorAll<HTMLElement>(".hk-tag-input-row")];
+  return [...document.querySelectorAll<HTMLElement>(".hk-tag-input-row")].filter(
+    (row) => !isLeaving(row),
+  );
+}
+
+/** The rows a panel drag may move: the selected ones, which carry both the
+ *  strip marker and their grip handle. */
+function reorderableRows(): HTMLElement[] {
+  return rows().filter((row) => row.hasAttribute("data-reorder"));
 }
 
 function rowLabels(): string[] {
@@ -149,11 +171,11 @@ function rowByLabel(label: string): HTMLElement {
 
 /** The row the keyboard cursor currently sits on (none = null). */
 function activeRow(): HTMLElement | null {
-  return document.querySelector<HTMLElement>(".hk-tag-input-row[data-active]");
+  return rows().find((row) => row.hasAttribute("data-active")) ?? null;
 }
 
 function customRow(): HTMLElement | null {
-  return document.querySelector<HTMLElement>('.hk-tag-input-row[data-custom="true"]');
+  return rows().find((row) => row.getAttribute("data-custom") === "true") ?? null;
 }
 
 function searchInput(): HTMLInputElement {
@@ -183,8 +205,10 @@ async function typeSearch(value: string): Promise<void> {
   await typeInto(searchInput(), value);
 }
 
-function pressKey(el: Element, key: string): void {
-  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+function pressKey(el: Element, key: string, init: KeyboardEventInit = {}): void {
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true, ...init }),
+  );
 }
 
 afterEach(async () => {
@@ -301,7 +325,7 @@ describe("HkTagInput", () => {
     const list = document.getElementById(id!);
     expect(list, "the referenced element exists").toBeTruthy();
     expect(list!.getAttribute("role")).toBe("listbox");
-    expect(list!.children).toHaveLength(0);
+    expect([...list!.children].filter((child) => !isLeaving(child))).toHaveLength(0);
 
     // …and the message itself is NOT owned by the listbox: a listbox may
     // only own options/groups (aria-required-children), so it sits beside.
@@ -314,10 +338,13 @@ describe("HkTagInput", () => {
   it("lists EVERY option — selected ones stay visible with a check glyph", async () => {
     const { container } = mountTagInput({ modelValue: ["news", "tech"] });
     await openPanel(container);
+    // Group-strict: the two selected rows come first, in the HOST's order
+    // ("news" before "tech" — not the catalog's), then the unselected ones
+    // in catalog order.
     expect(rowLabels()).toEqual([
       "News",
-      "中华人民共和国",
       "Technology",
+      "中华人民共和国",
       "Germany",
       "Retired",
     ]);
@@ -1118,5 +1145,782 @@ describe("HkTagInput", () => {
     expect(
       [...document.querySelectorAll(".hk-tag-input-tag-text")].map((n) => n.textContent),
     ).toEqual(["News", "Technology"]);
+  });
+});
+
+/** Pin an item strip's rects: happy-dom ships no layout engine, so the
+ *  items a drag measures are placed by hand (the HkSlider pinRect
+ *  pattern). `size` is the item's extent along the axis. */
+function pinStrip(items: HTMLElement[], size: number, axis: "x" | "y"): void {
+  items.forEach((el, index) => {
+    const start = index * size;
+    const box =
+      axis === "x"
+        ? { left: start, right: start + size, top: 0, bottom: size, width: size, height: size, x: start, y: 0 }
+        : { left: 0, right: size, top: start, bottom: start + size, width: size, height: size, x: 0, y: start };
+    Object.defineProperty(el, "getBoundingClientRect", {
+      configurable: true,
+      value: () => box as DOMRect,
+    });
+  });
+}
+
+/** Press `on` and move to `to`, WITHOUT releasing — for observing a held
+ *  drag (auto-scroll, drop markers) before the drop. Moves and releases are
+ *  window events: the drag listens at the window, because a real pointer
+ *  leaves the item it started on. `buttons` models the held button (1 for
+ *  the whole press, 0 on release), which is how the drag tells a live
+ *  gesture from one whose release the page never saw. */
+function holdPointer(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  on: HTMLElement,
+  pointerType: "mouse" | "touch" = "mouse",
+): void {
+  on.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 1,
+      pointerType,
+      button: 0,
+      buttons: 1,
+      clientX: from.x,
+      clientY: from.y,
+    }),
+  );
+  window.dispatchEvent(
+    new PointerEvent("pointermove", {
+      bubbles: true,
+      pointerId: 1,
+      pointerType,
+      buttons: 1,
+      clientX: to.x,
+      clientY: to.y,
+    }),
+  );
+}
+
+function releasePointer(
+  to: { x: number; y: number },
+  pointerType: "mouse" | "touch" = "mouse",
+): void {
+  window.dispatchEvent(
+    new PointerEvent("pointerup", {
+      bubbles: true,
+      pointerId: 1,
+      pointerType,
+      buttons: 0,
+      clientX: to.x,
+      clientY: to.y,
+    }),
+  );
+}
+
+/** A full gesture: press, move, release. */
+function dragPointer(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  on: HTMLElement,
+  pointerType: "mouse" | "touch" = "mouse",
+): void {
+  holdPointer(from, to, on, pointerType);
+  releasePointer(to, pointerType);
+}
+
+/** Wait out `count` animation frames — auto-scroll steps one per frame. */
+async function frames(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+}
+
+/** Pin a scrollable band and place its drag rows relative to the band's own
+ *  scroll offset — what a browser does to the content a scroll moves under
+ *  the pointer (happy-dom has no layout, so the geometry is stated). */
+function pinScrollBand(
+  surface: HTMLElement,
+  height: number,
+  rows: HTMLElement[],
+  rowSize = 40,
+): void {
+  Object.defineProperty(surface, "getBoundingClientRect", {
+    configurable: true,
+    value: () =>
+      ({ left: 0, right: 40, top: 0, bottom: height, width: 40, height, x: 0, y: 0 }) as DOMRect,
+  });
+  rows.forEach((row, index) => {
+    Object.defineProperty(row, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        const start = index * rowSize - surface.scrollTop;
+        return {
+          left: 0,
+          right: 40,
+          top: start,
+          bottom: start + rowSize,
+          width: 40,
+          height: rowSize,
+          x: 0,
+          y: start,
+        } as DOMRect;
+      },
+    });
+  });
+}
+
+/** The row the live drag would land on (the drop marker), or null. */
+function dropRow(): HTMLElement | null {
+  return rows().find((row) => row.hasAttribute("data-drop")) ?? null;
+}
+
+function grip(row: HTMLElement): HTMLElement {
+  const handle = row.querySelector<HTMLElement>(".hk-tag-input-grip");
+  expect(handle, "the selected row carries a drag handle").toBeTruthy();
+  return handle!;
+}
+
+function rowText(row: HTMLElement): string {
+  return row.querySelector(".hk-tag-input-row-label")?.textContent ?? "";
+}
+
+describe("HkTagInput panel geometry and drag reordering", () => {
+  it("hugs its own measure instead of the field's width, capped by maxHeight", async () => {
+    const { container } = mountTagInput({ modelValue: ["news"] });
+    // A full-width settings column (880px): far wider than the panel's
+    // designed 13–19rem measure, which is exactly the reported defect.
+    Object.defineProperty(field(container), "getBoundingClientRect", {
+      configurable: true,
+      value: () =>
+        ({ left: 0, right: 880, top: 0, bottom: 40, width: 880, height: 40, x: 0, y: 0 }) as DOMRect,
+    });
+    await openPanel(container);
+
+    const host = document.querySelector<HTMLElement>(".hk-select-popout-host")!;
+    expect(host, "the popout host renders").toBeTruthy();
+    // No anchor-width match: nothing pins the popout to the 880px field.
+    expect(host.style.minWidth).toBe("");
+
+    // The surface cap rides the panel through the SCSS hook, so a long
+    // catalog scrolls inside 18rem/45dvh instead of growing to 36rem.
+    const popout = document.querySelector<HTMLElement>(".hk-select-popout")!;
+    expect(popout.style.getPropertyValue("--hk-select-panel-max-height")).toBe(
+      "min(18rem, 45dvh)",
+    );
+  });
+
+  it("leaves the shared panel exactly as it was when the cap is not passed", async () => {
+    // The `maxHeight` prop is ADDITIVE, pinned at the DOM level rather than
+    // in source text: a panel mounted with no cap renders no hook and no
+    // inline max-height, i.e. the historic popout geometry.
+    const anchor = document.createElement("div");
+    document.body.appendChild(anchor);
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const app = createApp({
+      render: () =>
+        h(
+          HkSelectPanel,
+          { open: true, anchorRef: anchor, title: "Pick" },
+          { default: () => h("div", { class: "probe-row" }, "row") },
+        ),
+    });
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+
+    const popout = document.querySelector<HTMLElement>(".hk-select-popout");
+    expect(popout, "the popout renders").toBeTruthy();
+    expect(popout!.style.getPropertyValue("--hk-select-panel-max-height")).toBe("");
+    expect(popout!.style.maxHeight).toBe("");
+    expect(popout!.hasAttribute("style"), "no inline style at all").toBe(false);
+  });
+
+  it("regroups the rows: selected first in host order, then catalog order", async () => {
+    // The host order is "de" then "news" — deliberately NOT the catalog's
+    // (news precedes de there), so the assertion pins the host's order.
+    const { container } = mountTagInput({ modelValue: ["de", "news"] });
+    await openPanel(container);
+    expect(rowLabels()).toEqual([
+      "Germany",
+      "News",
+      "中华人民共和国",
+      "Technology",
+      "Retired",
+    ]);
+    // Only the selected rows are drag items — they carry the marker.
+    expect(reorderableRows().map(rowText)).toEqual(["Germany", "News"]);
+  });
+
+  it("filters WITHIN each group and never merges them", async () => {
+    const { container } = mountTagInput({
+      modelValue: ["tech", "news"],
+      allowCustom: true,
+    });
+    await openPanel(container);
+    // "e" matches News, Technology, Germany and Retired: the two selected
+    // rows keep the host order and stay ahead of the unselected ones.
+    await typeSearch("e");
+    expect(rowLabels()).toEqual([
+      "Technology",
+      "News",
+      "Germany",
+      "Retired",
+      "Use “e”",
+    ]);
+
+    // A query matching only unselected rows leaves the selected group
+    // empty — the groups do not collapse into one catalog order.
+    await typeSearch("retir");
+    expect(rowLabels()).toEqual(["Retired", "Use “retir”"]);
+  });
+
+  it("walks the keyboard stops in the RENDERED order", async () => {
+    const { container } = mountTagInput({ modelValue: ["de", "news"], allowCustom: true });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    await typeSearch("e");
+
+    const walked: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      pressKey(search, "ArrowDown");
+      await settle();
+      walked.push(rowText(activeRow()!));
+    }
+    // The cursor follows the regrouped rows, custom row last…
+    expect(walked).toEqual(["Germany", "News", "Technology", "Retired", "Use “e”"]);
+    // …and wraps back to the first rendered row.
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Germany"));
+  });
+
+  it("drags a chip by its body and emits the host's new order", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    const strip = tags(container);
+    expect(strip).toHaveLength(3);
+    pinStrip(strip, 60, "x");
+
+    // Press the first chip and pull the pointer past every midpoint: it
+    // lands in the last slot.
+    dragPointer({ x: 10, y: 10 }, { x: 200, y: 10 }, strip[0]);
+    await settle();
+
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news"]);
+    expect(tagTexts(container)).toEqual(["Technology", "Germany", "News"]);
+    // A reorder is not an edit: nothing was added or removed.
+    expect(events.add).toEqual([]);
+    expect(events.remove).toEqual([]);
+  });
+
+  it("drags a selected row by its grip and emits the host's new order", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    expect(selected.map(rowText)).toEqual(["News", "Technology", "Germany"]);
+    pinStrip(selected, 40, "y");
+
+    dragPointer({ x: 10, y: 10 }, { x: 10, y: 130 }, grip(selected[0]));
+    await settle();
+
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news"]);
+    expect(events.add).toEqual([]);
+    expect(events.remove).toEqual([]);
+    // The panel and the field agree on the new order.
+    expect(rowLabels().slice(0, 3)).toEqual(["Technology", "Germany", "News"]);
+  });
+
+  it("clamps a row drag to the selected group", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    expect(selected.map(rowText)).toEqual(["News", "Technology"]);
+    // EVERY row is measured, not just the drag items: a strip that wrongly
+    // included the unselected rows would otherwise resolve against
+    // unmeasured (all-zero) rects and slip through this test.
+    pinStrip(rows(), 40, "y");
+
+    // Aim far BELOW the group, deep into the unselected rows: the drop
+    // still lands on the last SELECTED slot, never inside that region.
+    dragPointer({ x: 10, y: 10 }, { x: 10, y: 600 }, grip(selected[0]));
+    await settle();
+
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+    expect(rowLabels()).toEqual([
+      "Technology",
+      "News",
+      "中华人民共和国",
+      "Germany",
+      "Retired",
+    ]);
+  });
+
+  it("keeps unselected rows out of the drag space entirely", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    expect(selected).toHaveLength(1);
+    expect(grip(selected[0])).toBeTruthy();
+
+    // An unselected row carries neither the drag marker nor a handle…
+    const unselected = rowByLabel("Germany");
+    expect(unselected.hasAttribute("data-reorder")).toBe(false);
+    expect(unselected.querySelector(".hk-tag-input-grip")).toBeNull();
+
+    // …and a press on it starts nothing, however far the pointer travels.
+    pinStrip([selected[0], unselected], 40, "y");
+    dragPointer({ x: 10, y: 70 }, { x: 10, y: 600 }, unselected);
+    await settle();
+    expect(events.modelValue).toEqual([]);
+  });
+
+  it("moves a panel row by key, so a custom tag in the array survives", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "gitee.com", "tech"],
+    });
+    await openPanel(container);
+    const selected = reorderableRows();
+    // Only the two catalog entries have rows; the custom key does not.
+    expect(selected.map(rowText)).toEqual(["News", "Technology"]);
+    pinStrip(selected, 40, "y");
+
+    dragPointer({ x: 10, y: 10 }, { x: 10, y: 70 }, grip(selected[0]));
+    await settle();
+
+    // "news" lands on "tech"'s host position; the custom key was neither
+    // dropped nor duplicated by a row drag it had no row in.
+    expect(events.modelValue.at(-1)).toEqual(["gitee.com", "tech", "news"]);
+    expect(tagTexts(container)).toEqual(["gitee.com", "Technology", "News"]);
+  });
+
+  it("keeps a sub-threshold press a click — and never drags from the ×", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"] });
+    pinStrip(tags(container), 60, "x");
+
+    // The × is a control: its press starts no drag at all, however far the
+    // pointer then travels — on touch just as on a mouse.
+    dragPointer({ x: 10, y: 10 }, { x: 200, y: 10 }, closeButtons(container)[0], "touch");
+    await settle();
+    expect(events.modelValue).toEqual([]);
+
+    // …and the click it does own still removes its tag.
+    closeButtons(container)[0].click();
+    await settle();
+    expect(events.remove).toEqual(["news"]);
+    expect(events.modelValue.at(-1)).toEqual(["tech"]);
+
+    // A press on the chip body that stays under the ~6px threshold is a
+    // click too — no reorder, no swallowed click.
+    const remaining = tags(container);
+    pinStrip(remaining, 60, "x");
+    dragPointer({ x: 10, y: 10 }, { x: 13, y: 10 }, remaining[0]);
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech"]);
+    expect(tagTexts(container)).toEqual(["Technology"]);
+  });
+
+  it("swallows the click a real chip drag would deliver to the field", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"] });
+    const strip = tags(container);
+    pinStrip(strip, 60, "x");
+
+    dragPointer({ x: 10, y: 10 }, { x: 200, y: 10 }, strip[0]);
+    // The gesture ended inside the field, so the browser delivers its click
+    // to the box: the drag owns it — the panel must not pop open behind
+    // the drop.
+    field(container).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await settle();
+
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+    expect(events.open).toEqual([]);
+  });
+
+  it("does not let a row drag's trailing click toggle the dragged row", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    pinStrip(selected, 40, "y");
+    dragPointer({ x: 10, y: 10 }, { x: 10, y: 70 }, grip(selected[0]));
+    // The pointer started and ended on the SAME row (a short drag), so the
+    // browser delivers its click there right after the release: the drag
+    // owns that click — otherwise the row the user just moved would toggle
+    // itself back OFF against the model it was moved in.
+    grip(selected[0]).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await settle();
+
+    expect(events.remove).toEqual([]);
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+  });
+
+  it("never lets a blind Enter remove a tag the query matches", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["tech"], allowCustom: true });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+
+    // "e" matches the SELECTED Technology first (group-strict order), then
+    // News / Germany / Retired. Enter with no cursor is the "type to add"
+    // gesture, so it takes the first row the field can still take instead of
+    // toggling the tag the user is looking at back off.
+    await typeSearch("e");
+    expect(rowLabels()[0]).toBe("Technology");
+    pressKey(search, "Enter");
+    await settle();
+    expect(events.add).toEqual(["news"]);
+    expect(events.remove).toEqual([]);
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+
+    // A query naming ONLY what the field already carries has nothing to add
+    // and nothing to remove — the same no-op rule a selected custom key
+    // already had; the row stays for a deliberate toggle.
+    await typeSearch("Technology");
+    expect(rowLabels()).toEqual(["Technology"]);
+    pressKey(search, "Enter");
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+    expect(events.remove).toEqual([]);
+    expect(rowByLabel("Technology").getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("keeps a tap on the grip from toggling its row", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news"] });
+    await openPanel(container);
+    const row = reorderableRows()[0];
+    expect(rowText(row)).toBe("News");
+
+    // No drag happened (no movement): the press is the handle's, not the
+    // row's — a handle that erased its tag on a tap would be a trap.
+    grip(row).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await settle();
+    expect(events.remove).toEqual([]);
+    expect(events.modelValue).toEqual([]);
+    expect(rowByLabel("News").getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("names the grip handle after the entry it moves", async () => {
+    const { container } = mountTagInput({ modelValue: ["news", "tech"] });
+    await openPanel(container);
+    // The handle's name is the localized `hikari::tagInput.reorder`
+    // template with the row's own label interpolated — the i18n key and
+    // its `{label}` placeholder are part of the contract.
+    const handle = grip(reorderableRows()[0]);
+    expect(rowText(reorderableRows()[0])).toBe("News");
+    expect(handle.getAttribute("aria-label")).toBe("Reorder News");
+    expect(handle.getAttribute("title")).toBe("Reorder News");
+    expect(handle.getAttribute("role")).toBe("button");
+    expect(handle.getAttribute("tabindex"), "pointer-only affordance").toBe("-1");
+  });
+
+  it("never lets a leaving row keep the id the field publishes", async () => {
+    // A catalog edit (an async reload) drops the row the cursor sits on: the
+    // row leaves through the list transition while the cursor stays on its
+    // index, where a DIFFERENT option now lives. An index-derived id would
+    // be worn by two nodes at once, so `aria-activedescendant` could resolve
+    // to the ghost; the ids are keyed, so the published one belongs to
+    // exactly one LIVING row.
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const value = ref<readonly string[]>(["news", "tech", "de"]);
+    const options = ref<readonly HkTagOption[]>(OPTIONS);
+    const Host = defineComponent({
+      name: "HkTagInputCatalogShrinkHost",
+      setup() {
+        return () =>
+          h(HkTagInput, {
+            modelValue: value.value,
+            options: options.value,
+            "onUpdate:modelValue": (keys: string[]) => {
+              value.value = keys;
+            },
+          });
+      },
+    });
+    const app = createApp(Host);
+    app.mount(container);
+    mounts.push({ app, container });
+    await settle();
+
+    chevron(container).click();
+    await settle();
+    pressKey(inlineInput(container)!, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("News"));
+
+    options.value = OPTIONS.filter((option) => option.key !== "news");
+    await nextTick();
+
+    const published = inlineInput(container)!.getAttribute("aria-activedescendant");
+    expect(published, "the field still publishes a row").toBeTruthy();
+    const matches = document.querySelectorAll(`[id="${published}"]`);
+    expect(matches, "the published id is worn by one row only").toHaveLength(1);
+    const live = matches[0] as HTMLElement;
+    expect(live.classList.contains("hk-list-reveal-leave-active")).toBe(false);
+    expect(live.getAttribute("role")).toBe("option");
+    expect(rowText(live)).toBe("Technology");
+  });
+
+  it("carries a panel drag past the visible band by scrolling the popout", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "cn-main", "tech", "de", "retired"],
+    });
+    await openPanel(container);
+    const selected = reorderableRows();
+    expect(selected.map(rowText)).toEqual([
+      "News",
+      "中华人民共和国",
+      "Technology",
+      "Germany",
+      "Retired",
+    ]);
+
+    // A two-row visible band (80px) over the five-row strip: the last row is
+    // only reachable by scrolling the surface — no new scroll region, the
+    // popout that already owns the one scrollbar.
+    const popout = document.querySelector<HTMLElement>(".hk-select-popout")!;
+    expect(popout).toBeTruthy();
+    pinScrollBand(popout, 80, selected);
+
+    // Press the first row and hold near the bottom edge.
+    holdPointer({ x: 10, y: 10 }, { x: 10, y: 78 }, grip(selected[0]));
+    await nextTick();
+    expect(dropRow(), "before any scrolling the slot is inside the band").toBe(
+      rowByLabel("中华人民共和国"),
+    );
+
+    for (let i = 0; i < 40 && popout.scrollTop < 120; i += 1) await frames(1);
+    expect(popout.scrollTop, "the surface is pulled along").toBeGreaterThanOrEqual(120);
+    expect(dropRow(), "the slot follows the scrolled content").toBe(
+      rowByLabel("Retired"),
+    );
+
+    releasePointer({ x: 10, y: 78 });
+    await settle();
+    // The dragged key landed last, which is what the scroll bought.
+    expect(events.modelValue.at(-1)).toEqual(["cn-main", "tech", "de", "retired", "news"]);
+    expect(tagTexts(container).at(-1)).toBe("News");
+
+    // Nothing scrolls without a live drag.
+    const settled = popout.scrollTop;
+    await frames(3);
+    expect(popout.scrollTop).toBe(settled);
+  });
+
+  it("scrolls the mobile sheet's own list band, not the popout", async () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 375,
+    });
+    try {
+      const { container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+      await openPanel(container);
+      // Phone width: the sheet is the surface, and the band that scrolls is
+      // its list — resolved at drag time, not assumed.
+      expect(document.querySelector(".hk-select-popout")).toBeNull();
+      const band = document.querySelector<HTMLElement>(".hk-select-sheet-list");
+      expect(band, "the sheet list renders").toBeTruthy();
+      const selected = reorderableRows();
+      pinScrollBand(band!, 80, selected);
+
+      holdPointer({ x: 10, y: 10 }, { x: 10, y: 78 }, grip(selected[0]));
+      await nextTick();
+      for (let i = 0; i < 40 && band!.scrollTop < 80; i += 1) await frames(1);
+      expect(band!.scrollTop, "the sheet band is pulled along").toBeGreaterThanOrEqual(80);
+      releasePointer({ x: 10, y: 78 });
+      await settle();
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        writable: true,
+        value: original,
+      });
+    }
+  });
+
+  it("keeps a leaving chip out of the drag strip", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    // Measure the whole strip BEFORE the removal: the removed chip keeps
+    // its rect while it squeezes out, so a drag that counted it would
+    // resolve a different slot.
+    pinStrip(tags(container), 60, "x");
+    closeButtons(container)[0].click();
+    await nextTick();
+
+    const live = tags(container);
+    expect(live.map((tag) => tag.textContent)).toEqual(["Technology", "Germany"]);
+    expect(
+      container.querySelectorAll(".hk-tag").length,
+      "the removed chip is still mounted (its leave)",
+    ).toBe(3);
+
+    // Drag the FIRST LIVING chip to the end. Counting the ghost would take
+    // the press for index 1 and emit the unchanged order instead.
+    dragPointer({ x: 70, y: 10 }, { x: 300, y: 10 }, live[0]);
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["de", "tech"]);
+    expect(tagTexts(container)).toEqual(["Germany", "Technology"]);
+  });
+
+  it("keeps a leaving row out of the panel drag strip", async () => {
+    const { events, container } = mountTagInput({
+      modelValue: ["news", "tech", "de", "cn-main"],
+    });
+    await openPanel(container);
+    expect(reorderableRows().map(rowText)).toEqual([
+      "News",
+      "Technology",
+      "Germany",
+      "中华人民共和国",
+    ]);
+    // Measure every row up front — the row about to leave keeps its rect.
+    pinStrip(rows(), 40, "y");
+
+    // "e" hides the selected 中华人民共和国: its row starts leaving and is
+    // still in the DOM for the leave window, while the OTHER three remain
+    // the drag strip. (One tick, not `settle()`: the ghost is guaranteed to
+    // be there the moment the patch lands — which is when a real drag would
+    // start — while later timers may already have swept it away.)
+    const search = searchInput();
+    search.value = "e";
+    search.dispatchEvent(new Event("input", { bubbles: true }));
+    await nextTick();
+    expect(reorderableRows().map(rowText)).toEqual(["News", "Technology", "Germany"]);
+    expect(
+      document.querySelectorAll('.hk-tag-input-row[data-reorder="true"]').length,
+      "the hidden row is still mounted (its leave)",
+    ).toBe(4);
+
+    dragPointer({ x: 10, y: 10 }, { x: 10, y: 200 }, grip(reorderableRows()[0]));
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news", "cn-main"]);
+    expect(rowLabels().slice(0, 3)).toEqual(["Technology", "Germany", "News"]);
+  });
+
+  it("moves the ACTIVE selected row with Alt+Arrow, and stops at the edges", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    const edits = () => events.modelValue.length;
+
+    // Park the cursor on the middle selected row.
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    // Alt+ArrowUp moves it one slot up inside the selected group.
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news", "de"]);
+    expect(events.add).toEqual([]);
+    expect(events.remove).toEqual([]);
+    expect(rowLabels().slice(0, 3)).toEqual(["Technology", "News", "Germany"]);
+    // The cursor followed the row it moved, it was not left behind.
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    // It is the group's first row now: another Alt+ArrowUp is a hard stop.
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(edits()).toBe(1);
+
+    // An UNSELECTED row has no place in the order — the chord does nothing.
+    // Rows are [Technology, News, Germany, 中华人民共和国, Retired] now, and
+    // the third of those is the first the field does not carry.
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("中华人民共和国"));
+    expect(rowByLabel("中华人民共和国").hasAttribute("data-selected")).toBe(false);
+    pressKey(search, "ArrowDown", { altKey: true });
+    await settle();
+    expect(edits()).toBe(1);
+
+    // …and with no row active at all there is nothing to move.
+    pressKey(search, "Escape");
+    await settle();
+    await untilSettled(() => rows().length);
+    await openPanel(container);
+    expect(activeRow()).toBeNull();
+    pressKey(searchInput(), "ArrowDown", { altKey: true });
+    await settle();
+    expect(edits()).toBe(1);
+  });
+
+  it("reorders at the maxTags cap — the cap freezes adds, not the order", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech"], maxTags: 2 });
+    await openPanel(container);
+    const search = searchInput();
+    search.focus();
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech", "news"]);
+    expect(events.add).toEqual([]);
+    expect(tagTexts(container)).toEqual(["Technology", "News"]);
+  });
+
+  it("keeps every chip and row a DIRECT child of its container", async () => {
+    // The FLIP groups render as fragments: no wrapper element may appear
+    // between the box and its chips, or between the listbox and its rows.
+    const { container } = mountTagInput({ modelValue: ["news", "tech"] });
+    const box = field(container);
+    for (const chip of tags(container)) expect(chip.parentElement).toBe(box);
+    expect(inlineInput(container)!.parentElement).toBe(box);
+
+    await openPanel(container);
+    const list = document.querySelector<HTMLElement>(".hk-tag-input-list")!;
+    expect(list.getAttribute("role")).toBe("listbox");
+    expect(rows()).toHaveLength(OPTIONS.length);
+    for (const row of rows()) expect(row.parentElement).toBe(list);
+  });
+
+  it("caps the mobile sheet too — on the band that scrolls", async () => {
+    const original = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 375,
+    });
+    try {
+      const { container } = mountTagInput({ modelValue: ["news"] });
+      await openPanel(container);
+      // Phone width: the sheet replaces the popout, and the same cap lands
+      // on the sheet's scrolling list (the surface the user actually drags).
+      expect(document.querySelector(".hk-select-popout-host")).toBeNull();
+      const list = document.querySelector<HTMLElement>(".hk-select-sheet-list");
+      expect(list, "the sheet list renders").toBeTruthy();
+      expect(list!.style.getPropertyValue("--hk-select-panel-max-height")).toBe(
+        "min(18rem, 45dvh)",
+      );
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        writable: true,
+        value: original,
+      });
+    }
+  });
+
+  it("leaves a removed chip through the list-transition leave", async () => {
+    // Both lists are HkListTransition groups (FLIP `move` + the reveal
+    // squeeze): a removal squeezes the chip out instead of vanishing, and
+    // the logical list is short immediately.
+    const { container } = mountTagInput({ modelValue: ["news", "tech"] });
+    closeButtons(container)[0].click();
+    await nextTick();
+    expect(container.querySelectorAll(".hk-tag.hk-list-reveal-leave-active")).toHaveLength(1);
+    expect(tagTexts(container)).toEqual(["Technology"]);
   });
 });

--- a/packages/vue/src/components/HkTagInput.tsx
+++ b/packages/vue/src/components/HkTagInput.tsx
@@ -7,11 +7,13 @@ import {
   type PropType,
 } from "vue";
 
-import { Check, ChevronDown, Plus, Search } from "lucide-vue-next";
+import { Check, ChevronDown, GripVertical, Plus, Search } from "lucide-vue-next";
 
 import { useI18n } from "../i18n/context";
+import { usePointerReorder } from "../composables/usePointerReorder";
 
 import HkInput from "./HkInput";
+import HkListTransition from "./HkListTransition";
 import HkSelectPanel from "./HkSelectPanel";
 import HkTag from "./HkTag";
 import "./HkTagInput.scss";
@@ -51,6 +53,29 @@ function isSubsequence(query: string, text: string): boolean {
 const WIDE_GLYPH =
   /[\u1100-\u115f\u2e80-\ua4cf\uac00-\ud7a3\uf900-\ufaff\ufe30-\ufe6f\uff00-\uff60\uffe0-\uffe6]/;
 
+/** Move the entry at `from` to the place of the entry at `to`, returning a
+ *  fresh array — or null when the move says nothing (out of range, or the
+ *  same slot). Insert-at-target semantics, which is what dropping one chip
+ *  or one selected row ON another means: the moved key ends up at the
+ *  target's index and the entries between them shift by one. */
+function moveTo(list: readonly string[], from: number, to: number): string[] | null {
+  if (from === to || from < 0 || to < 0 || from >= list.length || to >= list.length) {
+    return null;
+  }
+  const next = list.slice();
+  const [key] = next.splice(from, 1);
+  next.splice(to, 0, key);
+  return next;
+}
+
+/** The class HkListTransition paints on a node that is on its way OUT
+ *  (`variant="reveal"` keeps it mounted, with pointer events off, until its
+ *  squeeze-out ends). Such a node is no longer part of the list: it still
+ *  sits in the DOM — and, under a test DOM, forever — so every strip a drag
+ *  measures or indexes must skip it, or a drag started during a leave would
+ *  count a ghost and move the wrong key. */
+const LEAVING_CLASS = "hk-list-reveal-leave-active";
+
 /** One keyboard stop of the panel: a visible catalog row, or the
  *  trailing custom row when `allowCustom` offers one (always last). */
 type HkTagStop =
@@ -77,18 +102,59 @@ type HkTagStop =
  *     bottom sheet, outside-click/Escape closing and ONE SCROLLBAR PER
  *     WINDOW contract as every other picker. It deliberately mounts no
  *     scroll region of its own: the window surface scrolls the search
- *     field and the rows as one;
+ *     field and the rows as one. It also does NOT mirror the field's
+ *     width (`matchAnchorWidth` is off, the HkAffixPicker precedent): the
+ *     field is usually a full-width settings column while the catalog is
+ *     designed at 13–19rem, so an anchor-wide box would leave a large
+ *     empty band and park the surface's scrollbar far from the rows.
+ *     Instead the surface is capped through `maxHeight`
+ *     (`min(18rem, 45dvh)`), so a long catalog scrolls inside a panel
+ *     that hugs its own measure rather than stretching to the viewport;
  *   - ALL options are listed, each with a check glyph when selected —
  *     unlike HkAffixPicker's multi mode, which hides the selected keys,
  *     "is this tag used or not" must stay visible and togglable in one
  *     pass. Toggling never closes the panel (batch editing);
+ *   - ROWS ARE GROUP-STRICT: the selected options come first, in the
+ *     host's `modelValue` order, then the unselected catalog options in
+ *     catalog order, and the custom ("Use …") row is last. A query filters
+ *     WITHIN the two groups — it can hide rows, never merge or re-sort
+ *     them — and the keyboard stops (`stops`,
+ *     `aria-activedescendant`) walk exactly this rendered order;
  *   - ORDER IS HOST STATE: a newly added key is APPENDED to the end of
  *     `modelValue` ("first tag = primary" for hosts that care), an
  *     existing key is removed in place, and the emitted array is always
  *     a copy of the host's order with that one edit applied;
+ *   - REORDERING writes that same order back through
+ *     `update:modelValue` (no add/remove fires — nothing was added or
+ *     removed). Two drag surfaces, both with a ~6px movement threshold so
+ *     a plain click/tap still clicks:
+ *       * a CHIP is dragged by its BODY (its × never starts a drag, and
+ *         pressing any control inside a chip is not a drag at all); the
+ *         chip follows no ghost — the drop slot is highlighted and the
+ *         release emits the reordered array;
+ *       * in the PANEL only the SELECTED rows move, and only through the
+ *         explicit GRIP HANDLE at the row's trailing edge (the handle is
+ *         the one element that claims touch, so the sheet keeps scrolling
+ *         normally everywhere else, and a press on it that never became a
+ *         drag does not toggle its row). Holding the drag near the top or
+ *         bottom of the panel's own scroll region pulls the list along a
+ *         frame at a time, so a row can be carried past the visible band
+ *         of the (capped) surface in one gesture; nothing is scrolled
+ *         without a live drag. A row drag is CLAMPED to the selected
+ *         group: unselected rows are not drop targets and never move, and
+ *         a release past the group's end lands on its last position;
+ *     both lists are keyed HkListTransition groups (FLIP `move`), so the
+ *     moved chip/row and its neighbours animate into their new places,
+ *     with the library's usual reduced-motion opt-outs;
  *   - a key in `modelValue` that the catalog does not carry (a custom
  *     tag, or an option deleted since) degrades to its raw key as the
- *     tag label — the same rule as HkAffixPicker.tagEntries;
+ *     tag label — the same rule as HkAffixPicker.tagEntries. Such a key
+ *     has no panel row (the panel only lists the catalog), so a panel
+ *     drag is applied to the host's array BY KEY: the moved key lands on
+ *     the target key's position and whatever sat between them shifts by
+ *     one — a custom tag is never dropped, duplicated, or addressed by
+ *     an index the panel cannot see (and it can still be moved by its
+ *     own chip, where it is a first-class entry);
  *   - removal is IMMEDIATE: a tag's × emits `remove` + `update:modelValue`
  *     with no confirm dialog. This is a deliberate divergence from
  *     HkAffixPicker's `confirmRemove` two-step — a tag field is edited
@@ -108,9 +174,23 @@ type HkTagStop =
  * ends wrap — and publish it as `aria-activedescendant` on the inline
  * input and on the panel's search field. That is the activedescendant
  * pattern: focus never moves to a row, the row is only highlighted, and
- * Enter activates the active row (falling back to today's first
- * togglable row / custom row when nothing is active). Every open and
- * every query edit starts again with no active row.
+ * Enter activates the active row. With NO active row, Enter falls back to
+ * the first row the query can still ADD (a selected row is not an add
+ * target, so a blind Enter can never delete the tag the user is looking
+ * at), then to the custom row; a query naming only what the field already
+ * carries is a no-op. Every open and every query edit starts again with
+ * no active row.
+ *
+ * REORDERING IS ALSO A KEYBOARD AFFORDANCE: from the field's input, the
+ * panel's search box or a row that holds focus, Alt+ArrowUp /
+ * Alt+ArrowDown moves the ACTIVE selected row one slot inside the
+ * selected group (hard stops at its edges, a no-op for an unselected
+ * row). The grip handle is a pointer affordance; the field and the panel
+ * are otherwise pointer-only for reordering.
+ *
+ * `maxTags` freezes ADDS only. Reordering stays available at the cap:
+ * the order is host state, and a reorder adds nothing (nor removes
+ * anything).
  *
  * CONTROLLED: the component owns no selected state — `add` / `remove`
  * fire with the key and `update:modelValue` with the full next array, and
@@ -219,32 +299,62 @@ export const HkTagInput = defineComponent({
       }),
     );
 
-    /** Rows of the panel: EVERY option, filtered — never pruned by
-     *  selection (that is what makes "used / not used" visible).
-     *
-     *  Filtering is TWO-PASS over a single field at a time (never across
-     *  concatenated fields, which produces noise):
+    /** Does one catalog entry survive the current query? Filtering is
+     *  TWO-PASS over a single field at a time (never across concatenated
+     *  fields, which produces noise):
      *    1. an exact substring match for precision (label / meta / key /
      *       keywords, case-folded);
      *    2. an in-order character subsequence fallback (gaps allowed) —
      *       so a renamed or CJK-composed label like "中华人民共和国" is
-     *       still found by its short form "中国".
-     */
-    const filteredRows = computed<readonly HkTagOption[]>(() => {
+     *       still found by its short form "中国". */
+    function matchesQuery(option: HkTagOption, q: string): boolean {
+      if (!q) return true;
+      if (option.label.toLowerCase().includes(q)) return true;
+      if (option.meta && option.meta.toLowerCase().includes(q)) return true;
+      if (option.key.toLowerCase().includes(q)) return true;
+      if (option.keywords && option.keywords.toLowerCase().includes(q)) return true;
+      // Fuzzy fallback — per field, in-order subsequence, gaps allowed.
+      if (isSubsequence(q, option.label.toLowerCase())) return true;
+      if (option.meta && isSubsequence(q, option.meta.toLowerCase())) return true;
+      if (isSubsequence(q, option.key.toLowerCase())) return true;
+      return !!option.keywords && isSubsequence(q, option.keywords.toLowerCase());
+    }
+
+    /** Rows of the panel in its READING ORDER — every matching option,
+     *  never pruned by selection (that is what makes "used / not used"
+     *  visible), but GROUP-STRICT:
+     *    1. the selected options, in the host's `modelValue` order (the
+     *       order a drag writes back — the selected group IS the host's
+     *       array as far as this catalog can render it);
+     *    2. then the unselected options, in catalog order;
+     *    3. the custom row renders last, after this list.
+     *
+     *  The query filters WITHIN each group: it can hide rows, it can never
+     *  re-sort them or merge the two groups. */
+    const rows = computed<readonly HkTagOption[]>(() => {
       const q = query.value.trim().toLowerCase();
-      if (!q) return props.options;
-      return props.options.filter((o) => {
-        if (o.label.toLowerCase().includes(q)) return true;
-        if (o.meta && o.meta.toLowerCase().includes(q)) return true;
-        if (o.key.toLowerCase().includes(q)) return true;
-        if (o.keywords && o.keywords.toLowerCase().includes(q)) return true;
-        // Fuzzy fallback — per field, in-order subsequence, gaps allowed.
-        if (isSubsequence(q, o.label.toLowerCase())) return true;
-        if (o.meta && isSubsequence(q, o.meta.toLowerCase())) return true;
-        if (isSubsequence(q, o.key.toLowerCase())) return true;
-        return !!o.keywords && isSubsequence(q, o.keywords.toLowerCase());
+      const matched = props.options.filter((option) => matchesQuery(option, q));
+      if (selectedKeys.value.length === 0) return matched;
+      /** modelValue position of a key (a duplicated key keeps its first). */
+      const order = new Map<string, number>();
+      selectedKeys.value.forEach((key, index) => {
+        if (!order.has(key)) order.set(key, index);
       });
+      const selected: HkTagOption[] = [];
+      const rest: HkTagOption[] = [];
+      for (const option of matched) {
+        (order.has(option.key) ? selected : rest).push(option);
+      }
+      selected.sort((a, b) => (order.get(a.key) ?? 0) - (order.get(b.key) ?? 0));
+      return [...selected, ...rest];
     });
+
+    /** The rows a drag may move, in display order — the selected group,
+     *  which the render puts first, so index `i` here is display row `i`
+     *  AND the i-th drop target of the panel strip. */
+    const selectedRows = computed<readonly HkTagOption[]>(() =>
+      rows.value.filter((option) => selectedKeys.value.includes(option.key)),
+    );
 
     const customText = computed(() => query.value.trim());
 
@@ -273,25 +383,33 @@ export const HkTagInput = defineComponent({
      *  already at capacity. */
     const rowsDisabled = computed(() => props.disabled || atMax.value);
 
-    /** DOM id of one stop: the single spelling the ROW renders and
-     *  `aria-activedescendant` publishes, so the two can never drift. */
-    function stopId(kind: "option" | "custom", index = 0): string {
-      return kind === "custom" ? `${generatedId}-custom` : `${generatedId}-option-${index}`;
+    /** DOM id of a row stop: the single spelling the ROW renders and
+     *  `aria-activedescendant` publishes, so the two can never drift.
+     *
+     *  Keyed by the option's KEY rather than by its position, because a
+     *  position is not stable: rows reorder (a drag, the group regroup, a
+     *  query), and a leaving row keeps whatever id it had until its
+     *  squeeze-out ends — a positional id would then be worn by two nodes
+     *  at once and `aria-activedescendant` could resolve to the ghost.
+     *  `encodeURIComponent` keeps an arbitrary host key inside one id; two
+     *  catalog entries sharing a key are a host bug Vue already rejects
+     *  (duplicate vnode keys). */
+    function optionStopId(option: HkTagOption): string {
+      return `${generatedId}-option-${encodeURIComponent(option.key)}`;
     }
 
+    /** DOM id of the custom row — the one stop with no option behind it. */
+    const customStopId = `${generatedId}-custom`;
+
     /** The stops ArrowDown / ArrowUp walk, in the panel's reading order:
-     *  the visible rows, then the custom row as the LAST stop.
-     *
-     *  Indexed by position, not by key — the filter rebuilds the list on
-     *  every query edit (which clears the cursor) and an index can never
-     *  collide the way a host-supplied key could inside a DOM id. */
+     *  the visible rows, then the custom row as the LAST stop. */
     const stops = computed<readonly HkTagStop[]>(() => {
-      const list: HkTagStop[] = filteredRows.value.map((option, index) => ({
-        id: stopId("option", index),
+      const list: HkTagStop[] = rows.value.map((option) => ({
+        id: optionStopId(option),
         kind: "option" as const,
         option,
       }));
-      if (customVisible.value) list.push({ id: stopId("custom"), kind: "custom" });
+      if (customVisible.value) list.push({ id: customStopId, kind: "custom" });
       return list;
     });
 
@@ -301,6 +419,37 @@ export const HkTagInput = defineComponent({
     const activeStop = computed<HkTagStop | null>(
       () => stops.value[activeIndex.value] ?? null,
     );
+
+    /** The panel's keyboard reorder: move the ACTIVE row one slot inside
+     *  the selected group (the same edit a row drag makes, without a
+     *  pointer). Only a selected row has a place in that order, the ends of
+     *  the group are hard stops, and `false` means the key was not ours to
+     *  consume. The cursor stays on the key it was on — the stops rebuild
+     *  in the new order, so it follows the row the user moved. */
+    function nudgeActiveRow(delta: 1 | -1): boolean {
+      const stop = activeStop.value;
+      if (props.disabled || !stop || stop.kind !== "option") return false;
+      const group = selectedRows.value;
+      const from = group.findIndex((option) => option.key === stop.option.key);
+      if (from < 0) return false;
+      const to = from + delta;
+      if (to < 0 || to >= group.length) return false;
+      reorderSelectedRows(from, to);
+      activeIndex.value = to;
+      return true;
+    }
+
+    /** Alt+ArrowUp / Alt+ArrowDown on any of the field's keyboard surfaces
+     *  is the reorder key: it is consumed even when the cursor has nowhere
+     *  to go (an unselected or edge row), because Alt+Arrow is not a plain
+     *  arrow — the browser must not act on it either. Returns whether the
+     *  key belonged to the reorder. */
+    function onReorderKey(e: KeyboardEvent): boolean {
+      if (!e.altKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return false;
+      e.preventDefault();
+      nudgeActiveRow(e.key === "ArrowUp" ? -1 : 1);
+      return true;
+    }
 
     /** Walk the cursor one stop. From "nothing active" ArrowDown lands on
      *  the FIRST stop and ArrowUp on the last; from either end it wraps
@@ -319,6 +468,20 @@ export const HkTagInput = defineComponent({
     /** Rows that carry the raw key when the catalog's label is blank. */
     function labelOf(option: HkTagOption): string {
       return option.label.trim() ? option.label : option.key;
+    }
+
+    /** Accessible name of a selected row's drag handle: it names the entry
+     *  AND the action on the pointer surface (aria-label + title) instead of
+     *  leaving a bare glyph there. The reorder itself is pointer-only — the
+     *  row keeps its `option` role and its aria, the keyboard keeps the
+     *  activedescendant cursor plus the × / Backspace removal, and the
+     *  handle stays out of the tab order. (An option's children are
+     *  presentational to AT, so the handle's own name is not announced;
+     *  that is the accepted cost of keeping the row's existing roles.) */
+    function reorderLabel(option: HkTagOption): string {
+      return interpolate(t("hikari::tagInput.reorder", "Reorder {label}"), {
+        label: labelOf(option),
+      });
     }
 
     /** Is this row inert? The field being disabled or full freezes the
@@ -396,6 +559,88 @@ export const HkTagInput = defineComponent({
       toggle(option.key);
     }
 
+    /** A chip dropped on another chip. The field's own left-to-right order
+     *  IS the host's array order (tagEntries maps `modelValue` 1:1), so the
+     *  two display indices are the array indices — the only edit is the
+     *  move, and `update:modelValue` carries it. */
+    function reorderChips(from: number, to: number): void {
+      const next = moveTo(selectedKeys.value, from, to);
+      if (next) emit("update:modelValue", next);
+    }
+
+    /** A selected row dropped on another selected row. The panel's group
+     *  only carries keys the catalog lists, while `modelValue` may
+     *  interleave custom ones — so the display indices are mapped through
+     *  their KEYS and the move happens inside the host's own array: the
+     *  moved key lands on the target key's position and whatever sat
+     *  between the two shifts by one. A key the panel never showed is
+     *  therefore neither dropped nor inserted at an index it never had. */
+    function reorderSelectedRows(from: number, to: number): void {
+      const group = selectedRows.value;
+      const fromKey = group[from]?.key;
+      const toKey = group[to]?.key;
+      if (fromKey === undefined || toKey === undefined) return;
+      const next = moveTo(
+        selectedKeys.value,
+        selectedKeys.value.indexOf(fromKey),
+        selectedKeys.value.indexOf(toKey),
+      );
+      if (next) emit("update:modelValue", next);
+    }
+
+    /** The panel surface, as the drag strip's query root: the selected
+     *  rows are marked `data-reorder` and ONLY they are listed, so the
+     *  drop space ends with the selected group — an unselected row can
+     *  never be a landing slot (the clamp is structural, not a rule the
+     *  drag has to remember). */
+    const panelRef = ref<HTMLElement | null>(null);
+
+    /** The chips the field CARRIES, in display order (the drag strip). A
+     *  chip on its way out is not one of them — see LEAVING_CLASS. */
+    function liveChips(): HTMLElement[] {
+      return fieldRef.value
+        ? [
+            ...fieldRef.value.querySelectorAll<HTMLElement>(
+              `.hk-tag-input-tag:not(.${LEAVING_CLASS})`,
+            ),
+          ]
+        : [];
+    }
+
+    /** The selected rows, in display order (the panel's drag strip) — the
+     *  same leaving-node rule. */
+    function liveReorderRows(): HTMLElement[] {
+      return panelRef.value
+        ? [
+            ...panelRef.value.querySelectorAll<HTMLElement>(
+              `[data-reorder="true"]:not(.${LEAVING_CLASS})`,
+            ),
+          ]
+        : [];
+    }
+
+    const chipDrag = usePointerReorder({
+      axis: "x",
+      items: liveChips,
+      onDrop: reorderChips,
+    });
+
+    const rowDrag = usePointerReorder({
+      axis: "y",
+      items: liveReorderRows,
+      // The panel's own scroll region — the desktop popout or the mobile
+      // sheet's list band, whichever the surface mounted — so a long drag
+      // carries a row past the visible band by scrolling the surface that
+      // already owns THE scrollbar (never a region of this component's
+      // own). Resolved per drag, because the form factor is decided by the
+      // viewport at open time.
+      scrollContainer: () =>
+        panelRef.value?.closest<HTMLElement>(
+          ".hk-select-popout, .hk-select-sheet-list",
+        ) ?? null,
+      onDrop: reorderSelectedRows,
+    });
+
     /** The "Use “<query>”" row — the raw typed text becomes the tag. The
      *  query is consumed only when the tag was really added, so a no-op
      *  can never look like an accepted edit. */
@@ -409,8 +654,12 @@ export const HkTagInput = defineComponent({
     /** Enter resolves the typed query. With an active row that row wins —
      *  the keyboard cursor must be able to reach a row other than the top
      *  one. With nothing active it stays the HkAffixPicker order: the
-     *  first togglable row, otherwise the custom row (an inert top row
-     *  falls through instead of swallowing the key).
+     *  first row the query can still ADD, otherwise the custom row (an
+     *  inert top row falls through instead of swallowing the key, and so
+     *  does a row the field already carries — a blind Enter is an add
+     *  gesture, and since selected rows now sort FIRST, toggling the top
+     *  match would silently remove the very tag the user is looking at).
+     *  Removing stays a deliberate act: the row itself, or the cursor.
      *  An empty query is a no-op: Enter on a blank field must not pick
      *  the top of the catalog. */
     function commitQuery(): void {
@@ -422,12 +671,31 @@ export const HkTagInput = defineComponent({
       }
       const q = customText.value;
       if (!q) return;
-      const rows = filteredRows.value;
-      if (rows.length > 0 && !rowInert(rows[0])) {
-        toggleRow(rows[0]);
+      const addable = rows.value.find(
+        (option) => !rowInert(option) && !selectedKeys.value.includes(option.key),
+      );
+      if (addable) {
+        toggleRow(addable);
         return;
       }
       if (customVisible.value) addCustom();
+    }
+
+    /** A press inside the field that lands on a CHIP starts a potential
+     *  chip drag. Caught here on the box because the chip is rendered by
+     *  HkTag (whose root takes no arbitrary attributes): the press's own
+     *  target is resolved back to its chip, so the chip body is the handle
+     *  while the × — a button — is vetoed inside the composable. A press
+     *  on the input, the chevron or the empty space resolves to no chip
+     *  and is none of the drag's business. */
+    function onFieldPointerDown(e: PointerEvent): void {
+      if (props.disabled) return;
+      const chip = (e.target as HTMLElement | null)?.closest?.(".hk-tag-input-tag");
+      if (!chip) return;
+      // The SAME strip the drop measures: a chip on its way out is not a
+      // slot, and counting it would shift every index behind it.
+      const index = liveChips().indexOf(chip as HTMLElement);
+      if (index >= 0) chipDrag.start(e, index);
     }
 
     function onFieldClick(e: MouseEvent): void {
@@ -444,6 +712,7 @@ export const HkTagInput = defineComponent({
 
     function onInlineKeydown(e: KeyboardEvent): void {
       if (e.isComposing) return;
+      if (onReorderKey(e)) return;
       if (e.key === "Enter") {
         e.preventDefault();
         commitQuery();
@@ -481,6 +750,7 @@ export const HkTagInput = defineComponent({
 
     function onSearchKeydown(e: KeyboardEvent): void {
       if (e.isComposing) return;
+      if (onReorderKey(e)) return;
       if (e.key === "Enter") {
         e.preventDefault();
         commitQuery();
@@ -504,7 +774,10 @@ export const HkTagInput = defineComponent({
     function onPanelKeydown(e: KeyboardEvent): void {
       if (e.isComposing) return;
       const target = e.target as HTMLElement | null;
+      // A field's own arrows are that field's business — including the
+      // reorder chord, which onSearchKeydown/onInlineKeydown already took.
       if (target?.closest?.("input, textarea, select")) return;
+      if (onReorderKey(e)) return;
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
         moveActive(e.key === "ArrowDown" ? 1 : -1);
@@ -512,7 +785,7 @@ export const HkTagInput = defineComponent({
     }
 
     return () => {
-      const rows = filteredRows.value;
+      const visibleRows = rows.value;
       const searchPlaceholder =
         props.searchPlaceholder ?? t("hikari::tagInput.search", "Search");
       const emptyText = props.emptyText ?? t("hikari::tagInput.empty", "No matches");
@@ -555,20 +828,40 @@ export const HkTagInput = defineComponent({
             data-full={atMax.value || undefined}
             role={inputRendered ? undefined : "group"}
             aria-label={inputRendered ? undefined : title.value}
+            onPointerdown={onFieldPointerDown}
             onClick={onFieldClick}
           >
-            {tagEntries.value.map((entry) => (
-              <HkTag
-                key={entry.key}
-                class="hk-tag-input-tag"
-                size={tagSize.value}
-                closable={!props.disabled}
-                closeLabel={`${removeLabel} — ${entry.label}`}
-                onClose={() => removeKey(entry.key)}
-              >
-                <span class="hk-tag-input-tag-text">{entry.label}</span>
-              </HkTag>
-            ))}
+            {/* The chips are a keyed list, so a reorder FLIPs the moved
+              * chip and its neighbours into place. `tag=""` renders the
+              * group as a FRAGMENT (Vue's TransitionGroup contract for an
+              * absent tag): no wrapper element appears in the field, so
+              * every chip stays a direct item of the box's wrapping row
+              * exactly as before. The press itself is caught on the BOX
+              * below (HkTag accepts no arbitrary attributes), which is why
+              * the drag markers are classes, not data attributes. */}
+            <HkListTransition tag="" variant="reveal" move>
+              {tagEntries.value.map((entry, index) => {
+                const dragging = chipDrag.dragFrom.value === index;
+                const dropTarget =
+                  chipDrag.dragging.value && chipDrag.dragOver.value === index && !dragging;
+                return (
+                  <HkTag
+                    key={entry.key}
+                    class={[
+                      "hk-tag-input-tag",
+                      dragging ? "hk-tag-input-tag-dragging" : "",
+                      dropTarget ? "hk-tag-input-tag-drop" : "",
+                    ]}
+                    size={tagSize.value}
+                    closable={!props.disabled}
+                    closeLabel={`${removeLabel} — ${entry.label}`}
+                    onClose={() => removeKey(entry.key)}
+                  >
+                    <span class="hk-tag-input-tag-text">{entry.label}</span>
+                  </HkTag>
+                );
+              })}
+            </HkListTransition>
             {inputRendered ? (
               <input
                 ref={inputRef}
@@ -633,7 +926,15 @@ export const HkTagInput = defineComponent({
             anchorRef={fieldRef.value}
             title={title.value}
             placement="bottom-start"
-            matchAnchorWidth
+            // The panel hugs its own designed 13–19rem measure instead of
+            // stretching to the field's width (usually a full-width
+            // settings column): an anchor-wide surface would leave a band
+            // of empty popout beside the catalog and park the surface's
+            // scrollbar at the far edge of it. The cap keeps a long
+            // catalog scrolling inside that measure rather than growing
+            // toward the 36rem stylesheet ceiling.
+            matchAnchorWidth={false}
+            maxHeight="min(18rem, 45dvh)"
             onUpdate:open={(v: boolean) => {
               open.value = v;
             }}
@@ -645,7 +946,7 @@ export const HkTagInput = defineComponent({
                  * popout / sheet) owns THE single scrollbar and scrolls the
                  * search field with the rows; no inner max-height/overflow
                  * here, ever. */
-                <div class="hk-tag-input-panel">
+                <div class="hk-tag-input-panel" ref={panelRef}>
                   <div class="hk-tag-input-search" role="search">
                     <HkInput
                       modelValue={query.value}
@@ -678,74 +979,123 @@ export const HkTagInput = defineComponent({
                     aria-multiselectable="true"
                     aria-label={title.value}
                   >
-                    {rows.map((option, index) => {
-                      const selected = selectedKeys.value.includes(option.key);
-                      const inert = rowInert(option);
-                      const stop = stops.value[index];
-                      return (
+                    {/* The rows are a keyed list, so a reorder FLIPs the
+                      * moved row and its neighbours. `tag=""` renders the
+                      * group as a FRAGMENT (Vue's TransitionGroup contract
+                      * for an absent tag): the rows stay the listbox's OWN
+                      * children — still options of the listbox for
+                      * aria-required-children, still the flex items that
+                      * carry the option rhythm — with no wrapper element in
+                      * between. */}
+                    <HkListTransition tag="" variant="reveal" move>
+                      {visibleRows.map((option, index) => {
+                        const selected = selectedKeys.value.includes(option.key);
+                        const inert = rowInert(option);
+                        const stop = stops.value[index];
+                        // Only a selected row is a drag item: it carries the
+                        // marker the panel strip lists AND the grip that
+                        // starts the drag. An unselected row stays put — not
+                        // draggable, and not a drop target either.
+                        const reorderable = selected && !props.disabled;
+                        const dragging = rowDrag.dragFrom.value === index;
+                        const dropTarget =
+                          rowDrag.dragging.value &&
+                          rowDrag.dragOver.value === index &&
+                          !dragging;
+                        return (
+                          <div
+                            key={option.key}
+                            id={stop.id}
+                            role="option"
+                            tabindex={-1}
+                            class="hk-tag-input-row"
+                            aria-selected={selected}
+                            aria-disabled={inert || undefined}
+                            data-selected={selected || undefined}
+                            data-disabled={inert || undefined}
+                            data-active={activeId === stop.id || undefined}
+                            data-reorder={reorderable ? "true" : undefined}
+                            data-dragging={dragging || undefined}
+                            data-drop={dropTarget || undefined}
+                            onClick={(e: MouseEvent) => {
+                              e.stopPropagation();
+                              toggleRow(option);
+                            }}
+                          >
+                            <span class="hk-tag-input-check" aria-hidden="true">
+                              {selected && <Check size={14} />}
+                            </span>
+                            {option.flag && (
+                              <span class="hk-tag-input-row-flag" aria-hidden="true">
+                                {option.flag}
+                              </span>
+                            )}
+                            <span class="hk-tag-input-row-label">{labelOf(option)}</span>
+                            {option.meta && (
+                              <span class="hk-tag-input-row-meta">{option.meta}</span>
+                            )}
+                            {reorderable && (
+                              <span
+                                class="hk-tag-input-grip"
+                                role="button"
+                                tabindex={-1}
+                                aria-label={reorderLabel(option)}
+                                title={reorderLabel(option)}
+                                // The handle — and only the handle — claims
+                                // the gesture (touch-action: none), so the
+                                // sheet keeps scrolling under every other
+                                // part of the row.
+                                onPointerdown={(e: PointerEvent) => {
+                                  rowDrag.start(e, index);
+                                }}
+                                // A press on the handle that never became a
+                                // drag must not fall through to the row's
+                                // toggle: losing the tag the user reached
+                                // for is not what a handle means.
+                                onClick={(e: MouseEvent) => {
+                                  e.stopPropagation();
+                                }}
+                              >
+                                <GripVertical size={14} aria-hidden="true" />
+                              </span>
+                            )}
+                          </div>
+                        );
+                      })}
+                      {customVisible.value && (
                         <div
-                          key={option.key}
-                          id={stop.id}
+                          id={customStopId}
+                          key="hk-tag-input-custom"
                           role="option"
                           tabindex={-1}
                           class="hk-tag-input-row"
-                          aria-selected={selected}
-                          aria-disabled={inert || undefined}
-                          data-selected={selected || undefined}
-                          data-disabled={inert || undefined}
-                          data-active={activeId === stop.id || undefined}
+                          aria-selected={false}
+                          // The custom row is inert on exactly the same flag
+                          // as the option rows — the whole list (custom row
+                          // included) freezes when the field is disabled or
+                          // full, and reads inert to AT while it does.
+                          aria-disabled={rowsDisabled.value || undefined}
+                          data-custom="true"
+                          data-disabled={rowsDisabled.value || undefined}
+                          data-active={activeId === customStopId || undefined}
                           onClick={(e: MouseEvent) => {
                             e.stopPropagation();
-                            toggleRow(option);
+                            addCustom();
                           }}
                         >
                           <span class="hk-tag-input-check" aria-hidden="true">
-                            {selected && <Check size={14} />}
+                            <Plus size={14} />
                           </span>
-                          {option.flag && (
-                            <span class="hk-tag-input-row-flag" aria-hidden="true">
-                              {option.flag}
-                            </span>
-                          )}
-                          <span class="hk-tag-input-row-label">{labelOf(option)}</span>
-                          {option.meta && (
-                            <span class="hk-tag-input-row-meta">{option.meta}</span>
-                          )}
+                          <span class="hk-tag-input-row-label">{customLabel}</span>
                         </div>
-                      );
-                    })}
-                    {customVisible.value && (
-                      <div
-                        id={stopId("custom")}
-                        role="option"
-                        tabindex={-1}
-                        class="hk-tag-input-row"
-                        aria-selected={false}
-                        // The custom row is inert on exactly the same flag
-                        // as the option rows — the whole list (custom row
-                        // included) freezes when the field is disabled or
-                        // full, and reads inert to AT while it does.
-                        aria-disabled={rowsDisabled.value || undefined}
-                        data-custom="true"
-                        data-disabled={rowsDisabled.value || undefined}
-                        data-active={activeId === stopId("custom") || undefined}
-                        onClick={(e: MouseEvent) => {
-                          e.stopPropagation();
-                          addCustom();
-                        }}
-                      >
-                        <span class="hk-tag-input-check" aria-hidden="true">
-                          <Plus size={14} />
-                        </span>
-                        <span class="hk-tag-input-row-label">{customLabel}</span>
-                      </div>
-                    )}
+                      )}
+                    </HkListTransition>
                   </div>
                   {/* The empty message lives OUTSIDE the listbox: a listbox
                     * may only own options/groups (aria-required-children),
                     * and the element it hangs off must still exist while the
                     * panel is open for `aria-controls` to resolve. */}
-                  {rows.length === 0 && !customVisible.value && (
+                  {visibleRows.length === 0 && !customVisible.value && (
                     <div class="hk-tag-input-empty">{emptyText}</div>
                   )}
                 </div>

--- a/packages/vue/src/composables/usePointerReorder.test.ts
+++ b/packages/vue/src/composables/usePointerReorder.test.ts
@@ -1,0 +1,651 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { effectScope, type EffectScope } from "vue";
+
+import { usePointerReorder, type PointerReorder } from "./usePointerReorder";
+
+/** Items with PINNED rects — happy-dom ships no layout engine, so every
+ *  item is placed by hand along the axis under test (size 40, the same
+ *  geometry a 40px chip row or panel row would report). */
+function strip(axis: "x" | "y", count = 3, size = 40) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const items: HTMLElement[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const el = document.createElement("div");
+    el.textContent = `item-${i}`;
+    const start = i * size;
+    const box = {
+      left: axis === "x" ? start : 0,
+      right: axis === "x" ? start + size : size,
+      top: axis === "x" ? 0 : start,
+      bottom: axis === "x" ? size : start + size,
+      width: size,
+      height: size,
+      x: axis === "x" ? start : 0,
+      y: axis === "x" ? 0 : start,
+    };
+    Object.defineProperty(el, "getBoundingClientRect", {
+      configurable: true,
+      value: () => box as DOMRect,
+    });
+    container.appendChild(el);
+    items.push(el);
+  }
+  return { container, items };
+}
+
+/** Waits out `frames` animation frames — the auto-scroll loop steps once
+ *  per frame (the repo's useApproachEnd pattern). */
+async function frames(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+}
+
+/** A scrollable strip for the auto-scroll tests: the container reports a
+ *  fixed box and holds real `scrollTop`/`scrollLeft` numbers, and every
+ *  item is placed relative to the current scroll offset — which is exactly
+ *  what a browser does to the content a scroll moves under the pointer. */
+function scrollStrip(
+  axis: "x" | "y",
+  count: number,
+  size: number,
+  viewport: number,
+): { container: HTMLElement; items: HTMLElement[] } {
+  const container = document.createElement("div");
+  const box =
+    axis === "x"
+      ? { left: 0, right: viewport, top: 0, bottom: size }
+      : { left: 0, right: size, top: 0, bottom: viewport };
+  Object.defineProperty(container, "getBoundingClientRect", {
+    configurable: true,
+    value: () =>
+      ({ ...box, width: box.right - box.left, height: box.bottom - box.top, x: box.left, y: box.top }) as DOMRect,
+  });
+  document.body.appendChild(container);
+
+  const items: HTMLElement[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const el = document.createElement("div");
+    Object.defineProperty(el, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        const offset = (axis === "x" ? container.scrollLeft : container.scrollTop);
+        const start = i * size - offset;
+        const item =
+          axis === "x"
+            ? { left: start, right: start + size, top: 0, bottom: size }
+            : { left: 0, right: size, top: start, bottom: start + size };
+        return { ...item, width: size, height: size, x: item.left, y: item.top } as DOMRect;
+      },
+    });
+    container.appendChild(el);
+    items.push(el);
+  }
+  return { container, items };
+}
+
+const scopes: EffectScope[] = [];
+
+/** Mount the composable inside a real effect scope (the component case). */
+function harness(
+  axis: "x" | "y",
+  items: HTMLElement[],
+  threshold?: number,
+  scrollContainer?: () => HTMLElement | null,
+): { handle: PointerReorder; drops: Array<[number, number]> } {
+  const drops: Array<[number, number]> = [];
+  const scope = effectScope();
+  scopes.push(scope);
+  let handle!: PointerReorder;
+  scope.run(() => {
+    handle = usePointerReorder({
+      items: () => items,
+      axis,
+      threshold,
+      scrollContainer,
+      onDrop: (from, to) => drops.push([from, to]),
+    });
+  });
+  return { handle, drops };
+}
+
+/** Press item `index` and hand the event to the composable — exactly what
+ *  a component's `onPointerdown` handler does. `buttons` is 1 throughout a
+ *  press, as a real pointer reports it: a move with `buttons: 0` means the
+ *  button went up somewhere the page never saw, and the composable treats
+ *  it as the end of the gesture. */
+function press(
+  handle: PointerReorder,
+  items: HTMLElement[],
+  index: number,
+  coordinate: { x?: number; y?: number },
+  id = 1,
+): void {
+  const event = new PointerEvent("pointerdown", {
+    bubbles: true,
+    cancelable: true,
+    pointerId: id,
+    pointerType: "mouse",
+    button: 0,
+    buttons: 1,
+    clientX: coordinate.x ?? 0,
+    clientY: coordinate.y ?? 0,
+  });
+  items[index].dispatchEvent(event);
+  handle.start(event, index);
+}
+
+function move(x: number, y = 0, id = 1, buttons = 1): void {
+  window.dispatchEvent(
+    new PointerEvent("pointermove", {
+      bubbles: true,
+      pointerId: id,
+      pointerType: "mouse",
+      buttons,
+      clientX: x,
+      clientY: y,
+    }),
+  );
+}
+
+function up(x: number, y = 0, id = 1): void {
+  window.dispatchEvent(
+    new PointerEvent("pointerup", {
+      bubbles: true,
+      pointerId: id,
+      pointerType: "mouse",
+      buttons: 0,
+      clientX: x,
+      clientY: y,
+    }),
+  );
+}
+
+function cancel(id = 1): void {
+  window.dispatchEvent(
+    new PointerEvent("pointercancel", { bubbles: true, pointerId: id, pointerType: "touch" }),
+  );
+}
+
+afterEach(() => {
+  for (const scope of scopes.splice(0)) scope.stop();
+  document.body.innerHTML = "";
+});
+
+describe("usePointerReorder", () => {
+  it("keeps an idle press idle — a move under the threshold is not a drag", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(14);
+    expect(handle.dragging.value).toBe(false);
+    expect(handle.dragFrom.value).toBe(-1);
+    expect(handle.dragOver.value).toBe(-1);
+
+    up(14);
+    expect(drops).toEqual([]);
+    expect(handle.dragging.value).toBe(false);
+  });
+
+  it("honours a custom threshold", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items, 30);
+
+    press(handle, items, 0, { x: 10 });
+    move(30);
+    expect(handle.dragging.value, "20px is still under a 30px threshold").toBe(false);
+    move(75);
+    expect(handle.dragging.value).toBe(true);
+    up(75);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("publishes the drag state and resolves the slot from the item midpoints", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragFrom.value).toBe(0);
+    expect(handle.dragOver.value, "70 is past item 1's midpoint of 60").toBe(1);
+
+    up(70);
+    expect(drops).toEqual([[0, 1]]);
+    // The gesture released every listener and reset the published state.
+    expect(handle.dragging.value).toBe(false);
+    expect(handle.dragFrom.value).toBe(-1);
+    expect(handle.dragOver.value).toBe(-1);
+  });
+
+  it("resolves the landing slot along the declared axis only", () => {
+    const { items } = strip("y");
+    const { handle, drops } = harness("y", items);
+
+    // Item 2 spans y 80-120 (midpoint 100) and is dragged from y 90.
+    press(handle, items, 2, { y: 90 });
+    move(500, 90);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "x travel says nothing on a y strip").toBe(2);
+
+    move(0, 10);
+    expect(handle.dragOver.value, "10 is before item 0's midpoint of 20").toBe(0);
+    up(0, 10);
+    expect(drops).toEqual([[2, 0]]);
+  });
+
+  it("clamps a release past the end onto the last item of the strip", () => {
+    const { items } = strip("y");
+    const { handle, drops } = harness("y", items);
+
+    press(handle, items, 0, { y: 10 });
+    move(0, 5000);
+    expect(handle.dragOver.value).toBe(2);
+    up(0, 5000);
+    expect(drops).toEqual([[0, 2]]);
+  });
+
+  it("emits nothing when the drag lands back on the item it started on", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 1, { x: 50 });
+    move(70);
+    expect(handle.dragging.value).toBe(true);
+    up(52);
+    expect(drops).toEqual([]);
+  });
+
+  it("abandons the drag on pointercancel without emitting", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    cancel();
+    expect(handle.dragging.value).toBe(false);
+    expect(handle.dragFrom.value).toBe(-1);
+
+    // The gesture is forgotten: a stray move/up cannot resurrect it.
+    move(110);
+    up(110);
+    expect(drops).toEqual([]);
+  });
+
+  it("abandons the drag on Escape without emitting", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(handle.dragging.value).toBe(false);
+    up(110);
+    expect(drops).toEqual([]);
+  });
+
+  it("drops the trap and the listeners when the scope is torn down mid-drag", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+    const scope = scopes[scopes.length - 1];
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    scope.stop();
+    expect(handle.dragging.value).toBe(false);
+    up(110);
+    expect(drops).toEqual([]);
+  });
+
+  it("ignores a press that starts on an interactive control", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+    const button = document.createElement("button");
+    items[0].appendChild(button);
+
+    const event = new PointerEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 1,
+      button: 0,
+      buttons: 1,
+      clientX: 10,
+      clientY: 0,
+    });
+    button.dispatchEvent(event);
+    handle.start(event, 0);
+
+    move(110);
+    expect(handle.dragging.value).toBe(false);
+    up(110);
+    expect(drops).toEqual([]);
+  });
+
+  it("ignores a non-primary button and a second pointer gesturing at once", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    const right = new PointerEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 1,
+      button: 2,
+      buttons: 2,
+      clientX: 10,
+      clientY: 0,
+    });
+    items[0].dispatchEvent(right);
+    handle.start(right, 0);
+    move(110);
+    expect(handle.dragging.value, "the right button never drags").toBe(false);
+
+    // A live drag belongs to ONE pointer: a second finger is not a move.
+    press(handle, items, 0, { x: 10 }, 1);
+    move(70, 0, 1);
+    expect(handle.dragOver.value).toBe(1);
+    move(110, 0, 2);
+    expect(handle.dragOver.value, "the second pointer is ignored").toBe(1);
+    up(110, 0, 2);
+    expect(drops).toEqual([]);
+    up(70);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("resolves against the pointer's own LINE on a wrapping strip", () => {
+    // Two lines of chips with different widths (a real wrap):
+    //   line 1: [0] x0-100 (mid 50)   [1] x100-200 (mid 150)
+    //   line 2: [2] x0-60  (mid 30)   [3] x60-120  (mid 90)
+    const items: HTMLElement[] = [];
+    const geometry = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 0, right: 60, top: 40, bottom: 80 },
+      { left: 60, right: 120, top: 40, bottom: 80 },
+    ];
+    for (const box of geometry) {
+      const el = document.createElement("div");
+      Object.defineProperty(el, "getBoundingClientRect", {
+        configurable: true,
+        value: () =>
+          ({ ...box, width: box.right - box.left, height: box.bottom - box.top, x: box.left, y: box.top }) as DOMRect,
+      });
+      document.body.appendChild(el);
+      items.push(el);
+    }
+    const { handle, drops } = harness("x", items);
+
+    // Item 2 dragged right along ITS line lands on item 3. Measured against
+    // the whole strip instead, line 1's midpoints would answer 1.
+    press(handle, items, 2, { x: 5, y: 60 });
+    move(100, 60);
+    expect(handle.dragOver.value).toBe(3);
+    up(100, 60);
+    expect(drops).toEqual([[2, 3]]);
+
+    // A pointer below every line takes the NEAREST line, not the first one.
+    press(handle, items, 2, { x: 5, y: 60 });
+    move(100, 400);
+    expect(handle.dragOver.value).toBe(3);
+    up(100, 400);
+    expect(drops).toEqual([
+      [2, 3],
+      [2, 3],
+    ]);
+  });
+
+  it("retires a stale click trap when a new press starts", () => {
+    const { items } = strip("x");
+    const { handle } = harness("x", items);
+    const inner = document.createElement("span");
+    items[0].appendChild(inner);
+    const clicks: string[] = [];
+    items[0].addEventListener("click", () => clicks.push("row"));
+
+    // A drag whose trailing click never arrives leaves the trap armed…
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    up(70);
+    // …and the very next press retires it, so the click of the NEW gesture
+    // is a real user click and not the previous drag's ghost.
+    press(handle, items, 1, { x: 50 });
+    up(51);
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["row"]);
+  });
+
+  it("retires a stale trap even when the next press is rejected", () => {
+    const { items } = strip("x");
+    const { handle } = harness("x", items);
+    const button = document.createElement("button");
+    items[0].appendChild(button);
+    const clicks: string[] = [];
+    button.addEventListener("click", () => clicks.push("button"));
+
+    // A drag whose trailing click never arrived leaves the trap armed…
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    up(70);
+
+    // …and a press the composable REFUSES (a control inside the strip) still
+    // ends that window: the × must not look dead for the next 400ms.
+    const rejected = new PointerEvent("pointerdown", {
+      bubbles: true,
+      cancelable: true,
+      pointerId: 1,
+      pointerType: "mouse",
+      button: 0,
+      buttons: 1,
+      clientX: 10,
+      clientY: 0,
+    });
+    button.dispatchEvent(rejected);
+    handle.start(rejected, 0);
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["button"]);
+  });
+
+  it("abandons the drag when a move arrives with no button held", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    expect(handle.dragging.value).toBe(true);
+
+    // The release happened where the page could not see it (the pointer
+    // left the window); the next move reports no buttons and ends it.
+    move(110, 0, 1, 0);
+    expect(handle.dragging.value).toBe(false);
+    expect(handle.dragFrom.value).toBe(-1);
+
+    // Whatever arrives afterwards — including a stray `up` at a position
+    // the user never chose — must not drop the dead drag.
+    up(110);
+    expect(drops).toEqual([]);
+
+    // …and the strip is not wedged: the next press drags normally.
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    up(70);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("abandons the drag when the window loses focus", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    expect(handle.dragging.value).toBe(true);
+
+    window.dispatchEvent(new Event("blur"));
+    expect(handle.dragging.value).toBe(false);
+    expect(handle.dragFrom.value, "the strip is idle, not wedged").toBe(-1);
+    up(200);
+    expect(drops).toEqual([]);
+
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    up(70);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("abandons the drag when the page is hidden", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+    const hidden = Object.getOwnPropertyDescriptor(Document.prototype, "hidden");
+    Object.defineProperty(document, "hidden", { configurable: true, value: true });
+    try {
+      press(handle, items, 0, { x: 10 });
+      move(70);
+      document.dispatchEvent(new Event("visibilitychange"));
+      expect(handle.dragging.value).toBe(false);
+      up(200);
+      expect(drops).toEqual([]);
+    } finally {
+      if (hidden) Object.defineProperty(Document.prototype, "hidden", hidden);
+      else delete (document as unknown as Record<string, unknown>).hidden;
+    }
+  });
+
+  it("pulls a long drag along its scroller near the bottom edge", async () => {
+    // A 2-row band (80px) over a 5-row strip (40px rows): the last row can
+    // only be reached by scrolling.
+    const { container, items } = scrollStrip("y", 5, 40, 80);
+    const { handle, drops } = harness("y", items, undefined, () => container);
+
+    press(handle, items, 0, { y: 10 });
+    // Hold near the bottom edge (zone 56..80, pointer at 78).
+    move(0, 78);
+    expect(handle.dragging.value).toBe(true);
+    // …with nothing scrolled yet, the pointer can only reach the third row.
+    expect(handle.dragOver.value).toBe(1);
+
+    await frames(3);
+    expect(container.scrollTop, "the strip is being pulled along").toBeGreaterThan(0);
+    expect(handle.dragOver.value, "the slot follows the scrolled content").toBeGreaterThan(1);
+
+    // Held at the edge long enough for the last row to arrive, the release
+    // lands there — the whole point of the scroll.
+    for (let i = 0; i < 40 && container.scrollTop < 140; i += 1) await frames(1);
+    expect(container.scrollTop).toBeGreaterThanOrEqual(140);
+    expect(handle.dragOver.value).toBe(4);
+    up(0, 78);
+    expect(drops).toEqual([[0, 4]]);
+    // The drag is over: nothing keeps scrolling.
+    const settled = container.scrollTop;
+    await frames(3);
+    expect(container.scrollTop).toBe(settled);
+  });
+
+  it("pulls the strip back near the top edge", async () => {
+    const { container, items } = scrollStrip("y", 5, 40, 80);
+    const { handle, drops } = harness("y", items, undefined, () => container);
+    container.scrollTop = 120;
+
+    press(handle, items, 3, { y: 70 });
+    move(0, 2);
+    expect(handle.dragging.value).toBe(true);
+    await frames(3);
+    expect(container.scrollTop, "the strip is pulled back").toBeLessThan(120);
+    expect(container.scrollTop).toBeGreaterThanOrEqual(0);
+    expect(handle.dragOver.value, "the slot follows the content back").toBeLessThan(3);
+
+    // Carried all the way back, the row lands at the front.
+    for (let i = 0; i < 40 && container.scrollTop > 20; i += 1) await frames(1);
+    expect(handle.dragOver.value).toBe(0);
+    up(0, 2);
+    expect(drops).toEqual([[3, 0]]);
+  });
+
+  it("stops scrolling when the pointer leaves the edge zone", async () => {
+    const { container, items } = scrollStrip("y", 5, 40, 80);
+    const { handle } = harness("y", items, undefined, () => container);
+
+    press(handle, items, 0, { y: 10 });
+    move(0, 78);
+    await frames(2);
+    const scrolled = container.scrollTop;
+    expect(scrolled).toBeGreaterThan(0);
+
+    // Back to the middle of the band: the loop stops where it is.
+    move(0, 40);
+    await frames(3);
+    expect(container.scrollTop).toBe(scrolled);
+
+    // …and a move back into the zone picks the pull up again.
+    move(0, 79);
+    await frames(2);
+    expect(container.scrollTop).toBeGreaterThan(scrolled);
+    up(0, 40);
+  });
+
+  it("never scrolls without a live drag", async () => {
+    const { container, items } = scrollStrip("y", 5, 40, 80);
+    const { handle } = harness("y", items, undefined, () => container);
+
+    // A pointer hovering in the zone with no press at all.
+    move(0, 79);
+    move(0, 2);
+    await frames(3);
+    expect(container.scrollTop).toBe(0);
+
+    // A press that never became a drag (under the threshold).
+    press(handle, items, 0, { y: 78 });
+    move(0, 78);
+    await frames(3);
+    expect(container.scrollTop).toBe(0);
+    up(0, 78);
+
+    // A live drag DOES scroll…
+    press(handle, items, 0, { y: 10 });
+    move(0, 79);
+    await frames(2);
+    expect(container.scrollTop).toBeGreaterThan(0);
+    // …and the loop is gone with the drop.
+    up(0, 79);
+    const settled = container.scrollTop;
+    await frames(3);
+    expect(container.scrollTop).toBe(settled);
+
+    // A cancelled drag likewise.
+    press(handle, items, 0, { y: 10 });
+    move(0, 79);
+    await frames(2);
+    expect(container.scrollTop).toBeGreaterThan(settled);
+    cancel();
+    const cancelled = container.scrollTop;
+    await frames(3);
+    expect(container.scrollTop).toBe(cancelled);
+  });
+
+  it("swallows the click a drag would deliver, and only that one", () => {
+    const { items } = strip("x");
+    const { handle, drops } = harness("x", items);
+    const inner = document.createElement("span");
+    items[0].appendChild(inner);
+    const clicks: string[] = [];
+    items[0].addEventListener("click", () => clicks.push("row"));
+
+    // A plain press/release is a click: nothing is swallowed.
+    press(handle, items, 0, { x: 10 });
+    up(11);
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["row"]);
+
+    // A real drag is not: the trailing click is eaten at the window
+    // capture phase, so the row's own handler never sees it.
+    press(handle, items, 0, { x: 10 });
+    move(70);
+    up(70);
+    expect(drops).toEqual([[0, 1]]);
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["row"]);
+
+    // …and only that one: the next user click is delivered again.
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["row", "row"]);
+  });
+});

--- a/packages/vue/src/composables/usePointerReorder.ts
+++ b/packages/vue/src/composables/usePointerReorder.ts
@@ -1,0 +1,432 @@
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
+
+/** The axis a reorderable strip flows along: field chips run left to
+ *  right, stacked panel rows top to bottom. */
+export type PointerReorderAxis = "x" | "y";
+
+/** Pointer travel (px) that separates a click/tap from a drag — smaller
+ *  than any deliberate move, larger than the jitter a finger or a
+ *  shaky mouse produces while pressing. */
+const DEFAULT_THRESHOLD = 6;
+
+/** How long a finished drag keeps its click trap armed. The browser
+ *  delivers the post-drag click right after `pointerup` for a mouse and
+ *  up to a few hundred ms later for a touch tap; past that window the
+ *  trap can only be stale — a new press owns the next click, and eating
+ *  it would be worse than letting one through. */
+const CLICK_TRAP_MS = 400;
+
+/** Presses that start ON an interactive control never drag — the same
+ *  guard HkDraggableList applies to its rows: a button pressed to act
+ *  must act, not move the thing it sits in. */
+const INTERACTIVE = "button, a, input, textarea, select, [contenteditable]";
+
+/** Auto-scroll: how close to the scroller's edge (px) a live drag starts
+ *  pulling the strip along, and how many pixels one animation frame moves
+ *  it AT that edge (the step tapers to 1px at the zone's inner boundary,
+ *  so entering the zone is a nudge and holding at the edge is a run). */
+const EDGE_ZONE = 24;
+const EDGE_MAX_STEP = 12;
+
+/** System reduced-motion preference — animations snap instead of tweening.
+ *  The auto-scroll still runs; this only decides whether a surface that
+ *  eases its own scrolling (`scroll-behavior: smooth`) is allowed to. */
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches === true
+  );
+}
+
+export interface PointerReorderOptions {
+  /** Items in DISPLAY order. Re-read on every pointer move, so a list
+   *  re-rendering under a live drag resolves against what is actually on
+   *  screen — and whatever this returns IS the drop space: items a drag
+   *  may not land on are simply not listed (that is how a panel drag
+   *  stays clamped to the selected group). */
+  items: () => readonly (HTMLElement | null | undefined)[];
+  /** Flow direction of the strip (measured midpoints run along it). */
+  axis: PointerReorderAxis;
+  /** Fired once per real drop, with the display indices of the dragged
+   *  item and of the slot it landed in (`from !== to` — a release back on
+   *  the origin is a no-op, never an emit). */
+  onDrop: (from: number, to: number) => void;
+  /** Pointer travel in px that separates a click/tap from a drag. */
+  threshold?: number;
+  /** The element that scrolls the strip, resolved when the drag needs it
+   *  (the desktop popout or the mobile sheet's list — the surface that
+   *  already owns the scroll region; this only drives it). While a live
+   *  drag holds near the scroller's leading/trailing edge the strip is
+   *  pulled along one frame at a time, so a row can be carried past the
+   *  visible band instead of being dropped, scrolled and grabbed again.
+   *  Undefined (or null at that moment): no auto-scroll. */
+  scrollContainer?: () => HTMLElement | null;
+}
+
+export interface PointerReorder {
+  /** Display index of the item being dragged, `-1` while idle. */
+  dragFrom: Ref<number>;
+  /** Display index of the slot the release would land in, `-1` while
+   *  idle. */
+  dragOver: Ref<number>;
+  /** A press crossed the threshold and is being dragged. */
+  dragging: Ref<boolean>;
+  /** Watch a press on item `index` (item 0 of `items()` is index 0).
+   *  Nothing is reported until the pointer travels past the threshold,
+   *  so a tap stays a plain click and the page keeps its scrolling. */
+  start: (event: PointerEvent, index: number) => void;
+}
+
+/**
+ * usePointerReorder — pointer drag-to-reorder for a strip of elements.
+ *
+ * Framework-free of any list semantics: the caller hands over the items in
+ * display order and a drop callback, and gets back the drag state to paint
+ * (`dragFrom` / `dragOver` / `dragging`). The landing slot is resolved by
+ * the pointer's position against the item MIDPOINTS along the axis, inside
+ * the LINE the pointer is on across it — so a wrapping chip row (x axis,
+ * several lines) and a stacked panel column (y axis, one column) both
+ * behave the way the pointer looks like it should.
+ *
+ * The threshold is what keeps the gesture honest on a control that is also
+ * clickable: a press under ~6px is not a drag at all — no state is
+ * published, no reorder is emitted, and the click that follows reaches its
+ * handler untouched, so a tap on a chip still focuses the field. A real
+ * drag swallows that trailing click instead (the browser would otherwise
+ * deliver it to a common ancestor — or, on a short drag, to the row the
+ * user just moved, toggling it off); the trap is retired when it fires,
+ * when its window lapses, and by the next press.
+ *
+ * Touch: the composable itself never claims the page's panning (it calls
+ * no `preventDefault` on press), so the caller decides with CSS —
+ * `touch-action: none` on an explicit grip makes a drag exclusive, while a
+ * plain `pan-y` item gives way to the browser (which sends
+ * `pointercancel`, and the drag is abandoned without emitting).
+ *
+ * Nothing is emitted for a cancelled gesture — pointercancel, Escape, an
+ * unmount mid-drag, a window that loses focus, a hidden page, or a move
+ * that arrives with no button held (the pointer was released somewhere the
+ * page never saw) — and every listener is torn down on release, so an
+ * abandoned drag can never leak into the next interaction: a press whose
+ * release is lost must not fire a reorder later, at whatever position the
+ * pointer happens to be by then.
+ */
+export function usePointerReorder(options: PointerReorderOptions): PointerReorder {
+  const threshold = options.threshold ?? DEFAULT_THRESHOLD;
+  const axis = options.axis;
+
+  const dragFrom = ref(-1);
+  const dragOver = ref(-1);
+  const dragging = ref(false);
+
+  /** The pointer that owns the live press; a second pointer is ignored. */
+  let pointerId = -1;
+  let pressedIndex = -1;
+  let originX = 0;
+  let originY = 0;
+  let pressed = false;
+  let moved = false;
+  /** The pointer's last position, split by axis — the auto-scroll frames
+   *  re-resolve the drop target from it while the content moves under it. */
+  let lastMain = 0;
+  let lastCross = 0;
+  /** Auto-scroll: px per frame (signed: negative scrolls back), 0 = off. */
+  let scrollVelocity = 0;
+  let scrollFrameId = 0;
+  let clickTrap: ((event: MouseEvent) => void) | null = null;
+  /** Retires a live trap on the next press of ANY kind — the trailing
+   *  click either came already or never will, and a stale trap must not
+   *  eat a legitimate one (a press that `start` itself rejects — a
+   *  control, a second pointer, a right-click — still ends the window). */
+  let trapRetire: ((event: PointerEvent) => void) | null = null;
+  let clickTrapTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Item elements in display order, nulls dropped. */
+  function liveItems(): HTMLElement[] {
+    return options.items().filter((el): el is HTMLElement => el != null);
+  }
+
+  /** The display index the dragged item lands ON for a pointer at
+   *  (`main`, `cross`) — the pointer's coordinates split into the strip's
+   *  axis and the axis across it — starting from index `from`.
+   *
+   *  Resolved in two steps. First the LINE: items whose cross-axis span
+   *  holds the pointer (or is nearest to it) are the candidates, which is
+   *  what makes a WRAPPING chip row behave — a chip on the second line can
+   *  never be matched by a pointer on the first. A single-file strip (the
+   *  panel's column, whose rows all span the list width) has every item in
+   *  one span, so filtering by line is a strict no-op there — it only ever
+   *  separates items that really are on different lines.
+   *
+   *  Then the INSERTION POINT: the first candidate whose midpoint still
+   *  lies beyond the pointer (past the line's end when it is beyond every
+   *  candidate midpoint), which becomes a landing index by accounting for
+   *  the dragged item's own removal — dragging past one neighbour's
+   *  midpoint swaps with that neighbour instead of skipping it. -1 for an
+   *  empty strip. */
+  function indexAt(main: number, cross: number, from: number): number {
+    const items = liveItems();
+    if (items.length === 0) return -1;
+    const rects = items.map((item) => item.getBoundingClientRect());
+    // Nearest line wins: items in the pointer's own band score 0, and a
+    // pointer between two bands takes the closer one. The half-pixel
+    // tolerance keeps the siblings of ONE wrapped line together, whose
+    // bands can differ by sub-pixel rounding.
+    let nearest = Number.POSITIVE_INFINITY;
+    const lineGap = rects.map((rect) => {
+      const lo = axis === "x" ? rect.top : rect.left;
+      const hi = axis === "x" ? rect.bottom : rect.right;
+      const gap = cross < lo ? lo - cross : cross > hi ? cross - hi : 0;
+      if (gap < nearest) nearest = gap;
+      return gap;
+    });
+    let slot = -1;
+    for (let i = 0; i < rects.length; i += 1) {
+      if (lineGap[i] > nearest + 0.5) continue;
+      const rect = rects[i];
+      const mid = axis === "x" ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
+      if (main < mid) {
+        slot = i;
+        break;
+      }
+      slot = i + 1;
+    }
+    if (slot < 0) slot = items.length;
+    return from >= 0 && slot > from ? slot - 1 : slot;
+  }
+
+  /** The pointer's coordinates split by axis: the position along the strip
+   *  and the position across it. */
+  function pointerAt(event: PointerEvent): { main: number; cross: number } {
+    return axis === "x"
+      ? { main: event.clientX, cross: event.clientY }
+      : { main: event.clientY, cross: event.clientX };
+  }
+
+  /** How fast one frame should move the strip for a pointer at `main`:
+   *  0 outside the edge zones, a 1..EDGE_MAX_STEP px ramp inside them. The
+   *  zone is clamped to half the scroller, so a surface shorter than two
+   *  zones cannot have them overlap into a permanent scroll. */
+  function edgeVelocity(main: number): number {
+    const container = options.scrollContainer?.() ?? null;
+    if (!container) return 0;
+    const rect = container.getBoundingClientRect();
+    const lo = axis === "x" ? rect.left : rect.top;
+    const hi = axis === "x" ? rect.right : rect.bottom;
+    const span = hi - lo;
+    if (!Number.isFinite(span) || span <= 0) return 0;
+    const zone = Math.min(EDGE_ZONE, span / 2);
+    const ramp = (depth: number) => {
+      const clamped = Math.min(Math.max(depth, 0), zone);
+      return Math.max(1, Math.round((EDGE_MAX_STEP * clamped) / zone));
+    };
+    if (main < lo + zone) return -ramp(lo + zone - main);
+    if (main > hi - zone) return ramp(main - (hi - zone));
+    return 0;
+  }
+
+  /** One auto-scroll frame. The strip is re-read on demand, so the drop
+   *  target is re-resolved from the same pointer position after the
+   *  content moved under it — the slot follows what the user sees. */
+  function scrollTick(): void {
+    scrollFrameId = 0;
+    if (!pressed || !moved || scrollVelocity === 0) return;
+    const container = options.scrollContainer?.() ?? null;
+    if (!container) return;
+    const next =
+      (axis === "x" ? container.scrollLeft : container.scrollTop) + scrollVelocity;
+    if (prefersReducedMotion()) {
+      // The scroll is never gated on the preference — only the easing a
+      // smooth-scrolling surface would apply to it.
+      container.scrollTo(
+        axis === "x"
+          ? { left: next, behavior: "instant" }
+          : { top: next, behavior: "instant" },
+      );
+    } else if (axis === "x") {
+      container.scrollLeft = next;
+    } else {
+      container.scrollTop = next;
+    }
+    const over = indexAt(lastMain, lastCross, pressedIndex);
+    if (over >= 0) dragOver.value = over;
+    scrollFrameId = requestAnimationFrame(scrollTick);
+  }
+
+  /** Follow the pointer's edge zone: start the frame loop when a live drag
+   *  enters one, stop it the moment it leaves (or the drag ends), so an
+   *  idle strip never scrolls and no frame is scheduled for nothing. */
+  function syncAutoScroll(): void {
+    if (!pressed || !moved) {
+      stopAutoScroll();
+      return;
+    }
+    scrollVelocity = edgeVelocity(lastMain);
+    if (scrollVelocity === 0) stopAutoScroll();
+    else if (scrollFrameId === 0) scrollFrameId = requestAnimationFrame(scrollTick);
+  }
+
+  function stopAutoScroll(): void {
+    scrollVelocity = 0;
+    if (scrollFrameId !== 0) {
+      cancelAnimationFrame(scrollFrameId);
+      scrollFrameId = 0;
+    }
+  }
+
+  function dropClickTrap(): void {
+    if (clickTrapTimer !== null) {
+      clearTimeout(clickTrapTimer);
+      clickTrapTimer = null;
+    }
+    if (clickTrap) {
+      window.removeEventListener("click", clickTrap, { capture: true });
+      clickTrap = null;
+    }
+    if (trapRetire) {
+      window.removeEventListener("pointerdown", trapRetire, { capture: true });
+      trapRetire = null;
+    }
+  }
+
+  /** Swallow the ONE click a real drag would otherwise deliver — at the
+   *  WINDOW capture phase, so nothing down the path (a row's toggle, the
+   *  field's open handler, a host's own listener) ever sees it. The trap
+   *  disarms as it fires, when its window lapses, and on the next press of
+   *  any kind: the post-drag click is the only click a drag owns, and every
+   *  other one must reach its handler untouched. */
+  function trapClick(): void {
+    dropClickTrap();
+    clickTrap = (event: MouseEvent) => {
+      dropClickTrap();
+      event.stopPropagation();
+      event.preventDefault();
+    };
+    trapRetire = () => dropClickTrap();
+    window.addEventListener("click", clickTrap, { capture: true });
+    // Capture phase: the new gesture's own handlers see a clean window, and
+    // its click (if any) can never be mistaken for the drag's.
+    window.addEventListener("pointerdown", trapRetire, { capture: true });
+    clickTrapTimer = setTimeout(dropClickTrap, CLICK_TRAP_MS);
+  }
+
+  /** The page stopped being able to deliver this gesture's release: the
+   *  window lost focus, or the tab went to the background. Abandon it. */
+  function onPressLost(): void {
+    if (!pressed) return;
+    releaseDrag();
+  }
+
+  function onVisibilityChange(): void {
+    if (document.hidden) onPressLost();
+  }
+
+  /** Forget the whole gesture: listeners off, auto-scroll stopped, state
+   *  back to idle. */
+  function releaseDrag(): void {
+    stopAutoScroll();
+    window.removeEventListener("pointermove", onPointerMove);
+    window.removeEventListener("pointerup", onPointerUp);
+    window.removeEventListener("pointercancel", onPointerCancel);
+    window.removeEventListener("keydown", onKeyDown);
+    // Bubble phase, never capture: an ELEMENT's blur does not bubble, so
+    // this only ever sees the WINDOW losing focus (a capture listener would
+    // also fire for every input blur on the page).
+    window.removeEventListener("blur", onPressLost);
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    pressed = false;
+    moved = false;
+    pointerId = -1;
+    pressedIndex = -1;
+    dragging.value = false;
+    dragFrom.value = -1;
+    dragOver.value = -1;
+  }
+
+  function onPointerMove(event: PointerEvent): void {
+    if (!pressed || event.pointerId !== pointerId) return;
+    // No button held any more: the release happened where the page could
+    // not see it (the pointer left the window and came back). This is the
+    // only signal for that — a mouse that is merely moved around the page
+    // reports `buttons: 0` on every hover, so the very next move ends a
+    // wedged drag instead of letting a later stray `pointerup` apply it at
+    // a position the user never chose. (It rests on the spec's `buttons: 1`
+    // for an active contact of ANY pointer type, touch included; a pointer
+    // that broke that would simply end its drags on the first move, which
+    // is why the blur/visibility guards above exist as the backstop.)
+    if (event.buttons === 0) {
+      releaseDrag();
+      return;
+    }
+    if (!moved) {
+      const travel = Math.hypot(event.clientX - originX, event.clientY - originY);
+      if (travel < threshold) return;
+      moved = true;
+      dragging.value = true;
+      dragFrom.value = pressedIndex;
+    }
+    const at = pointerAt(event);
+    lastMain = at.main;
+    lastCross = at.cross;
+    const over = indexAt(lastMain, lastCross, pressedIndex);
+    if (over >= 0) dragOver.value = over;
+    syncAutoScroll();
+  }
+
+  function onPointerUp(event: PointerEvent): void {
+    if (!pressed || event.pointerId !== pointerId) return;
+    const from = pressedIndex;
+    const at = pointerAt(event);
+    const to = moved ? indexAt(at.main, at.cross, from) : from;
+    const dropped = moved && to >= 0 && to !== from;
+    // The drag is over either way — the trap only guards the click the
+    // browser is about to deliver.
+    if (moved) trapClick();
+    releaseDrag();
+    if (dropped) options.onDrop(from, to);
+  }
+
+  function onPointerCancel(event: PointerEvent): void {
+    if (!pressed || event.pointerId !== pointerId) return;
+    // The browser took the gesture (a scroll started): abandon it
+    // silently — a reorder must never come out of a cancelled drag.
+    releaseDrag();
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    if (event.key === "Escape") releaseDrag();
+  }
+
+  function start(event: PointerEvent, index: number): void {
+    if (pressed || event.defaultPrevented || event.button !== 0 || index < 0) return;
+    const target = event.target as HTMLElement | null;
+    if (target?.closest?.(INTERACTIVE)) return;
+    pressed = true;
+    moved = false;
+    pointerId = event.pointerId;
+    pressedIndex = index;
+    originX = event.clientX;
+    originY = event.clientY;
+    const at = pointerAt(event);
+    lastMain = at.main;
+    lastCross = at.cross;
+    // Window-level listeners: the drag must survive the pointer leaving
+    // the item it started on (there is no capture, so a release over a
+    // neighbouring element still lands here).
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerCancel);
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("blur", onPressLost);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      releaseDrag();
+      dropClickTrap();
+    });
+  }
+
+  return { dragFrom, dragOver, dragging, start };
+}

--- a/packages/vue/src/i18n/locales/ar/components.json
+++ b/packages/vue/src/i18n/locales/ar/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "بحث",
   "hikari::tagInput.empty": "لا تطابقات",
   "hikari::tagInput.remove": "إزالة",
-  "hikari::tagInput.addCustom": "استخدام \"{q}\""
+  "hikari::tagInput.addCustom": "استخدام \"{q}\"",
+  "hikari::tagInput.reorder": "إعادة الترتيب — {label}"
 }

--- a/packages/vue/src/i18n/locales/de/components.json
+++ b/packages/vue/src/i18n/locales/de/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "Suchen",
   "hikari::tagInput.empty": "Keine Treffer",
   "hikari::tagInput.remove": "Entfernen",
-  "hikari::tagInput.addCustom": "„{q}“ verwenden"
+  "hikari::tagInput.addCustom": "„{q}“ verwenden",
+  "hikari::tagInput.reorder": "Neu anordnen — {label}"
 }

--- a/packages/vue/src/i18n/locales/en/components.json
+++ b/packages/vue/src/i18n/locales/en/components.json
@@ -213,5 +213,6 @@
   "hikari::tagInput.search": "Search",
   "hikari::tagInput.empty": "No matches",
   "hikari::tagInput.remove": "Remove",
-  "hikari::tagInput.addCustom": "Use “{q}”"
+  "hikari::tagInput.addCustom": "Use “{q}”",
+  "hikari::tagInput.reorder": "Reorder {label}"
 }

--- a/packages/vue/src/i18n/locales/es/components.json
+++ b/packages/vue/src/i18n/locales/es/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "Buscar",
   "hikari::tagInput.empty": "Sin coincidencias",
   "hikari::tagInput.remove": "Quitar",
-  "hikari::tagInput.addCustom": "Usar «{q}»"
+  "hikari::tagInput.addCustom": "Usar «{q}»",
+  "hikari::tagInput.reorder": "Reordenar — {label}"
 }

--- a/packages/vue/src/i18n/locales/fr/components.json
+++ b/packages/vue/src/i18n/locales/fr/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "Rechercher",
   "hikari::tagInput.empty": "Aucun résultat",
   "hikari::tagInput.remove": "Retirer",
-  "hikari::tagInput.addCustom": "Utiliser « {q} »"
+  "hikari::tagInput.addCustom": "Utiliser « {q} »",
+  "hikari::tagInput.reorder": "Réorganiser — {label}"
 }

--- a/packages/vue/src/i18n/locales/ja/components.json
+++ b/packages/vue/src/i18n/locales/ja/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "検索",
   "hikari::tagInput.empty": "一致なし",
   "hikari::tagInput.remove": "削除",
-  "hikari::tagInput.addCustom": "「{q}」を使用"
+  "hikari::tagInput.addCustom": "「{q}」を使用",
+  "hikari::tagInput.reorder": "並べ替え — {label}"
 }

--- a/packages/vue/src/i18n/locales/ko/components.json
+++ b/packages/vue/src/i18n/locales/ko/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "검색",
   "hikari::tagInput.empty": "일치 항목 없음",
   "hikari::tagInput.remove": "제거",
-  "hikari::tagInput.addCustom": "\"{q}\" 사용"
+  "hikari::tagInput.addCustom": "\"{q}\" 사용",
+  "hikari::tagInput.reorder": "순서 변경 — {label}"
 }

--- a/packages/vue/src/i18n/locales/pt/components.json
+++ b/packages/vue/src/i18n/locales/pt/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "Pesquisar",
   "hikari::tagInput.empty": "Sem correspondências",
   "hikari::tagInput.remove": "Remover",
-  "hikari::tagInput.addCustom": "Usar \"{q}\""
+  "hikari::tagInput.addCustom": "Usar \"{q}\"",
+  "hikari::tagInput.reorder": "Reordenar — {label}"
 }

--- a/packages/vue/src/i18n/locales/ru/components.json
+++ b/packages/vue/src/i18n/locales/ru/components.json
@@ -208,5 +208,6 @@
   "hikari::tagInput.search": "Поиск",
   "hikari::tagInput.empty": "Нет совпадений",
   "hikari::tagInput.remove": "Удалить",
-  "hikari::tagInput.addCustom": "Использовать «{q}»"
+  "hikari::tagInput.addCustom": "Использовать «{q}»",
+  "hikari::tagInput.reorder": "Изменить порядок — {label}"
 }

--- a/packages/vue/src/i18n/locales/zh-Hans/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/components.json
@@ -217,5 +217,6 @@
   "hikari::tagInput.search": "搜索",
   "hikari::tagInput.empty": "没有匹配项",
   "hikari::tagInput.remove": "移除",
-  "hikari::tagInput.addCustom": "使用「{q}」"
+  "hikari::tagInput.addCustom": "使用「{q}」",
+  "hikari::tagInput.reorder": "拖动排序 — {label}"
 }

--- a/packages/vue/src/i18n/locales/zh-Hant/components.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/components.json
@@ -217,5 +217,6 @@
   "hikari::tagInput.search": "搜尋",
   "hikari::tagInput.empty": "沒有符合項目",
   "hikari::tagInput.remove": "移除",
-  "hikari::tagInput.addCustom": "使用「{q}」"
+  "hikari::tagInput.addCustom": "使用「{q}」",
+  "hikari::tagInput.reorder": "拖曳排序 — {label}"
 }


### PR DESCRIPTION
## 概要

用户两张截图反馈驱动：chest 后台系统设置里的「界面语言」标签编辑器（hikari `HkTagInput`）看着不对劲、也根本没法排序。逐条对应：

### 1. 右侧莫名其妙多出一块 + 面板过高
根因（读码确认）：`HkTagInput` 给 `HkSelectPanel` 传了 `matchAnchorWidth`，弹层因此被打上「等于字段宽」的 inline `min-width`；而面板内容自身上限是 `min(19rem, …)`。设置页那一栏是满宽字段，于是弹层盒比内容宽出一大截 —— 右边那片空白，以及被甩到最右侧、看起来和内容毫不相干的滚动条，都是这么来的（`HkAffixPicker` 早就因为同样原因传 `false`）。高度那边，surface 的既有上限是 `max(240px, min(36rem, …))`，11 条语言目录会一路撑到 ~28rem 而不是滚动。

- 面板不再镜像字段宽度，改用自己的设计尺度（13–19rem 并给定宽，避免内容变化时自身右边缘跳动）。
- `HkSelectPanel` 新增 **additive** 的 `maxHeight` prop（默认 `undefined` = 与今天完全一致），发布为 `--hk-select-panel-max-height`；`HkTagInput` 用它把 surface 限到 `min(18rem, 45dvh)`，于是长目录在**同一个** surface 滚动条里滚动（「每个窗口只有一条滚动条」的既有契约保持不变，契约测试也同步收紧而非放宽）。
- `@supports (height: 1dvh)` 守卫保住 vh/dvh 的解析期回退：不支持 dvh 的引擎根本不会求值 `var()`，落在原来的 vh 上限上，不可能变成 `none`。

### 2. 分组与排序语义
- 面板行严格分组：**已选项按宿主 `modelValue` 顺序在前**，未选项按目录序在后，自定义行最后；搜索在各组内过滤；键盘游标（`aria-activedescendant`）跟随渲染顺序。
- 换组动画用共享的 `HkListTransition`（`move` = FLIP）：某项被选中时会**滑到已选组末尾**，其余行让位；尊重 reduced-motion。

### 3. 拖拽排序
- **编辑框内的标签 chip**：按住本体即可拖动（× 不触发、约 6px 阈值区分点击与拖拽，触摸端未过阈值前不抢页面滚动）。
- **面板内已选行**：显式 grip 手柄拖动，落点**结构性**夹在已选组内（未选行根本不在落点集合里，不是事后判断）；未选行无手柄、不可拖。
- **边缘自动滚动**：指针贴住 surface 上/下边缘时逐帧滚动并实时重算落点，因此可以把一行一口气拖过可见区（用户的数据是 11 条全选、可见区约 7 行，没有这个就拖不到末尾）。移动端解析的是 sheet 自己的滚动元素，不假设桌面 popout。
- 新顺序一律经既有 `update:modelValue` 数组表达（chest 以「第一个标签 = 默认语言」为准，顺序就是语义）。
- 键盘：`Alt+↑/↓` 把当前游标所在**已选**行在已选组内移动一格（组边缘硬停、未选行不动、禁用态不动、无变化不发事件）。

### 4. 对抗验证挖出并修掉的两个真实缺陷（都是「跑出来的」，不是读出来的）
- **丢失 release 会把条带卡死并让下一次点击变成幽灵排序**：`usePointerReorder` 原本只在配对的 pointerup/cancel/Escape/卸载时收尾。按住拖 70px、在窗口外松手（页面收不到 pointerup）后再随便点一下 —— 会发出一次用户从没做过的 `update:modelValue`，而且那次点击还被 click-trap 吃掉；`window.blur`（Alt-Tab）后条带保持「拖拽中」，新按下被拒，随后一个游离的 `up` 会把**旧**拖拽应用到**新**指针位置。已补三重活性守卫：`window.blur`、`visibilitychange`(hidden)、以及 `pointermove` 见到 `buttons === 0`（唯一能覆盖「拖到窗口外、在桌面上松手」的信号）。刻意不加「距上次移动 >1s 作废」的时间界：那会误伤「拖到一半停住想几秒再松手」的正常操作。
- **两个拖拽条带把「正在离场」的节点也算作槽位**：`HkListTransition` 的离场节点会挂 ~150ms（happy-dom 下永不离场，所以既有测试看不见 —— 测试正好过滤掉它们）。实测：删掉第一个 chip 后立刻拖第一个**存活** chip 到最前，**移动的是另一个 key**；面板里若查询把 3 个已选行隐藏 2 个，拖拽直接**失效**（`selectedRows[to]` 为 undefined）。已在两侧条带（以及 chip 的按下索引）统一排除离场类，并把两个复现都变成测试。
- 另修：索引派生的 stop id 在离场窗口会重号（`aria-activedescendant` 可能指向已删除的幽灵行）→ 改为按 key 生成（`encodeURIComponent(option.key)`），顺带让 id 在重排后保持稳定。

### 5. 其它
- 契约 JSDoc 更新（新 Enter 规则：只做「加」、绝不因查询命中而删；`maxTags` 只冻结「加」、排序仍可用；拖拽/键盘两套affordance）。
- 新增 `hikari::tagInput.reorder` = "Reorder {label}" × 11 语言（grip 的 aria-label/title）。
- 测试：`HkTagInput` 75 条 + 契约 6 条 + `usePointerReorder` 18 条；每个新守卫都做了**变异验证**（拆掉守卫 → 对应测试必挂），并有 DOM 父子关系断言（chip 是字段盒的直接子节点、行是 listbox 的直接子节点）兜住未来误加包裹元素。
- 版本 `packages/vue/package.json` 0.42.2 → **0.43.0**（合并后打 `v0.43.0` 触发 npm 发布，chest 再拾取）。

## 验证

| 门禁 | 结果 |
|---|---|
| `vitest run`（packages/vue，连跑两次） | **149 文件 / 1329 用例全绿**（两次一致；本机负载高时 `HkDateTimePicker` 有既有的日期敏感 flake，单跑 22/22 通过，该文件本 PR 未触碰） |
| `vue-tsc --noEmit` | 0 错 |
| `sass` 编译改动过的 SCSS | 通过 |

两路独立对抗子代理（一路查面板几何 + 对其它消费者的影响面，一路查排序/拖拽/动画语义与测试诚实性），均要求给出可执行证据；两条 MAJOR 都是它们**实际跑出来**的复现（探针脚本在 `/tmp/reorder-probe/`，不在仓内）。

## 已知留待后续（本 PR 不做，已记录）
- `HkAffixPicker` 同样是「不镜像字段宽但仍有 36rem 上限」——它渲染的是 `HkMenu` 而非 `HkSelectPanel`，要给它限高得先在共享 `HkMenu` 上加转发 prop 并覆盖其桌面/移动两处调用点，属于另一个需要独立评审的改动。
- 面板拖拽在触摸端没有中途反馈；chip 为了拖动不再可选中文本。
