### PR TITLE
🔧 Adopt the org PR title check.

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,10 +1,3 @@
-# PR Title Check — validates PR titles against noa message rules.
-# Installed by: noa hook install-action
-# Requires: noa binary available in PATH (downloaded from GitHub Releases)
-#
-# The NOA_VERSION env var controls which release to fetch.
-# Defaults to "latest".
-
 name: PR Title Check
 
 on:
@@ -16,21 +9,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install noa
-        run: |
-          set -euo pipefail
-          VERSION="${NOA_VERSION:-latest}"
-          if [ "$VERSION" = "latest" ]; then
-            URL="https://github.com/celestia-island/noa/releases/latest/download/noa-linux-x86_64.tar.gz"
-          else
-            URL="https://github.com/celestia-island/noa/releases/download/${VERSION}/noa-linux-x86_64.tar.gz"
-          fi
-          curl -fsSL "$URL" -o /tmp/noa.tar.gz
-          tar -xzf /tmp/noa.tar.gz -C /usr/local/bin noa
-          chmod +x /usr/local/bin/noa
-
-      - name: Check PR title
-        run: noa hook validate-msg -m "${{ github.event.pull_request.title }}" -p celestia
+  pr-title-check:
+    uses: celestia-island/celestia-devtools/.github/workflows/pr-title-check.yml@master


### PR DESCRIPTION
Replaces this repo's repo-local title check with the org reusable workflow `celestia-island/celestia-devtools/.github/workflows/pr-title-check.yml@master`, which lints the PR title with celestia-devtools' `commit-msg-lint` on GitHub-hosted runners.
- Drops the per-run download of the `noa` release binary (glibc/`/usr/local/bin` install fragility) in favour of the shared linter the org rules name as authoritative.
- Runs on GitHub-hosted runners, so a title-only check never queues behind real builds on the shared self-hosted fleet.
- Trigger list and the `concurrency` block are preserved verbatim. The check is now reported as `pr-title-check / PR Title Check`; no ruleset in the org requires the old context (every protected repo requires only `lint-commits / Lint commit messages`).
- Dependabot PRs are exempt, matching the commit lint job.


Rebased onto current `master` to satisfy this repo's "require branches to be up to date" protection (`strict: true`); still a single commit with no merge commit.



Rebased again onto `master` (`fbb4a24231d8aaf813a5b650c0151573625eb5a0`) because a further master advance re-armed this repo's strict up-to-date requirement.
