### PR TITLE
✨ Align the customize row with the theme-menu icon column.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.5",
+  "version": "0.43.6",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkThemeToggle.contract.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.contract.test.ts
@@ -40,4 +40,24 @@ describe("HkThemeToggle row lead-cell contract", () => {
     // target the lead slot class.
     expect(css).not.toMatch(/\.s-theme-item-btn \.hk-menu-item-icon\s*\{/);
   });
+
+  it("aligns the customize row to the lead column without rescaling its glyph", () => {
+    const css = read("HkThemeToggle.scss");
+    // The customize affordance joins the 28px lead column (2026-09-11
+    // field report: its palette sat a full cell left of the rows' bitmap
+    // marks), but the glyph must keep the standard menu icon size —
+    // mi.icon normalizes svg to the cell, so the box is pinned back.
+    const block = css.match(
+      /\.s-theme-item-customize \.hk-menu-item-icon\s*\{[^}]*\}/,
+    );
+    expect(block).not.toBeNull();
+    expect(block![0]).toContain("width: 28px");
+    expect(block![0]).toContain("height: 28px");
+
+    const svgBlock = css.match(
+      /\.s-theme-item-customize \.hk-menu-item-icon > svg\s*\{[^}]*\}/,
+    );
+    expect(svgBlock).not.toBeNull();
+    expect(svgBlock![0]).toContain("var(--hk-menu-item-icon-box)");
+  });
 });

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -210,6 +210,26 @@
   height: 28px;
 }
 
+/* The customize affordance joins the theme rows' 28px lead column so the
+ * palette glyph and the row marks sit on one line and every name starts
+ * at the same x (2026-09-11 field report: with the lead cell at 28px and
+ * this row at the generic box, the selected theme's bitmap mark read a
+ * full cell to the right of the customize palette). The cell widens but
+ * the GLYPH keeps the standard menu icon size — mi.icon normalizes svg
+ * to the cell, so the box is pinned back explicitly; widening a cell
+ * must never re-scale its glyph (the 0.42.2 regression class). */
+.s-theme-item-customize .hk-menu-item-icon {
+  @include mi.icon;
+
+  width: 28px;
+  height: 28px;
+}
+
+.s-theme-item-customize .hk-menu-item-icon > svg {
+  width: var(--hk-menu-item-icon-box);
+  height: var(--hk-menu-item-icon-box);
+}
+
 /* Custom rows keep the name clear of the overlaid delete button. */
 .s-theme-item-row[data-custom] .s-theme-item-name {
   margin-right: 2rem;

--- a/packages/vue/src/components/HkThemeToggle.tsx
+++ b/packages/vue/src/components/HkThemeToggle.tsx
@@ -332,7 +332,7 @@ export const HkThemeToggle = defineComponent({
 
             <button
               type="button"
-              class="s-theme-item-btn"
+              class="s-theme-item-btn s-theme-item-customize"
               onClick={() => {
                 menuOpen.value = false;
                 if (props.externalCustomize) {


### PR DESCRIPTION
## Problem (field report 2026-09-11, mobile sheet)

Since #464 the theme rows' leading cell is 28px while the 自定义 (customize) affordance kept the generic icon box (16px desktop / 20px sheet). In the menu the selected theme's bitmap mark sits a full cell to the right of the customize palette — the two icon columns and the name starts don't line up.

## Fix

- The customize button gains a `s-theme-item-customize` class.
- Two flat rules give its icon cell the same 28px column as the lead cells, while pinning the glyph back to the standard menu icon box (`var(--hk-menu-item-icon-box)`, 16px desktop / 20px sheet) — `mi.icon` normalizes svg to the cell, so without the pin this would re-create the 0.42.2 glyph-rescale regression class that #464 fixed.

Desktop: 28px cell / 16px glyph; sheet: 28px cell / 20px glyph — the icon column, glyph centers and name starts all align with the theme rows at every zoom.

## Contract test

Third assertion pins both blocks: the 28px customize cell and the svg box pin (and #464's negative assertion still guarantees the bare `s-theme-item-btn` selector cannot return).

## Verification

- Targeted vitest 17/17; full cascade verified by actual sass compilation (specificity and source-order of every competing rule checked; sheet token context exercised).
- Chest side audited: theme rows (leading slot) unchanged, DPI entry (mode-extra) intentionally keeps the standard metrics.

Version: 0.43.6 (0.43.5 taken by the wave after #464). Chest lockfile pickup follows once this lands and the tag publishes.