### PR TITLE
📦 Release 0.43.4 for the affix picker cap and the drag lift.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.3",
+  "version": "0.43.4",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
## 为什么需要这个 PR

#466（`HkMenu`/`HkAffixPicker` 面板限高 + 拖拽抬起反馈）合并时，版本号**已经被并行的 #464 抬到 0.43.3 并从那个提交打标发布**，因此 #466 的改动在 master 上、但不在任何已发布的包里。npm 发布以 `packages/vue/package.json` 为准，故补一个号：**0.43.3 → 0.43.4**。

单一改动、无可捆绑的其它待办（本波剩余候选 `usePointerReorder.indexAt` 对宿主自定义 transform 的免疫情性加固属 composable 改动，需独立评审，不在本 PR）。

## 内容

- `packages/vue/package.json`：0.43.4（1 行）。
- 合并后打 `v0.43.4` 触发 npm 发布；随后 shittim-chest 拾取，用户才能在后台看到标签编辑器/标签选择器的这两处改进。

## 验证

- 相对 master 仅 1 行版本号，无代码差异；`commit-msg-lint` 本地通过。
- 上游 #466 的验证记录见该 PR（151 文件 / 1358 用例 + vue-tsc 0 + 独立对抗子代理跑出并修掉「等比缩放会让拖拽静默失效」）。
