### PR TITLE
🐛 Keep every drag's drop on the item the pointer actually grabbed.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.7",
+  "version": "0.43.8",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkTagInput.scss
+++ b/packages/vue/src/components/HkTagInput.scss
@@ -329,10 +329,12 @@
  * happened. The dimming stays LIGHT on purpose (0.85, the value of the
  * HkDraggableList/HkDraggableGrid drag ghost): the item must still read as
  * the one being moved, not fade out. `transform` reflows nothing — no
- * neighbour ever moves for it — and the axis rules below keep it out of the
- * drag's own geometry too. The raised shadow replaces the row's own
- * box-shadow faces for as long as the drag lasts (the keyboard cursor's
- * inset ring included: the lift is the live state).
+ * neighbour ever moves for it — and it cannot move the drag's own geometry
+ * either: the resolution reads the pressed item's line and midpoint from
+ * the layout captured when the press landed, before this lift is painted.
+ * The raised shadow replaces the row's own box-shadow faces for as long as
+ * the drag lasts (the keyboard cursor's inset ring included: the lift is
+ * the live state).
  *
  * Chips carry the state as classes (HkTag takes no arbitrary attributes),
  * panel rows as data attributes — both are assertable hooks that never
@@ -348,16 +350,17 @@
 }
 
 /* The scale runs ALONG each list's own drag axis — chips on X (a horizontal
- * strip), rows on Y (a vertical list). That split is TASTE, not geometry: a
- * small scale that follows the gesture keeps the lifted item tight in a
- * dense chip row. A drag resolves its landing slot from the items' LIVE
- * rects (usePointerReorder's `indexAt`): the item's MIDPOINT on the drag
- * axis picks the slot, and on the axis ACROSS it every item's span decides
- * which line the pointer is on — a filter that started out a no-op precisely
- * because every row spans the list's full width. The item being dragged may
- * not decide that line (a drop onto its own slot is already a no-op), so a
- * centre-anchored transform on it — along the axis or across it — leaves the
- * resolution exactly where it was. */
+ * strip), rows on Y (a vertical list): a small scale that follows the
+ * gesture keeps the lifted item tight in a dense chip row. WHICH axis it
+ * runs on is TASTE, not necessity — a drag resolves its landing slot from
+ * the items' live rects (usePointerReorder's `indexAt`), where every item's
+ * span on the axis ACROSS the drag decides which line the pointer is on and
+ * the item's MIDPOINT on the drag axis picks the slot, except that the item
+ * being dragged is measured by the geometry captured when the press landed,
+ * before this lift is painted: no transform on it, along the axis, across it
+ * or an isotropic `scale()`, can move the line it is dragged along. The line
+ * filter started out a no-op precisely because every row spans the list's
+ * full width. */
 .hk-tag-input-tag-dragging {
   transform: scaleX(1.03);
 }

--- a/packages/vue/src/components/HkTagInput.test.tsx
+++ b/packages/vue/src/components/HkTagInput.test.tsx
@@ -53,13 +53,16 @@ function mountTagInput(opts: MountOptions = {}) {
   };
   const container = document.createElement("div");
   document.body.appendChild(container);
+  /** The host's own array — the component's `modelValue` comes straight
+   *  from it, so a test can rewrite the order out of band (a host edit
+   *  landing mid-gesture) instead of only through the component's emits. */
+  const model = ref<readonly string[]>(opts.modelValue ?? []);
   const Host = defineComponent({
     name: "HkTagInputHost",
     setup() {
-      const value = ref<readonly string[]>(opts.modelValue ?? []);
       return () =>
         h(HkTagInput, {
-          modelValue: value.value,
+          modelValue: model.value,
           options: opts.options ?? OPTIONS,
           allowCustom: opts.allowCustom ?? false,
           label: opts.label,
@@ -72,7 +75,7 @@ function mountTagInput(opts: MountOptions = {}) {
           emptyText: opts.emptyText,
           "onUpdate:modelValue": (keys: string[]) => {
             events.modelValue.push(keys);
-            value.value = keys;
+            model.value = keys;
           },
           onAdd: (key: string) => events.add.push(key),
           onRemove: (key: string) => events.remove.push(key),
@@ -83,7 +86,7 @@ function mountTagInput(opts: MountOptions = {}) {
   const app = createApp(Host);
   app.mount(container);
   mounts.push({ app, container });
-  return { events, container };
+  return { events, container, model };
 }
 
 async function settle(): Promise<void> {
@@ -1192,6 +1195,15 @@ function holdPointer(
       clientY: from.y,
     }),
   );
+  movePointer(to, pointerType);
+}
+
+/** Move an already-held pointer — a second step of a gesture whose press
+ *  (and its exact travel) the test wants to control. */
+function movePointer(
+  to: { x: number; y: number },
+  pointerType: "mouse" | "touch" = "mouse",
+): void {
   window.dispatchEvent(
     new PointerEvent("pointermove", {
       bubbles: true,
@@ -1432,6 +1444,130 @@ describe("HkTagInput panel geometry and drag reordering", () => {
     expect(events.remove).toEqual([]);
     // The panel and the field agree on the new order.
     expect(rowLabels().slice(0, 3)).toEqual(["Technology", "Germany", "News"]);
+  });
+
+  it("leaves the order alone when a keyboard nudge lands under a held row drag", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    pinStrip(selected, 40, "y");
+    const search = searchInput();
+    search.focus();
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    // A drag on the FIRST row is held while the cursor's row is nudged with
+    // Alt+ArrowUp. The drag's landing slot is an index into the strip it
+    // grabbed, so a reorder under the held pointer would leave the release
+    // moving whatever now sits at that index — a different row, silently.
+    // The chord is still consumed (Alt+Arrow is not a plain arrow), it just
+    // has nothing to move while a pointer owns the order.
+    holdPointer({ x: 10, y: 10 }, { x: 10, y: 130 }, grip(selected[0]));
+    await settle();
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(events.modelValue, "the chord emits nothing mid-drag").toEqual([]);
+    expect(rowLabels().slice(0, 3), "the rows stayed where they were").toEqual([
+      "News",
+      "Technology",
+      "Germany",
+    ]);
+    releasePointer({ x: 10, y: 130 });
+    await settle();
+
+    // …and the drop moves the row the pointer actually grabbed.
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news"]);
+  });
+
+  it("keeps the chord out of a press that has not become a drag yet", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    pinStrip(selected, 40, "y");
+    const search = searchInput();
+    search.focus();
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    // The same chord, one step EARLIER: the pointer is down on the first
+    // row's grip but has not travelled the few pixels that turn a press into
+    // a drag, so nothing has been published yet. The press already owns the
+    // strip, though — crossing the threshold after the chord had moved a row
+    // would leave the drop resolving against a strip it never grabbed.
+    holdPointer({ x: 10, y: 10 }, { x: 12, y: 11 }, grip(selected[0]));
+    await settle();
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(events.modelValue, "the chord emits nothing under a live press").toEqual([]);
+
+    // Crossing the threshold now still moves the row the pointer grabbed.
+    movePointer({ x: 10, y: 130 });
+    releasePointer({ x: 10, y: 130 });
+    await settle();
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news"]);
+  });
+
+  it("keeps the chord out of a live CHIP drag too", async () => {
+    const { events, container } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const strip = tags(container);
+    pinStrip(strip, 60, "x");
+    const search = searchInput();
+    search.focus();
+    pressKey(search, "ArrowDown");
+    await settle();
+    pressKey(search, "ArrowDown");
+    await settle();
+    expect(activeRow()).toBe(rowByLabel("Technology"));
+
+    // The panel rows and the field's chips are two views of ONE array, so a
+    // chord that reorders the rows edits the strip a chip drag is resolving
+    // against — the drag has to hold the order whichever list it grabbed.
+    holdPointer({ x: 10, y: 10 }, { x: 200, y: 10 }, strip[0]);
+    await settle();
+    pressKey(search, "ArrowUp", { altKey: true });
+    await settle();
+    expect(events.modelValue, "the chord emits nothing mid-drag").toEqual([]);
+    expect(tagTexts(container), "the chips stayed where they were").toEqual([
+      "News",
+      "Technology",
+      "Germany",
+    ]);
+    releasePointer({ x: 200, y: 10 });
+    await settle();
+
+    // The chip the pointer grabbed is the one that moved.
+    expect(events.modelValue.at(-1)).toEqual(["tech", "de", "news"]);
+    expect(tagTexts(container)).toEqual(["Technology", "Germany", "News"]);
+  });
+
+  it("ends a row drag when the host reorders the list under it", async () => {
+    const { events, container, model } = mountTagInput({ modelValue: ["news", "tech", "de"] });
+    await openPanel(container);
+    const selected = reorderableRows();
+    pinStrip(selected, 40, "y");
+
+    holdPointer({ x: 10, y: 10 }, { x: 10, y: 130 }, grip(selected[0]));
+    await settle();
+    // The host rewrites its own order out of band while the drag is held:
+    // the index the drag resolves by no longer names the row it grabbed.
+    model.value = ["de", "news", "tech"];
+    await settle();
+    expect(rowLabels().slice(0, 3)).toEqual(["Germany", "News", "Technology"]);
+
+    releasePointer({ x: 10, y: 130 });
+    await settle();
+
+    // The gesture ends without a reorder — a drag may come to nothing, it
+    // must never move whichever row slid into the index it was holding.
+    expect(events.modelValue, "no reorder came out of the rewritten strip").toEqual([]);
+    expect(tagTexts(container)).toEqual(["Germany", "News", "Technology"]);
   });
 
   it("clamps a row drag to the selected group", async () => {
@@ -2059,14 +2195,16 @@ describe("HkTagInput drag feedback and text selection", () => {
 
   it("scales each list ALONG its drag axis and never across it", () => {
     // The drop slot is resolved from the items' live rects
-    // (usePointerReorder.indexAt): the item's midpoint on the drag axis
-    // picks the slot, and every item's span on the axis ACROSS it decides
-    // which line the pointer is on. A scale is symmetric about the centre,
-    // so scaling along the drag axis changes neither — while growing across
-    // it widens the dragged item's band, and a pointer a few pixels outside
-    // the strip would then match that item alone: every sibling falls out of
-    // the line filter and the drag silently collapses to a no-op. CSS is the
-    // only place this can regress, so each hook's own transform is pinned.
+    // (usePointerReorder.indexAt) except for the item being dragged, whose
+    // line across the list and midpoint along it come from the geometry
+    // captured when the press landed: the item's midpoint on the drag axis
+    // picks the slot, and each item's span on the axis ACROSS it decides
+    // which line the pointer is on. A transform ON the pressed item is
+    // measured from that pre-paint geometry either way, so the lift stays on
+    // the drag axis by TASTE — a small scale following the gesture keeps a
+    // dense chip row tight — rather than because the resolution needs it.
+    // CSS is the only place the lift can regress, so each hook's own
+    // transform is pinned.
     const axisTransform = (hook: string): string | undefined =>
       scss.match(
         new RegExp(`${hook.replace(/[[\]]/g, "\\$&")}\\s*\\{\\s*transform:\\s*([^;]+);`),

--- a/packages/vue/src/components/HkTagInput.tsx
+++ b/packages/vue/src/components/HkTagInput.tsx
@@ -155,11 +155,12 @@ type HkTagStop =
  *     lift scales ALONG each list's drag axis by TASTE, not by necessity: a
  *     small scale that follows the gesture keeps the lifted item's own
  *     footprint tight in a dense chip row. The drop slot is resolved from
- *     the items' live rects, but the dragged item never decides which line
- *     the pointer is on (it is only ever a candidate in the slot loop, and
- *     a drop onto its own slot is already a no-op), so a centre-preserving
- *     transform on it — along the axis, across it, or an isotropic
- *     `scale()` — leaves the resolution exactly where it was;
+ *     the items' live rects except for the item being dragged: its line
+ *     across the list and its midpoint along it come from the geometry
+ *     captured when the press landed, before the lift is painted, so no
+ *     transform on it — along the axis, across it, isotropic, or anchored
+ *     on an edge rather than its centre — can move the slot the pointer
+ *     resolves;
  *   - a key in `modelValue` that the catalog does not carry (a custom
  *     tag, or an option deleted since) degrades to its raw key as the
  *     tag label — the same rule as HkAffixPicker.tagEntries. Such a key
@@ -452,12 +453,22 @@ export const HkTagInput = defineComponent({
     /** The panel's keyboard reorder: move the ACTIVE row one slot inside
      *  the selected group (the same edit a row drag makes, without a
      *  pointer). Only a selected row has a place in that order, the ends of
-     *  the group are hard stops, and `false` means the key was not ours to
-     *  consume. The cursor stays on the key it was on — the stops rebuild
-     *  in the new order, so it follows the row the user moved. */
+     *  the group are hard stops, and `false` means there was nothing this
+     *  key could move. The cursor stays on the key it was on — the stops
+     *  rebuild in the new order, so it follows the row the user moved. */
     function nudgeActiveRow(delta: 1 | -1): boolean {
       const stop = activeStop.value;
       if (props.disabled || !stop || stop.kind !== "option") return false;
+      // A live press OWNS the order — either list's, and from the moment
+      // the press lands rather than from the moment it turns into a drag:
+      // the drag resolves its landing slot by INDEX, so a reorder under the
+      // held pointer (or under a press that is about to become one) would
+      // leave the release moving whatever now sits at that index — a
+      // different row, silently. The chord is still consumed by the caller
+      // either way (Alt+Arrow is not a plain arrow, and the browser must
+      // not act on it); it just has nothing to move while a pointer owns
+      // the list.
+      if (chipDrag.pressed.value || rowDrag.pressed.value) return false;
       const group = selectedRows.value;
       const from = group.findIndex((option) => option.key === stop.option.key);
       if (from < 0) return false;

--- a/packages/vue/src/composables/usePointerReorder.test.ts
+++ b/packages/vue/src/composables/usePointerReorder.test.ts
@@ -34,20 +34,135 @@ function strip(axis: "x" | "y", count = 3, size = 40) {
   return { container, items };
 }
 
+/** A hand-placed box: the geometry an element reports, on both axes. */
+interface Box {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/** Point an element at `box` — when it is built, and again mid-gesture by a
+ *  test that REPLACES the geometry: a transform painted on the dragged item
+ *  (the drag lift, a host's `scale()`) is exactly that, a live rect that
+ *  stops being the rect the item was laid out with. */
+function reshape(el: HTMLElement, box: Box): void {
+  Object.defineProperty(el, "getBoundingClientRect", {
+    configurable: true,
+    value: () => asRect(box),
+  });
+}
+
+/** `box` shaped the way the browser shapes a DOMRect read off an element. */
+function asRect(box: Box): DOMRect {
+  return {
+    ...box,
+    width: box.right - box.left,
+    height: box.bottom - box.top,
+    x: box.left,
+    y: box.top,
+  } as DOMRect;
+}
+
 /** Items with hand-placed boxes on BOTH axes — the wrapping-strip pattern,
  *  for the geometries only a transform produces (a band widened across the
  *  strip while the item keeps its place along it). */
-function boxes(geometry: Array<{ left: number; right: number; top: number; bottom: number }>): HTMLElement[] {
+function boxes(geometry: Box[]): HTMLElement[] {
   return geometry.map((box) => {
     const el = document.createElement("div");
-    Object.defineProperty(el, "getBoundingClientRect", {
-      configurable: true,
-      value: () =>
-        ({ ...box, width: box.right - box.left, height: box.bottom - box.top, x: box.left, y: box.top }) as DOMRect,
-    });
+    reshape(el, box);
     document.body.appendChild(el);
     return el;
   });
+}
+
+/** A strip whose items sit inside a FRAME that an ancestor moves as a whole
+ *  — the shape of a field (or a panel list) inside a page or a modal body
+ *  that scrolls: no scroller is handed to the composable at all, and the
+ *  items and the box they are laid out in travel together. `shift` moves
+ *  both, which is all an ancestor scroll does to a strip it does not own. */
+function framedStrip(geometry: Box[]): {
+  frame: HTMLElement;
+  items: HTMLElement[];
+  shift: (dx: number, dy: number) => void;
+  scale: (k: number) => void;
+} {
+  const frame = document.createElement("div");
+  document.body.appendChild(frame);
+  const live = geometry.map((box) => ({ ...box }));
+  const bounds = geometry.reduce(
+    (acc, box) => ({
+      left: Math.min(acc.left, box.left),
+      right: Math.max(acc.right, box.right),
+      top: Math.min(acc.top, box.top),
+      bottom: Math.max(acc.bottom, box.bottom),
+    }),
+    { left: Number.POSITIVE_INFINITY, right: Number.NEGATIVE_INFINITY, top: Number.POSITIVE_INFINITY, bottom: Number.NEGATIVE_INFINITY },
+  );
+  Object.defineProperty(frame, "getBoundingClientRect", {
+    configurable: true,
+    value: () => asRect(bounds),
+  });
+  const items = live.map((_box, i) => {
+    const el = document.createElement("div");
+    Object.defineProperty(el, "getBoundingClientRect", {
+      configurable: true,
+      value: () => asRect(live[i]),
+    });
+    frame.appendChild(el);
+    return el;
+  });
+  return {
+    frame,
+    items,
+    shift: (dx, dy) => {
+      live.forEach((box, i) => {
+        live[i] = {
+          left: geometry[i].left + dx,
+          right: geometry[i].right + dx,
+          top: geometry[i].top + dy,
+          bottom: geometry[i].bottom + dy,
+        };
+      });
+      bounds.left = Math.min(...live.map((box) => box.left));
+      bounds.right = Math.max(...live.map((box) => box.right));
+      bounds.top = Math.min(...live.map((box) => box.top));
+      bounds.bottom = Math.max(...live.map((box) => box.bottom));
+    },
+    /** Paint a uniform `scale(k)` on the frame about its own top-left
+     *  corner — what a browser paints on the box AND on everything laid out
+     *  inside it: the corner stays put while the content travels toward it,
+     *  which is exactly the movement a translation cannot describe. */
+    scale: (k: number) => {
+      const { left, top } = bounds;
+      const grow = (box: Box): Box => ({
+        left: left + (box.left - left) * k,
+        right: left + (box.right - left) * k,
+        top: top + (box.top - top) * k,
+        bottom: top + (box.bottom - top) * k,
+      });
+      live.forEach((box, i) => {
+        live[i] = grow(box);
+      });
+      const box = grow(bounds);
+      bounds.left = box.left;
+      bounds.right = box.right;
+      bounds.top = box.top;
+      bounds.bottom = box.bottom;
+    },
+  };
+}
+
+/** The rect an edge-anchored `transform: scale(k)` paints on a laid-out box:
+ *  the box grows AWAY from the anchored corner on both axes, so anchoring
+ *  the top or the bottom edge is what slides an item's cross-axis band onto
+ *  (or off) a neighbouring line while its layout band stays put. */
+function scaled(box: Box, k: number, anchorX: "left" | "right", anchorY: "top" | "bottom"): Box {
+  const width = (box.right - box.left) * k;
+  const height = (box.bottom - box.top) * k;
+  const left = anchorX === "left" ? box.left : box.right - width;
+  const top = anchorY === "top" ? box.top : box.bottom - height;
+  return { left, right: left + width, top, bottom: top + height };
 }
 
 /** Waits out `frames` animation frames — the auto-scroll loop steps once
@@ -61,7 +176,8 @@ async function frames(count: number): Promise<void> {
 /** A scrollable strip for the auto-scroll tests: the container reports a
  *  fixed box and holds real `scrollTop`/`scrollLeft` numbers, and every
  *  item is placed relative to the current scroll offset — which is exactly
- *  what a browser does to the content a scroll moves under the pointer. */
+ *  what a browser does to the content a scroll moves under the pointer,
+ *  along the strip AND across it. */
 function scrollStrip(
   axis: "x" | "y",
   count: number,
@@ -87,11 +203,12 @@ function scrollStrip(
       configurable: true,
       value: () => {
         const offset = (axis === "x" ? container.scrollLeft : container.scrollTop);
+        const across = (axis === "x" ? container.scrollTop : container.scrollLeft);
         const start = i * size - offset;
         const item =
           axis === "x"
-            ? { left: start, right: start + size, top: 0, bottom: size }
-            : { left: 0, right: size, top: start, bottom: start + size };
+            ? { left: start, right: start + size, top: -across, bottom: size - across }
+            : { left: -across, right: size - across, top: start, bottom: start + size };
         return { ...item, width: size, height: size, x: item.left, y: item.top } as DOMRect;
       },
     });
@@ -182,6 +299,32 @@ function cancel(id = 1): void {
   window.dispatchEvent(
     new PointerEvent("pointercancel", { bubbles: true, pointerId: id, pointerType: "touch" }),
   );
+}
+
+/** One whole gesture over a strip: press item `from` at `at`, optionally
+ *  paint `lift` on that item — a transform lands AFTER the press, which is
+ *  the whole point of the press-time snapshot — then run the pointer along
+ *  `path` and release on its last point. Returns the slot published after
+ *  every move, and the drop. */
+function gesture(
+  axis: "x" | "y",
+  items: HTMLElement[],
+  from: number,
+  at: { x: number; y: number },
+  path: Array<{ x: number; y: number }>,
+  lift?: { index: number; box: Box },
+): { over: number[]; drops: Array<[number, number]> } {
+  const { handle, drops } = harness(axis, items);
+  press(handle, items, from, at);
+  if (lift) reshape(items[lift.index], lift.box);
+  const over: number[] = [];
+  for (const point of path) {
+    move(point.x, point.y);
+    over.push(handle.dragOver.value);
+  }
+  const last = path[path.length - 1];
+  up(last.x, last.y);
+  return { over, drops };
 }
 
 afterEach(() => {
@@ -412,22 +555,27 @@ describe("usePointerReorder", () => {
   });
 
   it("resolves past a dragged chip whose own band is widened across the strip", () => {
-    // One line of three chips, the DRAGGED one (index 1) reporting a band
-    // widened ACROSS the strip — which is what any transform on it does: a
+    // One line of three chips, the DRAGGED one (index 1) carrying a band
+    // widened ACROSS the strip — which is what a transform on it does: a
     // host's `scale()` on a wrapper, a zoomed container, a theme animating a
     // chip. The pointer sits 3px outside the SIBLINGS' band (43 against
-    // 0-40) and inside the widened one, so the dragged chip is the unique
-    // zero-gap match: left to define the line on its own it filters every
-    // sibling out and the slot collapses onto its own index — a silent
-    // no-op, no reorder and no drop ring.
-    const items = boxes([
+    // 0-40) and inside the widened one, so the widened band is the unique
+    // zero-gap match: were it the geometry that defines the line, it would
+    // filter every sibling out and collapse the slot onto the chip's own
+    // index — a silent no-op, no reorder and no drop ring. The press read the
+    // chip's LAYOUT band, before the lift was painted, and that is the band
+    // the line is read on.
+    const laid: Box[] = [
       { left: 0, right: 100, top: 0, bottom: 40 },
-      { left: 100, right: 200, top: -8, bottom: 48 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
       { left: 200, right: 300, top: 0, bottom: 40 },
-    ]);
+    ];
+    const items = boxes(laid);
     const { handle, drops } = harness("x", items);
 
     press(handle, items, 1, { x: 150, y: 20 });
+    // The lift lands now — after the press was read.
+    reshape(items[1], { left: 100, right: 200, top: -8, bottom: 48 });
     move(260, 43);
     expect(handle.dragging.value).toBe(true);
     expect(handle.dragOver.value, "260 is past item 2's midpoint of 250").toBe(2);
@@ -437,26 +585,32 @@ describe("usePointerReorder", () => {
 
   it("resolves the panel rows the same way when the dragged row's band is widened", () => {
     // The same defect on the vertical strip, whose cross axis is x: the
-    // dragged row (index 1) reports its band widened from 0-40 to -8-48, so
-    // the pointer at x 44 is 4px outside the siblings' band and inside the
-    // dragged one. Both ends of the strip answer — the leading edge, then
-    // the last row.
-    const items = boxes([
+    // dragged row (index 1) is lifted with its band widened from 0-40 to
+    // -8-48, so the pointer at x 44 is 4px outside the siblings' band and
+    // inside the lifted one. Both ends of the strip answer — the leading
+    // edge, then the last row.
+    const laid: Box[] = [
       { left: 0, right: 40, top: 0, bottom: 40 },
-      { left: -8, right: 48, top: 40, bottom: 80 },
+      { left: 0, right: 40, top: 40, bottom: 80 },
       { left: 0, right: 40, top: 80, bottom: 120 },
-    ]);
+    ];
+    const widened: Box = { left: -8, right: 48, top: 40, bottom: 80 };
+    const items = boxes(laid);
     const { handle, drops } = harness("y", items);
 
     press(handle, items, 1, { x: 20, y: 60 });
+    reshape(items[1], widened);
     move(44, 5);
     expect(handle.dragging.value).toBe(true);
     expect(handle.dragOver.value, "5 is before every row's midpoint").toBe(0);
     up(44, 5);
     expect(drops).toEqual([[1, 0]]);
 
-    // …and 140 is past the last row's midpoint of 100.
+    // …and 140 is past the last row's midpoint of 100. The release dropped
+    // the lift, so the next press reads the row's layout box again.
+    reshape(items[1], laid[1]);
     press(handle, items, 1, { x: 20, y: 60 });
+    reshape(items[1], widened);
     move(44, 140);
     expect(handle.dragOver.value).toBe(2);
     up(44, 140);
@@ -468,11 +622,12 @@ describe("usePointerReorder", () => {
 
   it("resolves the no-drag path (from = -1) exactly as it always did", () => {
     // `from = -1` is the call with no drag in flight: nothing is the item
-    // being dragged, so nothing may be left out of the line — the exclusion
-    // is INERT there, not a rewrite of the resolution. The widened band
-    // therefore still owns the line on its own, which is the pre-fix value
-    // the strip resolved before the dragged item was ever excluded (the same
-    // gesture with `from = 1` answers 0 instead — see the panel-rows test).
+    // being dragged, so no origin geometry is in play and every item is
+    // measured by its own live rect — the widened band therefore still owns
+    // the line on its own, which is the value the strip resolved before the
+    // dragged item was ever read any other way (the same gesture with
+    // `from = 1` answers 0 instead — see the panel-rows test, whose press
+    // happens before its row is widened).
     const items = boxes([
       { left: 0, right: 40, top: 0, bottom: 40 },
       { left: -8, right: 48, top: 40, bottom: 80 },
@@ -495,13 +650,38 @@ describe("usePointerReorder", () => {
     expect(drops).toEqual([]);
   });
 
+  it("keeps the classic answer when the lines' bands overlap and nothing is transformed", () => {
+    // Chips of different heights on one wrapping row (align-items:
+    // flex-start) give the lines bands that OVERLAP rather than nest. The
+    // dragged chip (index 0) is the tallest, so a pointer pulled below the
+    // strip is nearest ITS band and the classic answer is its own slot —
+    // while the removed wave-5 heuristic, scoring the line off the siblings
+    // alone, raised the nearest gap to the shorter chips', pulled them into
+    // the walk and answered slot 1: a reorder out of a drag that resolves to
+    // its own slot, with nothing transformed anywhere.
+    const items = boxes([
+      { left: 0, right: 100, top: 0, bottom: 60 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ]);
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10, y: 20 });
+    move(200, 80);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "no sibling's line is as near the pointer as its own").toBe(0);
+    up(200, 80);
+    expect(drops, "a drag resolving to its own slot emits nothing").toEqual([]);
+  });
+
   it("lets the dragged item speak for a line no sibling shares", () => {
     // A chip wrapped onto a line of its own (index 2) while it is dragged:
-    // no sibling is on that line, so the dragged item's band IS the line the
-    // pointer is on and a drag within it stays the no-op it always was.
-    // Ignoring the dragged item's band outright instead would let the
-    // nearest OTHER line — a full row above — answer, and a 90px drag along
-    // its own line would jump the chip up into it.
+    // no sibling is on that line, so the band the chip was LAID OUT on IS
+    // the line the pointer is on — which is why the resolution needs no
+    // special case for the dragged item at all — and a drag within it stays
+    // the no-op it always was. Reading the line off the siblings only would
+    // let the nearest OTHER line — a full row above — answer, and a 90px
+    // drag along its own line would jump the chip up into it.
     const items = boxes([
       { left: 0, right: 100, top: 0, bottom: 40 },
       { left: 100, right: 200, top: 0, bottom: 40 },
@@ -515,6 +695,300 @@ describe("usePointerReorder", () => {
     expect(handle.dragOver.value, "the pointer is still on the chip's own line").toBe(2);
     up(100, 60);
     expect(drops).toEqual([]);
+  });
+
+  it("answers an edge-anchored cross-axis scale on a lone item as if it were not there", () => {
+    // The corner wave 5 recorded as unfixable-by-heuristic: a chip wrapped
+    // onto a line of its own, lifted 2.4x about its BOTTOM edge. The band
+    // grows 96px UP over the whole row above, so the band's CENTRE (32)
+    // lands inside that row's band (0-40) — the wave-5 centre test read the
+    // chip as sharing a line, left its exclusion inert, and the pointer on
+    // the chip's own line was answered from the row above (0 or 1 where the
+    // chip's own line answers 2). The band the press read is the chip's own
+    // line, whatever the lift does to the band afterwards.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 0, right: 60, top: 40, bottom: 80 },
+    ];
+    // 2.4x about the bottom-left corner: {0, 144, -16, 80}.
+    const lift = scaled(laid[2], 2.4, "left", "bottom");
+    expect(lift, "the lift covers the row above and the chip's own line").toEqual({
+      left: 0,
+      right: 144,
+      top: -16,
+      bottom: 80,
+    });
+    const cases = [
+      { point: { x: 30, y: 60 }, slot: 2 },
+      { point: { x: 100, y: 60 }, slot: 2 },
+      { point: { x: 30, y: 20 }, slot: 0 },
+      { point: { x: 100, y: 20 }, slot: 1 },
+    ];
+    for (const { point, slot } of cases) {
+      const oracle = gesture("x", boxes(laid), 2, { x: 5, y: 60 }, [point]);
+      const lifted = gesture("x", boxes(laid), 2, { x: 5, y: 60 }, [point], { index: 2, box: lift });
+      expect(oracle.over, `the unlifted chip answers ${slot} at ${JSON.stringify(point)}`).toEqual([slot]);
+      expect(
+        lifted.over,
+        `lifted, ${JSON.stringify(point)} answers exactly as if it were not transformed`,
+      ).toEqual(oracle.over);
+      expect(lifted.drops).toEqual(oracle.drops);
+    }
+  });
+
+  it("answers an edge-anchored scale onto a neighbour's line as if it were not there", () => {
+    // The other recorded corner: the dragged chip (index 1) shares the first
+    // line, and a 2.03x scale about its TOP edge grows its band over the
+    // whole second line — 2.03 is where that band is deep enough for its
+    // centre (40.6) to reach into the second line's band (40-80), the
+    // "shared" reading that left the chip's own live geometry deciding. A
+    // pointer on the second line has to land on the row under it.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+      { left: 0, right: 100, top: 40, bottom: 80 },
+      { left: 100, right: 200, top: 40, bottom: 80 },
+    ];
+    // 2.03x about the top-left corner: {100, 303, 0, 81.2}.
+    const lift = scaled(laid[1], 2.03, "left", "top");
+    expect(lift.bottom, "the band reaches into the second line").toBeGreaterThan(80);
+    const cases = [
+      { point: { x: 160, y: 60 }, slot: 4 },
+      { point: { x: 100, y: 60 }, slot: 3 },
+      { point: { x: 150, y: 20 }, slot: 1 },
+      { point: { x: 260, y: 20 }, slot: 2 },
+    ];
+    for (const { point, slot } of cases) {
+      const oracle = gesture("x", boxes(laid), 1, { x: 110, y: 20 }, [point]);
+      const lifted = gesture("x", boxes(laid), 1, { x: 110, y: 20 }, [point], { index: 1, box: lift });
+      expect(oracle.over, `the unlifted chip answers ${slot} at ${JSON.stringify(point)}`).toEqual([slot]);
+      expect(
+        lifted.over,
+        `lifted, ${JSON.stringify(point)} answers exactly as if it were not transformed`,
+      ).toEqual(oracle.over);
+      expect(lifted.drops).toEqual(oracle.drops);
+    }
+  });
+
+  it("measures the dragged item's laid-out midpoint, not the one its lift moved", () => {
+    // A lift anchored on the chip's LEADING edge — `transform-origin: left`
+    // on a scale along the drag axis, the growth reading as the chip still
+    // held where it was picked up — carries the chip's live midpoint 110px
+    // right of the one it was laid out with (150 -> 260). The walk measures
+    // the laid-out midpoint: a pointer 5px past item 2's midpoint lands on
+    // item 2, however far the lift stretched item 1 past it.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    // scaleX(3.2) about the leading edge: 100 -> 420, midpoint 260.
+    const lift: Box = { left: 100, right: 420, top: 0, bottom: 40 };
+    const cases = [
+      { point: { x: 255, y: 20 }, slot: 2 },
+      { point: { x: 280, y: 20 }, slot: 2 },
+      { point: { x: 210, y: 20 }, slot: 1 },
+    ];
+    for (const { point, slot } of cases) {
+      const oracle = gesture("x", boxes(laid), 1, { x: 150, y: 20 }, [point]);
+      const lifted = gesture("x", boxes(laid), 1, { x: 150, y: 20 }, [point], { index: 1, box: lift });
+      expect(oracle.over, `the unstretched chip answers ${slot} at ${JSON.stringify(point)}`).toEqual([slot]);
+      expect(
+        lifted.over,
+        `stretched, ${JSON.stringify(point)} answers exactly as if it were not`,
+      ).toEqual(oracle.over);
+      expect(lifted.drops).toEqual(oracle.drops);
+    }
+  });
+
+  it("keeps the pressed item's geometry on the content when the surface scrolls", () => {
+    // A host scrolling its own surface under a live drag — this composable's
+    // auto-scroll is not the only thing that moves the strip. The geometry
+    // the press read travels with the content along the strip, so the slot
+    // follows it: the same gesture aimed at the same CONTENT point without
+    // the scroll is the answer to match, and both are pinned below.
+    const { container, items } = scrollStrip("y", 6, 40, 200);
+    const { handle, drops } = harness("y", items, undefined, () => container);
+
+    press(handle, items, 2, { x: 20, y: 90 });
+    container.scrollTop = 80; // the host scrolls the surface
+    move(20, 60); // …with the pointer held where it is
+    expect(handle.dragOver.value, "the slot follows the content the scroll moved").toBe(3);
+    up(20, 60);
+    expect(drops).toEqual([[2, 3]]);
+
+    // The oracle: one strip, no scroll, the pointer on the same content
+    // point (80px further down the strip — what the scroll moved).
+    const plain = gesture("y", scrollStrip("y", 6, 40, 200).items, 2, { x: 20, y: 90 }, [
+      { x: 20, y: 140 },
+    ]);
+    expect(plain.over).toEqual([3]);
+    expect(plain.drops).toEqual(drops);
+  });
+
+  it("keeps the pressed item's band on the content when the surface scrolls across it", () => {
+    // The band is the cross-axis half of the same geometry, so a surface
+    // that scrolls ACROSS the strip (a wide wrapper around a column of rows)
+    // carries it too. With the content 30px to the left the pointer sits past
+    // the whole strip, so every band is equally far from it and the rows
+    // resolve the slot by their midpoints; a snapshot left at the
+    // press-time coordinates would be the band NEAREST the pointer instead,
+    // the pressed row would own the line on its own, and the drag would
+    // answer its own index.
+    const { container, items } = scrollStrip("y", 3, 40, 200);
+    const { handle, drops } = harness("y", items, undefined, () => container);
+
+    press(handle, items, 1, { x: 20, y: 60 });
+    container.scrollLeft = 30;
+    move(44, 100);
+    expect(handle.dragOver.value, "the band moved with the content, so the rows decide").toBe(2);
+    up(44, 100);
+    expect(drops).toEqual([[1, 2]]);
+
+    // The oracle: the same content point (30px further right — what the
+    // scroll moved) on a strip that never scrolled.
+    const plain = gesture("y", scrollStrip("y", 3, 40, 200).items, 1, { x: 20, y: 60 }, [
+      { x: 74, y: 100 },
+    ]);
+    expect(plain.over).toEqual([2]);
+    expect(plain.drops).toEqual(drops);
+  });
+
+  it("swallows the click of a drag it had to abandon", () => {
+    // An abandoned drag was still a drag: the pointer travelled past the
+    // threshold, so the click the browser delivers at wherever it came to
+    // rest is one the user never made. Left unswallowed it reaches the row
+    // under the pointer and toggles a tag the user did not press.
+    const items = boxes([
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ]);
+    const { handle, drops } = harness("x", items);
+    const inner = document.createElement("span");
+    items[0].appendChild(inner);
+    const clicks: string[] = [];
+    inner.addEventListener("click", () => clicks.push("row"));
+
+    press(handle, items, 0, { x: 10, y: 20 });
+    move(150, 20);
+    items.reverse(); // the strip reorders under the drag: it must give way
+    move(260, 20);
+    up(260, 20);
+    expect(drops).toEqual([]);
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks, "the abandoned drag swallowed its trailing click").toEqual([]);
+
+    // …and only that one: the next real click is delivered again.
+    inner.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(clicks).toEqual(["row"]);
+  });
+
+  it("abandons a drag whose strip reorders under it rather than dropping a foreign item", () => {
+    // The caller hands its items over in DISPLAY order, so the index a drag
+    // resolves is only meaningful while that index still names the element
+    // the press grabbed. A strip that reorders mid-gesture — a host edit
+    // from outside, a keyboard reorder, a row toggled by a second pointer, a
+    // leaving item that finally leaves — puts a different element there, and
+    // a drop resolved from that index would move whichever item slid into
+    // the slot: never the one the pointer is holding. The gesture ends
+    // instead, without a reorder.
+    const items = boxes([
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ]);
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10, y: 20 });
+    move(150, 20);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "150 is past the first chip's midpoint").toBe(1);
+
+    // The strip reorders under the live drag: index 0 is another chip now.
+    items.reverse();
+    move(260, 20);
+    expect(handle.dragging.value, "the drag ended with the strip it was reading").toBe(false);
+    expect(handle.dragFrom.value).toBe(-1);
+    expect(handle.dragOver.value).toBe(-1);
+    up(260, 20);
+    expect(drops, "nothing was dropped").toEqual([]);
+  });
+
+  it("keeps the pressed item's geometry on the content when the frame is SCALED under it", () => {
+    // A `scale()` or a zoom painted on the frame — or on an ancestor — during
+    // a live drag is not a movement the frame's DISPLACEMENT can describe:
+    // the frame's origin corner stays put while the content inside travels
+    // toward it, so a snapshot shifted by the corner's movement alone stays
+    // where the press left it while every sibling moves, and the closer the
+    // pressed chip sat to that corner the smaller the error looks. The
+    // snapshot travels with the frame's BOX instead — the same place inside
+    // it — so the drag resolves exactly as it would have against a strip
+    // laid out that way from the start: the pointer is past the whole
+    // (shrunken) strip, and the chip lands last.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const { items, scale } = framedStrip(laid);
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 1, { x: 150, y: 20 });
+    move(150, 20);
+    expect(handle.dragging.value, "a press that has not moved is not a drag").toBe(false);
+
+    scale(0.5); // the host zooms the strip under the live drag
+    move(130, 20);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "130 is past the third chip's scaled midpoint of 125").toBe(2);
+    up(130, 20);
+    expect(drops).toEqual([[1, 2]]);
+
+    // The oracle: the same gesture against a strip that was laid out that
+    // way all along (a 50px chip row, the pointer past its end).
+    const plain = gesture("x", boxes([
+      { left: 0, right: 50, top: 0, bottom: 40 },
+      { left: 50, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 150, top: 0, bottom: 40 },
+    ]), 1, { x: 75, y: 20 }, [{ x: 130, y: 20 }]);
+    expect(plain.over).toEqual([2]);
+    expect(plain.drops).toEqual(drops);
+  });
+
+  it("carries the pressed item's geometry with a frame an ancestor scrolls under it", () => {
+    // The chip field owns no scroller of its own, so nothing about this
+    // gesture is declared to the composable — while the page (or a modal
+    // body) the field sits in scrolls a line under the live drag, moving the
+    // chips and the frame they are laid out in together. A snapshot left in
+    // the press-time viewport coordinates stops sharing a line with every
+    // sibling, and because it is the ONE band that still holds the pointer,
+    // the pressed chip owns the line on its own: every sibling drops out of
+    // the filter and the drag collapses onto its own index — the silent
+    // no-op this resolution exists to prevent. The frame it was read in is
+    // what has to travel with it.
+    const laid: Box[] = [
+      { left: 0, right: 40, top: 0, bottom: 40 },
+      { left: 40, right: 80, top: 0, bottom: 40 },
+      { left: 80, right: 120, top: 0, bottom: 40 },
+    ];
+    const { items, shift } = framedStrip(laid);
+    const { handle, drops } = harness("x", items);
+
+    press(handle, items, 0, { x: 10, y: 20 });
+    shift(0, 40); // the ancestor scrolls the whole strip a line down
+    move(90, 20); // …with the pointer held where it was
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "90 is past item 1's midpoint and before item 2's").toBe(1);
+    up(90, 20);
+    expect(drops).toEqual([[0, 1]]);
+
+    // The oracle: the same gesture on a strip nothing moved under.
+    const plain = gesture("x", framedStrip(laid).items, 0, { x: 10, y: 20 }, [{ x: 90, y: 20 }]);
+    expect(plain.over).toEqual([1]);
+    expect(plain.drops).toEqual(drops);
   });
 
   it("retires a stale click trap when a new press starts", () => {

--- a/packages/vue/src/composables/usePointerReorder.ts
+++ b/packages/vue/src/composables/usePointerReorder.ts
@@ -71,10 +71,27 @@ export interface PointerReorder {
   dragOver: Ref<number>;
   /** A press crossed the threshold and is being dragged. */
   dragging: Ref<boolean>;
+  /** A press is LIVE — from the moment `start` accepted it, before it has
+   *  crossed the threshold into a drag. The strip is this gesture's until
+   *  it ends, so a caller that can change the order by other means (the
+   *  panel's own keyboard reorder, a host edit) can hold off while this is
+   *  `true`: the drag resolves by INDEX, and an order that moves under it
+   *  is an order the release would misread. */
+  pressed: Ref<boolean>;
   /** Watch a press on item `index` (item 0 of `items()` is index 0).
    *  Nothing is reported until the pointer travels past the threshold,
    *  so a tap stays a plain click and the page keeps its scrolling. */
   start: (event: PointerEvent, index: number) => void;
+}
+
+/** The geometry item `from` was LAID OUT with — its span across the strip
+ *  (`band`) and its position along it (`mid`), in the pointer's own
+ *  coordinates, both shifted by however much the item's frame has moved
+ *  since they were read. `usePointerReorder` reads it at press time,
+ *  before anything is painted on the item. */
+export interface PointerReorderOrigin {
+  band: { lo: number; hi: number };
+  mid: number;
 }
 
 /** The display index the dragged item lands ON for a pointer at
@@ -97,66 +114,60 @@ export interface PointerReorder {
  *  candidate midpoint), which becomes a landing index by accounting for
  *  the dragged item's own removal — dragging past one neighbour's
  *  midpoint swaps with that neighbour instead of skipping it. -1 for an
- *  empty strip. */
+ *  empty strip.
+ *
+ *  `origin` is item `from`'s LAYOUT geometry, and it is what both steps
+ *  read for that one item: the line filter scores it on the band it was
+ *  LAID OUT on and the walk measures its laid-out midpoint. That geometry
+ *  is trustworthy — it is the single rect read before anything was painted
+ *  on the item, so no drag lift and no host `scale()` can move the line the
+ *  user is dragging along, nor stop the walk short inside the item itself —
+ *  which is exactly what the item's LIVE rect cannot promise while the item
+ *  is being dragged. Every other item keeps its live rect: siblings are not
+ *  transformed by the drag. Omitted (or null), item `from` is measured by
+ *  its live rect like every other item, which is the classic resolution a
+ *  caller with no press to read an origin at gets. */
 export function indexAt(
   rects: readonly DOMRect[],
   axis: PointerReorderAxis,
   main: number,
   cross: number,
   from: number,
+  origin?: PointerReorderOrigin | null,
 ): number {
   if (rects.length === 0) return -1;
+  const own = origin && from >= 0 && from < rects.length ? origin : null;
   /** An item's span ACROSS the strip — the axis the line is read on. */
-  const band = (rect: DOMRect) =>
-    axis === "x" ? { lo: rect.top, hi: rect.bottom } : { lo: rect.left, hi: rect.right };
+  const band = (rect: DOMRect, index: number) => {
+    if (own && index === from) return own.band;
+    return axis === "x" ? { lo: rect.top, hi: rect.bottom } : { lo: rect.left, hi: rect.right };
+  };
+  /** An item's position ALONG the strip. */
+  const mid = (rect: DOMRect, index: number) => {
+    if (own && index === from) return own.mid;
+    return axis === "x" ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
+  };
   // Nearest line wins: items in the pointer's own band score 0, and a
   // pointer between two bands takes the closer one. The half-pixel
   // tolerance keeps the siblings of ONE wrapped line together, whose
-  // bands can differ by sub-pixel rounding.
-  const lineGap = rects.map((rect) => {
-    const { lo, hi } = band(rect);
+  // bands can differ by sub-pixel rounding. The dragged item is scored
+  // against its layout band like every other item — no exclusion, no
+  // centre test: with the geometry above it cannot be the band that a
+  // transform painted on it, so letting it speak (which a lone item on its
+  // own line must be able to do — a single-file strip has no other item to
+  // name that line) can no longer collapse the slot onto its own index.
+  const lineGap = rects.map((rect, index) => {
+    const { lo, hi } = band(rect, index);
     return cross < lo ? lo - cross : cross > hi ? cross - hi : 0;
   });
-  // The line is decided by the items OTHER than the one being dragged: a
-  // drop onto the dragged item's own slot is already a no-op, so it must
-  // never be the geometry that decides which line the pointer is on —
-  // which is what makes the resolution invariant to whatever transform the
-  // host paints on the item being moved. Its live rect reflects that
-  // transform (the drag lift, a zoomed container, a `scale()` on a wrapper),
-  // so a band widened across the strip would otherwise be the unique
-  // zero-gap match: every sibling filtered out, the slot collapsed onto the
-  // item's own index, and the whole drag a silent no-op.
   let nearest = Number.POSITIVE_INFINITY;
   for (let i = 0; i < lineGap.length; i += 1) {
-    if (i !== from && lineGap[i] < nearest) nearest = lineGap[i];
-  }
-  // …unless the dragged item is ALONE on its line — no sibling whose band
-  // holds its centre. A transform about the item's own centre (this
-  // library's lift, a zoomed container, a `scale()` on a wrapper) leaves
-  // that centre on the line the item was laid out on, whatever the band
-  // grew to, so a lone item's band IS that line: the exclusion above cannot
-  // see the line at all and the item speaks for itself — a single-file
-  // strip, or a chip wrapped onto a line of its own, keeps the answer it
-  // had. A transform that moves the centre OFF that line (an edge-anchored
-  // scale of ~2x or more, a translate of a whole line — nothing this
-  // library paints) is the one case these rects cannot read: the centre
-  // then decides from the line it landed on.
-  if (from >= 0 && from < rects.length) {
-    const own = band(rects[from]);
-    const centre = (own.lo + own.hi) / 2;
-    const shared = rects.some((rect, i) => {
-      if (i === from) return false;
-      const { lo, hi } = band(rect);
-      return centre >= lo - 0.5 && centre <= hi + 0.5;
-    });
-    if (!shared && lineGap[from] < nearest) nearest = lineGap[from];
+    if (lineGap[i] < nearest) nearest = lineGap[i];
   }
   let slot = -1;
   for (let i = 0; i < rects.length; i += 1) {
     if (lineGap[i] > nearest + 0.5) continue;
-    const rect = rects[i];
-    const mid = axis === "x" ? rect.left + rect.width / 2 : rect.top + rect.height / 2;
-    if (main < mid) {
+    if (main < mid(rects[i], i)) {
       slot = i;
       break;
     }
@@ -175,7 +186,12 @@ export function indexAt(
  * the pointer's position against the item MIDPOINTS along the axis, inside
  * the LINE the pointer is on across it — so a wrapping chip row (x axis,
  * several lines) and a stacked panel column (y axis, one column) both
- * behave the way the pointer looks like it should.
+ * behave the way the pointer looks like it should. The item being dragged
+ * is measured by the geometry it was LAID OUT with — snapshotted on press,
+ * before the lift is painted on it (`start`) and carried along with the
+ * frame it was read in, however that frame moves under the drag — so no
+ * transform an item picks up mid-drag can move the line it is dragged along
+ * or the midpoint it is compared against.
  *
  * The threshold is what keeps the gesture honest on a control that is also
  * clickable: a press under ~6px is not a drag at all — no state is
@@ -207,18 +223,29 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
   const dragFrom = ref(-1);
   const dragOver = ref(-1);
   const dragging = ref(false);
+  const pressed = ref(false);
 
   /** The pointer that owns the live press; a second pointer is ignored. */
   let pointerId = -1;
   let pressedIndex = -1;
   let originX = 0;
   let originY = 0;
-  let pressed = false;
   let moved = false;
   /** The pointer's last position, split by axis — the auto-scroll frames
    *  re-resolve the drop target from it while the content moves under it. */
   let lastMain = 0;
   let lastCross = 0;
+  /** The pressed item's LAYOUT geometry (`null` until a press reads it), the
+   *  FRAME it was laid out in (its parent element) and where that frame sat
+   *  when the geometry was read — the whole drag resolves against this
+   *  instead of the item's live rect, which carries the lift. */
+  let pressedBand: { lo: number; hi: number } | null = null;
+  let pressedMid = 0;
+  let pressedFrame: HTMLElement | null = null;
+  let pressedFrameBox: { x: number; y: number; w: number; h: number } | null = null;
+  /** The very ELEMENT the press landed on: the index the drag resolves by
+   *  is only meaningful while that index still names it (see `slotAt`). */
+  let pressedItem: HTMLElement | null = null;
   /** Auto-scroll: px per frame (signed: negative scrolls back), 0 = off. */
   let scrollVelocity = 0;
   let scrollFrameId = 0;
@@ -237,17 +264,90 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
 
   /** The slot the live strip resolves for a pointer at (`main`, `cross`),
    *  starting from index `from` — the elements measured, then handed to
-   *  `indexAt`, which carries the geometry's rules. */
+   *  `indexAt`, which carries the geometry's rules. One thing is checked
+   *  first: that the INDEX still names the element the press grabbed — a
+   *  keyboard reorder, a host edit, a row toggled by a second pointer or a
+   *  leaving item finally leaving all put a different element there. When it
+   *  does not, the gesture is abandoned rather than resolved: a drag may end
+   *  without a reorder, it never lands on an item the pointer did not
+   *  grab. */
   function slotAt(main: number, cross: number, from: number): number {
     const items = liveItems();
     if (items.length === 0) return -1;
+    if (pressedItem && items[pressedIndex] !== pressedItem) {
+      abandonDrag();
+      return -1;
+    }
     return indexAt(
       items.map((item) => item.getBoundingClientRect()),
       axis,
       main,
       cross,
       from,
+      layoutOrigin(),
     );
+  }
+
+  /** Where a frame's CONTENT sits in viewport coordinates — the box the
+   *  item is laid out in, minus that box's own scroll, which is the point
+   *  its children move with — and how big that box is. A scroller the items
+   *  sit directly in scrolls its children without moving its own box, so
+   *  the scroll has to come off explicitly; for every other element the
+   *  offsets are 0 and this is its box origin.
+   *
+   *  The scroll comes off at its own scale, which is right whenever the
+   *  frame is not ALSO transformed: this is a raw offset against a rect the
+   *  browser has already transformed, so a `scale()` on a frame that is
+   *  itself a scroller AND is scaled mid-drag would take it off at the
+   *  wrong magnitude — out of contract here, and the shapes this is written
+   *  for (a wrapping field, a panel list) are not scrollers at all: the
+   *  surface that scrolls them is their ancestor, and an ancestor's scroll
+   *  moves the frame's box like any other translation. */
+  function frameBox(frame: HTMLElement): { x: number; y: number; w: number; h: number } {
+    const rect = frame.getBoundingClientRect();
+    return {
+      x: rect.left - frame.scrollLeft,
+      y: rect.top - frame.scrollTop,
+      w: rect.width,
+      h: rect.height,
+    };
+  }
+
+
+  /** The pressed item's layout geometry for `indexAt`, placed in the frame's
+   *  box AS IT IS NOW. The snapshot is in VIEWPORT coordinates, so anything
+   *  that moves the frame under it — the auto-scroll this composable drives,
+   *  a host scrolling the surface or any scroller above it, a page scroll, a
+   *  re-parent, a transform on an ancestor — has to be carried with it, or
+   *  the line the item was laid out on would be compared against siblings
+   *  that have since moved away from it. `null` before any press, and for a
+   *  press whose item was not in the strip.
+   *
+   *  The carrier is the frame's BOX: a coordinate travels by the box's
+   *  displacement when the box keeps its size (a scroll of any kind, a
+   *  re-parent, a translation) and keeps its place INSIDE the box when the
+   *  box is resized — which is what a `scale()` or a zoom painted on the
+   *  frame or on an ancestor does to it, the box growing and shrinking with
+   *  the content it holds. A frame with no extent to scale against (no
+   *  layout at all, a `display: contents` frame) falls back to the
+   *  displacement. */
+  function layoutOrigin(): PointerReorderOrigin | null {
+    if (!pressedBand || !pressedFrameBox) return null;
+    const at = pressedFrameBox;
+    const now = pressedFrame && pressedFrame.isConnected ? frameBox(pressedFrame) : at;
+    const carry = (value: number, along: "x" | "y"): number => {
+      const from = along === "x" ? at.x : at.y;
+      const fromSpan = along === "x" ? at.w : at.h;
+      const to = along === "x" ? now.x : now.y;
+      const toSpan = along === "x" ? now.w : now.h;
+      return fromSpan > 0 && toSpan > 0
+        ? to + ((value - from) * toSpan) / fromSpan
+        : to + (value - from);
+    };
+    const down = axis === "x" ? "y" : "x";
+    const lo = carry(pressedBand.lo, down);
+    const hi = carry(pressedBand.hi, down);
+    return { band: { lo, hi }, mid: carry(pressedMid, axis) };
   }
 
   /** The pointer's coordinates split by axis: the position along the strip
@@ -285,7 +385,7 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
    *  content moved under it — the slot follows what the user sees. */
   function scrollTick(): void {
     scrollFrameId = 0;
-    if (!pressed || !moved || scrollVelocity === 0) return;
+    if (!pressed.value || !moved || scrollVelocity === 0) return;
     const container = options.scrollContainer?.() ?? null;
     if (!container) return;
     const next =
@@ -312,7 +412,7 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
    *  enters one, stop it the moment it leaves (or the drag ends), so an
    *  idle strip never scrolls and no frame is scheduled for nothing. */
   function syncAutoScroll(): void {
-    if (!pressed || !moved) {
+    if (!pressed.value || !moved) {
       stopAutoScroll();
       return;
     }
@@ -368,7 +468,7 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
   /** The page stopped being able to deliver this gesture's release: the
    *  window lost focus, or the tab went to the background. Abandon it. */
   function onPressLost(): void {
-    if (!pressed) return;
+    if (!pressed.value) return;
     releaseDrag();
   }
 
@@ -389,17 +489,21 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
     // also fire for every input blur on the page).
     window.removeEventListener("blur", onPressLost);
     document.removeEventListener("visibilitychange", onVisibilityChange);
-    pressed = false;
+    pressed.value = false;
     moved = false;
     pointerId = -1;
     pressedIndex = -1;
+    pressedBand = null;
+    pressedFrame = null;
+    pressedFrameBox = null;
+    pressedItem = null;
     dragging.value = false;
     dragFrom.value = -1;
     dragOver.value = -1;
   }
 
   function onPointerMove(event: PointerEvent): void {
-    if (!pressed || event.pointerId !== pointerId) return;
+    if (!pressed.value || event.pointerId !== pointerId) return;
     // No button held any more: the release happened where the page could
     // not see it (the pointer left the window and came back). This is the
     // only signal for that — a mouse that is merely moved around the page
@@ -429,7 +533,7 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
   }
 
   function onPointerUp(event: PointerEvent): void {
-    if (!pressed || event.pointerId !== pointerId) return;
+    if (!pressed.value || event.pointerId !== pointerId) return;
     const from = pressedIndex;
     const at = pointerAt(event);
     const to = moved ? slotAt(at.main, at.cross, from) : from;
@@ -441,8 +545,18 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
     if (dropped) options.onDrop(from, to);
   }
 
+  /** End a drag that must not resolve — the strip it was reading is no
+   *  longer the strip the press grabbed. The trailing click is swallowed
+   *  exactly as a drop's is: this WAS a drag (the pointer travelled past the
+   *  threshold), and the click the browser is about to deliver at wherever
+   *  the finger came to rest is one the user never made. */
+  function abandonDrag(): void {
+    if (moved) trapClick();
+    releaseDrag();
+  }
+
   function onPointerCancel(event: PointerEvent): void {
-    if (!pressed || event.pointerId !== pointerId) return;
+    if (!pressed.value || event.pointerId !== pointerId) return;
     // The browser took the gesture (a scroll started): abandon it
     // silently — a reorder must never come out of a cancelled drag.
     releaseDrag();
@@ -453,13 +567,36 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
   }
 
   function start(event: PointerEvent, index: number): void {
-    if (pressed || event.defaultPrevented || event.button !== 0 || index < 0) return;
+    if (pressed.value || event.defaultPrevented || event.button !== 0 || index < 0) return;
     const target = event.target as HTMLElement | null;
     if (target?.closest?.(INTERACTIVE)) return;
-    pressed = true;
+    pressed.value = true;
     moved = false;
     pointerId = event.pointerId;
     pressedIndex = index;
+    // The item's LAYOUT geometry, read NOW: this is the one moment nothing
+    // is painted on it yet — the drag state that carries the lift publishes
+    // only once the pointer crosses the threshold — so the rect is the line
+    // the strip laid the item out on, whatever a transform does to it for
+    // the rest of the gesture. The frame it was read in rides along (the
+    // item's own parent element, the box the strip is laid out in), so the
+    // snapshot can be carried with the content if that frame moves under
+    // the drag — see `layoutOrigin`.
+    const item = liveItems()[index];
+    const rect = item?.getBoundingClientRect();
+    pressedBand = rect
+      ? axis === "x"
+        ? { lo: rect.top, hi: rect.bottom }
+        : { lo: rect.left, hi: rect.right }
+      : null;
+    pressedMid = rect
+      ? axis === "x"
+        ? rect.left + rect.width / 2
+        : rect.top + rect.height / 2
+      : 0;
+    pressedFrame = item?.parentElement ?? null;
+    pressedFrameBox = pressedFrame ? frameBox(pressedFrame) : null;
+    pressedItem = item ?? null;
     originX = event.clientX;
     originY = event.clientY;
     const at = pointerAt(event);
@@ -483,5 +620,5 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
     });
   }
 
-  return { dragFrom, dragOver, dragging, start };
+  return { dragFrom, dragOver, dragging, pressed, start };
 }


### PR DESCRIPTION
## What this fixes

`usePointerReorder` resolves a drag's landing slot from the items' **bounding rects**, and the item being dragged is the one rect that stops being its own layout geometry the moment the drag starts: the lift (`scaleX/scaleY(1.03)` on the lifted chip/row) repaints it. Wave 5 (`#469`) worked around that by keeping the dragged item out of the "which line is the pointer on" filter unless its band **centre** still lay on its own laid-out line. That guard is exact only for **centre-preserving** transforms, so it left two documented corners where the answer was worse than before the guard existed:

* a **2.4× edge-anchored cross-axis scale** on a chip alone on a wrapped line (band centre lands inside the line above ⇒ the chip is read as sharing it, the exclusion applies, and the pointer on the chip's own line is answered from the row above: `0`/`1` where the untransformed gesture answers `2`);
* a **2.03× edge-anchored** one on a chip sharing its line (band centre reaches into the line below: `1` where the untransformed gesture answers `4`/`3`).

Both were recorded in `#469` as unfixable-by-heuristic. They are not: the heuristic was measuring the wrong object.

## The design (this PR is the design document — no doc file, per the workspace rule)

### 1. Measure the dragged item by the geometry it was LAID OUT with

The line an item sits on is a property of the **layout**, and it is readable: `start()` runs on `pointerdown`, and everything that carries the lift (`dragFrom` / `dragging`, and with them the CSS class that scales the item) is published only after the pointer crosses the 6px threshold. So at press the item's rect **is** its layout rect. `start()` reads it once and keeps it for the whole gesture:

* cross-axis **band** (`lo`/`hi` — the axis the line filter reads), and
* main-axis **midpoint** (the value the insertion walk compares against).

`indexAt(rects, axis, main, cross, from, origin?)` scores item `from` on that origin geometry in **both** steps; every other item keeps its live rect (siblings are not transformed by a drag). With `origin` omitted the function is the classic resolver, byte for byte — which is what keeps the no-drag path (`from = -1`) and every existing caller's semantics intact.

The wave-5 exclusion and its lone-line centre guard are **deleted**, not extended. With layout geometry the dragged item can safely speak for its own line again — which a chip wrapped onto a line of its own, or a single-file strip, must be able to do (no sibling can name that line).

### 2. Carry the snapshot with the frame it was read in

The snapshot is in **viewport** coordinates, and the resolution compares it against live sibling rects. Anything that moves the strip under a live drag therefore has to move the snapshot too, and "anything" is broader than the one scroller this composable is told about: the panel popout or the mobile sheet band, the composable's own auto-scroll, a page scroll, a modal body's scroller, a re-parent, a transform on an ancestor.

Rather than enumerate them, the snapshot is anchored to the item's **frame** — its parent element (`parentElement`: `HkTagInput`'s `HkListTransition tag=""` renders a fragment, so the chips' frame is `.hk-tag-input-box` and the rows' is `.hk-tag-input-list`, with no wrapper between strip and items) — recorded as `{ left - scrollLeft, top - scrollTop }` at press and re-read at every resolution:

* a scroller the items sit **inside** moves the frame's box ⇒ the delta is that movement;
* a scroller the items sit **directly in** scrolls its children without moving its own box ⇒ the `scrollLeft`/`scrollTop` term is that movement (this is why the subtraction is there at all);
* the auto-scroll this composable drives is just another scroll of one of those two shapes;
* the **lift** is painted on the item, never on the frame, so it cannot reach the snapshot;
* a detached frame reads no translation, and the snapshot then stays in press-time coordinates — degraded, never wrong-but-silent.

The carrier is the frame's **box**, not just its displacement: a coordinate keeps its place *inside* the box when the box is resized, which is exactly what a `scale()` or a zoom painted on the frame (or on an ancestor) does to it — the box grows and shrinks with the content it holds, so the snapshot travels with the content instead of staying where the press left it while every sibling moves away. A translation (any scroll of any kind, a re-parent, a transform on an ancestor) leaves the box's size alone and reduces to the plain displacement; a frame with no extent to scale against (no layout, `display: contents`) falls back to it too. A strip re-laid out under the drag in some other way — rows entering or leaving, which the reveal animation animates by height — is carried proportionally as well: approximate, and never worse than the displacement it replaces.

This also removes two failure modes of the previous "compensate the configured scroller's offsets" attempt: a surface that resolved only after the press double-counted its absolute offset, and the chip strip (which declares no scroller) did not compensate an ancestor scroll at all — a stale band there is the **unique** zero-gap line match, so the drag collapsed onto its own index and the drop silently did nothing. `options.scrollContainer` is now used **only** by the auto-scroll.

### 3. A press owns the order, and a drag never drops a foreign item

The resolution is by **index**, so it is only meaningful while that index still names the element the press grabbed. Two guards close that class of failure — both pre-existing, both found by adversarial verification of this wave:

* **The press owns the order.** `usePointerReorder` now exposes `pressed` (true from the moment `start()` accepts a press, not from the threshold), and `HkTagInput`'s `nudgeActiveRow` refuses to move anything while **either** strip has a live press. Before this, Alt+ArrowUp mid-drag reordered the model under the held pointer, and the release then moved whichever row had slipped into the dragged index — a plain-browser-reachable "the wrong row moved". The chord is still consumed (Alt+Arrow is not a plain arrow and the browser must not act on it); it just has nothing to move.
* **The strip must still be the press's.** `slotAt()` verifies `items[pressedIndex] === pressedItem` before resolving and abandons the gesture when it is not: a host `modelValue` rewrite, a second pointer toggling a row, a chip's × tapped mid-drag, a leaving item that finally leaves. The drag then ends without a reorder — a drag may come to nothing, it must never land on an item the pointer never grabbed — and it still swallows the browser's trailing click, exactly as a drop does, because it was a drag: without that the click lands on whatever row the pointer came to rest on and toggles a tag the user never pressed.

**Gates** (hikari has no eslint gate): `vitest run` **154 files / 1387 tests passed**; `vue-tsc --noEmit` exit 0; `sass` compiles the touched stylesheet with both `scaleX(1.03)`/`scaleY(1.03)` intact.

**Differential sweeps** against verbatim transcriptions of the pre-wave-5 and wave-5 resolvers (independent verifier, own oracle):

| claim | result |
|---|---|
| `origin` omitted ⇒ identical to pre-wave-5, every input | 0 mismatches / 13.2M cases (incl. `from = -1`, fractional/out-of-range `from`, NaN, ±Infinity, zero/negative-size and reversed rects, both axes) |
| layout-equal `origin` ⇒ as if no transform | 0 mismatches over the same corpus (1.59M with an origin) |
| the two recorded corners | 30.7M transformed samples (9 anchors × `k ∈ {0.2…4.9}` × translations × combinations): new **0 wrong**, wave-5 **2.19M wrong**, pre-wave-5-on-live-rect **2.71M wrong** |
| frame movement | popout scroll, mobile sheet band scroll, page scroll, an undeclared ancestor `overflow:auto` scroll and the composable's own auto-scroll each resolve exactly like the same gesture on a strip nothing moved under |

**Mutation checks** (file restored byte-exactly, sha256 verified each time) — every new test group bites:

| mutation | failing tests |
|---|---|
| no compensation in `layoutOrigin` | 3 (both scroll tests + the undeclared-ancestor-scroll test; the last collapses to `expected +0 to be 1` — the silent no-op) |
| snapshot not read at press / origin not passed | 4 |
| origin band (resp. mid) replaced by the live one | 3 (resp. 1) |
| wave-5 exclusion restored | 1 (the untransformed-overlapping-bands case: wave-5 answers `1` where the classic answer is `0`) |
| `pressed` guard weakened to `dragFrom` | 2 (the pre-threshold press and the live chip drag) |
| `pressed` guard removed | 1 |
| identity guard removed | 2 (composable + the host-rewrite case: `expected [['news','tech','de']] to deeply equal []`) |
| SCSS lift value mutated | 5/5 caught by the existing style pin |

**Known-flake note**: `HkDatePicker`/`HkDateTimePicker` fail intermittently under load (`expected 'August' to be '2026'`); they pass 50/50 in isolation and are untouched by this PR.

## Evidence

**Gates** (hikari has no eslint gate): `vitest run` **154 files / 1389 tests passed**; `vue-tsc --noEmit` exit 0; `sass` compiles the touched stylesheet with both `scaleX(1.03)`/`scaleY(1.03)` intact.

**Differential sweeps** against verbatim transcriptions of the pre-wave-5 and wave-5 resolvers (independent verifiers, own oracles):

| claim | result |
|---|---|
| `origin` omitted ⇒ identical to pre-wave-5, every input | 0 mismatches / 13.2M cases (incl. `from = -1`, fractional/out-of-range `from`, NaN, ±Infinity, zero/negative-size and inverted rects, both axes) |
| layout-equal `origin` ⇒ as if no transform | 0 mismatches over the same corpus (1.59M with an origin) |
| the two recorded corners | 30.7M transformed samples (9 anchors × `k ∈ {0.2…4.9}` × translations × combinations): new **0 wrong**, wave-5 **2.19M wrong**, pre-wave-5-on-live-rect **2.71M wrong** |
| transform fuzz, arbitrary transforms | 200k samples: new **0 wrong**, pre-wave-5 26,187, wave-5 23,764 |
| frame movement | popout scroll, mobile sheet band scroll, page scroll, an undeclared ancestor `overflow:auto` scroll, the composable's own auto-scroll, and a frame that scrolls while an ancestor moves each resolve exactly like the same gesture on a strip nothing moved under |

**Mutation checks** (file restored byte-exactly, sha256 verified each time) — every new test group bites:

| mutation | failing tests |
|---|---|
| no compensation in `layoutOrigin` | 3 (both scroll tests + the undeclared-ancestor-scroll test; the last collapses to `expected +0 to be 1` — the silent no-op) |
| shift sign flipped | 3 |
| frame carrier reduced to the displacement | 1 (the frame-scale case answers `1` where the re-laid-out strip answers `2`) |
| the abandoned drag's click trap removed | 1 (`expected [ 'row' ] to deeply equal []`) |
| snapshot not read at press / origin not passed | 4 |
| origin band (resp. mid) replaced by the live one | 3 (resp. 1) |
| wave-5 exclusion restored | 1 (the untransformed overlapping-bands case: wave-5 answers `1` where the classic answer is `0`) |
| `pressed` guard weakened to `dragFrom` | 2 (the pre-threshold press and the live chip drag) |
| `pressed` guard removed | 1 |
| identity guard removed | 2 (composable + the host-rewrite case: `expected [['news','tech','de']] to deeply equal []`) |
| SCSS lift value mutated | 5/5 caught by the existing style pin |

**Known-flake note**: `HkDatePicker`/`HkDateTimePicker` fail intermittently under load (`expected 'August' to be '2026'`, `HkDateTimePicker.test.ts:176`); they pass 50/50 in isolation and are untouched by this PR. The suite double-collects 4 theme test files through the `theme -> src/theme` symlink (150 files / 1324 tests is the deduplicated truth, pre-existing).

## Residual (deliberate, recorded)

A host that inserts or removes an item **before** `from` mid-drag changes what the index names; that is precisely what the new identity guard detects, and the gesture ends rather than dropping a foreign item. Re-anchoring the drag by key instead of index would be the next step if a caller ever needs a live drag to survive an out-of-band structural edit.

## Scope

Only `usePointerReorder` + its test change behaviour; `HkTagInput.tsx` gains the keyboard guard and follows the new contract sentences; `HkTagInput.scss` and the component test file are comment/test changes plus the new cases; the version goes 0.43.7 → 0.43.8. The composable is not re-exported (`src/index.ts` has no `usePointerReorder`, the exports map has no `./composables/*`), so the published surface is unchanged.
