### PR TITLE
🐛 Scope the widened theme-menu icon cell to the leading slot.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.2",
+  "version": "0.43.3",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkThemeToggle.contract.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.contract.test.ts
@@ -6,6 +6,13 @@
  * layout engine, so the geometry contract is pinned as an scss-text
  * assertion: the theme-row lead cell must carry an explicit size that
  * fits the widest host lead mark, not just the mixin's generic box.
+ *
+ * The widened cell must stay scoped to the lead slot (2026-09-12 field
+ * report): shipped first as a bare `.s-theme-item-btn .hk-menu-item-icon`
+ * rule, it also matched the 自定义 row and every host row reusing
+ * s-theme-item-btn (chest's mode-extra DPI entry) — and mi.icon
+ * normalizes those cells' svg to the cell, so their 14px glyphs rendered
+ * 28px wide.
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -19,10 +26,18 @@ describe("HkThemeToggle row lead-cell contract", () => {
   it("sizes the theme-row lead cell to fit a 28px swatch mark", () => {
     const css = read("HkThemeToggle.scss");
     const block = css.match(
-      /\.s-theme-item-btn \.hk-menu-item-icon\s*\{[^}]*\}/,
+      /\.s-theme-item-btn \.hk-menu-item-icon\.s-theme-item-lead\s*\{[^}]*\}/,
     );
     expect(block).not.toBeNull();
     expect(block![0]).toContain("width: 28px");
     expect(block![0]).toContain("height: 28px");
+  });
+
+  it("does not widen icon cells outside the leading slot", () => {
+    const css = read("HkThemeToggle.scss");
+    // A bare `.s-theme-item-btn .hk-menu-item-icon {` rule also hits the
+    // customize row and host mode-extra rows; the widened cell may only
+    // target the lead slot class.
+    expect(css).not.toMatch(/\.s-theme-item-btn \.hk-menu-item-icon\s*\{/);
   });
 });

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -188,15 +188,22 @@
   @include mi.label;
 }
 
-/* Leading check / customize glyphs share the spec's fixed icon cell —
- * sized for the WIDEST lead mark hosts render there, not the generic
- * 16px box: chest's three-dot palette swatch is 28px (3×8px dots + 2px
- * gaps), and a mark wider than its cell bleeds symmetrically out of the
- * cell into the row gap — at fractional zoom rounding the dots visually
- * overlap the name (2026-09-11 field report). A uniform 28px cell keeps
- * every row's name starting at the same x (swatch rows and icon rows
- * stay aligned) and leaves the bleed zero room at any zoom. */
-.s-theme-item-btn .hk-menu-item-icon {
+/* Leading slot glyphs share the spec's fixed icon cell — sized for the
+ * WIDEST lead mark hosts render there, not the generic 16px box: chest's
+ * three-dot palette swatch is 28px (3×8px dots + 2px gaps), and a mark
+ * wider than its cell bleeds symmetrically out of the cell into the row
+ * gap — at fractional zoom rounding the dots visually overlap the name
+ * (2026-09-11 field report). A uniform 28px cell keeps every row's name
+ * starting at the same x (swatch rows and icon rows stay aligned) and
+ * leaves the bleed zero room at any zoom.
+ *
+ * The widened cell is scoped to the LEAD slot only (2026-09-12 field
+ * report): the bare `.s-theme-item-btn .hk-menu-item-icon` this shipped
+ * as also matched the 自定义 row and every host row reusing
+ * s-theme-item-btn (chest's mode-extra DPI entry), where mi.icon
+ * normalizes the svg to the cell — their 14px glyphs rendered 28px
+ * wide. Rows without a leading slot keep the standard menu metrics. */
+.s-theme-item-btn .hk-menu-item-icon.s-theme-item-lead {
   @include mi.icon;
 
   width: 28px;


### PR DESCRIPTION
## Problem (field report 2026-09-12)

The 0.42.2 fix for the 28px three-dot swatch bleed ("a uniform 28px cell keeps every row's name starting at the same x") shipped with a bare `.s-theme-item-btn .hk-menu-item-icon` selector. That selector matches **every** icon cell inside **any** button reusing `s-theme-item-btn`:

- hikari's own 自定义 (customize) row at the bottom of the menu (`Palette size={14}`),
- host `mode-extra` rows — concretely shittim-chest's DPI entry (`Scaling size={14}`).

Because `mi.icon` normalizes the cell's svg (`> svg { width:100%; height:100% }`), those 14px glyphs rendered at **28px — 2x their designed size**, visibly larger than the 16px mode icons next to them. Verified live in the deployed dev.face CSS: both `.s-theme-item-btn .hk-menu-item-icon{width:28px;height:28px}` and the svg-fill rule were present in the production bundle.

## Fix

Scope the widened cell to the leading slot only:

```scss
.s-theme-item-btn .hk-menu-item-icon.s-theme-item-lead { width: 28px; height: 28px; }
```

- `s-theme-item-lead` renders only in the `item-leading` slot branch, which hikari renders for **every** theme row when the host provides the slot — so the original alignment goal (swatch rows and icon rows share one name x) is fully preserved.
- The check cell (`s-theme-item-check`, no-slots path), the customize row, and host mode-extra rows return to the standard menu metrics (16px desktop / 20px sheet).
- Known cosmetic tradeoff (same class as pre-0.42.2): with a slot-rendering host, theme-row names indent 28+8px while the customize row indents 16+8px — a 12px step between the list and the customize affordance, vs. 2x glyph blow-up.

## Contract test

- Positive assertion updated to the scoped selector.
- New negative assertion pins that no bare `.s-theme-item-btn .hk-menu-item-icon {` rule may return (the exact shape that caused this regression).

## Verification

- Full vitest suite: 151 files / 1346 tests green (`vue-tsc --noEmit` exit 0) — round 1.
- Independent second-round cross-check: diff contains exactly the three expected files; merge-base = master head ae72b60 (0.43.2 taken by #463, so this PR takes 0.43.3); contract test provably fails on the pre-fix scss and passes post-fix; targeted tests 16/16.

Version: 0.43.3 (0.43.2 published via #463). Chest lockfile pickup PR follows after this merges and the tag publishes.