### PR TITLE
📦 Release 0.43.2 for the tag editor panel and reorder work.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
## 为什么需要这个 PR

#462（标签编辑器面板几何 + 拖拽排序）合并时，版本号已经被并行的 #459 抬到 **0.43.1 并打标发布**，因此 #462 的改动**在 master 上、但不在任何已发布的 npm 包里**。npm 系列的发布以 `packages/vue/package.json` 的版本为准，故这里补一个号：**0.43.1 → 0.43.2**。

单一改动、无可捆绑的其它待办（#462 的后续项 `HkAffixPicker` 限高需要先给共享 `HkMenu` 加转发 prop，属独立需要评审的改动，不在本 PR 内）。

## 内容

- `packages/vue/package.json`：0.43.2（1 行）。
- 合并后打 `v0.43.2` 触发 npm 发布；随后 shittim-chest 拾取该版本，用户才能在后台「界面语言」标签编辑器里看到面板几何与拖拽排序的修复。

## 验证

- 相对 master 仅 1 行版本号改动，无代码差异；本地 `celestia-devtools verify-versions .` 与 `commit-msg-lint` 均通过。
- 上游 #462 本身的验证记录见该 PR（149→151 文件 / 1329→1345 用例两次全绿 + 两路对抗子代理多轮 + 真实浏览器 before/after 截图）。
