### PR TITLE
🐛 Read a dragged item's place in the list live, not from the press.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.9",
+  "version": "0.43.10",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/composables/usePointerReorder.test.ts
+++ b/packages/vue/src/composables/usePointerReorder.test.ts
@@ -268,6 +268,122 @@ function scrollerStrip(
   return { frame, items, scene };
 }
 
+/** A strip a BROWSER could have laid out: every element reports both of the
+ *  readings a real engine keeps apart — the box it is DRAWN in
+ *  (`getBoundingClientRect`, which every transform moves) and the box it is
+ *  LAID OUT in (`offsetLeft`/`offsetTop`/`offsetWidth`/`offsetHeight` along
+ *  an `offsetParent` chain, which no transform touches). One model drives
+ *  both, exactly as a browser would, so a test can re-lay the strip out (a
+ *  reorder, an insertion, a font change) or paint a transform on it and see
+ *  which reading the resolution followed. */
+function laidStrip(
+  layout: Box[],
+  frameLayout: { left: number; top: number; w: number; h: number },
+  frameDrawn: Box,
+  scene: {
+    scale?: number;
+    scroll?: number;
+    border?: { left: number; top: number };
+    /** The frame is `position: static`, so it is nobody's `offsetParent`:
+     *  the items' layout numbers are then measured from further up — the
+     *  fact that decides whether the frame's border still has to be added. */
+    staticFrame?: boolean;
+  } = {},
+): {
+  frame: HTMLElement;
+  items: HTMLElement[];
+  laid: Box[];
+  relayout: (next: Box[]) => void;
+  setFrameDrawn: (next: Box) => void;
+} {
+  const frame = document.createElement("div");
+  document.body.appendChild(frame);
+  const live = layout.map((box) => ({ ...box }));
+  const pins: Array<() => void> = [];
+  const border = scene.border ?? { left: 0, top: 0 };
+  const sceneOf = () => ({ scale: scene.scale ?? 1, scroll: scene.scroll ?? 0 });
+  frame.style.borderLeftWidth = `${border.left}px`;
+  frame.style.borderTopWidth = `${border.top}px`;
+
+  /** The box a browser draws for a laid-out box inside this frame. */
+  const drawn = (box: Box): Box => {
+    const { scale, scroll } = sceneOf();
+    const left = frameDrawn.left + (box.left - frameLayout.left - scroll) * scale;
+    const top = frameDrawn.top + (box.top - frameLayout.top) * scale;
+    return {
+      left,
+      right: left + (box.right - box.left) * scale,
+      top,
+      bottom: top + (box.bottom - box.top) * scale,
+    };
+  };
+
+  let frameDrawnBox = frameDrawn;
+  Object.defineProperty(frame, "getBoundingClientRect", {
+    configurable: true,
+    value: () => asRect(frameDrawnBox),
+  });
+  Object.defineProperty(frame, "offsetWidth", { configurable: true, get: () => frameLayout.w });
+  Object.defineProperty(frame, "offsetHeight", { configurable: true, get: () => frameLayout.h });
+  Object.defineProperty(frame, "offsetParent", { configurable: true, get: () => null });
+  Object.defineProperty(frame, "offsetLeft", { configurable: true, get: () => frameLayout.left });
+  Object.defineProperty(frame, "offsetTop", { configurable: true, get: () => frameLayout.top });
+  Object.defineProperty(frame, "scrollLeft", { configurable: true, get: () => sceneOf().scroll });
+  Object.defineProperty(frame, "scrollTop", { configurable: true, get: () => 0 });
+
+  const items = live.map((box, i) => {
+    const el = document.createElement("div");
+    frame.appendChild(el);
+    Object.defineProperty(el, "offsetParent", {
+      configurable: true,
+      get: () => (scene.staticFrame ? null : frame),
+    });
+    // A positioned frame is the items' offsetParent, so their offsets are
+    // measured from its PADDING edge; a static one is skipped and they are
+    // measured from the same place as the frame itself.
+    Object.defineProperty(el, "offsetLeft", {
+      configurable: true,
+      get: () =>
+        scene.staticFrame ? live[i].left : live[i].left - frameLayout.left - border.left,
+    });
+    Object.defineProperty(el, "offsetTop", {
+      configurable: true,
+      get: () => (scene.staticFrame ? live[i].top : live[i].top - frameLayout.top - border.top),
+    });
+    Object.defineProperty(el, "offsetWidth", {
+      configurable: true,
+      get: () => live[i].right - live[i].left,
+    });
+    Object.defineProperty(el, "offsetHeight", {
+      configurable: true,
+      get: () => live[i].bottom - live[i].top,
+    });
+    const pin = () =>
+      Object.defineProperty(el, "getBoundingClientRect", {
+        configurable: true,
+        value: () => asRect(drawn(live[i])),
+      });
+    pin();
+    pins.push(pin);
+    return el;
+  });
+
+  return {
+    frame,
+    items,
+    laid: live,
+    relayout: (next: Box[]) => {
+      next.forEach((box, i) => {
+        live[i] = { ...box };
+      });
+      pins.forEach((pin) => pin());
+    },
+    setFrameDrawn: (next: Box) => {
+      frameDrawnBox = next;
+    },
+  };
+}
+
 const scopes: EffectScope[] = [];
 
 /** Mount the composable inside a real effect scope (the component case). */
@@ -969,6 +1085,319 @@ describe("usePointerReorder", () => {
     expect(handle.dragOver.value, "260 is past the second chip's midpoint of 250").toBe(2);
     up(260, 20);
     expect(drops, "the drop is reported in the indices the strip has now").toEqual([[1, 2]]);
+  });
+
+  it("resolves against where the strip has RE-LAID the held item out", () => {
+    // A font, a zoom or an insertion around the strip re-lays it out under a
+    // live drag, so the item the pointer is holding is no longer where the
+    // press found it. The snapshot describes the old place; the layout
+    // numbers describe the new one, and the resolution has to follow the
+    // strip the user is looking at. The chips here shrink mid-drag, which
+    // brings the held chip's midpoint back behind the pointer: the walk that
+    // the press-time midpoint stopped short of now runs past the strip.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const strip = laidStrip(laid, { left: 0, top: 0, w: 300, h: 40 }, { left: 0, right: 300, top: 0, bottom: 40 });
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 1, { x: 150, y: 20 });
+    move(140, 20);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "the press-time midpoint is still ahead of the pointer").toBe(1);
+
+    // The strip is re-laid out under the drag: every chip, the held one
+    // included, is drawn at its new place.
+    strip.relayout([
+      { left: 0, right: 50, top: 0, bottom: 40 },
+      { left: 50, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 150, top: 0, bottom: 40 },
+    ]);
+    move(140, 20);
+    expect(handle.dragOver.value, "the pointer is past every chip of the new strip").toBe(2);
+    up(140, 20);
+    expect(drops).toEqual([[1, 2]]);
+  });
+
+  it("ignores a transform painted on the held item while it follows the layout", () => {
+    // The whole reason the snapshot exists: a transform on the item — the
+    // drag's own lift, a host animation, a zoomed wrapper — is painted, not
+    // laid out, and must not move the line or the midpoint the resolution
+    // reads. The layout numbers are blind to it, so following the layout
+    // costs nothing here: the same gesture resolves the same way with the
+    // held chip drawn twice as large and shifted.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const strip = laidStrip(laid, { left: 0, top: 0, w: 300, h: 40 }, { left: 0, right: 300, top: 0, bottom: 40 });
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 0, { x: 10, y: 20 });
+    move(150, 20);
+    expect(handle.dragOver.value).toBe(1);
+
+    // A host transform lands on the held chip: an edge-anchored cross-axis
+    // scale, plus a hard translation that carries its drawn box onto the line
+    // below and its drawn midpoint far past where it is laid out — the class
+    // of transform an earlier wave recorded as unfixable while the drawn box
+    // was what got measured. The pointer sits inside the moved band (where
+    // measuring the drawn box makes the held chip the only candidate line, so
+    // the walk stops on its own translated midpoint) and past the second
+    // chip's midpoint, which is where the layout answers "land after the
+    // second chip".
+    reshape(strip.items[0], { left: 100, right: 300, top: 40, bottom: 96 });
+    move(180, 45);
+    expect(handle.dragOver.value, "180 is past the second chip's midpoint of 150").toBe(1);
+    up(180, 45);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("carries the derived geometry through a frame that scrolls", () => {
+    // The derivation reads a LAYOUT position and maps it through the box the
+    // frame is drawn in, so the frame's own scroll (which slides the content
+    // inside that box) has to be taken off in the same units. The strip is
+    // scrolled mid-drag; the pointer stays where it is, over a different
+    // chip of the content.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+      { left: 300, right: 400, top: 0, bottom: 40 },
+    ];
+    const scene = { scale: 1, scroll: 0 };
+    const strip = laidStrip(
+      laid,
+      { left: 0, top: 0, w: 400, h: 40 },
+      { left: 0, right: 400, top: 0, bottom: 40 },
+      scene,
+    );
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 0, { x: 10, y: 20 });
+    move(40, 20);
+    expect(handle.dragOver.value, "40 is still short of the first chip's midpoint of 50").toBe(0);
+
+    scene.scroll = 120; // the frame scrolls the strip under the drag
+    strip.relayout(laid); // re-pin the drawn boxes at the new scroll
+    move(40, 20);
+    expect(handle.dragOver.value, "the chips moved back under the pointer with the content").toBe(1);
+    up(40, 20);
+    expect(drops).toEqual([[0, 1]]);
+  });
+
+  it("reads the frame's border the way the frame hands its layout numbers over", () => {
+    // The items' layout numbers are measured from their offsetParent's
+    // PADDING edge — so when the frame is that offsetParent its border has to
+    // be added back, and when the frame is `position: static` (nobody's
+    // offsetParent) the same numbers are already measured from its BORDER
+    // edge and adding it again would count it twice. Both shapes here are
+    // laid out identically and drawn identically: the resolution has to
+    // answer the same for both, and it has to keep the border's own scale.
+    const layout: Box[] = [
+      { left: 20, right: 60, top: 20, bottom: 60 },
+      { left: 80, right: 120, top: 20, bottom: 60 },
+      { left: 140, right: 180, top: 20, bottom: 60 },
+      { left: 200, right: 240, top: 20, bottom: 60 },
+    ];
+    const frameLayout = { left: 0, top: 0, w: 260, h: 80 };
+    const frameDrawn: Box = { left: 0, right: 260, top: 0, bottom: 80 };
+    const border = { left: 20, top: 20 };
+    for (const staticFrame of [false, true]) {
+      const strip = laidStrip(layout, frameLayout, frameDrawn, { border, staticFrame });
+      const { handle, drops } = harness("x", strip.items);
+      press(handle, strip.items, 0, { x: 30, y: 35 });
+      move(102, 62);
+      expect(handle.dragging.value, `staticFrame=${staticFrame}`).toBe(true);
+      expect(handle.dragOver.value, `staticFrame=${staticFrame} lands after the first chip`).toBe(1);
+      up(102, 62);
+      expect(drops, `staticFrame=${staticFrame}`).toEqual([[0, 1]]);
+    }
+  });
+
+  it("resolves exactly as the held item's own drawn box says, across frame shapes", () => {
+    // The differential form of the test above: for every shape a frame can
+    // have — positioned or static, with or without a border, drawn at its own
+    // size or scaled, scrolled or not, one line or two — the resolution has
+    // to answer what the held item's TRUE layout box answers. The sweep walks
+    // the pointer over each strip and compares against `indexAt` handed that
+    // true box, so any place the derived geometry drifts shows up wherever
+    // the drift can be observed, without hand-picking pointers.
+    const single: Box[] = [
+      { left: 12, right: 52, top: 12, bottom: 52 },
+      { left: 72, right: 112, top: 12, bottom: 52 },
+      { left: 132, right: 172, top: 12, bottom: 52 },
+    ];
+    const wrapped: Box[] = [
+      { left: 12, right: 52, top: 12, bottom: 52 },
+      { left: 72, right: 112, top: 12, bottom: 52 },
+      { left: 12, right: 52, top: 72, bottom: 112 },
+    ];
+    const scenes = [
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 0, right: 200, top: 0, bottom: 70 }, scene: {} },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 5, right: 235, top: 7, bottom: 112 }, scene: { scale: 1.5 } },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 5, right: 235, top: 7, bottom: 112 }, scene: { scale: 1.5, border: { left: 12, top: 12 } } },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 5, right: 235, top: 7, bottom: 112 }, scene: { scale: 1.5, border: { left: 12, top: 12 }, staticFrame: true } },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 0, right: 200, top: 0, bottom: 70 }, scene: { border: { left: 12, top: 12 } } },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 0, right: 200, top: 0, bottom: 70 }, scene: { border: { left: 12, top: 12 }, staticFrame: true } },
+      { layout: single, frame: { left: 0, top: 0, w: 200, h: 70 }, drawn: { left: 0, right: 200, top: 0, bottom: 70 }, scene: { scroll: 25 } },
+      { layout: wrapped, frame: { left: 0, top: 0, w: 200, h: 130 }, drawn: { left: 0, right: 200, top: 0, bottom: 130 }, scene: {} },
+      { layout: wrapped, frame: { left: 0, top: 0, w: 200, h: 130 }, drawn: { left: 0, right: 300, top: 0, bottom: 195 }, scene: { scale: 1.5, border: { left: 8, top: 8 } } },
+    ];
+    let compared = 0;
+    for (const [index, entry] of scenes.entries()) {
+      const strip = laidStrip(entry.layout, entry.frame, entry.drawn, entry.scene);
+      const rects = strip.items.map((el) => el.getBoundingClientRect());
+      // The line filter's tolerance is half a pixel wide, so the sweep has to
+      // land ON the band edges, not only near them.
+      const crosses = new Set<number>();
+      for (let cross = -10; cross <= 140; cross += 5) crosses.add(cross);
+      for (const rect of rects) {
+        for (const edge of [rect.top, rect.bottom]) {
+          for (const delta of [-2, -1, -0.5, 0, 0.5, 1, 2]) crosses.add(Number((edge + delta).toFixed(2)));
+        }
+      }
+      for (let from = 0; from < strip.items.length; from += 1) {
+        // The held item's own layout box, drawn — the geometry the resolution
+        // is supposed to be reading.
+        const truth = strip.items[from].getBoundingClientRect();
+        const trueOrigin = {
+          band: { lo: truth.top, hi: truth.bottom },
+          mid: truth.left + truth.width / 2,
+        };
+        for (let main = -20; main <= 240; main += 20) {
+          for (const cross of crosses) {
+            const { handle } = harness("x", strip.items);
+            press(handle, strip.items, from, { x: main - 40, y: cross });
+            move(main, cross);
+            const got = handle.dragOver.value;
+            const want = indexAt(rects, "x", main, cross, from, trueOrigin);
+            expect(got, `scene ${index} from ${from} at (${main}, ${cross})`).toBe(want);
+            up(main, cross);
+            compared += 1;
+          }
+        }
+      }
+    }
+    expect(compared, "the sweep really ran").toBeGreaterThan(1000);
+  }, 20_000);
+
+  it("keeps the carried snapshot when only half of the box can be read", () => {
+    // A box that reports one side and not the other cannot place anything: a
+    // zero width would put the midpoint on the item's own edge. The gesture
+    // here is one the derivation WOULD answer differently — the strip is
+    // re-laid out under the drag — so the assertion is the carried
+    // snapshot's answer, which is what a strip with no layout numbers at all
+    // gets.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const strip = laidStrip(laid, { left: 0, top: 0, w: 300, h: 40 }, {
+      left: 0,
+      right: 300,
+      top: 0,
+      bottom: 40,
+    });
+    Object.defineProperty(strip.items[1], "offsetWidth", { configurable: true, get: () => 0 });
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 1, { x: 150, y: 20 });
+    move(140, 20);
+    expect(handle.dragging.value).toBe(true);
+    expect(handle.dragOver.value, "the press-time midpoint still stops the walk").toBe(1);
+
+    strip.relayout([
+      { left: 0, right: 50, top: 0, bottom: 40 },
+      { left: 50, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 150, top: 0, bottom: 40 },
+    ]);
+    move(140, 20);
+    expect(handle.dragOver.value, "half a box is no box: the snapshot still resolves").toBe(1);
+    up(140, 20);
+    expect(drops).toEqual([]);
+  });
+
+  it("keeps the carried snapshot when the layout chain cannot be added up", () => {
+    // A chain that runs through something with no offsets of its own — an
+    // element inside `<svg>` reports no `offsetLeft` at all — sums to NaN,
+    // and a NaN origin answers every comparison the same way: it would place
+    // the item at the end of the strip. The chain is checked, and the gesture
+    // falls back to the snapshot.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const strip = laidStrip(laid, { left: 0, top: 0, w: 300, h: 40 }, {
+      left: 0,
+      right: 300,
+      top: 0,
+      bottom: 40,
+    });
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 1, { x: 150, y: 20 });
+    move(140, 20);
+    expect(handle.dragOver.value).toBe(1);
+
+    // The held chip's chain now passes through an element with no offsets.
+    const svgish = document.createElement("div");
+    Object.defineProperty(svgish, "offsetLeft", { configurable: true, get: () => undefined });
+    Object.defineProperty(svgish, "offsetTop", { configurable: true, get: () => undefined });
+    Object.defineProperty(svgish, "offsetParent", {
+      configurable: true,
+      get: () => strip.frame,
+    });
+    Object.defineProperty(strip.items[1], "offsetParent", {
+      configurable: true,
+      get: () => svgish,
+    });
+    strip.relayout([
+      { left: 0, right: 50, top: 0, bottom: 40 },
+      { left: 50, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 150, top: 0, bottom: 40 },
+    ]);
+    move(140, 20);
+    expect(handle.dragOver.value, "an unaddable chain keeps the snapshot's answer").toBe(1);
+    up(140, 20);
+    expect(drops).toEqual([]);
+  });
+
+  it("keeps the carried snapshot when the held item collapses", () => {
+    // A held chip re-laid out to no height has no line to be on: its derived
+    // band would be a point and the line filter would drop it, which is a
+    // resolution the layout cannot justify. The fallback answers instead.
+    const laid: Box[] = [
+      { left: 0, right: 100, top: 0, bottom: 40 },
+      { left: 100, right: 200, top: 0, bottom: 40 },
+      { left: 200, right: 300, top: 0, bottom: 40 },
+    ];
+    const strip = laidStrip(laid, { left: 0, top: 0, w: 300, h: 40 }, {
+      left: 0,
+      right: 300,
+      top: 0,
+      bottom: 40,
+    });
+    const { handle, drops } = harness("x", strip.items);
+
+    press(handle, strip.items, 1, { x: 150, y: 20 });
+    move(140, 20);
+    expect(handle.dragOver.value).toBe(1);
+
+    strip.relayout([
+      { left: 0, right: 50, top: 0, bottom: 40 },
+      { left: 50, right: 100, top: 20, bottom: 20 },
+      { left: 100, right: 150, top: 0, bottom: 40 },
+    ]);
+    move(140, 20);
+    expect(handle.dragOver.value, "a chip with no height has no line to stand on").toBe(1);
+    up(140, 20);
+    expect(drops).toEqual([]);
   });
 
   it("ends the gesture the moment the strip empties", () => {

--- a/packages/vue/src/composables/usePointerReorder.ts
+++ b/packages/vue/src/composables/usePointerReorder.ts
@@ -360,6 +360,78 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
     };
   }
 
+  /** Where an element's border box sits in a space its ancestors share: the
+   *  one number CSS transforms do not touch. `offsetLeft`/`offsetTop` are
+   *  LAYOUT positions — the drag's own lift, a host `scale()`, a FLIP
+   *  animation and a transition mid-flight all leave them exactly where they
+   *  were — so walking the offsetParent chain of the item and of its frame
+   *  and subtracting gives the item's current place inside the frame however
+   *  it is drawn. Both sides are walked to the same root, so a frame that is
+   *  not itself an offsetParent (a static frame) cancels exactly.
+   *
+   *  `through` reports whether the walk passed THROUGH the frame, which is
+   *  what decides how the two differ: an offset is measured from the
+   *  offsetParent's PADDING edge, so a chain that runs through the frame
+   *  leaves the difference measured from the frame's padding box (its border
+   *  has to be added back), while a chain that skips it — a frame that is
+   *  `position: static` is nobody's offsetParent — leaves the difference
+   *  measured from the frame's BORDER box, where adding the border again
+   *  would double-count it.
+   *
+   *  The chain must be walked LIVE: a transform (or even
+   *  `will-change: transform`) on an ancestor rebinds `offsetParent`. */
+  function layoutOffset(
+    el: HTMLElement,
+    frame: HTMLElement | null,
+  ): { x: number; y: number; through: boolean } {
+    let x = 0;
+    let y = 0;
+    let through = false;
+    for (let node: HTMLElement | null = el; node; node = node.offsetParent as HTMLElement | null) {
+      x += node.offsetLeft;
+      y += node.offsetTop;
+      if (node === frame) through = true;
+    }
+    return { x, y, through };
+  }
+
+  /** The pressed item's layout geometry read off the LIVE strip rather than
+   *  carried from the press — the answer to "where is the item I am holding
+   *  NOW?", which is what changes when the list reorders, an item is added or
+   *  removed around it, a font or a zoom changes, or the strip re-wraps.
+   *  `null` when there is no box to read (no layout engine at all, a detached
+   *  element, a collapsed or partially-readable one), which keeps the caller
+   *  on the carried snapshot. */
+  function derivedOrigin(): PointerReorderOrigin | null {
+    if (!pressedItem || !pressedFrame || !pressedFrame.isConnected) return null;
+    const box = frameBox(pressedFrame);
+    const itemW = pressedItem.offsetWidth;
+    const itemH = pressedItem.offsetHeight;
+    if (!(itemW > 0) || !(itemH > 0)) return null;
+    if (!(box.w > 0) || !(box.h > 0)) return null;
+    const at = layoutOffset(pressedItem, pressedFrame);
+    const of = layoutOffset(pressedFrame, null);
+    // A chain that runs through something without layout offsets of its own
+    // (an SVG ancestor, a foreignObject boundary) sums to NaN rather than
+    // failing: nothing can be placed from it, so the snapshot keeps the call.
+    if (!Number.isFinite(at.x) || !Number.isFinite(at.y)) return null;
+    if (!Number.isFinite(of.x) || !Number.isFinite(of.y)) return null;
+    const scaleX = box.laidW > 0 ? box.w / box.laidW : 1;
+    const scaleY = box.laidH > 0 ? box.h / box.laidH : 1;
+    /** The frame's own border, in the units it is DRAWN at — and only when
+     *  the walk into the frame came through it (`through`). */
+    const style = getComputedStyle(pressedFrame);
+    const borderLeft = at.through ? (parseFloat(style.borderLeftWidth) || 0) * scaleX : 0;
+    const borderTop = at.through ? (parseFloat(style.borderTopWidth) || 0) * scaleY : 0;
+    const left = box.x + borderLeft + (at.x - of.x - box.scrollX) * scaleX;
+    const top = box.y + borderTop + (at.y - of.y - box.scrollY) * scaleY;
+    const width = itemW * scaleX;
+    const height = itemH * scaleY;
+    return axis === "x"
+      ? { band: { lo: top, hi: top + height }, mid: left + width / 2 }
+      : { band: { lo: left, hi: left + width }, mid: top + height / 2 };
+  }
+
   /** The pressed item's layout geometry for `indexAt`, placed where the
    *  frame puts it NOW. The snapshot is in VIEWPORT coordinates, so anything
    *  that moves the frame under it — the auto-scroll this composable drives,
@@ -385,6 +457,8 @@ export function usePointerReorder(options: PointerReorderOptions): PointerReorde
    *  A frame with no box to read any of this from falls back to the plain
    *  displacement. */
   function layoutOrigin(): PointerReorderOrigin | null {
+    const live = derivedOrigin();
+    if (live) return live;
     if (!pressedBand || !pressedFrameBox) return null;
     const at = pressedFrameBox;
     const now = pressedFrame && pressedFrame.isConnected ? frameBox(pressedFrame) : at;


### PR DESCRIPTION
## What this fixes

0.43.8 and 0.43.9 taught a drag to **re-anchor on the element** it grabbed, so a list that moves under the gesture keeps the drop on the right item. The **geometry** stayed the press's: the item's line across the strip and its position along it were snapshotted at pointerdown and carried only by the *frame's* movement. Anything that moves the item **within** its frame therefore leaves that snapshot describing a place the item no longer occupies:

* a reorder under the gesture (the element re-anchors, the geometry does not);
* an item added or removed around the held one;
* a font or a display-zoom change;
* a window resize that re-wraps the strip.

The resolution then stops the insertion walk on a phantom midpoint and/or assigns the pointer to the wrong line, so the release **comes to nothing** (or, in the re-wrap case, lands somewhere else). A study measured it at **16.3%** of gestures in reorder scenarios and **17.0%** with no reorder at all — and reproduced it end-to-end in Chromium with the real component: press a chip, cross the 6px threshold, rewrite the host array, release ⇒ `update:modelValue` never fires, with the snapshot **74–311px** off for chips and **90–180px** for panel rows.

## The fix

Read the geometry **off the live strip** instead of carrying it:

`offsetLeft` / `offsetTop` / `offsetWidth` / `offsetHeight` are **layout** numbers — a CSS transform, on the element, on a transition mid-flight, or on any ancestor, does not move them (measured in Chromium, byte-identical). Walking the `offsetParent` chain of the item and of its frame to a common space, subtracting, adding the frame's border back (a positioned `offsetParent` measures from its padding edge) and mapping through the box the frame is **drawn** in (`scale = rect.width / offsetWidth`, plus the frame's own scroll) answers "where is the item I am holding **now**?" — and it is blind to every transform painted on the item, which is exactly what the snapshot existed to avoid.

`offsetLeft`/`offsetTop` are measured from the **padding** edge of an `offsetParent`, which is a fact the frame's border has to be read against: when the frame *is* the item's `offsetParent` the difference of the two offset sums is measured from the frame's padding box, so its border is added back — scaled by the scale the frame is drawn at; when the frame is `position: static` it is nobody's `offsetParent`, the chain skips it, and the same difference is already measured from its **border** box, so adding the border again would count it twice. `layoutOffset` reports whether the walk passed **through** the frame, and the border is added only then.

The carried snapshot stays as the **fallback** for a strip with no layout to read (no layout engine, a detached element, a collapsed box — the guards are per-axis and reject a half-readable or NaN box), so nothing changes where the derivation cannot run.

### Why this and not the other two candidates

A measured head-to-head over **217,998 resolutions** in 8 buckets (clean, our own lift, a host transform on the item, reorder-only, compound, frame/ancestor transform, fractional geometry, give-up shapes), driven through the real composable against the oracle "the item's true current layout rect":

| variant | wrong vs oracle | fixed | broken | gestures that come to nothing | wrong drops |
|---|---|---|---|---|---|
| shipped 0.43.9 | 4,313 (1.98%) | — | — | 4,253 | 60 |
| live re-measure on the re-anchor (+ frame box) | 4,073 | 2,301 | 2,061 | 4,073 | 0 |
| live re-measure **every** resolution | 11,958 | 2,301 | 9,946 | 11,958 | 0 |
| **this revision (transform-free derivation)** | **221 (0.10%)** | **4,092** | **0** | **221** | **0** |

* **Re-measuring the drawn rect is the wrong tool**: it re-exposes the item's own painted transform — the wave-5 class of defect two waves removed. In the compound bucket (host transform on the item **and** a reorder) the shipped snapshot is wrong on 738 resolutions, the re-measure variants on 2,235, this revision on **0**.
* **Dropping the pressed item from the insertion walk** (the other obvious simplification) is exact for single-line strips but changes wrapping semantics — 5.31% drift even with fresh geometry, and it throws the item to the end of the strip when its line holds no other candidate. It also leaves the line (band) staleness untouched, which dominates in wrapping strips. Refuted with 13M swept cases.
* Our own lift can never harm the derivation: `scaleX(1.03)`/`scaleY(1.03)` are centre-anchored on the drag axis, so neither the band nor the midpoint moves (3.6e-15px at every ramp fraction).

## Evidence

* **Gates** (hikari has no eslint gate): `vitest run` **154 files / 1403 tests passed**; `vue-tsc --noEmit` exit 0; `sass` compiles the touched stylesheet.
* **New tests** carry a harness that models what a browser keeps apart — the box an element is *drawn* in (`getBoundingClientRect`) and the box it is *laid out* in (`offsetLeft`/`offsetTop`/`offsetWidth`/`offsetHeight` along an `offsetParent` chain) — from one model, with knobs for the frame's border, its drawn scale, its scroll and whether it is `position: static`. A test can therefore re-lay the strip out, scale it, or paint a transform on it and see which reading the resolution followed:
  * `resolves against where the strip has RE-LAID the held item out` — killed by removing the derivation;
  * `ignores a transform painted on the held item while it follows the layout` — killed by deriving from the drawn rect instead of the offset chain (the wave-5 collapse);
  * `carries the derived geometry through a frame that scrolls` — killed by dropping the scroll term;
  * `reads the frame's border the way the frame hands its layout numbers over` — a positioned and a static frame laid out and drawn identically must answer identically;
  * `resolves exactly as the held item's own drawn box says, across frame shapes` — a differential sweep over nine frames (positioned/static × border/no border × scale 1/1.5 × scrolled × one line/two lines) × every `from` × a pointer grid with probes ON the band edges, compared against `indexAt` handed the item's true drawn layout box. This is what catches the border and scale terms;
  * `keeps the carried snapshot when only half of the box can be read`, `…when the held item collapses`, `…when the layout chain cannot be added up` — each kills a weakened guard, the last one the NaN a chain through an element without offsets (`<svg>`) would otherwise produce.
* **Mutation matrix** — every term is pinned by a test that fails without it: the derivation itself, the offset chain (vs the drawn rect), the frame's scroll, the border (present only through the frame), the frame's scale, the per-axis guards, and the axis mapping.
* **Real-browser validation** (the unit suite cannot cover this: happy-dom reports every box as 0, so it exercises the fallback): a vite dev server + Playwright + real `page.mouse` over the shipped build, re-running the reproduction gestures, the sweeps, a causality mutant and a boundary probe — recorded in the PR thread.

## Contract and residual (deliberate)

* **Fallback**: a strip with no readable layout keeps 0.43.9's behaviour exactly (this is also what the unit suite exercises).
* **Give-ups**: a rotated or skewed frame (this resolution is axis-aligned by construction, like `indexAt` itself); an item lifted out of flow (`position: absolute`); a detached frame or item. Each returns to the carried snapshot rather than guessing.
* **Precision**: the band is the load-bearing value (the line filter tolerates ~0.5px, one-sided); the offset numbers are integers, so the derived band carries ≤~0.6px on chips (0.000px on panel rows in the browser measurements). The midpoint tolerates a full row pitch — which is why a small geometry error on the held item only shows up through the band or in a wrapping strip. A sub-pixel size from `getComputedStyle` is a possible refinement if the band's rounding ever matters.
* The frame's border is added **scaled** by the frame's drawn scale, and the guard that rejects a frame drawn without a box are both exact by construction but only weakly observable: in a single-line strip the held item's own geometry is absorbed by the walk, and a frame drawn zero-wide degenerates the carried snapshot the same way. The border is pinned by the shaped sweep; the frame-box half of the guard is defensive (the component's real frames always draw a box, which the browser run confirms) and is recorded here rather than asserted.
* An independent reviewer measured the **integer rounding** of `offsetLeft`/`offsetTop`/`offsetWidth`/`offsetHeight` against fractional layouts: the derived box can sit up to ~1.3px from the drawn one. A 4.3M-point search for a pointer where that changes a resolved slot found none (the same search finds 192 on the previous revision), and the browser sweeps agree — but it is a property of the primitive, not of this code.
* The derivation must re-read the `offsetParent` chain every resolution: a transform (or `will-change: transform`) on an ancestor **rebinds** `offsetParent`.

## Scope

Only `packages/vue/src/composables/usePointerReorder.ts` (+ its test) changes behaviour; the version goes 0.43.9 → 0.43.10. The composable is not re-exported, so the published surface is unchanged.
