### PR TITLE
🎨 Sweep every component stylesheet and draw selection emphasis inside the border box.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.10",
+  "version": "0.43.11",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -90,6 +90,10 @@
   background: rgb(var(--color-primary) / 20%);
 }
 
+.s-about-modal-link:active {
+  background: rgb(var(--color-primary) / 26%);
+}
+
 .s-about-modal-link:focus-visible {
   box-shadow:
     0 0 0 2px rgb(var(--color-surface)),

--- a/packages/vue/src/components/HkAboutModal.scss
+++ b/packages/vue/src/components/HkAboutModal.scss
@@ -78,15 +78,22 @@
 
 .s-about-modal-link {
   padding: var(--space-4, 0.25rem) var(--space-8, 0.5rem);
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm, 4px);
   background: rgb(var(--color-primary) / 12%);
   color: rgb(var(--color-primary));
   font-size: var(--text-xs, 0.75rem);
   text-decoration: none;
+  transition: background 200ms ease;
 }
 
 .s-about-modal-link:hover {
   background: rgb(var(--color-primary) / 20%);
+}
+
+.s-about-modal-link:focus-visible {
+  box-shadow:
+    0 0 0 2px rgb(var(--color-surface)),
+    0 0 0 4px rgb(var(--color-primary));
 }
 
 .s-about-modal-footer {

--- a/packages/vue/src/components/HkAdaptiveDialog.scss
+++ b/packages/vue/src/components/HkAdaptiveDialog.scss
@@ -10,7 +10,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
   flex: 1;
   min-width: 0;
 }
@@ -18,5 +18,5 @@
 .hk-adaptive-dialog-footer {
   display: flex;
   justify-content: flex-end;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
 }

--- a/packages/vue/src/components/HkAffixPicker.scss
+++ b/packages/vue/src/components/HkAffixPicker.scss
@@ -40,7 +40,7 @@
 
 .hk-affix-chip-label {
   font-weight: 600;
-  font-size: var(--text-sm, 14px);
+  font-size: var(--text-sm, 0.8125rem);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -51,6 +51,13 @@
   color: rgb(var(--color-muted));
 }
 
+/* Open disclosure state (aria-expanded sits on the chip button): flip the
+ * caret so the popup direction reads at a glance. Instant swap — no
+ * transition, so the reduced-motion guard below needs no entry. */
+.hk-affix-chip[aria-expanded="true"] .hk-affix-chip-caret {
+  transform: rotate(180deg);
+}
+
 /* ── popup head: tags (multi) + search ─────────────────────────────── */
 .hk-affix-head {
   display: flex;
@@ -58,18 +65,18 @@
 }
 
 .hk-affix-search {
-  padding: 8px 10px 6px;
+  padding: var(--space-8, 8px) var(--space-10, 10px) var(--space-6, 6px);
 }
 
 .hk-affix-tags {
-  padding: 10px 10px 8px;
+  padding: var(--space-10, 10px) var(--space-10, 10px) var(--space-8, 8px);
   border-bottom: 1px solid var(--border-faint);
 }
 
 .hk-affix-tag-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-6, 6px);
   min-width: min(18rem, 100%);
   max-width: 24rem;
 }
@@ -82,9 +89,9 @@
 .hk-affix-tag {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-8, 8px);
   min-height: 2.25rem;
-  padding: 4px var(--space-16);
+  padding: var(--space-4, 4px) var(--space-16, 16px);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   background: rgb(var(--color-surface) / var(--opacity-half));
@@ -110,7 +117,7 @@
   min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-6, 6px);
   padding: 0;
   border: 0;
   background: transparent;
@@ -178,7 +185,7 @@
   height: 1.5rem;
   padding: 0;
   border: 0;
-  border-radius: 999px;
+  border-radius: var(--radius-full, 999px);
   background: transparent;
   color: rgb(var(--color-muted));
   cursor: pointer;
@@ -223,30 +230,38 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 4px 6px 8px;
+  padding: var(--space-4, 4px) var(--space-6, 6px) var(--space-8, 8px);
 }
 
 .hk-affix-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-8, 8px);
   width: 100%;
   min-height: 2.25rem;
-  padding: 4px 8px;
+  padding: var(--space-4, 4px) var(--space-8, 8px);
   border: none;
   border-radius: var(--radius-sm, 6px);
   background: transparent;
   color: rgb(var(--color-text));
-  font-size: var(--text-sm, 14px);
+  font-size: var(--text-sm, 0.8125rem);
   text-align: start;
   cursor: pointer;
   appearance: none;
   transition: background 0.1s ease;
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     background: rgb(var(--color-primary) / 10%);
     outline: none;
+  }
+
+  /* Keyboard position is drawn INSIDE the row (HkSelectionGrid branch-fix
+   * pattern) and distinct from the hover tint, so overlapping popup/sheet
+   * chrome cannot shave a per-side outer ring and focus reads as focus. */
+  &:focus-visible {
+    background: rgb(var(--color-primary) / 10%);
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
   }
 
   &[data-active] {
@@ -266,22 +281,20 @@
     }
   }
 
-  /* The "Use <query>" free-text row reads as an add affordance. */
+  /* The "Use <query>" free-text row reads as an add affordance. Truncation
+   * comes from the base .hk-affix-row-label — only the emphasis is new. */
   &[data-custom="true"] {
     color: rgb(var(--color-primary));
 
     .hk-affix-row-label {
       font-weight: 600;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
     }
   }
 }
 
 .hk-affix-row-flag {
   flex: none;
-  font-size: calc(var(--text-base, 15px) * 1.05);
+  font-size: calc(var(--text-base, 0.875rem) * 1.05);
   line-height: 1;
   font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
     sans-serif;
@@ -298,14 +311,14 @@
 .hk-affix-row-meta {
   flex: none;
   color: rgb(var(--color-muted));
-  font-size: calc(var(--text-sm, 14px) * 0.9);
+  font-size: calc(var(--text-sm, 0.8125rem) * 0.9);
   font-variant-numeric: tabular-nums;
 }
 
 .hk-affix-empty {
-  padding: 14px 12px;
+  padding: var(--space-14, 14px) var(--space-12, 12px);
   color: rgb(var(--color-muted));
-  font-size: var(--text-sm, 14px);
+  font-size: var(--text-sm, 0.8125rem);
   text-align: center;
 }
 

--- a/packages/vue/src/components/HkAffixPicker.scss
+++ b/packages/vue/src/components/HkAffixPicker.scss
@@ -12,7 +12,10 @@
   align-items: center;
   gap: 0.3rem;
   max-width: 11rem;
-  padding: 2px 6px 2px 4px;
+  /* Logical axes: the wide side reserves caret room at inline-end and
+   * flips together with the host input's RTL suffix/prefix side. */
+  padding-block: 2px;
+  padding-inline: 4px 6px;
   border: none;
   border-radius: var(--radius-sm, 6px);
   background: transparent;
@@ -23,6 +26,10 @@
   &:hover:not(:disabled),
   &:focus-visible:not(:disabled) {
     background: rgb(var(--color-primary) / 14%);
+  }
+
+  &:active:not(:disabled) {
+    background: rgb(var(--color-primary) / 20%);
   }
 
   &:disabled {
@@ -80,7 +87,7 @@
   padding: 4px var(--space-16);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
-  background: rgb(var(--color-surface) / var(--opacity-half, 50%));
+  background: rgb(var(--color-surface) / var(--opacity-half));
   transition: border-color 0.12s ease, background 0.12s ease;
 
   &:hover {
@@ -110,9 +117,14 @@
   color: rgb(var(--color-text));
   font-size: var(--text-sm);
   line-height: 1.4;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   appearance: none;
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
 }
 
 .hk-affix-tag-flag {
@@ -226,7 +238,7 @@
   background: transparent;
   color: rgb(var(--color-text));
   font-size: var(--text-sm, 14px);
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   appearance: none;
   transition: background 0.1s ease;
@@ -246,7 +258,10 @@
     opacity: 0.5;
     cursor: default;
 
-    &:hover {
+    /* The button stays keyboard-focusable (data-disabled only), so the
+     * unpickable row must not paint the pickable tint on focus either. */
+    &:hover,
+    &:focus-visible {
       background: transparent;
     }
   }

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -6,7 +6,7 @@
   border-radius: var(--hi-radius-md, 8px);
   border: 1px solid transparent;
   border-inline-start-width: 4px;
-  color: var(--hi-color-text-primary);
+  color: var(--hi-color-text-primary, #333);
 }
 
 .hk-alert-banner {
@@ -37,35 +37,35 @@
 /* ── Variants ──────────────────────────────────── */
 
 .hk-alert-error {
-  background: color-mix(in srgb, var(--hi-color-danger) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-danger) 15%, transparent);
-  border-inline-start-color: var(--hi-color-danger);
+  background: color-mix(in srgb, var(--hi-color-danger, #f85149) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-danger, #f85149) 15%, transparent);
+  border-inline-start-color: var(--hi-color-danger, #f85149);
 
-  .hk-alert-icon { color: var(--hi-color-danger); }
+  .hk-alert-icon { color: var(--hi-color-danger, #f85149); }
 }
 
 .hk-alert-warning {
-  background: color-mix(in srgb, var(--hi-color-warning) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-warning) 15%, transparent);
-  border-inline-start-color: var(--hi-color-warning);
+  background: color-mix(in srgb, var(--hi-color-warning, #d29922) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-warning, #d29922) 15%, transparent);
+  border-inline-start-color: var(--hi-color-warning, #d29922);
 
-  .hk-alert-icon { color: var(--hi-color-warning); }
+  .hk-alert-icon { color: var(--hi-color-warning, #d29922); }
 }
 
 .hk-alert-info {
-  background: color-mix(in srgb, var(--hi-color-primary) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-primary) 15%, transparent);
-  border-inline-start-color: var(--hi-color-primary);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 15%, transparent);
+  border-inline-start-color: var(--hi-color-primary, #58a6ff);
 
-  .hk-alert-icon { color: var(--hi-color-primary); }
+  .hk-alert-icon { color: var(--hi-color-primary, #58a6ff); }
 }
 
 .hk-alert-success {
-  background: color-mix(in srgb, var(--hi-color-success) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-success) 15%, transparent);
-  border-inline-start-color: var(--hi-color-success);
+  background: color-mix(in srgb, var(--hi-color-success, #3fb950) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-success, #3fb950) 15%, transparent);
+  border-inline-start-color: var(--hi-color-success, #3fb950);
 
-  .hk-alert-icon { color: var(--hi-color-success); }
+  .hk-alert-icon { color: var(--hi-color-success, #3fb950); }
 }
 
 /* ── Icon ──────────────────────────────────────── */
@@ -87,14 +87,13 @@
 .hk-alert-title {
   margin: 0 0 2px;
   font-weight: 600;
-  font-size: inherit;
   line-height: 1.4;
 }
 
 .hk-alert-text {
   margin: 0;
   line-height: 1.5;
-  color: color-mix(in srgb, var(--hi-color-text-secondary) 85%, transparent);
+  color: color-mix(in srgb, var(--hi-color-text-secondary, #666) 85%, transparent);
 }
 
 /* ── Close button ──────────────────────────────── */
@@ -109,18 +108,18 @@
   border: 0;
   background: transparent;
   border-radius: var(--hi-radius-sm, 4px);
-  color: var(--hi-color-muted);
+  color: var(--hi-color-muted, #666);
   cursor: pointer;
   padding: 0;
   transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
 
   &:hover {
-    background: var(--hi-color-surface);
-    color: var(--hi-color-text-primary);
+    background: var(--hi-color-surface, #fff);
+    color: var(--hi-color-text-primary, #333);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary);
+    outline: 2px solid var(--hi-color-primary, #58a6ff);
     outline-offset: 2px;
   }
 }

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -1,8 +1,8 @@
 .hk-alert {
   display: flex;
   align-items: flex-start;
-  gap: var(--hi-space-12, 12px);
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  gap: var(--space-12, 12px);
+  padding: var(--space-12, 12px) var(--space-16, 16px);
   border-radius: var(--hi-radius-md, 8px);
   border: 1px solid transparent;
   border-inline-start-width: 4px;
@@ -20,18 +20,18 @@
 /* ── Sizes ─────────────────────────────────────── */
 
 .hk-alert-sm {
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
-  font-size: var(--hi-text-xs, 0.75rem);
+  padding: var(--space-8, 8px) var(--space-12, 12px);
+  font-size: var(--text-xs, 0.75rem);
 }
 
 .hk-alert-md {
   /* md padding == the .hk-alert base values; only the type size differs. */
-  font-size: var(--hi-text-sm, 0.875rem);
+  font-size: var(--text-sm, 0.875rem);
 }
 
 .hk-alert-lg {
-  padding: var(--hi-space-16, 16px) var(--hi-space-24, 24px);
-  font-size: var(--hi-text-base, 1rem);
+  padding: var(--space-16, 16px) var(--space-24, 24px);
+  font-size: var(--text-base, 1rem);
 }
 
 /* ── Variants ──────────────────────────────────── */

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -5,7 +5,7 @@
   padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
   border-radius: var(--hi-radius-md, 8px);
   border: 1px solid transparent;
-  border-left-width: 4px;
+  border-inline-start-width: 4px;
   color: var(--hi-color-text-primary);
 }
 
@@ -25,7 +25,7 @@
 }
 
 .hk-alert-md {
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  /* md padding == the .hk-alert base values; only the type size differs. */
   font-size: var(--hi-text-sm, 0.875rem);
 }
 
@@ -39,7 +39,7 @@
 .hk-alert-error {
   background: color-mix(in srgb, var(--hi-color-danger) 8%, transparent);
   border-color: color-mix(in srgb, var(--hi-color-danger) 15%, transparent);
-  border-left-color: var(--hi-color-danger);
+  border-inline-start-color: var(--hi-color-danger);
 
   .hk-alert-icon { color: var(--hi-color-danger); }
 }
@@ -47,7 +47,7 @@
 .hk-alert-warning {
   background: color-mix(in srgb, var(--hi-color-warning) 8%, transparent);
   border-color: color-mix(in srgb, var(--hi-color-warning) 15%, transparent);
-  border-left-color: var(--hi-color-warning);
+  border-inline-start-color: var(--hi-color-warning);
 
   .hk-alert-icon { color: var(--hi-color-warning); }
 }
@@ -55,7 +55,7 @@
 .hk-alert-info {
   background: color-mix(in srgb, var(--hi-color-primary) 8%, transparent);
   border-color: color-mix(in srgb, var(--hi-color-primary) 15%, transparent);
-  border-left-color: var(--hi-color-primary);
+  border-inline-start-color: var(--hi-color-primary);
 
   .hk-alert-icon { color: var(--hi-color-primary); }
 }
@@ -63,7 +63,7 @@
 .hk-alert-success {
   background: color-mix(in srgb, var(--hi-color-success) 8%, transparent);
   border-color: color-mix(in srgb, var(--hi-color-success) 15%, transparent);
-  border-left-color: var(--hi-color-success);
+  border-inline-start-color: var(--hi-color-success);
 
   .hk-alert-icon { color: var(--hi-color-success); }
 }
@@ -117,5 +117,10 @@
   &:hover {
     background: var(--hi-color-surface);
     color: var(--hi-color-text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--hi-color-primary);
+    outline-offset: 2px;
   }
 }

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -31,7 +31,7 @@
 
 .hk-alert-lg {
   padding: var(--space-16, 16px) var(--space-24, 24px);
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
 }
 
 /* ── Variants ──────────────────────────────────── */

--- a/packages/vue/src/components/HkAltSignIn.scss
+++ b/packages/vue/src/components/HkAltSignIn.scss
@@ -5,7 +5,6 @@
 .hk-alt-signin {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   width: 100%;
 }
 
@@ -25,8 +24,15 @@
     opacity var(--duration-normal, 0.3s) ease;
 }
 
-.hk-alt-signin__trigger:hover:not(:disabled) {
+.hk-alt-signin__trigger:hover:not(:disabled),
+.hk-alt-signin__trigger[aria-expanded="true"] {
   color: var(--hi-color-text-secondary, #999);
+}
+
+/* Keyboard position feedback on the full-width disclosure row. */
+.hk-alt-signin__trigger:focus-visible:not(:disabled) {
+  outline: 2px solid var(--hi-color-primary, #58a6ff);
+  outline-offset: 2px;
 }
 
 .hk-alt-signin__trigger:disabled {
@@ -51,5 +57,5 @@
   flex-direction: column;
   gap: var(--space-2, 0.125rem);
   min-width: 12rem;
-  padding: var(--space-4, 0.25rem) var(--space-4, 0.25rem);
+  padding: var(--space-4, 0.25rem);
 }

--- a/packages/vue/src/components/HkAltSignIn.scss
+++ b/packages/vue/src/components/HkAltSignIn.scss
@@ -45,7 +45,7 @@
 .hk-alt-signin__rule {
   flex: 1 1 auto;
   height: 1px;
-  background: var(--hi-color-border-subtle, rgba(0, 0, 0, 0.08));
+  background: var(--border-subtle);
 }
 
 .hk-alt-signin__label {

--- a/packages/vue/src/components/HkAuthMethodList.scss
+++ b/packages/vue/src/components/HkAuthMethodList.scss
@@ -7,8 +7,7 @@
 .s-auth-methods-divider {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 10px;
+  gap: var(--space-10, 0.625rem);
   margin: 0 0 var(--space-4, 0.25rem);
   color: var(--hi-color-muted, #999);
   font-size: var(--text-xs, 0.75rem);

--- a/packages/vue/src/components/HkAuthMethodList.scss
+++ b/packages/vue/src/components/HkAuthMethodList.scss
@@ -31,9 +31,10 @@
 
 /* Fixed icon + label columns: the two spans keep the same width on every
    row, so icons and labels align across buttons while each button stays a
-   centered hk-btn-block. HkButton has a fragment root, so inbound classes
-   don't fall through — scope everything off the `.s-auth-methods`
-   container (descendant match: the component wrapper is display:contents).
+   centered hk-btn-block. The part classes sit on the default-slot spans
+   inside HkButton's single <button> root — scope everything off the
+   `.s-auth-methods` container (descendant match: the component wrapper
+   is display:contents).
    The label column width is MEASURED by the component (widest label text
    + 1px headroom, published as `--auth-methods-label-width` on its
    wrapper, inherited into the rows); the `max-content` fallback only

--- a/packages/vue/src/components/HkAuthSubmitButton.scss
+++ b/packages/vue/src/components/HkAuthSubmitButton.scss
@@ -1,12 +1,12 @@
 .s-auth-submit {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-6, 0.375rem);
   width: 100%;
 }
 
 .s-auth-submit-error {
   margin: 0;
-  font-size: 0.8125rem;
-  color: rgb(var(--color-danger, 229 62 62));
+  font-size: var(--text-sm, 0.8125rem);
+  color: rgb(var(--color-danger, 240 70 80));
 }

--- a/packages/vue/src/components/HkAuthSubmitButton.scss
+++ b/packages/vue/src/components/HkAuthSubmitButton.scss
@@ -8,5 +8,5 @@
 .s-auth-submit-error {
   margin: 0;
   font-size: var(--text-sm, 0.8125rem);
-  color: rgb(var(--color-danger, 240 70 80));
+  color: rgb(var(--color-error, 240 70 80));
 }

--- a/packages/vue/src/components/HkAvatar.scss
+++ b/packages/vue/src/components/HkAvatar.scss
@@ -19,12 +19,6 @@
   }
 }
 
-.hk-avatar-xs {
-  width: 24px;
-  height: 24px;
-  font-size: 0.625rem;
-}
-
 .hk-avatar-sm {
   width: 32px;
   height: 32px;
@@ -43,24 +37,6 @@
   font-size: 1rem;
 }
 
-.hk-avatar-xl {
-  width: 64px;
-  height: 64px;
-  font-size: 1.25rem;
-}
-
-.hk-avatar-circular {
-  border-radius: 50%;
-}
-
-.hk-avatar-rounded {
-  border-radius: 8px;
-}
-
-.hk-avatar-square {
-  border-radius: 0;
-}
-
 .hk-avatar-fallback {
   width: 100%;
   height: 100%;
@@ -71,23 +47,7 @@
   font-weight: 600;
 }
 
-.hk-avatar-icon {
-  color: var(--hi-color-text-secondary);
-  opacity: 0.8;
-}
-
-.hk-avatar-img {
-  display: block;
-  width: 100%;
-  height: 100%;
-}
-
 [data-theme="dark"] .hk-avatar {
   background-color: var(--hi-surface);
-  color: var(--hi-color-text-secondary);
-}
-
-[data-theme="dark"] .hk-avatar-icon {
-  color: var(--hi-color-text-secondary);
-  opacity: 0.6;
+  color: var(--hi-color-text-secondary, rgba(255, 255, 255, 0.6));
 }

--- a/packages/vue/src/components/HkAvatar.scss
+++ b/packages/vue/src/components/HkAvatar.scss
@@ -9,7 +9,6 @@
   overflow: hidden;
   background-color: var(--hi-color-gray-200, #E5E7EB);
   color: var(--hi-color-gray-600, #4B5563);
-  font-weight: 500;
   transition: all 0.2s ease;
 
   img {
@@ -20,21 +19,23 @@
 }
 
 .hk-avatar-sm {
-  width: 32px;
-  height: 32px;
-  font-size: 0.75rem;
+  width: var(--space-32);
+  height: var(--space-32);
+  font-size: var(--text-xs);
 }
 
 .hk-avatar-md {
-  width: 40px;
-  height: 40px;
-  font-size: 0.875rem;
+  width: var(--space-40);
+  height: var(--space-40);
+  font-size: var(--text-base);
 }
 
 .hk-avatar-lg {
+  /* 48px: --space-48 exists only in theme/_layout.scss, not in every
+     token sheet this component's other tokens live in — keep literal. */
   width: 48px;
   height: 48px;
-  font-size: 1rem;
+  font-size: var(--text-md);
 }
 
 .hk-avatar-fallback {

--- a/packages/vue/src/components/HkBadge.scss
+++ b/packages/vue/src/components/HkBadge.scss
@@ -7,6 +7,9 @@
  * (rendered as inline --hk-badge-* custom properties).
  */
 
+// Use theme variables with namespace to avoid conflicts
+@use "./hikari-vars" as vars;
+
 .hk-badge {
   --hk-badge-text: inherit;
   --hk-badge-bg: transparent;
@@ -39,7 +42,7 @@
 
 /* ---------- typography ---------- */
 .hk-badge[data-mono] {
-  font-family: var(--font-mono);
+  font-family: var(--font-mono, vars.$hikari-font-family-mono);
 }
 
 .hk-badge[data-uppercase] {
@@ -49,8 +52,8 @@
 
 /* ---------- dot indicator ---------- */
 .hk-badge [data-el="dot"] {
-  width: 6px;
-  height: 6px;
+  width: var(--space-6);
+  height: var(--space-6);
   border-radius: 50%;
   background: var(--hk-badge-text);
   flex-shrink: 0;

--- a/packages/vue/src/components/HkBadge.scss
+++ b/packages/vue/src/components/HkBadge.scss
@@ -32,11 +32,6 @@
   padding: var(--space-1) var(--space-6);
 }
 
-.hk-badge[data-size="md"] {
-  font-size: var(--text-xs);
-  padding: var(--space-2) var(--space-8);
-}
-
 /* ---------- shape ---------- */
 .hk-badge[data-pill="false"] {
   border-radius: var(--radius-sm);
@@ -45,7 +40,6 @@
 /* ---------- typography ---------- */
 .hk-badge[data-mono] {
   font-family: var(--font-mono);
-  font-weight: 600;
 }
 
 .hk-badge[data-uppercase] {

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -4,12 +4,12 @@
 // transient toasts read as one stack; the card itself follows the toast
 // item conventions (variant background, icon column, clamped message)
 // with a button row appended. Pointer events pass through the column
-// and re-enable on the card, exactly like toasts.
+// and re-enable on the per-card slot, exactly like toasts.
 
 .hk-blocking-toast-container {
   position: fixed;
   top: 4rem;
-  right: 1rem;
+  inset-inline-end: 1rem;
   z-index: var(--hk-z-toast, 4000);
   max-width: 24rem;
   pointer-events: none;
@@ -36,7 +36,6 @@
   font-size: var(--hi-text-base, 0.875rem);
   line-height: 1.4;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
-  pointer-events: auto;
   backdrop-filter: blur(12px);
 }
 
@@ -115,6 +114,15 @@
 .hk-blocking-toast-leave-to {
   opacity: 0;
   transform: translateX(1rem);
+}
+
+// RTL: the fixed column sits at the inline-end (physical left) side, so
+// the slide direction flips with it (house pattern: HkTimeline.scss).
+// The leave-pin contract writes physical right/top inline, which within
+// the shrink-to-fit column is edge-agnostic (slot width == column width).
+[dir="rtl"] .hk-blocking-toast-enter-from,
+[dir="rtl"] .hk-blocking-toast-leave-to {
+  transform: translateX(-1rem);
 }
 
 .hk-blocking-toast-move {

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -19,7 +19,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-12, 12px);
+  gap: var(--space-12, 12px);
 }
 
 .hk-blocking-toast-slot {
@@ -30,10 +30,10 @@
 .hk-blocking-toast-card {
   display: flex;
   align-items: flex-start;
-  gap: var(--hi-space-8, 8px);
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  gap: var(--space-8, 8px);
+  padding: var(--space-12, 12px) var(--space-16, 16px);
   border-radius: var(--hi-radius-sm, 4px);
-  font-size: var(--hi-text-base, 0.875rem);
+  font-size: var(--text-base, 0.875rem);
   line-height: 1.4;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(12px);
@@ -52,7 +52,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
 }
 
 .hk-blocking-toast-title {
@@ -71,7 +71,7 @@
 .hk-blocking-toast-actions {
   display: flex;
   justify-content: flex-end;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
 }
 
 // Variant backgrounds follow the HkToast conventions (including the

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -57,7 +57,6 @@
 }
 
 .hk-blocking-toast-title {
-  font-size: 1em;
   font-weight: 700;
 }
 
@@ -120,4 +119,14 @@
 
 .hk-blocking-toast-move {
   transition: transform var(--hi-duration-normal, 0.3s) ease;
+}
+
+// Reduced motion: drop the slide/FLIP choreography, cards snap in and
+// out (house pattern: HkListTransition.scss / HkExpansionPanel.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-blocking-toast-enter-active,
+  .hk-blocking-toast-leave-active,
+  .hk-blocking-toast-move {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkBoard.scss
+++ b/packages/vue/src/components/HkBoard.scss
@@ -37,10 +37,8 @@
   pointer-events: none;
 }
 
-.hk-board-edge {
-  fill: none;
-  stroke-linecap: round;
-}
+// Edge ink (fill/stroke/linecap) is set as presentation attributes on every
+// emitted path (HkBoard.tsx) — no CSS declaration here, only per-edge attrs.
 
 .hk-board-node {
   position: absolute;
@@ -63,8 +61,9 @@
   justify-content: center;
   padding: 0 var(--space-6);
   box-sizing: border-box;
+  // NOTE: no text-overflow here — the shell is a flex container, ellipsis
+  // only renders on block containers; clipping is owned by overflow: hidden.
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--text-2xs);
   color: rgb(var(--color-text));
@@ -72,11 +71,29 @@
   border: 1px solid rgb(var(--color-primary) / 45%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-elevated);
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+
+  // Every visible node is click-interactive (HkBoard.tsx emits `nodeClick`
+  // on a short tap for draggable and read-only nodes alike), so the shell
+  // carries hover/press emphasis. The press ring draws INSIDE the border
+  // box (HkSelectionGrid model) so overlapping chrome cannot shave it.
+  &:hover {
+    border-color: rgb(var(--color-primary) / 80%);
+  }
+
+  &:active {
+    box-shadow:
+      var(--shadow-elevated),
+      inset 0 0 0 1px rgb(var(--color-primary) / 45%);
+  }
 }
 
 .hk-board-minimap {
   position: absolute;
-  right: var(--space-10);
+  // Logical property: the corner dock mirrors in RTL (same spot in LTR).
+  inset-inline-end: var(--space-10);
   bottom: var(--space-10);
   z-index: 6;
   pointer-events: auto;

--- a/packages/vue/src/components/HkBoard.scss
+++ b/packages/vue/src/components/HkBoard.scss
@@ -96,5 +96,8 @@
   inset-inline-end: var(--space-10);
   bottom: var(--space-10);
   z-index: 6;
+  // Defensive re-enable (the inner HkMinimap root asserts it too,
+  // HkMinimap.scss:15): keeps the dock alive if a host ever parks the
+  // board under an ancestor `pointer-events: none`.
   pointer-events: auto;
 }

--- a/packages/vue/src/components/HkBreadcrumb.scss
+++ b/packages/vue/src/components/HkBreadcrumb.scss
@@ -46,27 +46,6 @@
   // Position
   position: relative;
 
-  // Not the last item
-  &:not(:last-child) {
-    // Separator
-    .hk-breadcrumb-separator {
-      margin-left: 0.5rem;
-      color: var(--hi-color-text-secondary);
-      opacity: 0.5;
-      // DISABLED - migrated to JS animation
-
-      // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
-
-      // Glow effect on separator
-      filter: drop-shadow(0 0 4px var(--hi-primary));
-
-      svg {
-        width: 1rem;
-        height: 1rem;
-      }
-    }
-  }
-
   // Last item (current page)
   &:last-child {
     .hk-breadcrumb-link {
@@ -91,13 +70,14 @@
   text-decoration: none;
   white-space: nowrap;
 
-  // Cursor
-  cursor: pointer;
-
-  // Transitions
-  // DISABLED - migrated to JS animation
-
-  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+  // Transitions — house convention (200ms ease on color/background/
+  // box-shadow, cf. HkSelectionGrid). The old value was commented out as
+  // "migrated to JS animation", but HkBreadcrumb.tsx ships no animation
+  // code, so hover/focus snapped.
+  transition:
+    color 200ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease;
 
   // Padding
   padding: 0.25rem 0.5rem;
@@ -109,41 +89,32 @@
   align-items: center;
   gap: 0.375rem;
 
-  // Icon
-  .hk-breadcrumb-icon {
-    flex-shrink: 0;
-    width: 1rem;
-    height: 1rem;
-    // DISABLED - migrated to JS animation
+  // Interactive affordance only for REAL links: items without `to` render
+  // as a <span class="hk-breadcrumb-link"> (HkBreadcrumb.tsx) — a pointer
+  // cursor + hover fill on that dead span read as a broken link.
+  &[href] {
+    cursor: pointer;
 
-    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+    // Hover state
+    &:hover {
+      color: var(--hi-color-text-primary);
+      background: var(--hi-primary);
 
-    svg {
-      width: 100%;
-      height: 100%;
+      // Glow effect on text
+      text-shadow: 0 0 8px var(--hi-primary);
     }
   }
 
-  // Hover state
-  &:hover {
-    color: var(--hi-color-text-primary);
-    background: var(--hi-primary);
-
-    .hk-breadcrumb-icon {
-      color: var(--hi-color-primary);
-      filter: drop-shadow(0 0 4px var(--hi-primary));
-    }
-
-    // Glow effect on text
-    text-shadow: 0 0 8px var(--hi-primary);
-  }
-
-  // Active/focus state
+  // Keyboard focus (spans are not focusable, so <a href> only): house
+  // double ring (HkButton pattern). The former single 2px primary ring
+  // shared its ink with the focus fill and merged into it / got shaved
+  // per-side by overlapping chrome.
   &:focus-visible {
     outline: none;
     background: var(--hi-primary);
     box-shadow:
-      0 0 0 2px var(--hi-primary),
+      0 0 0 2px rgb(var(--color-surface)),
+      0 0 0 4px rgb(var(--color-primary)),
       0 0 12px var(--hi-primary);
   }
 
@@ -158,6 +129,11 @@
 // Breadcrumb Separator
 // ------
 
+// Separator styling lives at TOP LEVEL, not scoped under
+// `.hk-breadcrumb-item:not(:last-child)` — every rendered separator sits in
+// a non-last item (HkBreadcrumb.tsx renders it only for index < len-1), and
+// the deeper base specificity made the sm/lg size overrides below
+// cascade-dead. Spacing uses a logical property so it mirrors in RTL.
 .hk-breadcrumb-separator {
   // Layout
   display: inline-flex;
@@ -166,56 +142,17 @@
   // Typography
   font-size: 0.875rem;
 
-  // Transitions
-  // DISABLED - migrated to JS animation
+  // Spacing
+  margin-inline-start: 0.5rem;
+  color: var(--hi-color-text-secondary);
+  opacity: 0.5;
 
-  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
+  // Glow effect on separator
+  filter: drop-shadow(0 0 4px var(--hi-primary));
 
-  // Custom separator glow
-  &.hk-breadcrumb-separator-glow {
-    color: var(--hi-color-primary);
-    opacity: 0.8;
-    filter: drop-shadow(0 0 6px var(--hi-primary));
-  }
-}
-
-// ------
-// Separator Variants
-// ------
-
-// Slash separator
-.hk-breadcrumb-separator-slash {
-  &::before {
-    content: '/';
-  }
-}
-
-// Arrow separator
-.hk-breadcrumb-separator-arrow {
-  &::before {
-    content: '›';
-    font-size: 1.1em;
-  }
-}
-
-// Double arrow separator
-.hk-breadcrumb-separator-double-arrow {
-  &::before {
-    content: '»';
-    font-size: 0.9em;
-  }
-}
-
-// Chevron separator (default with icon)
-.hk-breadcrumb-separator-chevron {
-  // Uses chevron-right icon
-}
-
-// Dot separator
-.hk-breadcrumb-separator-dot {
-  &::before {
-    content: '•';
-    font-size: 1.2em;
+  svg {
+    width: 1rem;
+    height: 1rem;
   }
 }
 
@@ -321,33 +258,6 @@
 }
 
 // ------
-// Icon Styles
-// ------
-
-.hk-breadcrumb-icon {
-  // Layout
-  display: inline-flex;
-  align-items: center;
-
-  // Size
-  width: 1rem;
-  height: 1rem;
-
-  // Color
-  color: var(--hi-color-text-secondary);
-
-  // Transitions
-  // DISABLED - migrated to JS animation
-
-  // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
-
-  svg {
-    width: 100%;
-    height: 100%;
-  }
-}
-
-// ------
 // Size Variants
 // ------
 
@@ -358,15 +268,10 @@
   .hk-breadcrumb-link {
     padding: 0.125rem 0.375rem;
     margin: -0.125rem -0.375rem;
-
-    .hk-breadcrumb-icon {
-      width: 0.875rem;
-      height: 0.875rem;
-    }
   }
 
   .hk-breadcrumb-separator {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
     font-size: 0.75rem;
 
     svg {
@@ -376,10 +281,8 @@
   }
 }
 
-.hk-breadcrumb-md {
-  font-size: vars.$hikari-font-size-sm;
-  gap: 0.5rem;
-}
+// NOTE: no .hk-breadcrumb-md rule — the tsx always applies the md class
+// (default size) and it restated the base values exactly.
 
 .hk-breadcrumb-lg {
   font-size: 1rem;
@@ -388,15 +291,10 @@
   .hk-breadcrumb-link {
     padding: 0.375rem 0.625rem;
     margin: -0.375rem -0.625rem;
-
-    .hk-breadcrumb-icon {
-      width: 1.125rem;
-      height: 1.125rem;
-    }
   }
 
   .hk-breadcrumb-separator {
-    margin-left: 0.625rem;
+    margin-inline-start: 0.625rem;
     font-size: 1rem;
 
     svg {
@@ -418,9 +316,6 @@
     background: var(--hi-card-bg);
     padding: 0.375rem 0.75rem;
     border-radius: vars.$hikari-radius-fui-sm;
-    // DISABLED - migrated to JS animation
-
-    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
 
     &:not(:last-child):hover {
       background: var(--hi-primary);
@@ -442,19 +337,16 @@
     padding: 0.375rem 0.875rem;
     border-radius: 999px;
     border: 1px solid var(--hi-color-border);
-    // DISABLED - migrated to JS animation
 
-    // transition: all vars.$hikari-duration-fast vars.$hikari-ease-smooth;
-
-    &:not(:last-child) {
-      &:hover {
-        background: var(--hi-primary);
-        border-color: var(--hi-primary);
-      }
+    &:not(:last-child):hover {
+      background: var(--hi-primary);
+      border-color: var(--hi-primary);
     }
 
+    // Solid fill: the former linear-gradient(135deg, primary, primary) had
+    // identical stops and rendered exactly this solid.
     &:last-child {
-      background: linear-gradient(135deg, var(--hi-primary), var(--hi-primary));
+      background: var(--hi-primary);
       border-color: var(--hi-primary);
       box-shadow:
         0 0 12px var(--hi-primary),
@@ -462,29 +354,6 @@
     }
   }
 }
-
-// ------
-// Separator Animations
-// ------
-
-// Animated separator (pulsing glow)
-.hk-breadcrumb-separator-animated {
-  // DISABLED - migrated to JS animation
-
-  // animation: breadcrumb-separator-pulse 2s ease-in-out infinite;
-}
-
-// DISABLED - migrated to JS animation
-// @keyframes breadcrumb-separator-pulse {
-//   0%, 100% {
-//     opacity: 0.5;
-//     filter: drop-shadow(0 0 4px var(--hi-primary));
-//   }
-//   50% {
-//     opacity: 1;
-//     filter: drop-shadow(0 0 8px var(--hi-primary));
-//   }
-// }
 
 // ------
 // Collapsible Breadcrumb (for mobile)
@@ -509,72 +378,12 @@
 }
 
 // ------
-// Animations
-// ------
-
-// Fade-in animation
-.hk-breadcrumb-animate-in {
-  .hk-breadcrumb-item {
-    opacity: 0;
-    // DISABLED - migrated to JS animation
-
-    // animation: breadcrumb-fade-in vars.$hikari-duration-normal vars.$hikari-ease-smooth forwards;
-
-    @for $i from 1 through 10 {
-      &:nth-child(#{$i}) {
-        animation-delay: #{$i * 0.1s};
-      }
-    }
-  }
-}
-
-// DISABLED - migrated to JS animation
-// @keyframes breadcrumb-fade-in {
-//   from {
-//     opacity: 0;
-//     transform: translateY(-4px);
-//   }
-//   to {
-//     opacity: 1;
-//     transform: translateY(0);
-//   }
-// }
-
-// Slide-in animation
-.hk-breadcrumb-slide-in {
-  .hk-breadcrumb-item {
-    opacity: 0;
-    // DISABLED - migrated to JS animation
-
-    // animation: breadcrumb-slide-in vars.$hikari-duration-normal vars.$hikari-ease-smooth forwards;
-
-    @for $i from 1 through 10 {
-      &:nth-child(#{$i}) {
-        animation-delay: #{$i * 0.08s};
-      }
-    }
-  }
-}
-
-// DISABLED - migrated to JS animation
-// @keyframes breadcrumb-slide-in {
-//   from {
-//     opacity: 0;
-//     transform: translateX(-8px);
-//   }
-//   to {
-//     opacity: 1;
-//     transform: translateX(0);
-//   }
-// }
-
-// ------
 // Custom Colors
 // ------
 
 .hk-breadcrumb-primary {
   .hk-breadcrumb-link {
-    &:hover {
+    &[href]:hover {
       color: var(--hi-color-primary);
       text-shadow: 0 0 8px var(--hi-color-primary);
     }
@@ -583,7 +392,7 @@
 
 .hk-breadcrumb-success {
   .hk-breadcrumb-link {
-    &:hover {
+    &[href]:hover {
       color: var(--hi-color-success);
       text-shadow: 0 0 8px var(--hi-color-success);
     }
@@ -592,7 +401,7 @@
 
 .hk-breadcrumb-warning {
   .hk-breadcrumb-link {
-    &:hover {
+    &[href]:hover {
       color: var(--hi-color-warning);
       text-shadow: 0 0 8px var(--hi-color-warning);
     }
@@ -601,7 +410,7 @@
 
 .hk-breadcrumb-danger {
   .hk-breadcrumb-link {
-    &:hover {
+    &[href]:hover {
       color: var(--hi-color-danger);
       text-shadow: 0 0 8px var(--hi-color-danger);
     }

--- a/packages/vue/src/components/HkBreadcrumb.scss
+++ b/packages/vue/src/components/HkBreadcrumb.scss
@@ -28,7 +28,7 @@
   line-height: 1.5;
 
   // Gap
-  gap: 0.5rem;
+  gap: var(--space-8);
 }
 
 // ------
@@ -77,17 +77,18 @@
   transition:
     color 200ms ease,
     background 200ms ease,
-    box-shadow 200ms ease;
+    box-shadow 200ms ease,
+    filter 200ms ease;
 
   // Padding
-  padding: 0.25rem 0.5rem;
-  margin: -0.25rem -0.5rem;
+  padding: var(--space-4) var(--space-8);
+  margin: calc(-1 * var(--space-4)) calc(-1 * var(--space-8));
   border-radius: vars.$hikari-radius-fui-sm;
 
   // Display
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--space-6);
 
   // Interactive affordance only for REAL links: items without `to` render
   // as a <span class="hk-breadcrumb-link"> (HkBreadcrumb.tsx) — a pointer
@@ -102,6 +103,11 @@
 
       // Glow effect on text
       text-shadow: 0 0 8px var(--hi-primary);
+    }
+
+    // Press feedback (house idiom: HkButton brightness dip)
+    &:active {
+      filter: brightness(0.95);
     }
   }
 
@@ -140,10 +146,10 @@
   align-items: center;
 
   // Typography
-  font-size: 0.875rem;
+  font-size: var(--text-base);
 
   // Spacing
-  margin-inline-start: 0.5rem;
+  margin-inline-start: var(--space-8);
   color: var(--hi-color-text-secondary);
   opacity: 0.5;
 
@@ -154,6 +160,13 @@
     width: 1rem;
     height: 1rem;
   }
+}
+
+// RTL mirrors the chevron: the tsx always renders a right-pointing glyph,
+// which reads backwards on the flipped axis (HkTimeline precedent —
+// scaleX mirrors paint only; the box is symmetric around its center).
+[dir="rtl"] .hk-breadcrumb-separator svg {
+  transform: scaleX(-1);
 }
 
 // ------
@@ -171,15 +184,12 @@
     // Layout
     display: inline-flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: var(--space-4);
 
     // Arrow icon
     .hk-breadcrumb-dropdown-arrow {
       width: 0.75rem;
       height: 0.75rem;
-      // DISABLED - migrated to JS animation
-
-      // transition: transform vars.$hikari-duration-fast vars.$hikari-ease-smooth;
 
       svg {
         width: 100%;
@@ -214,12 +224,7 @@
       0 0 0 1px var(--hi-white-5, rgba(255, 255, 255, 0.05)) inset;
 
     // Padding
-    padding: 0.5rem;
-
-    // Transitions
-    // DISABLED - migrated to JS animation
-
-    // transition: all vars.$hikari-duration-normal vars.$hikari-ease-smooth;
+    padding: var(--space-8);
 
     // Animation
     opacity: 0;
@@ -249,10 +254,10 @@
   @include mi.item;
 
   // Spacing
-  margin: 0.125rem 0;
+  margin: var(--space-2) 0;
 
-  // Typography
-  color: var(--hi-color-text-primary);
+  // Typography — the mixin owns the row ink (rgb(var(--color-text) / 88%));
+  // the former full-opacity color here silently defeated it in-rule.
   text-decoration: none;
   white-space: nowrap;
 }
@@ -262,17 +267,17 @@
 // ------
 
 .hk-breadcrumb-sm {
-  font-size: 0.75rem;
-  gap: 0.375rem;
+  font-size: var(--text-xs);
+  gap: var(--space-6);
 
   .hk-breadcrumb-link {
-    padding: 0.125rem 0.375rem;
-    margin: -0.125rem -0.375rem;
+    padding: var(--space-2) var(--space-6);
+    margin: calc(-1 * var(--space-2)) calc(-1 * var(--space-6));
   }
 
   .hk-breadcrumb-separator {
-    margin-inline-start: 0.375rem;
-    font-size: 0.75rem;
+    margin-inline-start: var(--space-6);
+    font-size: var(--text-xs);
 
     svg {
       width: 0.875rem;
@@ -285,17 +290,17 @@
 // (default size) and it restated the base values exactly.
 
 .hk-breadcrumb-lg {
-  font-size: 1rem;
-  gap: 0.625rem;
+  font-size: var(--text-md);
+  gap: var(--space-10);
 
   .hk-breadcrumb-link {
-    padding: 0.375rem 0.625rem;
-    margin: -0.375rem -0.625rem;
+    padding: var(--space-6) var(--space-10);
+    margin: calc(-1 * var(--space-6)) calc(-1 * var(--space-10));
   }
 
   .hk-breadcrumb-separator {
-    margin-inline-start: 0.625rem;
-    font-size: 1rem;
+    margin-inline-start: var(--space-10);
+    font-size: var(--text-md);
 
     svg {
       width: 1.125rem;

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -151,9 +151,14 @@
   backdrop-filter: blur(var(--blur-sm));
 }
 
+/* background stays the base surface — the hover declaration only restated
+   it; hover emphasis comes from the border-color change below. */
 .hk-btn-secondary:hover:not(:disabled) {
-  background: rgb(var(--color-surface));
   border-color: var(--c-primary-strong);
+}
+
+.hk-btn-secondary:active:not(:disabled) {
+  filter: brightness(0.95);
 }
 
 /* ---- Outline ---- */
@@ -169,6 +174,10 @@
   border-color: rgb(var(--color-primary));
 }
 
+.hk-btn-outline:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
 /* ---- Ghost ---- */
 
 .hk-btn-ghost {
@@ -181,6 +190,10 @@
   background: var(--c-primary-light);
 }
 
+.hk-btn-ghost:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
 /* ---- Danger ---- */
 
 .hk-btn-danger {
@@ -191,6 +204,10 @@
 .hk-btn-danger:hover:not(:disabled) {
   filter: brightness(1.1);
   box-shadow: var(--shadow-button-danger);
+}
+
+.hk-btn-danger:active:not(:disabled) {
+  filter: brightness(0.95);
 }
 
 /* ---- Block ---- */

--- a/packages/vue/src/components/HkButton.scss
+++ b/packages/vue/src/components/HkButton.scss
@@ -133,7 +133,10 @@
   }
 }
 
-.hk-btn-primary:hover:not(:disabled) {
+/* :not(:focus-visible) keeps the keyboard double ring winning while a
+   focused button is under the cursor — this hover rule's (0,3,0)
+   box-shadow would otherwise beat the (0,2,0) :focus-visible ring. */
+.hk-btn-primary:hover:not(:disabled):not(:focus-visible) {
   filter: brightness(1.1);
   box-shadow: var(--shadow-button);
 }
@@ -201,7 +204,7 @@
   color: rgb(var(--color-on-solid));
 }
 
-.hk-btn-danger:hover:not(:disabled) {
+.hk-btn-danger:hover:not(:disabled):not(:focus-visible) {
   filter: brightness(1.1);
   box-shadow: var(--shadow-button-danger);
 }
@@ -218,6 +221,9 @@
 
 /* ---- Loading ---- */
 
+/* pointer-events: none is deliberate, not dead: the tsx already forces
+   `disabled` while loading (HkButton.tsx), so this only suppresses the
+   :disabled not-allowed cursor — a busy spinner reads busy, not broken. */
 .hk-btn-loading {
   pointer-events: none;
 }

--- a/packages/vue/src/components/HkCaptchaWidget.scss
+++ b/packages/vue/src/components/HkCaptchaWidget.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--space-8, 0.5rem);
-  min-height: 4rem;
+  min-height: var(--space-64, 4rem);
 }
 
 .s-captcha-widget-loading {
@@ -19,9 +19,8 @@
 
 .s-captcha-widget-placeholder {
   justify-content: center;
-  min-height: 4rem;
   padding: var(--space-16, 1rem);
-  border: 1px dashed var(--border-faint, rgb(var(--color-border) / 15%));
+  border: 1px dashed var(--border-faint, rgb(var(--color-border) / 10%));
   border-radius: var(--radius-md, 8px);
   color: rgb(var(--color-muted));
   font-size: var(--text-xs, 0.75rem);

--- a/packages/vue/src/components/HkCard.scss
+++ b/packages/vue/src/components/HkCard.scss
@@ -22,6 +22,15 @@
   border-color: var(--c-primary-intense);
 }
 
+.hk-card-hoverable:active {
+  border-color: rgb(var(--color-primary) / 45%);
+}
+
+.hk-card-hoverable:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: 2px;
+}
+
 .hk-card-header {
   padding: var(--space-12) var(--space-16);
   border-bottom: 1px solid var(--border-faint);

--- a/packages/vue/src/components/HkCard.scss
+++ b/packages/vue/src/components/HkCard.scss
@@ -1,8 +1,8 @@
 @use "../tokens";
 
-/* HkCard — canonical surface card. Hover effect mirrors the node card:
-   only box-shadow and border-color animate. No transforms, so the card
-   never displaces its neighbors or triggers layout reflow. */
+/* HkCard — canonical surface card. Hover emphasis is border-color only
+   (the base elevation shadow is already at its resting value). No
+   transforms, so the card never displaces neighbors or reflows layout. */
 .hk-card {
   display: block;
   overflow: hidden;
@@ -15,13 +15,10 @@
 
 .hk-card-hoverable {
   cursor: pointer;
-  transition:
-    box-shadow var(--duration-normal) ease,
-    border-color var(--duration-normal) ease;
+  transition: border-color var(--duration-normal) ease;
 }
 
 .hk-card-hoverable:hover {
-  box-shadow: var(--shadow-elevated);
   border-color: var(--c-primary-intense);
 }
 
@@ -45,5 +42,5 @@
 
 .hk-card-footer {
   padding: var(--space-12) var(--space-16);
-  border-top: 1px solid rgb(var(--color-border) / 10%);
+  border-top: 1px solid var(--border-faint);
 }

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -23,7 +23,7 @@
   justify-content: center;
   width: 1.125rem;
   height: 1.125rem;
-  border-radius: var(--hi-radius-xs, 4px);
+  border-radius: var(--hi-radius-sm, 4px);
   border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   transition:
@@ -40,16 +40,9 @@
 .hk-checkbox-box[data-checked] {
   background: var(--hi-color-primary, #ff6b9d);
   border-color: var(--hi-color-primary, #ff6b9d);
-  color: rgb(var(--color-on-solid-text, 255 255 255));
 }
 
 .hk-checkbox-box[data-indeterminate] {
-  background: var(--hi-color-primary, #ff6b9d);
-  border-color: var(--hi-color-primary, #ff6b9d);
-}
-
-.hk-checkbox:hover .hk-checkbox-box[data-checked],
-.hk-checkbox[data-animating] .hk-checkbox-box[data-checked] {
   background: var(--hi-color-primary, #ff6b9d);
   border-color: var(--hi-color-primary, #ff6b9d);
 }
@@ -62,6 +55,15 @@
   height: 0;
   opacity: 0;
   pointer-events: none;
+}
+
+/* Keyboard focus: the native input is visually hidden, so draw the house
+   double ring (HkButton/HkTable pattern) on the box via :has();
+   :focus-visible keeps mouse toggles ring-free. */
+.hk-checkbox-box:has(.hk-checkbox-input:focus-visible) {
+  box-shadow:
+    0 0 0 2px var(--hi-color-surface, rgba(255, 255, 255, 0.95)),
+    0 0 0 4px var(--hi-color-primary, #ff6b9d);
 }
 
 /* ---------- markers ---------- */

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -5,7 +5,7 @@
 .hk-checkbox {
   display: inline-flex;
   align-items: center;
-  gap: var(--hi-space-8, 0.5rem);
+  gap: var(--space-8, 0.5rem);
   cursor: pointer;
   user-select: none;
 }

--- a/packages/vue/src/components/HkColorPicker.scss
+++ b/packages/vue/src/components/HkColorPicker.scss
@@ -10,7 +10,6 @@
 .hk-color-picker[data-layout="row"] {
   .hk-color-picker-swatch-btn {
     flex-direction: row;
-    align-items: center;
     gap: var(--space-8);
     width: 100%;
   }
@@ -26,12 +25,8 @@
     max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
-    text-align: left;
+    text-align: start;
   }
-}
-
-.hk-color-picker-trigger {
-  outline: none;
 }
 
 .hk-color-picker-swatch-btn {
@@ -45,6 +40,14 @@
   background: none;
   cursor: pointer;
   outline: none;
+}
+
+/* The trigger button removes the outline; restore a keyboard indicator
+   with the house double ring (HkButton pattern). */
+.hk-color-picker-swatch-btn:focus-visible {
+  box-shadow:
+    0 0 0 2px rgb(var(--color-surface)),
+    0 0 0 4px rgb(var(--color-primary));
 }
 
 .hk-color-picker-swatch {
@@ -134,7 +137,6 @@
   min-width: 60px;
   height: 10px;
   border-radius: var(--radius-full);
-  display: block;
   overflow: hidden;
   box-shadow: inset 0 0 0 1px rgb(0 0 0 / 10%);
   // Explicit on the hit targets too (not only the container): touch-action
@@ -173,12 +175,24 @@
   &:active { cursor: grabbing; }
 }
 
+/* Thumb hover scale is a transform micro-interaction; drop the scale and
+   the transform transition for reduced-motion users (house pattern). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-color-picker-slider-thumb {
+    transition: none;
+  }
+
+  .hk-color-picker-slider-thumb:hover {
+    transform: translate(-50%, -50%);
+  }
+}
+
 .hk-color-picker-slider-value {
   font-size: var(--text-2xs);
   font-weight: 500;
   color: rgb(var(--color-muted));
   width: 26px;
-  text-align: right;
+  text-align: end;
   flex-shrink: 0;
   font-variant-numeric: tabular-nums;
 }

--- a/packages/vue/src/components/HkContextRing.scss
+++ b/packages/vue/src/components/HkContextRing.scss
@@ -10,6 +10,11 @@
   cursor: pointer;
   border-radius: var(--radius-full, 999px);
   -webkit-tap-highlight-color: transparent;
+  transition: background-color 200ms ease;
+
+  &:hover {
+    background: rgb(var(--color-text) / 6%);
+  }
 
   &:focus-visible {
     outline: 2px solid rgb(var(--color-primary));
@@ -79,7 +84,7 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 2px;
+  gap: var(--space-2, 0.125rem);
 }
 
 .hk-ctx-legend-row {
@@ -93,9 +98,8 @@
 .hk-ctx-legend-swatch {
   width: 8px;
   height: 8px;
-  border-radius: 2px;
+  border-radius: var(--radius-xs, 2px);
   align-self: center;
-  flex-shrink: 0;
 }
 
 .hk-ctx-legend-label {
@@ -112,7 +116,7 @@
 .hk-ctx-legend-pct {
   color: rgb(var(--color-muted));
   font-variant-numeric: tabular-nums;
-  text-align: right;
+  text-align: end;
   min-width: 3ch;
 }
 

--- a/packages/vue/src/components/HkCookieConsent.scss
+++ b/packages/vue/src/components/HkCookieConsent.scss
@@ -1,8 +1,8 @@
 .s-cookie-consent {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 0.625rem;
+  gap: var(--space-4, 0.25rem);
+  font-size: var(--text-2xs, 0.625rem);
   color: rgb(var(--color-muted));
 }
 
@@ -11,8 +11,17 @@
   border: none;
   color: rgb(var(--color-primary));
   cursor: pointer;
-  font-size: 0.625rem;
+  font-size: var(--text-2xs, 0.625rem);
   font-weight: 600;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
 }
 
 .s-cookie-consent-icon {

--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -20,13 +20,13 @@
 .hk-dp-native {
   width: 100%;
   min-height: 2.5rem;
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  padding: var(--space-8, 8px) var(--space-12, 12px);
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--hi-radius-sm, 4px);
   color: rgb(var(--color-text));
   font-family: inherit;
-  font-size: var(--hi-text-sm, 0.875rem);
+  font-size: var(--text-sm, 0.875rem);
   line-height: 1.5;
   transition:
     background-color var(--hi-duration-fast, 0.15s) ease,
@@ -38,7 +38,7 @@
   position: relative;
   display: flex;
   align-items: center;
-  gap: var(--hi-space-6, 6px);
+  gap: var(--space-6, 6px);
   cursor: pointer;
   user-select: none;
 }
@@ -75,8 +75,8 @@
 
 .hk-dp-trigger-sm {
   min-height: 2rem;
-  padding: var(--hi-space-4, 4px) var(--hi-space-10, 10px);
-  font-size: var(--hi-text-xs, 0.75rem);
+  padding: var(--space-4, 4px) var(--space-10, 10px);
+  font-size: var(--text-xs, 0.75rem);
 }
 
 .hk-dp-value {
@@ -131,13 +131,13 @@
 /* ── Calendar panel ──────────────────────────────────────────── */
 
 .hk-dp-popover.hk-popover-panel {
-  padding: var(--hi-space-10, 10px) var(--hi-space-12, 12px) var(--hi-space-8, 8px);
+  padding: var(--space-10, 10px) var(--space-12, 12px) var(--space-8, 8px);
 }
 
 .hk-dp-panel {
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
   min-width: 17.5rem;
   user-select: none;
   color: var(--hi-color-text-primary);
@@ -159,7 +159,7 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
   /* Fixed height keeps the header row — and therefore the shared stage
    * height — identical in every view and locale (enlarged on touch). */
   height: var(--hk-picker-header);
@@ -168,7 +168,7 @@
 .hk-dp-header-side {
   display: flex;
   align-items: center;
-  gap: var(--hi-space-2, 2px);
+  gap: var(--space-2, 2px);
   min-width: 0;
 }
 
@@ -212,21 +212,21 @@
 }
 
 .hk-dp-title {
-  font-size: var(--hi-text-sm, 0.875rem);
+  font-size: var(--text-sm, 0.875rem);
   font-weight: 600;
   color: var(--hi-color-text-primary);
   font-variant-numeric: tabular-nums;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
 }
 
 .hk-dp-title-btn {
   appearance: none;
   background: transparent;
   border: 0;
-  padding: var(--hi-space-2, 2px) var(--hi-space-4, 4px);
+  padding: var(--space-2, 2px) var(--space-4, 4px);
   font: inherit;
   font-weight: 600;
   color: inherit;
@@ -265,7 +265,7 @@
 
 .hk-dp-wd {
   text-align: center;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
   height: var(--hk-picker-wd);
@@ -289,7 +289,7 @@
   justify-content: center;
   color: color-mix(in srgb, var(--hi-color-text-secondary) 70%, transparent);
   cursor: pointer;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
 
@@ -338,7 +338,7 @@
 .hk-dp-footer {
   display: flex;
   justify-content: center;
-  padding-top: var(--hi-space-6, 6px);
+  padding-top: var(--space-6, 6px);
   border-top: 1px solid color-mix(in srgb, var(--hi-color-border) 10%, transparent);
 }
 

--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -13,13 +13,11 @@
   opacity: 0.5;
 }
 
-/* ── Trigger ─────────────────────────────────────────────────── */
-
-.hk-dp-trigger {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: var(--hi-space-6, 6px);
+/* ── Trigger / native input ──────────────────────────────────── */
+/* The custom trigger and the native <input type="date"> carry
+ * byte-identical field chrome, so those declarations live in one group. */
+.hk-dp-trigger,
+.hk-dp-native {
   width: 100%;
   min-height: 2.5rem;
   padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
@@ -30,16 +28,25 @@
   font-family: inherit;
   font-size: var(--hi-text-sm, 0.875rem);
   line-height: 1.5;
-  cursor: pointer;
-  user-select: none;
   transition:
     background-color var(--hi-duration-fast, 0.15s) ease,
     border-color var(--hi-duration-fast, 0.15s) ease,
     box-shadow var(--hi-duration-fast, 0.15s) ease;
 }
 
+.hk-dp-trigger {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--hi-space-6, 6px);
+  cursor: pointer;
+  user-select: none;
+}
+
 .hk-dp:not(.is-disabled) .hk-dp-trigger:hover,
-.hk-dp-trigger:focus-visible {
+.hk-dp:not(.is-disabled) .hk-dp-native:hover,
+.hk-dp-trigger:focus-visible,
+.hk-dp-native:focus-visible {
   border-color: rgb(var(--color-focused-border));
 }
 
@@ -53,8 +60,9 @@
   }
 }
 
-/* Focus ring + open state live on the trigger itself. */
-.hk-dp-trigger:focus-visible {
+/* Focus ring + open state live on the field itself. */
+.hk-dp-trigger:focus-visible,
+.hk-dp-native:focus-visible {
   outline: none;
   box-shadow: var(--shadow-focus);
   background: rgb(var(--color-surface));
@@ -102,7 +110,6 @@
 
   .hk-dp-trigger:hover &,
   .hk-dp-trigger:focus &,
-  .hk-dp-trigger:focus-visible &,
   .hk-dp-clear:focus-visible {
     opacity: 1;
   }
@@ -153,9 +160,6 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: var(--hi-space-4, 4px);
-}
-
-.hk-dp-header {
   /* Fixed height keeps the header row — and therefore the shared stage
    * height — identical in every view and locale (enlarged on touch). */
   height: var(--hk-picker-header);
@@ -192,6 +196,10 @@
     color: var(--hi-color-text-primary);
   }
 
+  &:active:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
   &:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
     outline-offset: 1px;
@@ -208,7 +216,6 @@
   font-weight: 600;
   color: var(--hi-color-text-primary);
   font-variant-numeric: tabular-nums;
-  text-align: center;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -233,6 +240,10 @@
     color: var(--hi-color-primary);
   }
 
+  &:active:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
   &:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
     outline-offset: 1px;
@@ -243,7 +254,7 @@
 .hk-dp-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 2px;
+  gap: var(--space-2, 2px);
 }
 
 /* Month/year pick grids sit in the same fixed stage as the day grid and
@@ -287,6 +298,10 @@
     color: var(--hi-color-text-primary);
   }
 
+  &:active:not(:disabled) {
+    filter: brightness(0.95);
+  }
+
   &:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
     outline-offset: -1px;
@@ -299,10 +314,6 @@
   &.is-disabled {
     cursor: default;
     opacity: 0.25;
-
-    &:hover {
-      background: transparent;
-    }
   }
 
   &.is-today:not(.is-selected) {
@@ -315,10 +326,6 @@
     background: var(--hi-color-primary);
     color: rgb(var(--color-on-solid-text, 255 255 255));
     font-weight: 600;
-
-    &:hover {
-      background: var(--hi-color-primary);
-    }
   }
 }
 
@@ -336,36 +343,13 @@
 }
 
 /* ── Native mobile input ─────────────────────────────────────── */
+/* Unique native-input bits only; the shared field chrome comes from the
+ * .hk-dp-trigger / .hk-dp-native group at the top of the file. */
 
 .hk-dp-native {
   display: block;
-  width: 100%;
-  min-height: 2.5rem;
   box-sizing: border-box;
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
-  background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
-  border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
-  color: rgb(var(--color-text));
-  font-family: inherit;
-  font-size: var(--hi-text-sm, 0.875rem);
-  line-height: 1.5;
   font-variant-numeric: tabular-nums;
-  transition:
-    background-color var(--hi-duration-fast, 0.15s) ease,
-    border-color var(--hi-duration-fast, 0.15s) ease,
-    box-shadow var(--hi-duration-fast, 0.15s) ease;
-}
-
-.hk-dp:not(.is-disabled) .hk-dp-native:hover,
-.hk-dp-native:focus-visible {
-  border-color: rgb(var(--color-focused-border));
-}
-
-.hk-dp-native:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
-  background: rgb(var(--color-surface));
 }
 
 .hk-dp.is-disabled .hk-dp-native {

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -7,7 +7,7 @@
 .hk-dtp {
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
   user-select: none;
   /* Fill the host (inline sheets/dialogs) instead of collapsing to the
    * grid's min-content width — a bottom-sheet calendar should use the
@@ -20,7 +20,7 @@
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
   /* Fixed height keeps the header row — and therefore the shared stage
    * height — identical in every view and locale (enlarged on touch). */
   height: var(--hk-picker-header);
@@ -29,7 +29,7 @@
 .hk-dtp-header-side {
   display: flex;
   align-items: center;
-  gap: var(--hi-space-2, 2px);
+  gap: var(--space-2, 2px);
   min-width: 0;
 }
 
@@ -38,7 +38,7 @@
 }
 
 .hk-dtp-title {
-  font-size: var(--hi-text-sm, 0.875rem);
+  font-size: var(--text-sm, 0.875rem);
   font-weight: 600;
   color: var(--hi-color-text-primary);
   font-variant-numeric: tabular-nums;
@@ -46,14 +46,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
 }
 
 .hk-dtp-title-btn {
   appearance: none;
   background: transparent;
   border: 0;
-  padding: var(--hi-space-2, 2px) var(--hi-space-4, 4px);
+  padding: var(--space-2, 2px) var(--space-4, 4px);
   font: inherit;
   font-weight: 600;
   color: inherit;
@@ -108,7 +108,7 @@
 
 .hk-dtp-wd {
   text-align: center;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
   height: var(--hk-picker-wd);
@@ -132,7 +132,7 @@
   justify-content: center;
   color: color-mix(in srgb, var(--hi-color-text-secondary) 70%, transparent);
   cursor: pointer;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
 
@@ -184,7 +184,7 @@
 
 .hk-dtp-cell[data-variant="pick"] {
   height: var(--hk-picker-pick);
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 500;
 }
 
@@ -208,7 +208,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--hi-space-10, 10px);
+  gap: var(--space-10, 10px);
   /* Spacing comes from the .hk-dtp gap (the row sits under the fixed
    * stage in every view); only the separator border remains. */
   border-top: 1px solid color-mix(in srgb, var(--hi-color-border) 10%, transparent);
@@ -247,7 +247,7 @@
 }
 
 .hk-dtp-step-val {
-  font-size: var(--hi-text-base, 1rem);
+  font-size: var(--text-base, 1rem);
   font-variant-numeric: tabular-nums;
   min-width: 1.75rem;
   text-align: center;
@@ -256,19 +256,19 @@
 }
 
 .hk-dtp-time-sep {
-  font-size: var(--hi-text-base, 1rem);
+  font-size: var(--text-base, 1rem);
   color: var(--hi-color-muted);
-  padding-top: var(--hi-space-10, 10px);
+  padding-top: var(--space-10, 10px);
 }
 
 .hk-dtp-today {
-  margin-inline-start: var(--hi-space-4, 4px);
+  margin-inline-start: var(--space-4, 4px);
   appearance: none;
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
   border-radius: var(--hi-radius-sm, 4px);
-  padding: var(--hi-space-4, 4px) var(--hi-space-10, 10px);
-  font-size: var(--hi-text-xs, 0.75rem);
+  padding: var(--space-4, 4px) var(--space-10, 10px);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
   cursor: pointer;
@@ -296,13 +296,13 @@
   appearance: none;
   display: inline-flex;
   align-items: center;
-  gap: var(--hi-space-6, 6px);
-  padding: var(--hi-space-4, 4px) var(--hi-space-10, 10px);
+  gap: var(--space-6, 6px);
+  padding: var(--space-4, 4px) var(--space-10, 10px);
   background: var(--hi-color-surface);
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
   border-radius: var(--hi-radius-sm, 4px);
   color: color-mix(in srgb, var(--hi-color-text-secondary) 70%, transparent);
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   cursor: pointer;
   transition: border-color var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
@@ -344,7 +344,7 @@
 }
 
 .hk-dtp-popup {
-  padding: var(--hi-space-8, 8px);
+  padding: var(--space-8, 8px);
   min-width: 260px;
 }
 
@@ -368,8 +368,8 @@
 .hk-dtp-popup-foot {
   display: flex;
   justify-content: flex-end;
-  padding: var(--hi-space-8, 8px) var(--hi-space-2, 2px) var(--hi-space-2, 2px);
-  margin-top: var(--hi-space-8, 8px);
+  padding: var(--space-8, 8px) var(--space-2, 2px) var(--space-2, 2px);
+  margin-top: var(--space-8, 8px);
   border-top: 1px solid color-mix(in srgb, var(--hi-color-border) 10%, transparent);
 }
 
@@ -379,8 +379,8 @@
   color: rgb(var(--color-on-solid-text, 255 255 255));
   border: 0;
   border-radius: var(--hi-radius-sm, 4px);
-  padding: var(--hi-space-6, 6px) var(--hi-space-14, 14px);
-  font-size: var(--hi-text-xs, 0.75rem);
+  padding: var(--space-6, 6px) var(--space-14, 14px);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   cursor: pointer;
   transition: filter var(--hi-duration-fast, 0.15s) ease;
@@ -397,13 +397,13 @@
   width: 100%;
   min-height: 2.5rem;
   box-sizing: border-box;
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  padding: var(--space-8, 8px) var(--space-12, 12px);
   background: var(--hi-color-surface);
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
   border-radius: var(--hi-radius-sm, 4px);
   color: var(--hi-color-text-primary);
   font-family: inherit;
-  font-size: var(--hi-text-sm, 0.875rem);
+  font-size: var(--text-sm, 0.875rem);
   font-variant-numeric: tabular-nums;
   line-height: 1.5;
 

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -21,9 +21,6 @@
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: var(--hi-space-8, 8px);
-}
-
-.hk-dtp-header {
   /* Fixed height keeps the header row — and therefore the shared stage
    * height — identical in every view and locale (enlarged on touch). */
   height: var(--hk-picker-header);
@@ -106,7 +103,7 @@
 .hk-dtp-grid {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 2px;
+  gap: var(--space-2, 2px);
 }
 
 .hk-dtp-wd {
@@ -242,6 +239,11 @@
     color: var(--hi-color-text-primary);
     background: var(--hi-color-surface);
   }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
+    outline-offset: 1px;
+  }
 }
 
 .hk-dtp-step-val {
@@ -260,7 +262,7 @@
 }
 
 .hk-dtp-today {
-  margin-left: var(--hi-space-4, 4px);
+  margin-inline-start: var(--hi-space-4, 4px);
   appearance: none;
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
@@ -270,12 +272,16 @@
   font-weight: 600;
   color: var(--hi-color-muted);
   cursor: pointer;
-  align-self: center;
   transition: color var(--hi-duration-fast, 0.15s) ease, border-color var(--hi-duration-fast, 0.15s) ease;
 
   &:hover {
     color: var(--hi-color-text-primary);
     border-color: color-mix(in srgb, var(--hi-color-primary) 50%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
+    outline-offset: 1px;
   }
 }
 
@@ -306,6 +312,11 @@
     border-color: color-mix(in srgb, var(--hi-color-primary) 50%, transparent);
     color: var(--hi-color-text-primary);
   }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent);
+    outline-offset: 1px;
+  }
 }
 
 .hk-dtp-trigger-icon {
@@ -324,6 +335,12 @@
 
 .hk-dtp-trigger-chev.is-open {
   transform: rotate(180deg);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-dtp-trigger-chev {
+    transition: none;
+  }
 }
 
 .hk-dtp-popup {

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -247,7 +247,7 @@
 }
 
 .hk-dtp-step-val {
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
   font-variant-numeric: tabular-nums;
   min-width: 1.75rem;
   text-align: center;
@@ -256,7 +256,7 @@
 }
 
 .hk-dtp-time-sep {
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
   color: var(--hi-color-muted);
   padding-top: var(--space-10, 10px);
 }

--- a/packages/vue/src/components/HkDivider.scss
+++ b/packages/vue/src/components/HkDivider.scss
@@ -32,23 +32,23 @@
 }
 
 .hk-divider-spacing-xs {
-  --hk-divider-space: var(--hi-space-2, 0.125rem);
+  --hk-divider-space: var(--space-2, 0.125rem);
 }
 
 .hk-divider-spacing-sm {
-  --hk-divider-space: var(--hi-space-4, 0.25rem);
+  --hk-divider-space: var(--space-4, 0.25rem);
 }
 
 .hk-divider-spacing-md {
-  --hk-divider-space: var(--hi-space-6, 0.375rem);
+  --hk-divider-space: var(--space-6, 0.375rem);
 }
 
 .hk-divider-spacing-lg {
-  --hk-divider-space: var(--hi-space-8, 0.5rem);
+  --hk-divider-space: var(--space-8, 0.5rem);
 }
 
 .hk-divider-spacing-xl {
-  --hk-divider-space: var(--hi-space-12, 0.75rem);
+  --hk-divider-space: var(--space-12, 0.75rem);
 }
 
 .hk-divider[class*="hk-divider-spacing-"]:not(.hk-divider-vertical) {
@@ -64,21 +64,21 @@
 }
 
 .hk-divider-vertical.hk-divider-length-xs {
-  height: var(--hi-space-8, 0.5rem);
+  height: var(--space-8, 0.5rem);
 }
 
 .hk-divider-vertical.hk-divider-length-sm {
-  height: var(--hi-space-12, 0.75rem);
+  height: var(--space-12, 0.75rem);
 }
 
 .hk-divider-vertical.hk-divider-length-md {
-  height: var(--hi-space-16, 1rem);
+  height: var(--space-16, 1rem);
 }
 
 .hk-divider-vertical.hk-divider-length-lg {
-  height: var(--hi-space-24, 1.5rem);
+  height: var(--space-24, 1.5rem);
 }
 
 .hk-divider-vertical.hk-divider-length-xl {
-  height: var(--hi-space-32, 2rem);
+  height: var(--space-32, 2rem);
 }

--- a/packages/vue/src/components/HkDivider.scss
+++ b/packages/vue/src/components/HkDivider.scss
@@ -59,27 +59,26 @@
   margin-inline: var(--hk-divider-space);
 }
 
-.hk-divider-vertical.hk-divider-length-xs {
+.hk-divider-vertical[class*="hk-divider-length-"] {
   align-self: center;
+}
+
+.hk-divider-vertical.hk-divider-length-xs {
   height: var(--hi-space-8, 0.5rem);
 }
 
 .hk-divider-vertical.hk-divider-length-sm {
-  align-self: center;
   height: var(--hi-space-12, 0.75rem);
 }
 
 .hk-divider-vertical.hk-divider-length-md {
-  align-self: center;
   height: var(--hi-space-16, 1rem);
 }
 
 .hk-divider-vertical.hk-divider-length-lg {
-  align-self: center;
   height: var(--hi-space-24, 1.5rem);
 }
 
 .hk-divider-vertical.hk-divider-length-xl {
-  align-self: center;
   height: var(--hi-space-32, 2rem);
 }

--- a/packages/vue/src/components/HkDraggableGrid.scss
+++ b/packages/vue/src/components/HkDraggableGrid.scss
@@ -1,30 +1,30 @@
 .hk-draggable-grid {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-draggable-grid-row {
   display: flex;
   flex-wrap: nowrap;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-draggable-grid-row-phantom {
   min-height: 44px;
   border: 1px dashed var(--hi-color-primary, #58a6ff);
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
 }
 
 .hk-draggable-grid-cell {
-  flex: 0 0 calc((100% - (var(--hk-grid-cols, 3) - 1) * 0.5rem) / var(--hk-grid-cols, 3));
+  flex: 0 0 calc((100% - (var(--hk-grid-cols, 3) - 1) * var(--space-8, 0.5rem)) / var(--hk-grid-cols, 3));
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
   min-height: 44px;
-  padding: 0.5rem 0.625rem;
-  border-radius: 4px;
+  padding: var(--space-8, 0.5rem) var(--space-10, 0.625rem);
+  border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-subtle, #21262d);
   border: 1px solid var(--hi-color-border, #30363d);
   transition:
@@ -48,7 +48,6 @@
     border-color: var(--hi-color-primary, #58a6ff);
     background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
     cursor: grabbing;
-    z-index: 0;
   }
 
   &[data-placeholder="before"] {
@@ -57,6 +56,13 @@
 
   &[data-locked] {
     opacity: 0.65;
+    cursor: default;
+
+    /* Locked cells never start a drag (tsx returns early) — no hover
+     * affordance and no grab cursor on their surface. */
+    &:hover {
+      border-color: var(--hi-color-border, #30363d);
+    }
   }
 
   .hk-draggable-grid[data-dragging] & {
@@ -70,10 +76,20 @@
   box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #58a6ff);
 }
 
+/* RTL flips the flex flow, so the before/after insertion markers must
+ * swap physical sides to keep pointing at the inline edge (HkBreadcrumb
+ * precedent for the [dir="rtl"] override form). */
+[dir="rtl"] .hk-draggable-grid-cell[data-placeholder="before"] {
+  box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #58a6ff);
+}
+
+[dir="rtl"] .hk-draggable-grid-row[data-placeholder-row="after"] {
+  box-shadow: inset 2px 0 0 0 var(--hi-color-primary, #58a6ff);
+}
+
 .hk-draggable-grid-cell-placeholder-target {
   border: none;
   background: transparent;
-  min-height: 44px;
 }
 
 .hk-draggable-grid-handle {
@@ -100,7 +116,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-draggable-grid-ghost {
@@ -113,7 +129,7 @@
   box-shadow:
     0 8px 24px rgb(0 0 0 / 28%),
     0 2px 6px rgb(0 0 0 / 18%);
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-elevated, #161b22);
   backdrop-filter: blur(2px);
   pointer-events: none;
@@ -131,5 +147,19 @@
     transform: none;
     opacity: 1;
     width: 100%;
+  }
+}
+
+/* The dragging cell's scale-down is a non-trivial transform animation —
+ * drop it (and the transitions) under reduced motion (HkExpansionPanel
+ * precedent). The ghost's pointer-follow is direct manipulation with no
+ * transition, so it needs no guard. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-draggable-grid-cell {
+    transition: none;
+
+    &[data-dragging] {
+      transform: none;
+    }
   }
 }

--- a/packages/vue/src/components/HkDraggableList.scss
+++ b/packages/vue/src/components/HkDraggableList.scss
@@ -1,16 +1,16 @@
 .hk-draggable-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-4, 4px);
 }
 
 .hk-draggable-list-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  min-height: 40px;
-  padding: 0.5rem 0.625rem;
-  border-radius: 4px;
+  gap: var(--space-8, 0.5rem);
+  min-height: var(--space-40, 40px);
+  padding: var(--space-8, 0.5rem) var(--space-10, 0.625rem);
+  border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-subtle, #21262d);
   border: 1px solid var(--hi-color-border, #30363d);
   transition:
@@ -20,7 +20,6 @@
     background 150ms ease;
   user-select: none;
   -webkit-user-select: none;
-  transform-origin: center;
 
   &:hover {
     border-color: var(--hi-color-text-tertiary, #8b949e);
@@ -33,7 +32,6 @@
     border-color: var(--hi-color-primary, #58a6ff);
     background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
     cursor: grabbing;
-    z-index: 0;
   }
 
   &[data-placeholder="before"] {
@@ -58,7 +56,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
+  width: var(--space-20, 20px);
   flex-shrink: 0;
   color: var(--hi-color-text-tertiary, #8b949e);
   cursor: grab;
@@ -78,7 +76,7 @@
   min-width: 0;
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-draggable-list-ghost {
@@ -86,12 +84,14 @@
   top: 0;
   left: 0;
   margin: 0;
-  transform: translate3d(0, 0, 0) scale(1.02);
+  // No transform here: the tsx always writes the full translate3d inline
+  // (attachGhost/moveGhost) before the ghost paints — a class transform
+  // (e.g. a scale lift) could never win the cascade against it.
   opacity: 0.85;
   box-shadow:
     0 8px 24px rgb(0 0 0 / 28%),
     0 2px 6px rgb(0 0 0 / 18%);
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-elevated, #161b22);
   backdrop-filter: blur(2px);
   pointer-events: none;
@@ -109,5 +109,16 @@
     transform: none;
     opacity: 1;
     width: 100%;
+  }
+}
+
+/* Reduced motion: the dragging press cue (scale + dim) must snap instead
+   of animating; the hover border/background fades stay (house convention).
+   The ghost itself is pointer-positioned via inline transform — 1:1
+   direct manipulation, not autonomous motion — so it is left alone.
+   (house pattern: HkAffixPicker.scss / HkExpansionPanel.scss guards) */
+@media (prefers-reduced-motion: reduce) {
+  .hk-draggable-list-item {
+    transition: border-color 150ms ease, background 150ms ease;
   }
 }

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -220,3 +220,23 @@
     }
   }
 }
+
+/* Reduced motion: the width/height size morph and the four slide
+   directions snap instead of animating — the surface machine's
+   zero-duration probe (useSurfaceMachine.completeNow) finalizes open/
+   close immediately. The overlay scrim's fade is already flattened by
+   the same media query inside scrim-fade().
+   (house pattern: HkModal.scss / HkPopover.scss guards) */
+@media (prefers-reduced-motion: reduce) {
+  .hk-drawer-panel,
+  .hk-drawer-left-enter-active,
+  .hk-drawer-right-enter-active,
+  .hk-drawer-top-enter-active,
+  .hk-drawer-bottom-enter-active,
+  .hk-drawer-left-leave-active,
+  .hk-drawer-right-leave-active,
+  .hk-drawer-top-leave-active,
+  .hk-drawer-bottom-leave-active {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -118,7 +118,7 @@
 }
 
 .hk-drawer-title {
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
   font-weight: 700;
   color: var(--hi-color-text-primary, #333);
 }

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -112,13 +112,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--hi-space-12, 0.75rem) var(--hi-space-16, 1rem);
+  padding: var(--space-12, 0.75rem) var(--space-16, 1rem);
   border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
   flex-shrink: 0;
 }
 
 .hk-drawer-title {
-  font-size: var(--hi-text-base, 1rem);
+  font-size: var(--text-base, 1rem);
   font-weight: 700;
   color: var(--hi-color-text-primary, #333);
 }
@@ -147,7 +147,7 @@
   /* Consumers nesting a self-padded menu (HkMenuPanel) zero this via
      --hk-drawer-body-padding so nav rows and the footer menu share one
      left edge. */
-  padding: var(--hk-drawer-body-padding, var(--hi-space-16, 1rem));
+  padding: var(--hk-drawer-body-padding, var(--space-16, 1rem));
 
   /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
      hidden, never styled. */
@@ -161,7 +161,7 @@
 .hk-drawer-footer {
   /* HkMenuPanel carries its own inset; zero this variable when the
      footer hosts one so both edges align. */
-  padding: var(--hk-drawer-footer-padding, var(--hi-space-12, 0.75rem) var(--hi-space-16, 1rem));
+  padding: var(--hk-drawer-footer-padding, var(--space-12, 0.75rem) var(--space-16, 1rem));
   border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
   flex-shrink: 0;
 }

--- a/packages/vue/src/components/HkEmptyState.scss
+++ b/packages/vue/src/components/HkEmptyState.scss
@@ -6,15 +6,15 @@
   padding: var(--hi-space-48, 3rem) var(--hi-space-16, 1rem);
   text-align: center;
   background: var(--hk-empty-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(var(--blur-sm, 8px));
   border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
   border-radius: var(--hi-radius-md, 0.5rem);
   box-sizing: border-box;
 }
 
 .hk-empty-icon {
-  width: 48px;
-  height: 48px;
+  width: var(--space-48, 3rem);
+  height: var(--space-48, 3rem);
   margin-bottom: var(--hi-space-12, 0.75rem);
   color: var(--hi-color-text-secondary, #666);
   opacity: 0.5;
@@ -61,7 +61,6 @@
 .hk-empty-state--fill {
   width: 100%;
   height: 100%;
-  min-height: 100%;
 }
 
 /* Loading variant keeps a comfortable spinner area in short hosts. */

--- a/packages/vue/src/components/HkEmptyState.scss
+++ b/packages/vue/src/components/HkEmptyState.scss
@@ -24,7 +24,7 @@
 }
 
 .hk-empty-title {
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
   font-weight: 600;
   color: var(--hi-color-text-primary, #333);
   margin: 0 0 var(--space-8, 0.5rem);

--- a/packages/vue/src/components/HkEmptyState.scss
+++ b/packages/vue/src/components/HkEmptyState.scss
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: var(--hi-space-48, 3rem) var(--hi-space-16, 1rem);
+  padding: var(--space-48, 3rem) var(--space-16, 1rem);
   text-align: center;
   background: var(--hk-empty-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
   backdrop-filter: blur(var(--blur-sm, 8px));
@@ -15,7 +15,7 @@
 .hk-empty-icon {
   width: var(--space-48, 3rem);
   height: var(--space-48, 3rem);
-  margin-bottom: var(--hi-space-12, 0.75rem);
+  margin-bottom: var(--space-12, 0.75rem);
   color: var(--hi-color-text-secondary, #666);
   opacity: 0.5;
   display: flex;
@@ -24,22 +24,22 @@
 }
 
 .hk-empty-title {
-  font-size: var(--hi-text-base, 1rem);
+  font-size: var(--text-base, 1rem);
   font-weight: 600;
   color: var(--hi-color-text-primary, #333);
-  margin: 0 0 var(--hi-space-8, 0.5rem);
+  margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-empty-desc {
-  font-size: var(--hi-text-sm, 0.8125rem);
+  font-size: var(--text-sm, 0.8125rem);
   color: var(--hi-color-text-secondary, #666);
-  margin: 0 0 var(--hi-space-16, 1rem);
+  margin: 0 0 var(--space-16, 1rem);
   max-width: 24rem;
   line-height: 1.5;
 }
 
 .hk-empty-action {
-  margin-top: var(--hi-space-4, 0.25rem);
+  margin-top: var(--space-4, 0.25rem);
 }
 
 /* fit="page" (default): full width on mobile — the page supplies the outer

--- a/packages/vue/src/components/HkErrorLanding.scss
+++ b/packages/vue/src/components/HkErrorLanding.scss
@@ -43,7 +43,7 @@
   border: 1px solid rgb(var(--hel-border) / 70%);
   border-radius: var(--radius-xl, 20px);
   box-shadow: var(--shadow-lg, 0 18px 48px rgb(0 0 0 / 8%));
-  padding: 2.25rem 1.75rem 1.75rem;
+  padding: 2.25rem var(--space-28, 1.75rem) var(--space-28, 1.75rem);
   text-align: center;
 
   // Tone wash bleeding down from the top edge behind the icon — gives the
@@ -188,14 +188,14 @@
 .hk-error-landing__details {
   position: relative;
   margin-top: var(--space-16, 1rem);
-  text-align: left;
+  text-align: start;
 }
 
 .hk-error-landing__details-label {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 0 2px;
+  gap: var(--space-4, 4px);
+  padding: 0 var(--space-2, 2px);
   font-size: var(--text-xs, 0.75rem);
   font-weight: 500;
   letter-spacing: 0.02em;
@@ -269,6 +269,6 @@
 
 @media (max-width: 480px) {
   .hk-error-landing__card {
-    padding: 1.75rem 1.125rem 1.5rem;
+    padding: var(--space-28, 1.75rem) 1.125rem var(--space-24, 1.5rem);
   }
 }

--- a/packages/vue/src/components/HkExpansionPanel.scss
+++ b/packages/vue/src/components/HkExpansionPanel.scss
@@ -37,12 +37,16 @@
   background: none;
   color: rgb(var(--color-text));
   font: inherit;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   outline: none;
 
   &:hover {
     background: var(--c-primary-faint);
+  }
+
+  &:active:not(:disabled) {
+    background: var(--c-primary-dim);
   }
 
   &:focus-visible {
@@ -62,7 +66,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2);
   min-width: 0;
 }
 

--- a/packages/vue/src/components/HkFab.scss
+++ b/packages/vue/src/components/HkFab.scss
@@ -7,7 +7,7 @@
   z-index: var(--hk-fab-z, 40);
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
   pointer-events: none;
 
   &[data-positioning="fixed"] { position: fixed; }
@@ -15,15 +15,15 @@
   // Layout axis follows the expansion direction (DOM order [actions, main]).
   &[data-expand="up"] { flex-direction: column; }
   &[data-expand="down"] { flex-direction: column-reverse; }
-  &[data-expand="left"] { flex-direction: row; }
+  &[data-expand="left"] { flex-direction: row; } // row = initial value
   &[data-expand="right"] { flex-direction: row-reverse; }
 
   // Base insets: safe-area aware, extended by --hk-fab-offset-*.
-  --_hk-fab-x: max(0.875rem, env(safe-area-inset-left, 0px));
-  --_hk-fab-y: max(0.875rem, env(safe-area-inset-bottom, 0px));
+  --_hk-fab-x: max(var(--space-14, 0.875rem), env(safe-area-inset-left, 0px));
+  --_hk-fab-y: max(var(--space-14, 0.875rem), env(safe-area-inset-bottom, 0px));
 
   &[data-corner$="-right"] {
-    --_hk-fab-x: max(0.875rem, env(safe-area-inset-right, 0px));
+    --_hk-fab-x: max(var(--space-14, 0.875rem), env(safe-area-inset-right, 0px));
     right: calc(var(--_hk-fab-x) + var(--hk-fab-offset-x, 0px));
   }
 
@@ -32,7 +32,7 @@
   }
 
   &[data-corner^="top"] {
-    --_hk-fab-y: max(0.875rem, env(safe-area-inset-top, 0px));
+    --_hk-fab-y: max(var(--space-14, 0.875rem), env(safe-area-inset-top, 0px));
     top: calc(var(--_hk-fab-y) + var(--hk-fab-offset-y, 0px));
   }
 
@@ -87,7 +87,7 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   color: var(--hi-color-text-secondary, #555);
   background: color-mix(in srgb, var(--hi-color-surface, #fff) 78%, transparent);
   border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
-  backdrop-filter: blur(4px); // chip language shared with autotag pills
+  backdrop-filter: blur(var(--blur-xs, 4px)); // chip language shared with autotag pills
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
 
   &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #fff) 92%, transparent); }
@@ -120,12 +120,12 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.375rem;
+  gap: var(--space-6, 0.375rem);
   appearance: none;
   -webkit-appearance: none;
-  padding: 0 0.5rem;
-  min-width: 2rem;
-  height: 2rem;
+  padding: 0 var(--space-8, 0.5rem);
+  min-width: var(--space-32, 2rem);
+  height: var(--space-32, 2rem);
   font-size: 0.6875rem;
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -134,7 +134,7 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
   border-radius: var(--hi-radius-full, 9999px);
   cursor: pointer;
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(var(--blur-xs, 4px));
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
   opacity: 0;
   transform: scale(0.4);
@@ -148,6 +148,8 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
 
   &:focus-visible { outline: 2px solid var(--hi-color-primary, #7aa2f7); outline-offset: 1px; }
   &:disabled { opacity: 0.35; cursor: not-allowed; }
+  // 82%→94% mirrors the main glass hover ladder (78%→92%).
+  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #fff) 94%, transparent); }
 }
 
 // Staggered reveal while expanded (CSS only, via nth-child delay).
@@ -156,7 +158,22 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   opacity: 1;
   transform: scale(1);
 
+  // Press feedback lives inside the expanded rule on purpose: at equal
+  // specificity a base-level :active would lose to scale(1) above.
+  &:active:not(:disabled) { transform: scale(0.94); }
+
   @for $i from 1 through 6 {
     &:nth-child(#{$i}) { transition-delay: #{($i - 1) * 30}ms; }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-fab-button,
+  .hk-fab-mini {
+    transition: none;
+  }
+
+  .hk-fab[data-expanded="true"] .hk-fab-mini {
+    transition-delay: 0s;
   }
 }

--- a/packages/vue/src/components/HkFileBrowserDialog.scss
+++ b/packages/vue/src/components/HkFileBrowserDialog.scss
@@ -72,7 +72,7 @@
   /* "/" separators between segments (the root crumb renders its own). */
   & + .hk-file-browser-crumb::before {
     content: "/";
-    margin-right: var(--space-4);
+    margin-inline-end: var(--space-4);
     color: color-mix(in srgb, rgb(var(--color-muted)) 60%, transparent);
   }
 
@@ -229,7 +229,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-8);
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 /* Compact type-filter select (HkSelect trigger inside). */
@@ -261,7 +261,7 @@
     color var(--duration-normal) var(--ease-standard);
 
   & + .hk-file-browser-layout-btn {
-    border-left: 1px solid var(--border-subtle);
+    border-inline-start: 1px solid var(--border-subtle);
   }
 
   &:hover:not([data-active]) {
@@ -382,7 +382,7 @@
   gap: var(--space-8);
   align-items: center;
   padding: var(--space-6) var(--space-12);
-  text-align: left;
+  text-align: start;
 }
 
 .hk-file-browser-list-head {
@@ -416,9 +416,12 @@
     background: var(--c-primary-subtle);
   }
 
+  // Keyboard focus is drawn INSIDE the border box (HkSelectionGrid model):
+  // rows scroll beneath the sticky list head (position: sticky + opaque
+  // surface bg), which shaves the top edge of an outer spread ring.
   &:focus-visible {
-    box-shadow: var(--shadow-focus);
-    outline: none;
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
   }
 
   &[data-selected] {
@@ -429,6 +432,12 @@
   &[data-kind="dir"] .hk-file-browser-col-name {
     font-weight: 600;
   }
+}
+
+/* RTL mirrors the physical-left selection bar (house pattern:
+ * HkDraggableGrid.scss flips its inset insertion markers the same way). */
+[dir="rtl"] .hk-file-browser-row[data-selected] {
+  box-shadow: inset -2px 0 0 rgb(var(--color-primary));
 }
 
 .hk-file-browser-col-name {
@@ -442,7 +451,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  text-align: right;
+  text-align: end;
   font-size: var(--text-xs);
   color: rgb(var(--color-muted));
 }
@@ -466,7 +475,7 @@
   border-radius: var(--radius-md);
   background: transparent;
   font-family: inherit;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   transition:
     background-color var(--duration-normal) var(--ease-standard),
@@ -476,9 +485,11 @@
     border-color: var(--c-primary-medium);
   }
 
+  // Same inside-the-border-box focus ring as the list rows: grid tiles
+  // also scroll beneath the sticky list head in the modal scroller.
   &:focus-visible {
-    box-shadow: var(--shadow-focus);
-    outline: none;
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
   }
 
   &[data-selected] {

--- a/packages/vue/src/components/HkFileField.scss
+++ b/packages/vue/src/components/HkFileField.scss
@@ -12,8 +12,8 @@
 }
 
 .hk-file-field-required {
-  margin-left: var(--space-4);
-  color: var(--hi-color-danger);
+  margin-inline-start: var(--space-4);
+  color: var(--hi-color-danger, #f85149);
 }
 
 .hk-file-box {
@@ -34,7 +34,7 @@
   }
 
   &[data-error] {
-    border-color: var(--hi-color-danger);
+    border-color: var(--hi-color-danger, #f85149);
   }
 
   &[data-disabled] {
@@ -54,13 +54,24 @@
   border: 0;
   color: rgb(var(--color-text));
   font: inherit;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
+  transition: background-color var(--duration-normal) var(--ease-standard);
+
+  /* Pressable primary affordance (real <button> in the tsx) — the house
+   * quiet-trigger hover/active wash (cf. HkSelect option rows). */
+  &:hover:not(:disabled) {
+    background: var(--c-primary-subtle, rgb(var(--color-primary) / 8%));
+  }
+
+  &:active:not(:disabled) {
+    background: var(--c-primary-dim, rgb(var(--color-primary) / 10%));
+  }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary);
+    outline: 2px solid var(--hi-color-primary, #58a6ff);
     outline-offset: 2px;
-    border-radius: var(--radius-xs);
+    border-radius: var(--radius-xs, 2px);
   }
 
   &:disabled {
@@ -96,7 +107,7 @@
   padding: 0;
   background: transparent;
   border: 0;
-  border-radius: var(--radius-xs);
+  border-radius: var(--radius-xs, 2px);
   color: rgb(var(--color-text) / 55%);
   cursor: pointer;
 
@@ -106,7 +117,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary);
+    outline: 2px solid var(--hi-color-primary, #58a6ff);
     outline-offset: 1px;
   }
 }
@@ -132,5 +143,5 @@
 }
 
 .hk-file-field-error {
-  color: var(--hi-color-danger);
+  color: var(--hi-color-danger, #f85149);
 }

--- a/packages/vue/src/components/HkFilePickerField.scss
+++ b/packages/vue/src/components/HkFilePickerField.scss
@@ -1,3 +1,5 @@
+@use "./hikari-vars" as vars;
+
 .hk-file-picker-field {
   display: block;
 }
@@ -26,10 +28,14 @@
 
   &:focus-within {
     border-color: color-mix(in srgb, rgb(var(--color-text)) 38%, transparent);
+    /* Visible keyboard focus ring on the text input (which sets
+     * outline: none) — sibling pattern: the inline-rename input pairs
+     * border shift + var(--shadow-focus). */
+    box-shadow: var(--shadow-focus);
   }
 
   &[data-error] {
-    border-color: var(--hi-color-danger);
+    border-color: var(--hi-color-danger, #f85149);
   }
 
   &[data-disabled] {
@@ -47,9 +53,9 @@
   justify-content: center;
   width: 1.75rem;
   height: 1.75rem;
-  border-radius: var(--radius-xs);
-  background: color-mix(in srgb, var(--hi-color-primary) 14%, transparent);
-  color: var(--hi-color-primary);
+  border-radius: var(--radius-xs, 2px);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 14%, transparent);
+  color: var(--hi-color-primary, #58a6ff);
   pointer-events: none;
 }
 
@@ -70,7 +76,7 @@
 
   /* Paths are code — mono by default, opt out with :mono="false". */
   .hk-file-picker-box[data-mono] & {
-    font-family: var(--font-mono, ui-monospace, monospace);
+    font-family: var(--font-mono, vars.$hikari-font-family-mono);
   }
 
   &:disabled {
@@ -88,6 +94,6 @@
   color: rgb(var(--color-text) / 60%);
 
   &[data-error] {
-    color: var(--hi-color-danger);
+    color: var(--hi-color-danger, #f85149);
   }
 }

--- a/packages/vue/src/components/HkGaugeRing.scss
+++ b/packages/vue/src/components/HkGaugeRing.scss
@@ -2,3 +2,11 @@
   position: relative;
   display: inline-flex;
 }
+
+// The 0.8s dash sweep rides an INLINE transition on the progress circles
+// (HkGaugeRing.tsx), so the guard needs !important to beat it.
+@media (prefers-reduced-motion: reduce) {
+  .hk-gauge-ring circle {
+    transition: none !important;
+  }
+}

--- a/packages/vue/src/components/HkHoverRevealAction.scss
+++ b/packages/vue/src/components/HkHoverRevealAction.scss
@@ -27,25 +27,34 @@
     transform 0.15s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
+/* Revealed state, shared by the tsx-managed hover/touch reveal
+   (.is-revealed) and keyboard focus anywhere in the wrapper
+   (:focus-within) — without the focus path the extension's real
+   buttons stay tab-reachable yet invisible (HkTabs renders its
+   add actions there). */
+.hk-hover-reveal.is-revealed > .hk-hover-reveal-extension,
+.hk-hover-reveal:focus-within > .hk-hover-reveal-extension {
+  opacity: 1;
+  pointer-events: auto;
+}
+
 .hk-hover-reveal[data-placement="right"] > .hk-hover-reveal-extension {
-  left: 100%;
+  inset-inline-start: 100%;
   top: 50%;
   transform: translate(-4px, -50%);
 }
-.hk-hover-reveal[data-placement="right"].is-revealed > .hk-hover-reveal-extension {
-  opacity: 1;
-  pointer-events: auto;
+.hk-hover-reveal[data-placement="right"].is-revealed > .hk-hover-reveal-extension,
+.hk-hover-reveal[data-placement="right"]:focus-within > .hk-hover-reveal-extension {
   transform: translate(4px, -50%);
 }
 
 .hk-hover-reveal[data-placement="left"] > .hk-hover-reveal-extension {
-  right: 100%;
+  inset-inline-end: 100%;
   top: 50%;
   transform: translate(4px, -50%);
 }
-.hk-hover-reveal[data-placement="left"].is-revealed > .hk-hover-reveal-extension {
-  opacity: 1;
-  pointer-events: auto;
+.hk-hover-reveal[data-placement="left"].is-revealed > .hk-hover-reveal-extension,
+.hk-hover-reveal[data-placement="left"]:focus-within > .hk-hover-reveal-extension {
   transform: translate(-4px, -50%);
 }
 
@@ -54,9 +63,8 @@
   top: 100%;
   transform: translate(-50%, -4px);
 }
-.hk-hover-reveal[data-placement="bottom"].is-revealed > .hk-hover-reveal-extension {
-  opacity: 1;
-  pointer-events: auto;
+.hk-hover-reveal[data-placement="bottom"].is-revealed > .hk-hover-reveal-extension,
+.hk-hover-reveal[data-placement="bottom"]:focus-within > .hk-hover-reveal-extension {
   transform: translate(-50%, 4px);
 }
 
@@ -65,8 +73,14 @@
   bottom: 100%;
   transform: translate(-50%, 4px);
 }
-.hk-hover-reveal[data-placement="top"].is-revealed > .hk-hover-reveal-extension {
-  opacity: 1;
-  pointer-events: auto;
+.hk-hover-reveal[data-placement="top"].is-revealed > .hk-hover-reveal-extension,
+.hk-hover-reveal[data-placement="top"]:focus-within > .hk-hover-reveal-extension {
   transform: translate(-50%, -4px);
+}
+
+/* Reduced motion: keep the opacity fade, drop the transform slide. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-hover-reveal-extension {
+    transition: opacity 0.15s ease;
+  }
 }

--- a/packages/vue/src/components/HkHoverRevealAction.scss
+++ b/packages/vue/src/components/HkHoverRevealAction.scss
@@ -39,7 +39,11 @@
 }
 
 .hk-hover-reveal[data-placement="right"] > .hk-hover-reveal-extension {
-  inset-inline-start: 100%;
+  /* Anchors stay PHYSICAL on purpose: placement is a physical prop
+     (consumers pass literal left/right) and the slide transforms below
+     are physical too — logical axes here would mirror the box in RTL
+     while the motion still slides the old way. */
+  left: 100%;
   top: 50%;
   transform: translate(-4px, -50%);
 }
@@ -49,7 +53,7 @@
 }
 
 .hk-hover-reveal[data-placement="left"] > .hk-hover-reveal-extension {
-  inset-inline-end: 100%;
+  right: 100%;
   top: 50%;
   transform: translate(4px, -50%);
 }

--- a/packages/vue/src/components/HkIcon.scss
+++ b/packages/vue/src/components/HkIcon.scss
@@ -118,21 +118,3 @@
 .hk-icon-muted {
   color: var(--hi-color-text-secondary);
 }
-
-// ------
-// Transitions
-// ------
-
-.hk-icon-transition {
-  transition: color 150ms ease-in-out;
-
-  svg path,
-  svg circle,
-  svg rect,
-  svg ellipse,
-  svg polygon,
-  svg polyline,
-  svg line {
-    transition: fill 150ms ease-in-out, stroke 150ms ease-in-out;
-  }
-}

--- a/packages/vue/src/components/HkIconButton.scss
+++ b/packages/vue/src/components/HkIconButton.scss
@@ -54,7 +54,8 @@
   // Transitions - use CSS variables
   transition: var(--hi-icon-button-transition);
 
-  // Resting transform stays none — the :active press supplies its own.
+  // Resting transform stays none and the press keeps it that way — the
+  // press feedback is the background wash only.
 
   // Cursor
   cursor: pointer;
@@ -87,7 +88,6 @@
 
   &:where(:active:not(:disabled)) {
     background: var(--hi-icon-button-bg-active);
-    transform: var(--hi-icon-button-transform-active);
   }
 
   // ------

--- a/packages/vue/src/components/HkIconButton.scss
+++ b/packages/vue/src/components/HkIconButton.scss
@@ -6,14 +6,15 @@
 // Hikari IconButton Component - FUI Styling
 // Three-layer CSS variable system:
 // - Layer1: Foundation variables (foundation.scss)
-// - Layer2: Component variables (icon-button-vars.scss)
+// - Layer2: Component variables (HkIconButtonVars.scss)
 // - Custom: Runtime overrides via AnimationBuilder
 //
-// NOTE: Hover effects are handled by Glow wrapper, not here
+// NOTE: This sheet now carries baseline hover/press feedback via the
+// --hi-icon-button-* active vars; hosts can out-rank it (see below).
 // ------
 
 .hk-icon-button {
-  // Layer2 variables are defined in icon-button-vars.scss
+  // Layer2 variables are defined in HkIconButtonVars.scss
 
   // Layout
   display: inline-flex;
@@ -22,7 +23,6 @@
   flex-shrink: 0;
   padding: 0;
   line-height: 0;
-  gap: 0;
 
   // Size - use CSS variables
   width: var(--hi-icon-button-size);
@@ -54,84 +54,47 @@
   // Transitions - use CSS variables
   transition: var(--hi-icon-button-transition);
 
-  // No transform - controlled by AnimationBuilder via Glow wrapper
+  // Resting transform stays none — the :active press supplies its own.
 
   // Cursor
   cursor: pointer;
 
-  // Focus state - only outline, no color changes
+  // Focus state - only outline, no color changes (the glyph color var is
+  // identical at rest, so re-declaring it here would be a no-op)
   &:focus-visible {
     outline: 2px solid var(--hi-icon-button-border-color-focus);
     outline-offset: 2px;
-    color: var(--hi-icon-button-icon-color);
-
-    .hk-icon-button-icon {
-      color: var(--hi-icon-button-icon-color);
-    }
   }
 
   // Disabled state
   &:disabled {
     background: var(--hi-icon-button-bg-disabled);
-    color: var(--hi-icon-button-icon-color-disabled);
     cursor: not-allowed;
     pointer-events: none;
   }
 
-  // No active state - controlled by AnimationBuilder via Glow wrapper
+  // Hover / press feedback. The old contract deferred these to the
+  // Rust-side Glow wrapper, but Vue-library hosts render no Glow
+  // (window-close.scss and the lightbox close each had to paint their
+  // own tint). These defaults consume the designed active vars from
+  // HkIconButtonVars.scss; :where() keeps both rules at (0,1,0) so any
+  // host hover paint — .hk-window-close's (0,3,0) tint, the lightbox
+  // chip's (0,4,0) re-assertion — still outranks them (zero-specificity
+  // guard pattern from styles/theme/base.scss).
+  &:where(:hover:not(:disabled):not(:active)) {
+    background: var(--hi-icon-button-bg-hover, var(--hi-icon-button-bg-active));
+  }
 
-  // ------
-  // Size Variants - Variables defined in icon-button-vars.scss
-  // ------
-
-  &.hk-icon-button-16,
-  &.hk-icon-button-24,
-  &.hk-icon-button-32,
-  &.hk-icon-button-36,
-  &.hk-icon-button-40 {
-    // Size variables are already set by the classes in icon-button-vars.scss
+  &:where(:active:not(:disabled)) {
+    background: var(--hi-icon-button-bg-active);
+    transform: var(--hi-icon-button-transform-active);
   }
 
   // ------
-  // Variant: Ghost (default - transparent)
+  // Size/variant hooks carry no rules here: .hk-icon-button-16/24/32/36/40
+  // and -ghost/-borderless/-primary/-secondary/-danger/-success get all of
+  // their custom properties from HkIconButtonVars.scss.
   // ------
-
-  &.hk-icon-button-ghost,
-  &.hk-icon-button-borderless {
-    // Variables defined in icon-button-vars.scss
-  }
-
-  // ------
-  // Variant: Primary (solid primary color)
-  // ------
-
-  &.hk-icon-button-primary {
-    // Variables defined in icon-button-vars.scss
-  }
-
-  // ------
-  // Variant: Secondary (solid secondary color)
-  // ------
-
-  &.hk-icon-button-secondary {
-    // Variables defined in icon-button-vars.scss
-  }
-
-  // ------
-  // Variant: Danger (solid danger color)
-  // ------
-
-  &.hk-icon-button-danger {
-    // Variables defined in icon-button-vars.scss
-  }
-
-  // ------
-  // Variant: Success (solid success color)
-  // ------
-
-  &.hk-icon-button-success {
-    // Variables defined in icon-button-vars.scss
-  }
 
   // ------
   // Icon Styles - Use CSS Variables
@@ -169,8 +132,12 @@
   &:disabled .hk-icon-button-icon {
     color: var(--hi-icon-button-icon-color-disabled);
   }
+}
 
-  .hk-icon-button-disabled {
-    opacity: 0.3;
+// The transition above drives the press transform; snap it under reduced
+// motion (house pattern: HkFab.scss / HkExpansionPanel.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-icon-button {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkIconButtonVars.scss
+++ b/packages/vue/src/components/HkIconButtonVars.scss
@@ -2,9 +2,10 @@
 // Layer2 - IconButton Component Variables
 //
 // This file defines component-level CSS variables for the IconButton component.
-// These variables can be overridden at runtime via AnimationBuilder.
+// These variables can be overridden by host theme layers.
 //
-// NOTE: Hover effects are handled by Glow wrapper, not here.
+// NOTE: Hover feedback is not styled in this layer; window-close.scss adds
+// its own hover grammar for close controls.
 // Only base, active, and disabled states are defined.
 
 // ------
@@ -26,18 +27,14 @@
   --hi-icon-button-bg-active: var(--hi-bg-surface-dark);
   --hi-icon-button-bg-disabled: rgba(128, 128, 128, 0.1);
 
-  // Border Colors
-  --hi-icon-button-border-color: transparent;
+  // Border Colors (focus ring only; the base button draws no border)
   --hi-icon-button-border-color-focus: var(--hi-border-color-focus);
-
-  // Shadow & Glow (used by Glow wrapper)
-  --hi-icon-button-glow: var(--hi-glow-color);
 
   // ------
   // 2. Border Radius System
   // ------
 
-  --hi-icon-button-radius: 4px;
+  --hi-icon-button-radius: var(--radius-sm, 4px);
 
   // ------
   // 3. Animation System
@@ -45,15 +42,13 @@
 
   // Duration
   --hi-icon-button-duration: var(--hi-duration-fast);
-  --hi-icon-button-duration-active: var(--hi-duration-instant);
 
   // Easing
   --hi-icon-button-easing: var(--hi-ease-default);
 
-  // Transition
-  --hi-icon-button-transition:
-    background-color var(--hi-icon-button-duration) var(--hi-icon-button-easing),
-    transform var(--hi-icon-button-duration-active) var(--hi-icon-button-easing);
+  // Transition (background only; CSS applies no transform to the button)
+  --hi-icon-button-transition: background-color var(--hi-icon-button-duration)
+    var(--hi-icon-button-easing);
 
   // ------
   // 4. Size System
@@ -61,13 +56,6 @@
 
   --hi-icon-button-size: 40px;
   --hi-icon-button-icon-size: var(--hi-icon-size-sm);
-
-  // ------
-  // 5. Transform System
-  // ------
-
-  --hi-icon-button-transform: none;
-  --hi-icon-button-transform-active: scale(0.95);
 }
 
 // ------
@@ -108,11 +96,7 @@
   --hi-icon-button-icon-color: var(--hi-color-text-secondary);
   --hi-icon-button-icon-color-active: var(--hi-color-text-secondary);
 
-  --hi-icon-button-bg: transparent;
   --hi-icon-button-bg-active: var(--hi-color-gray-20, rgba(128, 128, 128, 0.2));
-
-  --hi-icon-button-border-color: transparent;
-  --hi-icon-button-glow: var(--hi-glow-color);
 }
 
 // ------
@@ -131,7 +115,6 @@
   --hi-icon-button-bg-active: var(--hi-color-primary-dark);
 
   --hi-icon-button-border-color-focus: var(--hi-color-primary);
-  --hi-icon-button-glow: var(--hi-glow-color);
 }
 
 // ------
@@ -146,7 +129,6 @@
   --hi-icon-button-bg-active: var(--hi-color-secondary-dark);
 
   --hi-icon-button-border-color-focus: var(--hi-color-secondary);
-  --hi-icon-button-glow: var(--hi-glow-color);
 }
 
 // ------
@@ -161,7 +143,6 @@
   --hi-icon-button-bg-active: var(--hi-color-danger-dark);
 
   --hi-icon-button-border-color-focus: var(--hi-color-danger);
-  --hi-icon-button-glow: var(--hi-glow-color);
 }
 
 // ------
@@ -176,5 +157,4 @@
   --hi-icon-button-bg-active: var(--hi-color-success-dark);
 
   --hi-icon-button-border-color-focus: var(--hi-color-success);
-  --hi-icon-button-glow: var(--hi-glow-color);
 }

--- a/packages/vue/src/components/HkImageLightbox.scss
+++ b/packages/vue/src/components/HkImageLightbox.scss
@@ -93,8 +93,6 @@
   top: var(--space-12, 0.75rem);
   right: var(--space-12, 0.75rem);
   z-index: 2;
-  background: var(--hi-icon-button-bg);
-  color: var(--hi-icon-button-icon-color);
   backdrop-filter: blur(6px);
 
   &:hover,
@@ -115,9 +113,12 @@
     }
   }
 
+  // Focus ring rides INSIDE the chip (negative offset, HkSelectionGrid
+  // precedent): an outward ring floats over raw imagery and vanishes on
+  // light photos.
   &:focus-visible {
     outline: 2px solid rgb(255 255 255 / 80%);
-    outline-offset: 2px;
+    outline-offset: -2px;
   }
 }
 

--- a/packages/vue/src/components/HkImagePreview.scss
+++ b/packages/vue/src/components/HkImagePreview.scss
@@ -16,15 +16,23 @@
 // Enlarge affordance: the tile acts as a button once the image is up.
 .hk-image-preview.is-zoomable {
   cursor: zoom-in;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 
   &:hover {
-    border-color: var(--hi-color-primary, #ffc0cb);
-    box-shadow: 0 0 0 1px var(--hi-color-primary, #ffc0cb);
+    border-color: var(--hi-color-primary, #58a6ff);
+    // Emphasis drawn INSIDE the border box (HkSelectionGrid precedent):
+    // outer spread rings get shaved per-side by overlapping chrome.
+    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #58a6ff);
+  }
+
+  // Press feedback matching the house button pattern (HkButton variants,
+  // HkSelectionGrid): the tile is role="button" once zoomable.
+  &:active {
+    filter: brightness(0.95);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary, #ffc0cb);
+    outline: 2px solid var(--hi-color-primary, #58a6ff);
     outline-offset: 2px;
   }
 }
@@ -35,10 +43,10 @@
   width: 100%;
   height: 100%;
   // object-fit comes from the prop (inline style).
-  opacity: 1;
-
   // Hidden while loading so the shimmer shows through; the real pixels
   // fade in on the load event.
+  transition: opacity 0.2s ease;
+
   &.is-pending {
     opacity: 0;
   }
@@ -57,9 +65,9 @@
   justify-content: center;
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-primary, #ffc0cb) 8%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-primary, #ffc0cb) 18%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-primary, #ffc0cb) 8%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-image-preview-shimmer 1.5s ease-in-out infinite;

--- a/packages/vue/src/components/HkImageViewer.scss
+++ b/packages/vue/src/components/HkImageViewer.scss
@@ -31,3 +31,11 @@
   align-items: center;
   justify-content: center;
 }
+
+// Reduced motion: pan/zoom keeps working, the transform just stops
+// gliding (house pattern — HkExpansionPanel / HkAffixPicker).
+@media (prefers-reduced-motion: reduce) {
+  .hk-image-viewer-img {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -18,7 +18,7 @@
 }
 
 .hk-input-required {
-  margin-left: var(--space-2);
+  margin-inline-start: var(--space-2);
   color: rgb(var(--color-error));
 }
 
@@ -34,7 +34,12 @@
   border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: var(--radius-sm);
   overflow: hidden;
-  transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) var(--ease-standard);
+  /* Longhand on purpose: the comma shorthand attached the duration to the
+   * LAST property only, so hover border-color and the focus-within
+   * background/box-shadow snapped at 0s (HkButton F5, same disease). */
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform, filter;
+  transition-duration: var(--duration-normal);
+  transition-timing-function: var(--ease-standard);
   color: rgb(var(--color-text));
 
   &:hover:not(.hk-input-box-disabled) {
@@ -163,28 +168,6 @@
   resize: none;
 }
 
-.hk-input-box[data-autogrow] {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-}
-
-.hk-input-autogrow {
-  flex: 1;
-  min-height: 0;
-}
-
-.hk-input-textarea[data-autogrow] {
-  position: relative;
-  inset: unset;
-  width: 100%;
-  flex: 0 0 auto;
-  resize: none;
-  overflow: hidden;
-  min-height: 2.5rem;
-  text-align: start;
-}
-
 .hk-input-affix {
   display: flex;
   align-items: center;
@@ -282,10 +265,14 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: var(--color-text-secondary, #888);
+  /* Contract tokens, not the raw app triplets: --color-text-secondary is a
+   * bare "R G B" triplet, so using it directly as a color is invalid at
+   * computed-value time (the rule silently inherits); --color-text-primary
+   * is not defined anywhere. --hi-color-* wrap the triplets in rgb(). */
+  color: var(--hi-color-text-secondary, #888);
   cursor: pointer;
 
   &:hover {
-    color: var(--color-text-primary, #222);
+    color: var(--hi-color-text-primary, #222);
   }
 }

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -68,7 +68,6 @@
 }
 
 .hk-input-box[data-autogrow] {
-  display: flex;
   flex-direction: column;
   align-items: stretch;
 }
@@ -145,7 +144,6 @@
 .hk-input-element.hk-input-textarea {
   position: relative;
   inset: unset;
-  width: 100%;
   height: auto;
   flex: 1;
   min-width: 0;
@@ -274,5 +272,20 @@
 
   &:hover {
     color: var(--hi-color-text-primary, #222);
+  }
+
+  // Keyboard parity (house icon-button pattern, HkIconButton): this real
+  // <button> had a hover state only, so keyboard focus was invisible.
+  // Offset 2px is safe here — the toggle rides the box's inline padding,
+  // well inside the box's overflow:hidden clip edge.
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+    border-radius: var(--radius-sm);
+  }
+
+  // Press feedback matching the house button pattern (HkButton variants).
+  &:active {
+    filter: brightness(0.95);
   }
 }

--- a/packages/vue/src/components/HkJsonTree.scss
+++ b/packages/vue/src/components/HkJsonTree.scss
@@ -50,7 +50,9 @@
   display: flex;
   align-items: baseline;
   min-height: 1.55em;
-  padding: 0 var(--space-6, 0.375rem);
+  /* Inline paddingLeft (tsx) always overrides the left half; spell out the
+     dead slot so the live right inset is not mistaken for symmetric. */
+  padding: 0 var(--space-6, 0.375rem) 0 0;
   border-radius: var(--radius-xs, 2px);
   cursor: default;
 }
@@ -70,7 +72,7 @@
   width: var(--jt-toggle);
   height: var(--jt-toggle);
   flex-shrink: 0;
-  margin-right: 2px;
+  margin-inline-end: var(--space-2, 0.125rem);
   /* The toggle box has no text baseline of its own — pin it to the line
      top instead of letting it join the row's baseline group with a
      synthesized border-box baseline. */
@@ -115,7 +117,7 @@
 
 .s-jt-colon {
   color: rgb(var(--color-muted));
-  margin-right: 0.35em;
+  margin-inline-end: 0.35em;
 }
 
 .s-jv-null {
@@ -123,21 +125,24 @@
   font-style: italic;
 }
 
+/* Value colors join the shared --code-* family (see tokens.scss) so themes
+   restyle the tree together with HkToolBlock's code blocks; fallbacks keep
+   the One Dark originals. */
 .s-jv-str {
-  color: #98c379;
+  color: var(--code-string, #98c379);
   word-break: break-all;
 }
 
 .s-jv-num {
-  color: #d19a66;
+  color: var(--code-number, #d19a66);
 }
 
 .s-jv-bool {
-  color: #c678dd;
+  color: var(--code-keyword, #c678dd);
 }
 
 .s-jv-str-raw {
-  color: #98c379;
+  color: var(--code-string, #98c379);
   white-space: pre-wrap;
   word-break: break-all;
 }
@@ -146,8 +151,8 @@
   color: rgb(var(--color-muted) / 0.6);
   font-size: var(--text-3xs, 0.5rem);
   font-style: italic;
-  margin-left: 0.75em;
   font-weight: 400;
+  margin-inline-start: 0.75em;
 }
 
 .s-jt-badge {
@@ -162,7 +167,6 @@
 }
 
 .s-jt-badge.is-open {
-  color: rgb(var(--color-muted));
   background: transparent;
   border-color: transparent;
   font-weight: 400;

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -1,7 +1,10 @@
 .hk-kw-search {
   display: flex;
   flex-direction: column;
-  gap: var(--space-10, 1.25rem);
+  /* Token names follow the VALUES this component has always rendered
+   * (the old --hi-space-* names never resolved), not the numerals:
+   * 1.25rem is --space-20, not --space-10. */
+  gap: var(--space-20, 1.25rem);
   padding: var(--space-4, 0.25rem) 0;
 }
 
@@ -9,7 +12,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-8, 0.5rem);
-  padding: var(--space-8, 0.5rem) var(--space-10, 0.75rem);
+  padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-kw-border, rgb(var(--color-border) / 8%));
   border-radius: var(--hi-radius-lg, 0.75rem);
@@ -74,7 +77,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--hi-radius-sm, 0.25rem);
-  padding: var(--space-8, 0.5rem) var(--space-10, 0.75rem);
+  padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   cursor: pointer;
   width: 100%;
   color: var(--hi-color-text-primary, #333);
@@ -92,7 +95,9 @@
 }
 
 .hk-kw-search-empty {
-  padding: var(--space-24, 3rem) var(--space-8, 0.5rem);
+  /* 3rem sits beyond the theme scale (--space-40 ends it); the token
+   * name documents the intent, the fallback keeps the rendered size. */
+  padding: var(--space-48, 3rem) var(--space-8, 0.5rem);
   text-align: center;
   font-size: var(--text-base, 0.875rem);
   color: var(--hi-color-text-secondary, #666);

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -11,13 +11,13 @@
   gap: var(--hi-space-8, 0.5rem);
   padding: var(--hi-space-8, 0.5rem) var(--hi-space-10, 0.75rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
-  border: 1px solid var(--hk-kw-border, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--hk-kw-border, rgb(var(--color-border) / 8%));
   border-radius: var(--hi-radius-lg, 0.75rem);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:focus-within {
     border-color: var(--hi-color-primary, #58a6ff);
-    box-shadow: 0 0 0 3px rgba(88, 166, 255, 0.12);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
   }
 }
 
@@ -34,7 +34,7 @@
   border: 0;
   outline: none;
   color: var(--hi-color-text-primary, #333);
-  font-size: 0.875rem;
+  font-size: var(--text-base, 0.875rem);
 }
 
 .hk-kw-search-clear {
@@ -49,6 +49,11 @@
 
   &:hover {
     color: var(--hi-color-text-primary, #333);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+    outline-offset: 2px;
   }
 }
 
@@ -65,7 +70,7 @@
 
 .hk-kw-search-result {
   appearance: none;
-  text-align: left;
+  text-align: start;
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--hi-radius-sm, 0.25rem);
@@ -77,19 +82,20 @@
 
   &:hover {
     background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
-    border-color: rgba(0, 0, 0, 0.06);
+    border-color: rgb(var(--color-border) / 6%);
+  }
+
+  &:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+    outline-offset: 2px;
   }
 }
 
 .hk-kw-search-empty {
   padding: var(--hi-space-24, 3rem) var(--hi-space-8, 0.5rem);
   text-align: center;
-  font-size: 0.875rem;
+  font-size: var(--text-base, 0.875rem);
   color: var(--hi-color-text-secondary, #666);
-}
-
-.hk-kw-search-result-semantic {
-  display: block;
 }
 
 .hk-kw-search-semantic {
@@ -107,7 +113,7 @@
 }
 
 .hk-kw-search-semantic-title {
-  font-size: 0.875rem;
+  font-size: var(--text-base, 0.875rem);
   font-weight: 600;
   color: var(--hi-color-text-primary, #333);
   overflow: hidden;
@@ -120,7 +126,7 @@
   font-size: var(--hi-text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   color: var(--hi-color-primary, #58a6ff);
-  background: rgba(88, 166, 255, 0.12);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
   padding: 0 var(--hi-space-6, 0.375rem);
   border-radius: var(--hi-radius-sm, 0.25rem);
   line-height: 1.5;
@@ -143,7 +149,7 @@
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--hi-color-text-secondary, #666);
-  background: rgba(0, 0, 0, 0.04);
+  background: rgb(var(--color-border) / 4%);
   padding: 0 var(--hi-space-6, 0.375rem);
   border-radius: var(--hi-radius-sm, 0.25rem);
 }

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -1,15 +1,15 @@
 .hk-kw-search {
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-10, 1.25rem);
-  padding: var(--hi-space-4, 0.25rem) 0;
+  gap: var(--space-10, 1.25rem);
+  padding: var(--space-4, 0.25rem) 0;
 }
 
 .hk-kw-search-box {
   display: flex;
   align-items: center;
-  gap: var(--hi-space-8, 0.5rem);
-  padding: var(--hi-space-8, 0.5rem) var(--hi-space-10, 0.75rem);
+  gap: var(--space-8, 0.5rem);
+  padding: var(--space-8, 0.5rem) var(--space-10, 0.75rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-kw-border, rgb(var(--color-border) / 8%));
   border-radius: var(--hi-radius-lg, 0.75rem);
@@ -44,7 +44,7 @@
   color: var(--hi-color-text-secondary, #666);
   cursor: pointer;
   display: inline-flex;
-  padding: var(--hi-space-2, 0.125rem);
+  padding: var(--space-2, 0.125rem);
   border-radius: var(--hi-radius-sm, 0.25rem);
 
   &:hover {
@@ -64,8 +64,8 @@
 .hk-kw-search-results {
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-4, 0.25rem);
-  padding: 0 var(--hi-space-2, 0.125rem);
+  gap: var(--space-4, 0.25rem);
+  padding: 0 var(--space-2, 0.125rem);
 }
 
 .hk-kw-search-result {
@@ -74,7 +74,7 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--hi-radius-sm, 0.25rem);
-  padding: var(--hi-space-8, 0.5rem) var(--hi-space-10, 0.75rem);
+  padding: var(--space-8, 0.5rem) var(--space-10, 0.75rem);
   cursor: pointer;
   width: 100%;
   color: var(--hi-color-text-primary, #333);
@@ -92,7 +92,7 @@
 }
 
 .hk-kw-search-empty {
-  padding: var(--hi-space-24, 3rem) var(--hi-space-8, 0.5rem);
+  padding: var(--space-24, 3rem) var(--space-8, 0.5rem);
   text-align: center;
   font-size: var(--text-base, 0.875rem);
   color: var(--hi-color-text-secondary, #666);
@@ -101,7 +101,7 @@
 .hk-kw-search-semantic {
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-4, 0.25rem);
+  gap: var(--space-4, 0.25rem);
   min-width: 0;
 }
 
@@ -109,7 +109,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: var(--hi-space-8, 0.5rem);
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-kw-search-semantic-title {
@@ -123,17 +123,17 @@
 
 .hk-kw-search-semantic-score {
   flex-shrink: 0;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   color: var(--hi-color-primary, #58a6ff);
   background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
-  padding: 0 var(--hi-space-6, 0.375rem);
+  padding: 0 var(--space-6, 0.375rem);
   border-radius: var(--hi-radius-sm, 0.25rem);
   line-height: 1.5;
 }
 
 .hk-kw-search-semantic-snippet {
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-text-secondary, #666);
   line-height: 1.5;
   display: -webkit-box;
@@ -145,11 +145,11 @@
 
 .hk-kw-search-semantic-source {
   align-self: flex-start;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--hi-color-text-secondary, #666);
   background: rgb(var(--color-border) / 4%);
-  padding: 0 var(--hi-space-6, 0.375rem);
+  padding: 0 var(--space-6, 0.375rem);
   border-radius: var(--hi-radius-sm, 0.25rem);
 }

--- a/packages/vue/src/components/HkLabel.scss
+++ b/packages/vue/src/components/HkLabel.scss
@@ -30,5 +30,10 @@
     &:hover {
       text-decoration: underline;
     }
+
+    &:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+      outline-offset: 2px;
+    }
   }
 }

--- a/packages/vue/src/components/HkLabel.scss
+++ b/packages/vue/src/components/HkLabel.scss
@@ -9,16 +9,16 @@
 
 .hk-label {
   display: inline;
-  font-size: var(--hi-text-base, 0.875rem);
+  font-size: var(--text-base, 0.875rem);
   line-height: 1.5;
   color: var(--hi-color-text-primary, #333);
 
   &.hk-label-sm {
-    font-size: var(--hi-text-xs, 0.75rem);
+    font-size: var(--text-xs, 0.75rem);
   }
 
   &.hk-label-lg {
-    font-size: var(--hi-text-md, 1rem);
+    font-size: var(--text-md, 1rem);
   }
 
   a {

--- a/packages/vue/src/components/HkListTransition.scss
+++ b/packages/vue/src/components/HkListTransition.scss
@@ -1,4 +1,9 @@
-.hk-list-move {
+/* FLIP move: vue applies `${name}-move` (runtime-dom resolves moveClass
+ * as `${name}-move`), never a bare `.hk-list-move`. pop/slide/fade share
+ * the normal duration; grow/reveal define their staggered bases below. */
+.hk-list-pop-move,
+.hk-list-slide-move,
+.hk-list-fade-move {
   transition: transform var(--hi-duration-normal, 0.3s) ease;
 }
 
@@ -50,6 +55,16 @@
 .hk-list-slide-leave-to {
   opacity: 0;
   transform: translateX(12px);
+}
+
+/* RTL: reading direction flips, so slide enters from the right and
+ * exits to the left (HkBreadcrumb/HkBlockingToast [dir="rtl"] form). */
+[dir="rtl"] .hk-list-slide-enter-from {
+  transform: translateX(12px);
+}
+
+[dir="rtl"] .hk-list-slide-leave-to {
+  transform: translateX(-12px);
 }
 
 .hk-list-fade-enter-active {

--- a/packages/vue/src/components/HkLoadMore.scss
+++ b/packages/vue/src/components/HkLoadMore.scss
@@ -25,6 +25,16 @@
   background: linear-gradient(to left, transparent, rgb(var(--color-muted) / 35%));
 }
 
+/* The flex row flips in RTL, so the hairlines mirror too: transparent
+ * stays on the outer edge, muted towards the central control. */
+[dir="rtl"] .hk-load-more-rule {
+  background: linear-gradient(to left, transparent, rgb(var(--color-muted) / 35%));
+}
+
+[dir="rtl"] .hk-load-more-rule-end {
+  background: linear-gradient(to right, transparent, rgb(var(--color-muted) / 35%));
+}
+
 .hk-load-more-core {
   flex: none;
   display: inline-flex;
@@ -39,7 +49,7 @@
   font-size: var(--text-2xs);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
-  color: rgb(var(--color-text-tertiary));
+  transition: opacity 200ms ease;
 }
 
 .hk-load-more[data-state="loading"] .hk-load-more-count {
@@ -49,5 +59,4 @@
 .hk-load-more-end {
   font-size: var(--text-2xs);
   letter-spacing: 0.08em;
-  color: rgb(var(--color-text-tertiary));
 }

--- a/packages/vue/src/components/HkLocalizedInput.scss
+++ b/packages/vue/src/components/HkLocalizedInput.scss
@@ -20,7 +20,6 @@
  * keep focus inside the input. */
 .hk-localized-input-chip {
   padding: 0;
-  border-radius: var(--radius-sm, 999px);
   background: transparent;
   color: rgb(var(--color-muted));
 
@@ -54,26 +53,27 @@
  * The base HkInput box flows affixes as a flex ROW (single-line input
  * absolutely positioned over the box) — but a textarea-type element is
  * in-flow, so the language chip would land BELOW the field. Pin it to
- * the field's top-right corner instead and keep every text line clear
- * of the chip column via the measured affix width. */
+ * the field's top inline-end corner instead and keep every text line
+ * clear of the chip column via the measured affix width. Logical
+ * properties throughout: the pinned chips and the textarea clearance
+ * mirror with the writing direction, matching the base field's
+ * logical padding-inline / margin-inline-start affix layout. */
 .hk-localized-input[data-multiline] {
   .hk-input-affix.hk-input-suffix {
     position: absolute;
-    top: 6px;
-    right: var(--space-8, 8px);
-    margin-inline-start: 0;
+    top: var(--space-6, 6px);
+    inset-inline-end: var(--space-8, 8px);
   }
 
   .hk-input-affix.hk-input-prefix {
     position: absolute;
-    top: 6px;
-    left: var(--space-8, 8px);
-    margin-inline-end: 0;
+    top: var(--space-6, 6px);
+    inset-inline-start: var(--space-8, 8px);
   }
 
   .hk-input-element.hk-input-textarea {
-    padding-right: calc(var(--space-12, 12px) + var(--hk-input-affix-end-w, 0px));
-    padding-left: calc(var(--space-12, 12px) + var(--hk-input-affix-start-w, 0px));
+    padding-inline-end: calc(var(--space-12, 12px) + var(--hk-input-affix-end-w, 0px));
+    padding-inline-start: calc(var(--space-12, 12px) + var(--hk-input-affix-start-w, 0px));
   }
 }
 

--- a/packages/vue/src/components/HkLogWindow.scss
+++ b/packages/vue/src/components/HkLogWindow.scss
@@ -29,9 +29,21 @@
   color: rgb(var(--color-muted));
   font-size: var(--text-xs, 0.75rem);
   cursor: pointer;
+  /* Declared here on purpose: these s-log classes intentionally escape
+   * the `button:where(:not([class^="hk-"])…)` element baseline (base.scss),
+   * which currently supplies their transition/focus ring only by accident
+   * of the hk- exclusion — do not lean on it. */
+  transition: background 200ms ease, color 200ms ease, border-color 200ms ease,
+    box-shadow 200ms ease, opacity 200ms ease;
 }
 
-.s-log-tab:hover:not([data-active]) {
+.s-log-tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--color-surface)), 0 0 0 4px rgb(var(--color-primary));
+}
+
+.s-log-tab:hover:not([data-active]),
+.s-log-btn:hover:not([data-active]) {
   background: rgb(var(--color-primary) / 12%);
   color: rgb(var(--color-text));
 }
@@ -51,6 +63,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* Reset the element-baseline button padding (base.scss button-base
+   * reaches these non-hk buttons): 0.5rem/1rem inside the fixed 1.75rem
+   * border-box collapses the content box and off-centers the icon. */
+  padding: 0;
   width: 1.75rem;
   height: 1.75rem;
   border: 1px solid var(--border-faint, rgb(var(--color-border) / 12%));
@@ -58,11 +74,13 @@
   background: rgb(var(--color-surface));
   color: rgb(var(--color-muted));
   cursor: pointer;
+  transition: background 200ms ease, color 200ms ease, border-color 200ms ease,
+    box-shadow 200ms ease, opacity 200ms ease;
 }
 
-.s-log-btn:hover:not([data-active]) {
-  background: rgb(var(--color-primary) / 12%);
-  color: rgb(var(--color-text));
+.s-log-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--color-surface)), 0 0 0 4px rgb(var(--color-primary));
 }
 
 .s-log-btn[data-active] {

--- a/packages/vue/src/components/HkLogo.scss
+++ b/packages/vue/src/components/HkLogo.scss
@@ -13,6 +13,14 @@ a.hk-logo {
   text-decoration: none;
 }
 
+/* Keyboard parity (HkButton double ring): the anchor variant otherwise
+ * falls back to the rectangular UA outline. The div variant never
+ * matches :focus-visible (not focusable without a tsx tabindex). */
+a.hk-logo:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgb(var(--color-surface)), 0 0 0 4px rgb(var(--color-primary));
+}
+
 .hk-logo-img {
   display: block;
   border-radius: var(--hi-radius-md, 8px);
@@ -23,14 +31,15 @@ a.hk-logo {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--hi-color-primary);
+  /* Contract token with hex fallback (house idiom). No radius here: the
+   * only render site is inside .hk-logo, whose matching border-radius +
+   * overflow: hidden already clip this exactly-fitting child. */
+  background: var(--hi-color-primary, #58a6ff);
   color: rgb(var(--color-on-solid-text, 255 255 255));
-  border-radius: var(--hi-radius-md, 8px);
 }
 
 .hk-logo-initial {
   font-weight: 700;
   font-size: 50%;
   line-height: 1;
-  user-select: none;
 }

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -31,7 +31,7 @@
 .hk-markdown ul,
 .hk-markdown ol {
   margin: 0.5em 0;
-  padding-left: 1.5em;
+  padding-inline-start: 1.5em;
 }
 
 .hk-markdown li {
@@ -107,7 +107,7 @@
 .hk-markdown blockquote {
   margin: 0.75em 0;
   padding: 0.5em 1em;
-  border-left: 3px solid var(--hi-color-text-tertiary, #8b949e);
+  border-inline-start: 3px solid var(--hi-color-text-tertiary, #8b949e);
   color: var(--hi-color-text-secondary, #8b949e);
 }
 
@@ -121,7 +121,7 @@
 .hk-markdown td {
   padding: 0.5em 0.75em;
   border: 1px solid var(--hi-color-border, #30363d);
-  text-align: left;
+  text-align: start;
 }
 
 .hk-markdown th {
@@ -155,7 +155,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: color-mix(in srgb, var(--hi-color-surface) 70%, transparent);
+  background: color-mix(in srgb, var(--hi-color-surface, #fff) 70%, transparent);
   backdrop-filter: blur(4px);
   z-index: 10;
 }

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -2,7 +2,7 @@
 @use "./hikari-vars" as vars;
 
 .hk-markdown {
-  font-size: 0.875rem;
+  font-size: var(--text-base);
   line-height: 1.7;
   color: var(--hi-color-text-primary, #c9d1d9);
   position: relative;
@@ -59,13 +59,11 @@
   position: relative;
   margin: 0.75em 0;
   padding: 1em;
-  border-radius: 4px;
-  font-size: 0.8125rem;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
   line-height: 1.5;
-  user-select: none;
-  cursor: pointer;
   overflow-x: auto;
-  background: var(--hi-color-bg-subtle, #0d1117);
+  background: var(--hi-color-bg-subtle, #21262d);
 
   /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
      hidden, never styled. */
@@ -83,7 +81,7 @@
 .hk-md-code-lang {
   position: absolute;
   top: 0.25em;
-  right: 0.5em;
+  inset-inline-end: 0.5em;
   font-size: 0.625em;
   color: var(--hi-color-text-tertiary, #8b949e);
   opacity: 0.6;
@@ -97,7 +95,7 @@
   margin: 0;
   padding: 0.5rem 0;
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   line-height: 1.6;
   color: var(--hi-color-text-primary, #c9d1d9);
   white-space: pre-wrap;
@@ -138,6 +136,14 @@
   text-decoration: underline;
 }
 
+/* Rendered GFM links are real anchors — keyboard-focusable, so they need
+   the house :focus-visible ring (HkFab/HkContextRing pattern). Ring uses
+   the same contract var as the link ink so it matches in every theme. */
+.hk-markdown a:focus-visible {
+  outline: 2px solid var(--hi-color-primary, #58a6ff);
+  outline-offset: 2px;
+}
+
 .hk-markdown hr {
   border: none;
   border-top: 1px solid var(--hi-color-border, #30363d);
@@ -146,7 +152,7 @@
 
 .hk-markdown img {
   max-width: 100%;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .hk-markdown-overlay {

--- a/packages/vue/src/components/HkMediaControlBar.scss
+++ b/packages/vue/src/components/HkMediaControlBar.scss
@@ -10,11 +10,9 @@
 }
 
 .hk-media-btn.hk-btn {
-  min-width: 28px;
-  height: 28px;
+  min-width: var(--space-28);
+  height: var(--space-28);
   padding: 0 var(--space-6);
-  font-size: var(--text-xs);
-  font-weight: 600;
 }
 
 .hk-media-play.hk-btn {

--- a/packages/vue/src/components/HkMediaSlider.scss
+++ b/packages/vue/src/components/HkMediaSlider.scss
@@ -20,7 +20,6 @@
 .hk-media-slider-buffered {
   position: absolute;
   inset: 0 auto 0 0;
-  height: 100%;
   border-radius: var(--radius-sm);
   background: rgb(var(--color-muted) / 40%);
 }
@@ -28,7 +27,6 @@
 .hk-media-slider-fill {
   position: absolute;
   inset: 0 auto 0 0;
-  height: 100%;
   border-radius: var(--radius-sm);
   background: rgb(var(--color-primary));
 }

--- a/packages/vue/src/components/HkMenu.scss
+++ b/packages/vue/src/components/HkMenu.scss
@@ -60,7 +60,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hk-menu-row {
+  .hk-menu-row,
+  .hk-menu-sidebar-group-toggle .hk-menu-more {
     transition: none;
   }
 }
@@ -81,19 +82,11 @@
 
 .hk-menu-sidebar-row {
   @include mi.item;
-
-  .hk-menu-label {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
 }
 
-.hk-menu-sidebar-row .hk-menu-item-icon {
-  @include mi.icon;
-}
+/* Label and icon grammar comes from the shared .hk-menu-label /
+ * .hk-menu-item-icon rules above — sidebar rows carry those classes, so
+ * no sidebar-scoped copies are needed. */
 
 .hk-menu-sidebar-group {
   display: flex;
@@ -117,14 +110,14 @@
 }
 
 .hk-menu-sidebar-badge {
-  margin-left: auto;
+  margin-inline-start: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 18px;
   height: 18px;
   padding: 0 var(--space-4, 4px);
-  border-radius: 999px;
+  border-radius: var(--radius-full, 999px);
   background: rgb(var(--color-error, 240 70 80));
   color: #fff;
   font-size: var(--text-2xs, 10px);

--- a/packages/vue/src/components/HkMenu.scss
+++ b/packages/vue/src/components/HkMenu.scss
@@ -59,13 +59,6 @@
   min-width: 0;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .hk-menu-row,
-  .hk-menu-sidebar-group-toggle .hk-menu-more {
-    transition: none;
-  }
-}
-
 /* ── sidebar variant ────────────────────────────────────────────── */
 /* Inline vertical nav list — always rendered, no popover machinery.
  * Rows share the unified menu-item spec's grammar (metrics + states),
@@ -102,6 +95,19 @@
   transform: rotate(90deg);
 }
 
+/* RTL mirrors the expand chevron: the tsx always renders a right-pointing
+ * glyph, which reads backwards on the flipped axis (HkBreadcrumb
+ * precedent — scaleX mirrors paint only). An open group composes the
+ * same +90° turn after the mirror, so the open glyph points down in
+ * both directions. */
+[dir="rtl"] .hk-menu-more {
+  transform: scaleX(-1);
+}
+
+[dir="rtl"] .hk-menu-sidebar-group[data-open] .hk-menu-sidebar-group-toggle .hk-menu-more {
+  transform: scaleX(-1) rotate(90deg);
+}
+
 .hk-menu-sidebar-children {
   display: flex;
   flex-direction: column;
@@ -117,10 +123,23 @@
   min-width: 18px;
   height: 18px;
   padding: 0 var(--space-4, 4px);
-  border-radius: var(--radius-full, 999px);
-  background: rgb(var(--color-error, 240 70 80));
+  border-radius: var(--radius-full, 9999px);
+  background: rgb(var(--color-error, 247 118 142));
   color: #fff;
   font-size: var(--text-2xs, 10px);
   font-weight: 700;
   line-height: 1;
+}
+
+/* Reduced motion resets live AFTER the rules they guard so `transition: none`
+ * wins the cascade (the chevron's (0,2,0) transform transition used to be
+ * declared later in source order, leaving this guard dead for it). Sidebar
+ * rows carry the same mi.item color fades as .hk-menu-row, so they reset
+ * too. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-menu-row,
+  .hk-menu-sidebar-row,
+  .hk-menu-sidebar-group-toggle .hk-menu-more {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkMenuIdentityItem.scss
+++ b/packages/vue/src/components/HkMenuIdentityItem.scss
@@ -15,7 +15,7 @@
 .hk-menu-identity-item__avatar {
   width: 36px;
   height: 36px;
-  border-radius: 9999px;
+  border-radius: var(--radius-full, 9999px);
   overflow: hidden;
   flex-shrink: 0;
   display: flex;
@@ -42,7 +42,7 @@
   display: flex;
   flex-direction: column;
   min-width: 0;
-  gap: 2px;
+  gap: var(--space-2, 2px);
 }
 
 .hk-menu-identity-item__name {
@@ -66,5 +66,5 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2, 2px);
-  margin-top: 2px;
+  margin-top: var(--space-2, 2px);
 }

--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -1,7 +1,9 @@
 .hk-minimap {
   position: absolute;
   bottom: 12px;
-  right: 12px;
+  // Corner overlay anchor mirrors in RTL like the sibling HkZoomToolbar
+  // (inset-inline-end: 8px there).
+  inset-inline-end: 12px;
   z-index: 50;
   width: 160px;
   background: rgb(var(--color-surface) / 0.82);
@@ -62,7 +64,9 @@
   background: transparent;
   color: rgb(var(--color-text));
   cursor: pointer;
-  transition: background 0.1s ease, color 0.1s ease;
+  transition:
+    background var(--hi-duration-fast, 0.15s) ease,
+    color var(--hi-duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled) {
     background: rgb(var(--color-primary) / 0.1);
@@ -72,6 +76,14 @@
   &:disabled {
     color: rgb(var(--color-muted) / 40%);
     cursor: not-allowed;
+  }
+
+  // Keyboard focus ring drawn INSIDE the border box: the card clips
+  // (overflow: hidden) and the bar pads only 3px vertically, so an outer
+  // ring would be shaved per-side (HkSelectionGrid precedent).
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
   }
 }
 

--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -1,16 +1,19 @@
 .hk-minimap {
   position: absolute;
-  bottom: 12px;
+  bottom: var(--space-12);
   // Corner overlay anchor mirrors in RTL like the sibling HkZoomToolbar
   // (inset-inline-end: 8px there).
-  inset-inline-end: 12px;
+  inset-inline-end: var(--space-12);
   z-index: 50;
   width: 160px;
   background: rgb(var(--color-surface) / 0.82);
   border: 1px solid var(--border-faint);
   border-radius: var(--radius-sm);
   backdrop-filter: blur(var(--blur-md));
-  cursor: pointer;
+  // The root is a drag-to-pan surface (no click action): grab cursor, and
+  // the drag state tints the border like hover escalates it (HkBoard's
+  // draggable grab/grabbing precedent).
+  cursor: grab;
   overflow: hidden;
   pointer-events: auto;
   /* The minimap owns its own drag gestures — the surrounding pannable
@@ -24,6 +27,7 @@
 
   &[data-dragging] {
     cursor: grabbing;
+    border-color: rgb(var(--color-primary) / 0.5);
   }
 }
 
@@ -40,7 +44,6 @@
   gap: 2px;
   padding: 3px 8px;
   border-top: 1px solid var(--border-faint);
-  pointer-events: auto;
 }
 
 // Toolbar-only form (no overview map): shrink-wrap the card around the
@@ -73,6 +76,10 @@
     color: rgb(var(--color-primary));
   }
 
+  &:active:not(:disabled) {
+    background: rgb(var(--color-primary) / 0.18);
+  }
+
   &:disabled {
     color: rgb(var(--color-muted) / 40%);
     cursor: not-allowed;
@@ -85,10 +92,6 @@
     outline: 2px solid rgb(var(--color-primary));
     outline-offset: -2px;
   }
-}
-
-.hk-mm-zoom-reset-btn svg {
-  stroke-width: 2px;
 }
 
 .hk-mm-zoom-label {

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -146,9 +146,9 @@
 }
 
 // Compact lead content (e.g. a context ring) rendered before the title.
-// The title's auto right margin overrides the space-between distribution,
-// so the lead + title cluster sits on the left and the close button stays
-// on the right edge.
+// The title's auto inline-end margin overrides the space-between
+// distribution, so the lead + title cluster sits at inline-start and the
+// close button stays pinned at inline-end (mirrors correctly in RTL).
 .hk-modal-header-lead {
   display: flex;
   align-items: center;
@@ -159,7 +159,7 @@
   gap: var(--hk-modal-header-lead-gap, 0.75rem);
 
   .hk-modal-title {
-    margin-right: auto;
+    margin-inline-end: auto;
   }
 }
 
@@ -250,22 +250,21 @@
 // .hk-scroll-container-autotag.
 .hk-modal-autofollow-tag {
   position: absolute;
-  right: 0.75rem;
-  bottom: 0.625rem;
+  inset-inline-end: var(--space-12);
+  bottom: var(--space-10);
   z-index: 6;
   pointer-events: none;
   user-select: none;
   -webkit-user-select: none;
-  padding: 2px 8px;
-  font-size: 0.625rem;
+  padding: var(--space-2) var(--space-8);
+  font-size: var(--text-2xs);
   letter-spacing: 0.04em;
-  color: var(--hi-color-muted);
-  background: color-mix(in srgb, var(--hi-color-surface) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border) 12%, transparent);
+  color: var(--hi-color-muted, #666);
+  background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
   border-radius: var(--hi-radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
 }
 
 // Jump-back FAB (HkFab root) — floats above scroll content while follow
@@ -286,7 +285,7 @@
     var(--hk-modal-divider-color, var(--hi-color-border, rgba(0, 0, 0, 0.06)));
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: var(--space-8);
   flex-shrink: 0;
 
   // Conditional footer slots (phases without actions, close transitions)
@@ -314,8 +313,9 @@
 // ------
 @media (max-width: 767px) {
   .hk-modal-content {
+    // !important beats the inline maxWidth (width prop); base width: 100%
+    // already applies at every viewport, so only the cap is re-asserted.
     max-width: 100% !important;
-    width: 100%;
     // Bottom-docked, content-hugging: `top: auto` lets the sheet size
     // itself from its content instead of stretching from the top inset
     // down to the bottom gap (2026-08-30 user report: the node-detail
@@ -369,12 +369,6 @@
     opacity: 0;
     height: auto;
     transform: translateY(100%);
-  }
-
-  // Keep children pinned (same reason as desktop) — height stays auto.
-  .hk-modal-content-enter-active > *,
-  .hk-modal-content-leave-active > * {
-    flex: 0 0 auto;
   }
 
   .hk-modal-header {

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -250,7 +250,10 @@
 // .hk-scroll-container-autotag.
 .hk-modal-autofollow-tag {
   position: absolute;
-  inset-inline-end: var(--space-12);
+  /* Physical right on purpose: this tag and .hk-scroll-container-autotag
+     are visual twins pinned beside the physical corner FAB model — both
+     must anchor the same side in every direction. */
+  right: var(--space-12, 0.75rem);
   bottom: var(--space-10);
   z-index: 6;
   pointer-events: none;

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -20,7 +20,7 @@
   backdrop-filter: blur(var(--blur-md));
   pointer-events: none;
   user-select: none;
-  animation: hk-modal-breadcrumb-in 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-modal-breadcrumb-in var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-modal-breadcrumb-crumb {
@@ -47,6 +47,14 @@
   color: var(--hi-color-text-secondary, #666);
   opacity: 0.5;
   flex-shrink: 0;
+}
+
+// RTL mirrors the chevron: the tsx always renders a right-pointing glyph,
+// which reads backwards on the flipped axis (HkBreadcrumb.scss precedent —
+// there the class wraps the svg, here the class IS the svg, so the mirror
+// lands on the element itself; static transform, no motion to guard).
+[dir="rtl"] .hk-modal-breadcrumb-sep {
+  transform: scaleX(-1);
 }
 
 @keyframes hk-modal-breadcrumb-in {

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -8,11 +8,11 @@
   z-index: var(--hk-breadcrumb-z, 2500);
   display: flex;
   align-items: center;
-  // --hi-space-N contract tokens are N px across the library (HkTable,
+  // --space-N contract tokens are N px across the library (HkTable,
   // HkAlert, HkDrawer); keep fallbacks on that scale so hosts defining the
   // family don't collapse this strip (8px→4px gap, 32px→16px padding).
-  gap: var(--hi-space-8, 0.5rem);
-  padding: var(--hi-space-12, 0.75rem) var(--hi-space-32, 2rem);
+  gap: var(--space-8, 0.5rem);
+  padding: var(--space-12, 0.75rem) var(--space-32, 2rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-breadcrumb-border, rgba(0, 0, 0, 0.06));
   border-radius: var(--hi-radius-md, 0.5rem);
@@ -26,14 +26,14 @@
 .hk-modal-breadcrumb-crumb {
   display: inline-flex;
   align-items: center;
-  gap: var(--hi-space-8, 0.5rem);
+  gap: var(--space-8, 0.5rem);
 }
 
 .hk-modal-breadcrumb-item {
   display: inline-flex;
   align-items: center;
   line-height: 1.4;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-text-secondary, #666);
   white-space: nowrap;

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -8,13 +8,16 @@
   z-index: var(--hk-breadcrumb-z, 2500);
   display: flex;
   align-items: center;
-  gap: var(--hi-space-4, 0.5rem);
-  padding: var(--hi-space-6, 0.75rem) var(--hi-space-16, 2rem);
+  // --hi-space-N contract tokens are N px across the library (HkTable,
+  // HkAlert, HkDrawer); keep fallbacks on that scale so hosts defining the
+  // family don't collapse this strip (8px→4px gap, 32px→16px padding).
+  gap: var(--hi-space-8, 0.5rem);
+  padding: var(--hi-space-12, 0.75rem) var(--hi-space-32, 2rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-breadcrumb-border, rgba(0, 0, 0, 0.06));
   border-radius: var(--hi-radius-md, 0.5rem);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
-  backdrop-filter: blur(16px);
+  backdrop-filter: blur(var(--blur-md));
   pointer-events: none;
   user-select: none;
   animation: hk-modal-breadcrumb-in 0.15s cubic-bezier(0.16, 1, 0.3, 1);
@@ -23,7 +26,7 @@
 .hk-modal-breadcrumb-crumb {
   display: inline-flex;
   align-items: center;
-  gap: var(--hi-space-4, 0.5rem);
+  gap: var(--hi-space-8, 0.5rem);
 }
 
 .hk-modal-breadcrumb-item {
@@ -54,5 +57,13 @@
   to {
     opacity: 1;
     transform: translate(-50%, -50%);
+  }
+}
+
+// House reduced-motion guard (HkExpansionPanel / HkTooltip pattern): the
+// entrance is a transform slide — drop it, keep the strip visible instantly.
+@media (prefers-reduced-motion: reduce) {
+  .hk-modal-breadcrumb {
+    animation: none;
   }
 }

--- a/packages/vue/src/components/HkModelTag.scss
+++ b/packages/vue/src/components/HkModelTag.scss
@@ -20,8 +20,8 @@
 // (The extra .hk-badge term out-specifies hikari's own
 // `.hk-badge[data-pill="false"]` radius so import order cannot flip it.)
 .s-model-tag-group .hk-badge.s-model-tag-num {
-  border-start-start-radius: var(--radius-sm);
-  border-end-start-radius: var(--radius-sm);
+  border-start-start-radius: var(--radius-sm, 4px);
+  border-end-start-radius: var(--radius-sm, 4px);
   border-start-end-radius: 0;
   border-end-end-radius: 0;
   border-inline-end: none;
@@ -35,8 +35,8 @@
 .s-model-tag-group .hk-badge.s-model-tag-name {
   border-start-start-radius: 0;
   border-end-start-radius: 0;
-  border-start-end-radius: var(--radius-sm);
-  border-end-end-radius: var(--radius-sm);
+  border-start-end-radius: var(--radius-sm, 4px);
+  border-end-end-radius: var(--radius-sm, 4px);
   border-inline-start-color: rgb(var(--color-muted) / 35%);
   min-width: 0;
   overflow: hidden;
@@ -45,7 +45,7 @@
 // No `#tag` segment (bare model id): the name badge stands alone and
 // keeps the full badge radius — the divider/seam styling never shows.
 .s-model-tag-group .hk-badge.s-model-tag-name:only-child {
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-sm, 4px);
 }
 
 .s-model-tag-name-text {
@@ -90,7 +90,7 @@
 .s-model-card-stats {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 2px var(--space-10, 0.625rem);
+  gap: var(--space-2, 0.125rem) var(--space-10, 0.625rem);
   align-items: baseline;
 }
 
@@ -124,8 +124,8 @@
 .s-model-card-cap {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 2px var(--space-6, 0.375rem);
+  gap: var(--space-4, 0.25rem);
+  padding: var(--space-2, 0.125rem) var(--space-6, 0.375rem);
   border-radius: var(--radius-sm, 4px);
   background: rgb(var(--color-primary) / 10%);
   color: rgb(var(--color-primary));

--- a/packages/vue/src/components/HkModelTag.scss
+++ b/packages/vue/src/components/HkModelTag.scss
@@ -13,21 +13,31 @@
   min-width: 0;
 }
 
-// Number segment: keeps its left rounding, square right edge at the seam.
+// Number segment: keeps its inline-start rounding, square inline-end
+// edge at the seam. Logical corners so the joined geometry survives an
+// RTL flip (the flex row mirrors, and physical left/right radii would
+// land on the wrong sides).
 // (The extra .hk-badge term out-specifies hikari's own
 // `.hk-badge[data-pill="false"]` radius so import order cannot flip it.)
 .s-model-tag-group .hk-badge.s-model-tag-num {
-  border-radius: var(--radius-sm) 0 0 var(--radius-sm);
-  border-right: none;
+  border-start-start-radius: var(--radius-sm);
+  border-end-start-radius: var(--radius-sm);
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+  border-inline-end: none;
   flex-shrink: 0;
 }
 
-// Name segment: square left edge at the seam — its own left border IS the
-// divider line (darkened a notch so the seam reads clearly against both
-// badge fills). Must be allowed to shrink so the text can ellipsize.
+// Name segment: square inline-start edge at the seam — its own
+// inline-start border IS the divider line (darkened a notch so the seam
+// reads clearly against both badge fills). Must be allowed to shrink so
+// the text can ellipsize.
 .s-model-tag-group .hk-badge.s-model-tag-name {
-  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-  border-left-color: rgb(var(--color-muted) / 35%);
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+  border-start-end-radius: var(--radius-sm);
+  border-end-end-radius: var(--radius-sm);
+  border-inline-start-color: rgb(var(--color-muted) / 35%);
   min-width: 0;
   overflow: hidden;
 }
@@ -90,7 +100,7 @@
 }
 
 .s-model-card-col2 {
-  text-align: right;
+  text-align: end;
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-variant-numeric: tabular-nums;
 }

--- a/packages/vue/src/components/HkNavItem.scss
+++ b/packages/vue/src/components/HkNavItem.scss
@@ -24,7 +24,7 @@
   background: none;
   border: 1px solid transparent;
   width: 100%;
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   transition:
     background-color var(--hi-duration-fast, 0.15s) ease,
@@ -62,16 +62,20 @@
 .hk-nav-item-button {
   cursor: pointer;
 
+  /* Focus ring drawn inside the border box (offset -2px, the
+     HkSelectionGrid precedent): child rows sit inside the
+     overflow:hidden .hk-nav-item-children container, whose edges shave
+     the top/bottom legs of an outer ring. */
   &:focus-visible {
     outline: 2px solid var(--hi-color-primary);
-    outline-offset: 2px;
+    outline-offset: -2px;
   }
 }
 
 .hk-nav-item-link {
   &:focus-visible {
     outline: 2px solid var(--hi-color-primary);
-    outline-offset: 2px;
+    outline-offset: -2px;
   }
 }
 
@@ -94,6 +98,12 @@
 }
 
 .hk-nav-item-children {
-  padding-left: 1rem;
+  padding-inline-start: 1rem;
   overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-nav-item-arrow {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkNavItem.scss
+++ b/packages/vue/src/components/HkNavItem.scss
@@ -57,22 +57,13 @@
     opacity: 0.4;
     pointer-events: none;
   }
-}
-
-.hk-nav-item-button {
-  cursor: pointer;
 
   /* Focus ring drawn inside the border box (offset -2px, the
      HkSelectionGrid precedent): child rows sit inside the
      overflow:hidden .hk-nav-item-children container, whose edges shave
-     the top/bottom legs of an outer ring. */
-  &:focus-visible {
-    outline: 2px solid var(--hi-color-primary);
-    outline-offset: -2px;
-  }
-}
-
-.hk-nav-item-link {
+     the top/bottom legs of an outer ring. Every row — button and link
+     variants alike — carries .hk-nav-item, so one (0,2,0) rule covers
+     them all. */
   &:focus-visible {
     outline: 2px solid var(--hi-color-primary);
     outline-offset: -2px;
@@ -89,6 +80,18 @@
   text-overflow: ellipsis;
 }
 
+/* Child-row badge (tsx emits it bare): a small push-to-end pill so it
+   never competes with the ellipsizing label for space. Auto inline-start
+   margin is the house push-to-end pattern and survives the RTL flip. */
+.hk-nav-item-badge {
+  flex-shrink: 0;
+  margin-inline-start: auto;
+  padding: 0 var(--space-6, 0.375rem);
+  border-radius: var(--radius-sm, 4px);
+  background: color-mix(in srgb, var(--hi-color-muted) 12%, transparent);
+  font-size: var(--text-2xs, 0.625rem);
+}
+
 .hk-nav-item-arrow {
   transition: transform 0.2s;
 }
@@ -98,7 +101,7 @@
 }
 
 .hk-nav-item-children {
-  padding-inline-start: 1rem;
+  padding-inline-start: var(--space-16, 1rem);
   overflow: hidden;
 }
 

--- a/packages/vue/src/components/HkNumberInput.scss
+++ b/packages/vue/src/components/HkNumberInput.scss
@@ -1,5 +1,5 @@
 /* Field caption, mirroring .hk-input-label in HkInput.scss (the number
-   input carries its own copy so it does not depend on HInput's stylesheet
+   input carries its own copy so it does not depend on HkInput's stylesheet
    being loaded too). */
 .hk-input-label {
   display: block;
@@ -25,7 +25,7 @@
   align-items: center;
   background: var(--hi-color-surface);
   border: 1px solid var(--hi-color-border);
-  border-radius: var(--hi-radius-md, 6px);
+  border-radius: var(--hi-radius-md, 8px);
   overflow: hidden;
   transition:
     background-color var(--hi-transition-base, 200ms cubic-bezier(0.4, 0, 0.2, 1)),
@@ -53,9 +53,10 @@
   outline: none;
   color: var(--hi-color-text-primary);
   font-family: inherit;
-  font-size: 0.875rem;
+  /* Font size / horizontal padding come from the per-size blocks below —
+     the size class is always on the wrapper (HkNumberInput.tsx), so the
+     md block is the single source for those metrics. */
   line-height: 1.5;
-  padding: 0 0.75rem;
 
   &::placeholder {
     color: var(--hi-color-muted);
@@ -83,11 +84,11 @@
 }
 
 .hk-number-input-prefix {
-  padding-inline-start: 0.75rem;
+  padding-inline-start: var(--space-12, 0.75rem);
 }
 
 .hk-number-input-suffix {
-  padding-inline-end: 0.5rem;
+  padding-inline-end: var(--space-8, 0.5rem);
 }
 
 .hk-number-input-steppers {
@@ -107,7 +108,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 1.5rem;
+  /* Width comes from the per-size blocks below (the size class is always
+     on the wrapper); height stays here as the size-independent half. */
   height: 50%;
   padding: 0;
   background: transparent;
@@ -137,18 +139,18 @@
 /* --- Size variants --- */
 
 .hk-number-input-sm .hk-number-input-field {
-  font-size: 0.75rem;
-  padding: 0 0.5rem;
-  height: 1.75rem;
+  font-size: var(--text-xs, 0.75rem);
+  padding: 0 var(--space-8, 0.5rem);
+  height: var(--space-28, 1.75rem);
 }
 
 .hk-number-input-sm .hk-number-input-prefix,
 .hk-number-input-sm .hk-number-input-suffix {
-  font-size: 0.75rem;
+  font-size: var(--text-xs, 0.75rem);
 }
 
 .hk-number-input-sm .hk-number-input-step {
-  width: 1.25rem;
+  width: var(--space-20, 1.25rem);
 }
 
 .hk-number-input-sm .hk-number-input-step svg {
@@ -157,33 +159,33 @@
 }
 
 .hk-number-input-md .hk-number-input-field {
-  font-size: 0.875rem;
-  padding: 0 0.75rem;
+  font-size: var(--text-base, 0.875rem);
+  padding: 0 var(--space-12, 0.75rem);
   height: 2.25rem;
 }
 
 .hk-number-input-md .hk-number-input-prefix,
 .hk-number-input-md .hk-number-input-suffix {
-  font-size: 0.875rem;
+  font-size: var(--text-base, 0.875rem);
 }
 
 .hk-number-input-md .hk-number-input-step {
-  width: 1.5rem;
+  width: var(--space-24, 1.5rem);
 }
 
 .hk-number-input-lg .hk-number-input-field {
-  font-size: 1rem;
-  padding: 0 1rem;
+  font-size: var(--text-md, 1rem);
+  padding: 0 var(--space-16, 1rem);
   height: 2.75rem;
 }
 
 .hk-number-input-lg .hk-number-input-prefix,
 .hk-number-input-lg .hk-number-input-suffix {
-  font-size: 1rem;
+  font-size: var(--text-md, 1rem);
 }
 
 .hk-number-input-lg .hk-number-input-step {
-  width: 1.75rem;
+  width: var(--space-28, 1.75rem);
 }
 
 .hk-number-input-lg .hk-number-input-step svg {

--- a/packages/vue/src/components/HkNumberInput.scss
+++ b/packages/vue/src/components/HkNumberInput.scss
@@ -83,11 +83,11 @@
 }
 
 .hk-number-input-prefix {
-  padding-left: 0.75rem;
+  padding-inline-start: 0.75rem;
 }
 
 .hk-number-input-suffix {
-  padding-right: 0.5rem;
+  padding-inline-end: 0.5rem;
 }
 
 .hk-number-input-steppers {
@@ -98,7 +98,9 @@
      against the real box height and the divider spans it fully —
      content-sized centering left a floating ~28px stack in a 36px box. */
   align-self: stretch;
-  border-left: 1px solid var(--hi-color-border);
+  /* Inline-start so the divider faces the field/suffix side in both
+     LTR and RTL (the flex row flips under direction: rtl). */
+  border-inline-start: 1px solid var(--hi-color-border);
 }
 
 .hk-number-input-step {

--- a/packages/vue/src/components/HkPageHeader.scss
+++ b/packages/vue/src/components/HkPageHeader.scss
@@ -33,8 +33,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--space-28, 1.75rem);
+  height: var(--space-28, 1.75rem);
   flex-shrink: 0;
   border-radius: var(--radius-sm, 6px);
   background: rgb(var(--color-primary) / 10%);
@@ -59,8 +59,9 @@
   align-items: center;
   gap: var(--space-8, 0.5rem);
   flex-shrink: 0;
-  /* Align the tool row with the title baseline; wrapped rows (narrow
-     screens) fall back to stretch alignment via flex-wrap. */
+  /* Align the tool row with the title baseline; align-items: flex-end
+     applies per wrapped line too, and this 2px nudge optically matches
+     the title's descender space. */
   padding-block-end: var(--space-2, 0.125rem);
 }
 
@@ -73,7 +74,7 @@
   }
 
   .hk-page-header-icon {
-    width: 1.5rem;
-    height: 1.5rem;
+    width: var(--space-24, 1.5rem);
+    height: var(--space-24, 1.5rem);
   }
 }

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -16,7 +16,7 @@
 }
 
 .hk-pwd-required {
-  margin-left: 0.125rem;
+  margin-inline-start: var(--space-2);
   color: var(--hi-color-danger, #f85149);
 }
 
@@ -25,7 +25,7 @@
   display: flex;
   align-items: center;
   min-height: 2.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-8) var(--space-12);
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
   border-radius: 6px;
@@ -51,7 +51,7 @@
 
 .hk-pwd-box[data-error][data-focused] {
   border-color: var(--hi-color-danger, #f85149);
-  box-shadow: 0 0 0 3px rgba(248, 81, 73, 0.15);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-danger, #f85149) 15%, transparent);
 }
 
 .hk-pwd-box[data-disabled] {
@@ -101,12 +101,15 @@
   cursor: pointer;
 }
 
-.hk-pwd-box:focus-within .hk-pwd-lock,
-.hk-pwd-box[data-focused] .hk-pwd-lock {
-  color: var(--hi-color-primary, #58a6ff);
+/* Hover feedback for the hold-to-reveal control, mirroring the blur
+ * hint's hover; suppressed while revealing (press restores full
+ * primary) and while disabled (reveal is unreachable). */
+.hk-pwd-box:not([data-disabled]) .hk-pwd-lock-filled:hover:not([data-revealing]) {
+  color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 75%, transparent);
 }
 
-.hk-pwd-lock[data-revealing] {
+.hk-pwd-box:focus-within .hk-pwd-lock,
+.hk-pwd-box[data-focused] .hk-pwd-lock {
   color: var(--hi-color-primary, #58a6ff);
 }
 
@@ -128,7 +131,7 @@
   justify-content: center;
   z-index: 1;
   user-select: none;
-  font-size: 0.875rem;
+  font-size: var(--text-base);
   color: var(--hi-color-primary, rgba(88, 166, 255, 0.7));
   animation: hk-pwd-breathe 3s ease-in-out infinite;
   /* Default overflow strategy: hard-cut with an ellipsis (the marquee
@@ -150,6 +153,17 @@
   50% { opacity: 0.7; }
 }
 
+/* Reduced motion: stop the infinite breathe pulse. The global switch
+ * (`html[data-css-animations="0"]`) pauses it too when the host wired
+ * it; the media block covers hosts that never did. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-pwd-placeholder,
+  .hk-pwd-blur-hint,
+  .hk-pwd-select-hint {
+    animation: none;
+  }
+}
+
 .hk-pwd-blur-hint {
   position: absolute;
   inset: 0;
@@ -158,7 +172,7 @@
   justify-content: center;
   z-index: 1;
   user-select: none;
-  font-size: 0.875rem;
+  font-size: var(--text-base);
   font-style: italic;
   color: var(--hi-color-text-secondary, #666);
   cursor: pointer;
@@ -182,7 +196,7 @@
   justify-content: center;
   z-index: 1;
   user-select: none;
-  font-size: 0.875rem;
+  font-size: var(--text-base);
   font-style: italic;
   color: var(--hi-color-text-secondary, #666);
   pointer-events: none;
@@ -199,7 +213,7 @@
   pointer-events: none;
   user-select: none;
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
-  font-size: 0.8125rem;
+  font-size: var(--text-sm);
   letter-spacing: 0.04em;
   color: var(--hi-color-text-primary, #333);
 }
@@ -220,7 +234,7 @@
 
 .hk-pwd-strength {
   position: absolute;
-  right: 0.75rem;
+  inset-inline-end: var(--space-12);
   top: 50%;
   transform: translateY(-50%);
   width: 0.55rem;
@@ -235,29 +249,25 @@
 
 .hk-pwd-strength[data-level="weak"] {
   background: var(--hi-color-danger, #f85149);
-  box-shadow: 0 0 6px rgba(248, 81, 73, 0.6);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-danger, #f85149) 60%, transparent);
 }
 
 .hk-pwd-strength[data-level="fair"] {
   background: var(--hi-color-warning, #d29922);
-  box-shadow: 0 0 6px rgba(210, 153, 34, 0.6);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-warning, #d29922) 60%, transparent);
 }
 
 .hk-pwd-strength[data-level="strong"] {
   background: var(--hi-color-success, #3fb950);
-  box-shadow: 0 0 6px rgba(63, 185, 80, 0.6);
-}
-
-.hk-pwd-hints {
-  min-height: 0;
+  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-success, #3fb950) 60%, transparent);
 }
 
 .hk-pwd-hint {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
-  font-size: 0.75rem;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
 }
 
 .hk-pwd-hint[data-variant="caps"] {
@@ -268,25 +278,15 @@
   color: var(--hi-color-danger, #f85149);
 }
 
-.hk-pwd-hint-enter-active,
-.hk-pwd-hint-leave-active {
-  transition: opacity 0.3s ease;
-}
-
-.hk-pwd-hint-enter-from,
-.hk-pwd-hint-leave-to {
-  opacity: 0;
-}
-
 .hk-pwd-error {
-  margin-top: 0.25rem;
-  font-size: 0.75rem;
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
   color: var(--hi-color-danger, #f85149);
 }
 
 .hk-pwd-hint-text {
-  margin-top: 0.25rem;
-  font-size: 0.75rem;
+  margin-top: var(--space-4);
+  font-size: var(--text-xs);
   color: var(--hi-color-text-secondary, #666);
 }
 

--- a/packages/vue/src/components/HkPhaseTransition.scss
+++ b/packages/vue/src/components/HkPhaseTransition.scss
@@ -20,6 +20,22 @@
   transform: translateY(-8px);
 }
 
+/* Reduced motion: keep the opacity cross-fade, drop the translateY
+ * slide. The global animation switch (`html[data-css-animations="0"]`)
+ * disables these transitions too when the host wired it; the media
+ * block covers hosts that never did. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-phase-enter-active,
+  .hk-phase-leave-active {
+    transition: opacity var(--hi-duration-fast, 0.15s) ease;
+  }
+
+  .hk-phase-enter-from,
+  .hk-phase-leave-to {
+    transform: none;
+  }
+}
+
 .hk-phase-content {
   width: 100%;
 }

--- a/packages/vue/src/components/HkPhoneInput.scss
+++ b/packages/vue/src/components/HkPhoneInput.scss
@@ -9,13 +9,11 @@
  * handling live there). A button so it is focusable and AT-reachable;
  * mousedown is suppressed in the shared picker so clicking it never
  * steals focus from the number field. */
-.hk-phone-chip {
-  max-width: 11rem;
-}
-
+/* Width cap comes from the shared .hk-affix-chip base (max-width: 11rem);
+ * this class stays a tsx/test hook for hosts to layer overrides on. */
 .hk-phone-chip-dial {
   font-weight: 600;
-  font-size: var(--text-sm, 14px);
+  font-size: var(--text-sm, 0.8125rem);
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
@@ -23,4 +21,11 @@
 .hk-phone-chip-caret {
   flex: none;
   color: rgb(var(--color-muted));
+}
+
+/* Open disclosure state (aria-expanded sits on the chip button): flip the
+ * caret like the shared default chip does (HkAffixPicker.scss). Instant
+ * swap — no transition, so no reduced-motion entry is needed. */
+.hk-phone-chip[aria-expanded="true"] .hk-phone-chip-caret {
+  transform: rotate(180deg);
 }

--- a/packages/vue/src/components/HkPickerPane.scss
+++ b/packages/vue/src/components/HkPickerPane.scss
@@ -44,7 +44,8 @@
 .hk-dp-stage,
 .hk-dtp-stage {
   position: relative;
-  height: calc(var(--hk-picker-header) + var(--hk-picker-wd) + 6 * var(--hk-picker-cell) + 10px);
+  height: calc(var(--hk-picker-header) + var(--hk-picker-wd) + 6 * var(--hk-picker-cell) +
+    5 * var(--space-2, 2px));
 }
 
 .hk-dp-pane,
@@ -72,22 +73,48 @@
 
 .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active,
 .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active {
-  animation: hk-picker-pane-fwd-in var(--hi-duration-normal, 0.18s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-fwd-in var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active,
 .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active {
-  animation: hk-picker-pane-fwd-out var(--hi-duration-normal, 0.18s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-fwd-out var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="back"] > .hk-picker-pane-enter-active,
 .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-enter-active {
-  animation: hk-picker-pane-back-in var(--hi-duration-normal, 0.18s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-back-in var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="back"] > .hk-picker-pane-leave-active,
 .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-leave-active {
-  animation: hk-picker-pane-back-out var(--hi-duration-normal, 0.18s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-back-out var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* RTL: reading direction flips, so a forward drill flows left→right —
+ * swap the fwd/back keyframes (HkListTransition/HkBlockingToast
+ * [dir="rtl"] form; same registered keyframes, mirrored direction).
+ * Only the name is overridden: duration and easing carry over from the
+ * rules above, and the reduced-motion / data-css-animations guards below
+ * still win with !important. */
+[dir="rtl"] .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active,
+[dir="rtl"] .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active {
+  animation-name: hk-picker-pane-back-in;
+}
+
+[dir="rtl"] .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active,
+[dir="rtl"] .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active {
+  animation-name: hk-picker-pane-back-out;
+}
+
+[dir="rtl"] .hk-dp-stage[data-dir="back"] > .hk-picker-pane-enter-active,
+[dir="rtl"] .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-enter-active {
+  animation-name: hk-picker-pane-fwd-in;
+}
+
+[dir="rtl"] .hk-dp-stage[data-dir="back"] > .hk-picker-pane-leave-active,
+[dir="rtl"] .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-leave-active {
+  animation-name: hk-picker-pane-fwd-out;
 }
 
 /* The leaving pane overlays the fixed stage so the entering pane can take

--- a/packages/vue/src/components/HkPlaceholderMarquee.scss
+++ b/packages/vue/src/components/HkPlaceholderMarquee.scss
@@ -58,7 +58,11 @@
   }
 
   &__copy {
-    padding-right: 24px;
+    // Trailing cushion between copies. Kept as a px literal (not a token)
+    // on purpose: it must equal COPY_SPACING = 24 in the tsx overflow math
+    // at every root font size. Logical axis so the cushion trails the
+    // reading direction under RTL hosts.
+    padding-inline-end: 24px;
   }
 
   // Hidden probe mode (text fits): visibility keeps the element laid out —
@@ -74,8 +78,9 @@
     width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
+    // white-space stays local (ellipsis-trio idiom); text-align: center
+    // was dropped — the root already centers and hosts may re-align it.
     white-space: nowrap;
-    text-align: center;
   }
 }
 

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -68,16 +68,12 @@
   border: 1px solid rgb(var(--color-border) / 20%);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-dropdown);
-  padding: var(--space-4, 12px);
+  padding: var(--space-4, 0.25rem);
 }
 
 /* Locale picker menu items — unified menu-item spec (./_menu-item.scss). */
 .hk-popup-menu-item {
   @include mi.item;
-}
-
-.hk-popup-menu-item[data-active]:hover {
-  background: var(--c-primary-dim, rgb(var(--color-primary) / 10%));
 }
 
 .hk-locale-submenu {
@@ -125,6 +121,9 @@
   border-left: 0;
   border-right: 0;
   border-bottom: 0;
+  // The panel is a programmatic focus surface (tabindex="-1", focused on
+  // sheet open) — suppress the UA focus ring like .hk-modal-content.
+  outline: none;
   max-height: min(
     72vh,
     calc(
@@ -223,7 +222,7 @@
   font-size: var(--text-base, 0.875rem);
   font-weight: 600;
   letter-spacing: 0.02em;
-  color: rgb(var(--color-muted, 140 140 140));
+  color: rgb(var(--color-muted, 108 108 108));
   user-select: none;
   -webkit-user-select: none;
 }

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -203,8 +203,11 @@
   display: flex;
   align-items: center;
   gap: var(--space-8, 0.5rem);
-  padding: 0 var(--space-8, 0.5rem) var(--space-8, 0.5rem)
-    var(--hk-sheet-title-inset, var(--space-12, 0.75rem));
+  // Logical longhand (was physical `0 x y title-inset`): the title inset is
+  // the inline START edge so RTL mirrors it with the mirrored title/close.
+  padding-block: 0 var(--space-8, 0.5rem);
+  padding-inline: var(--hk-sheet-title-inset, var(--space-12, 0.75rem))
+    var(--space-8, 0.5rem);
 }
 
 .hk-popover-sheet-title {
@@ -228,8 +231,9 @@
 .hk-popover-sheet-close {
   // Legacy placement hook — the chrome lives on the shared .hk-icon-button
   // / .hk-window-close rules (window-close.scss) since the unified-close
-  // wave. Only the right-edge pinning stays here.
-  margin-left: auto;
+  // wave. Only the trailing-edge pinning stays here (logical, so the close
+  // mirrors to the left in RTL like HkInput/HkTagInput's auto inline start).
+  margin-inline-start: auto;
 }
 
 .hk-popover-sheet-enter-active {
@@ -257,6 +261,11 @@
 @include sf.scrim-fade("hk-popover-scrim");
 
 @media (prefers-reduced-motion: reduce) {
+  // Pop transitions included: the anchored panel's translateY+scale pop is
+  // the same non-trivial motion the sheet slide already silences here
+  // (house pattern: HkExpansionPanel.scss / HkAffixPicker.scss guards).
+  .hk-popover-enter-active,
+  .hk-popover-leave-active,
   .hk-popover-sheet-enter-active,
   .hk-popover-sheet-leave-active {
     transition: none;

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -20,7 +20,7 @@
 }
 
 .hk-popup-select-required {
-  margin-left: var(--space-2);
+  margin-inline-start: var(--space-2);
   color: rgb(var(--color-error));
 }
 
@@ -28,7 +28,10 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: var(--space-8) var(--space-32) var(--space-8) var(--space-12);
+  // Logical longhand: the wide end inset clears the arrow on the inline END
+  // edge, so an RTL locale mirrors both the padding and the arrow with it.
+  padding: var(--space-8) var(--space-12);
+  padding-inline-end: var(--space-32);
   min-height: 2.5rem;
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   
@@ -41,7 +44,13 @@
   text-align: center;
   cursor: pointer;
   outline: none;
-  transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) var(--ease-standard);
+  /* Longhand on purpose: the former comma-separated shorthand declared one
+   * transition per property where only `filter` carried the duration — the
+   * rest animated at 0s so hover/focus snapped (HkButton.scss precedent). */
+  transition-property: background-color, border-color, color, box-shadow,
+    opacity, transform, filter;
+  transition-duration: var(--duration-normal);
+  transition-timing-function: var(--ease-standard);
   position: relative;
 }
 
@@ -80,7 +89,7 @@
 
 .hk-popup-select-arrow {
   position: absolute;
-  right: 0.75rem;
+  inset-inline-end: 0.75rem;
   color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
   pointer-events: none;
   flex-shrink: 0;

--- a/packages/vue/src/components/HkPopupSelect.scss
+++ b/packages/vue/src/components/HkPopupSelect.scss
@@ -58,6 +58,11 @@
   border-color: var(--c-primary-strong);
 }
 
+// Press feedback (house pattern: HkButton.scss :active brightness dip).
+.hk-popup-select-trigger:active:not(:disabled):not([data-disabled]) {
+  filter: brightness(0.95);
+}
+
 .hk-popup-select-trigger:focus,
 .hk-popup-select-trigger[data-state="open"] {
   border-color: rgb(var(--color-focused-border));
@@ -89,10 +94,9 @@
 
 .hk-popup-select-arrow {
   position: absolute;
-  inset-inline-end: 0.75rem;
+  inset-inline-end: var(--space-12);
   color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
   pointer-events: none;
-  flex-shrink: 0;
   transition: transform var(--duration-normal) ease;
 }
 
@@ -124,8 +128,8 @@
   @include mi.item;
 }
 
-/* Highlight face yields to checked/active (see HkSelect.scss). */
-.hk-popup-select-item:hover:not([data-checked]):not([data-active]),
+/* Keyboard highlight face yields to checked/active; the hover face comes
+ * from mi.item's own guarded :hover (identical values, higher specificity). */
 .hk-popup-select-item[data-highlighted]:not([data-checked]):not([data-active]) {
   background: var(--c-primary-subtle, rgb(var(--color-primary) / 8%));
   border-color: var(--c-primary-medium, rgb(var(--color-primary) / 25%));
@@ -146,3 +150,11 @@
 // lit a second nested scrollbar inside the same window. The desktop
 // popout keeps its 240px content cap + viewport scroll, where the
 // viewport bar is the popup's only scrollbar.
+
+// Chevron flip is a transform animation — house reduced-motion guard
+// (HkExpansionPanel.scss silences its chevron the same way).
+@media (prefers-reduced-motion: reduce) {
+  .hk-popup-select-arrow {
+    transition: none;
+  }
+}

--- a/packages/vue/src/components/HkProgressBar.scss
+++ b/packages/vue/src/components/HkProgressBar.scss
@@ -31,10 +31,12 @@
 .hk-progress-bar-secondary {
   position: absolute;
   top: 0;
-  left: 0;
+  // Logical: anchors to the inline start like the in-flow fill, so an RTL
+  // track keeps the secondary bar on the same side as the fill.
+  inset-inline-start: 0;
   height: 100%;
   border-radius: var(--radius-full);
-  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: width var(--duration-normal) var(--ease-standard);
   opacity: 0.3;
 
   &-loading {
@@ -54,7 +56,7 @@
   position: relative;
   height: 100%;
   border-radius: var(--radius-full);
-  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: width var(--duration-normal) var(--ease-standard);
 
   &-loading {
     background: rgb(var(--color-primary));
@@ -105,18 +107,30 @@
   // No per-block rounding — flush multi-color blocks would otherwise show
   // hairlines at the seams.
   border-radius: 0;
-  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: width var(--duration-normal) var(--ease-standard);
   background: rgb(var(--color-primary));
 }
 
+// Keyframes animate the logical inset so the sweep mirrors in RTL together
+// with the fill/secondary anchoring (LTR-identical).
 @keyframes hk-progress-indeterminate {
   0% {
-    left: -40%;
+    inset-inline-start: -40%;
   }
   60% {
-    left: 100%;
+    inset-inline-start: 100%;
   }
   100% {
-    left: 100%;
+    inset-inline-start: 100%;
+  }
+}
+
+// House pattern (HkExpansionPanel.scss / HkAffixPicker.scss guards): the
+// infinite indeterminate sweep must not run under reduced motion; the bar
+// rests as a static 40% block at the inline start, like the done/error
+// variants rest at full width.
+@media (prefers-reduced-motion: reduce) {
+  .hk-progress-bar-indeterminate {
+    animation: none;
   }
 }

--- a/packages/vue/src/components/HkProgressBar.scss
+++ b/packages/vue/src/components/HkProgressBar.scss
@@ -133,4 +133,12 @@
   .hk-progress-bar-indeterminate {
     animation: none;
   }
+
+  // Width is a size animation — progress steps snap instead of animating
+  // (house guard: HkTokenUsagePanel's bar fill).
+  .hk-progress-bar-fill,
+  .hk-progress-bar-secondary,
+  .hk-progress-bar-seg {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkProgressDialog.scss
+++ b/packages/vue/src/components/HkProgressDialog.scss
@@ -9,9 +9,9 @@
 
 .s-progress-dialog-log {
   border-radius: 0.375rem;
-  background: rgba(0, 0, 0, 0.06);
-  padding: 0.5rem;
+  background: var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  padding: var(--space-8, 0.5rem);
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
-  font-size: 0.75rem;
+  font-size: var(--text-xs, 0.75rem);
   line-height: 1.5;
 }

--- a/packages/vue/src/components/HkProgressDialog.scss
+++ b/packages/vue/src/components/HkProgressDialog.scss
@@ -9,7 +9,9 @@
 
 .s-progress-dialog-log {
   border-radius: 0.375rem;
-  background: var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  /* 6% black wash, not the border token: --hi-color-border resolves to a
+     15% tint that would visibly darken the log panel. */
+  background: rgba(0, 0, 0, 0.06);
   padding: var(--space-8, 0.5rem);
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-xs, 0.75rem);

--- a/packages/vue/src/components/HkProgressRing.scss
+++ b/packages/vue/src/components/HkProgressRing.scss
@@ -9,32 +9,25 @@
 .hk-progress-ring-svg {
   width: 100%;
   height: 100%;
-  transform: rotate(0deg);
 }
 
 .hk-progress-ring-track {
   stroke: var(--hk-progress-ring-track, var(--hi-color-border, rgba(0, 0, 0, 0.12)));
-  transition: stroke 0.3s ease;
-}
-
-.hk-progress-ring-fill {
-  stroke: var(--hi-color-primary, #58a6ff);
-  transition:
-    stroke-dashoffset 0.3s ease,
-    stroke 0.3s ease;
-}
-
-.hk-progress-ring-success .hk-progress-ring-fill {
-  stroke: var(--hi-color-success, #3fb950);
+  transition: stroke var(--duration-normal) var(--ease-standard);
 }
 
 // Segmented-mode arcs: segments without an explicit `color` fall back to
 // the theme primary (same default as the single-value fill).
+.hk-progress-ring-fill,
 .hk-progress-ring-seg {
   stroke: var(--hi-color-primary, #58a6ff);
   transition:
-    stroke-dashoffset 0.3s ease,
-    stroke 0.3s ease;
+    stroke-dashoffset var(--duration-normal) var(--ease-standard),
+    stroke var(--duration-normal) var(--ease-standard);
+}
+
+.hk-progress-ring-success .hk-progress-ring-fill {
+  stroke: var(--hi-color-success, #3fb950);
 }
 
 .hk-progress-ring-exception .hk-progress-ring-fill {

--- a/packages/vue/src/components/HkProtocolModal.scss
+++ b/packages/vue/src/components/HkProtocolModal.scss
@@ -2,6 +2,3 @@
  * content and the HkModal body scroller is THE scrollbar. The old
  * `bodyHeight`-driven nested scroll region (with its own overlay chrome)
  * was removed as dead API — no consumer in the family ever passed it. */
-.s-protocol-modal {
-  position: relative;
-}

--- a/packages/vue/src/components/HkQrCode.scss
+++ b/packages/vue/src/components/HkQrCode.scss
@@ -16,8 +16,8 @@
 }
 
 .hk-qr-label {
-  font-size: var(--text-2xs, 0.75rem);
+  font-size: var(--text-2xs, 0.625rem);
   line-height: 1.4;
-  color: rgb(var(--color-muted, 120 113 108));
+  color: rgb(var(--color-muted, 108 108 108));
   text-align: center;
 }

--- a/packages/vue/src/components/HkRadio.scss
+++ b/packages/vue/src/components/HkRadio.scss
@@ -1,6 +1,6 @@
 .hk-radio-group {
   display: flex;
-  gap: 1rem;
+  gap: var(--space-16, 1rem);
 
   &-horizontal {
     flex-direction: row;
@@ -12,18 +12,18 @@
   }
 
   &-sm {
-    gap: 0.5rem;
+    gap: var(--space-8, 0.5rem);
   }
 
   &-lg {
-    gap: 1.25rem;
+    gap: var(--space-20, 1.25rem);
   }
 }
 
 .hk-radio {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
   cursor: pointer;
   user-select: none;
 
@@ -43,8 +43,8 @@
   border: 1px solid var(--hi-color-border);
   background: var(--hi-color-surface);
   transition:
-    border-color 0.3s ease,
-    background 0.3s ease;
+    border-color var(--hi-duration-normal, 0.3s) ease,
+    background var(--hi-duration-normal, 0.3s) ease;
   flex-shrink: 0;
   position: relative;
 
@@ -81,6 +81,15 @@
   height: 0;
   opacity: 0;
   pointer-events: none;
+}
+
+/* Keyboard focus: the native input is visually hidden, so draw the house
+   double ring (HkButton/HkCheckbox pattern) on the box via :has();
+   :focus-visible keeps mouse clicks ring-free. */
+.hk-radio-box:has(.hk-radio-input:focus-visible) {
+  box-shadow:
+    0 0 0 2px var(--hi-color-surface, rgba(255, 255, 255, 0.95)),
+    0 0 0 4px var(--hi-color-primary, #ff6b9d);
 }
 
 /* --- Dot --- */

--- a/packages/vue/src/components/HkRichInput.scss
+++ b/packages/vue/src/components/HkRichInput.scss
@@ -27,10 +27,24 @@
   background: rgb(var(--color-surface) / 0.5);
   cursor: pointer;
   overflow: hidden;
+  transition:
+    border-color var(--duration-short, 0.15s) ease,
+    background var(--duration-short, 0.15s) ease;
 
   &[data-variant="media"] {
     width: 72px;
     height: 48px;
+  }
+
+  /* Clickable tile (previewAttachment) with no hover/press affordance;
+   * color/background only, so no reduced-motion guard is needed. */
+  &:hover {
+    border-color: rgb(var(--color-primary) / 45%);
+    background: rgb(var(--color-surface) / 0.8);
+  }
+
+  &:active {
+    background: rgb(var(--color-surface) / 0.9);
   }
 }
 
@@ -47,22 +61,21 @@
   }
 }
 
-.s-rich-input-attachment-play {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #fff;
-  background: rgb(0 0 0 / 25%);
-}
-
+.s-rich-input-attachment-play,
 .s-rich-input-attachment-progress {
   position: absolute;
   inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.s-rich-input-attachment-play {
+  color: #fff;
+  background: rgb(0 0 0 / 25%);
+}
+
+.s-rich-input-attachment-progress {
   background: rgb(0 0 0 / 30%);
 }
 
@@ -90,12 +103,13 @@
 .s-rich-input-attachment-remove {
   position: absolute;
   top: 2px;
-  right: 2px;
+  inset-inline-end: 2px;
   opacity: 0;
   transition: opacity var(--duration-short, 0.15s) ease;
 }
 
-.s-rich-input-attachment:hover .s-rich-input-attachment-remove {
+.s-rich-input-attachment:hover .s-rich-input-attachment-remove,
+.s-rich-input-attachment:focus-within .s-rich-input-attachment-remove {
   opacity: 1;
 }
 
@@ -125,15 +139,17 @@
     border-color: rgb(var(--color-primary));
   }
 
-  .s-rich-input-textarea {
+  /* The `s-rich-input-textarea` class passed to HInput never reaches the
+   * DOM (inheritAttrs:false + filteredAttrs strip class), so strip the
+   * embedded input's chrome on its real carrier (.hk-input-box) instead.
+   * The :focus-within twin outranks HkInput's own focus ring regardless
+   * of stylesheet order. */
+  .hk-input-box,
+  .hk-input-box:focus-within {
     border: none;
     box-shadow: none;
     background: transparent;
   }
-}
-
-.s-rich-input-textarea {
-  width: 100%;
 }
 
 /* ── Tools row ──────────────────────────────────────────────────── */

--- a/packages/vue/src/components/HkRollingNumber.scss
+++ b/packages/vue/src/components/HkRollingNumber.scss
@@ -3,15 +3,13 @@
   font-variant-numeric: tabular-nums;
   line-height: 1;
 
-  [data-el="char"] {
-    display: inline-block;
-  }
+  /* char/slot/digit are all flex items (root and roll are flex
+     containers), so their display blockifies and vertical-align never
+     applies — no explicit display/vertical-align declarations. */
 
   [data-el="slot"] {
-    display: inline-block;
     position: relative;
     overflow: hidden;
-    vertical-align: baseline;
     height: 1em;
   }
 
@@ -22,7 +20,6 @@
   }
 
   [data-el="digit"] {
-    display: block;
     height: 1em;
   }
 }
@@ -33,5 +30,16 @@
   }
   to {
     transform: translateY(-1em);
+  }
+}
+
+/* Reduced motion: stop the digit roll. The global switch
+ * (`html[data-css-animations="0"]`) pauses it too when the host wired
+ * it; the media block covers hosts that never did. Safe: the component
+ * arms a cron fallback that force-commits the final digit whenever
+ * `animationend` never fires. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-rolling-number [data-el="roll"] {
+    animation: none;
   }
 }

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -45,7 +45,7 @@
    content fade. The fade size custom property is declared on the
    root so consumers can override it from the container element. */
 .hk-scroll-container[data-fade="true"] {
-  --hk-scroll-fade-size: 24px;
+  --hk-scroll-fade-size: var(--space-24);
 }
 
 .hk-scroll-container[data-fade="true"][data-h-overflow="end"] > .hk-scroll-container-viewport {
@@ -56,6 +56,18 @@
 .hk-scroll-container[data-fade="true"][data-h-overflow="start"] > .hk-scroll-container-viewport {
   -webkit-mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
   mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
+}
+
+/* RTL: the horizontal scroll start/end edges swap sides, so the
+ * directional fades flip (the "both" mask is end-symmetric — no flip). */
+[dir="rtl"] .hk-scroll-container[data-fade="true"][data-h-overflow="end"] > .hk-scroll-container-viewport {
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
+  mask-image: linear-gradient(to right, transparent 0, #000 var(--hk-scroll-fade-size));
+}
+
+[dir="rtl"] .hk-scroll-container[data-fade="true"][data-h-overflow="start"] > .hk-scroll-container-viewport {
+  -webkit-mask-image: linear-gradient(to left, transparent 0, #000 var(--hk-scroll-fade-size));
+  mask-image: linear-gradient(to left, transparent 0, #000 var(--hk-scroll-fade-size));
 }
 
 .hk-scroll-container[data-fade="true"][data-h-overflow="both"] > .hk-scroll-container-viewport {
@@ -90,18 +102,18 @@
 
 .hk-scroll-container-autotag {
   position: absolute;
-  right: 0.625rem;
-  bottom: 0.625rem;
+  right: var(--space-10);
+  bottom: var(--space-10);
   z-index: 6;
   pointer-events: none;
   user-select: none;
   -webkit-user-select: none;
-  padding: 2px 8px;
-  font-size: 0.625rem;
+  padding: var(--space-2) var(--space-8);
+  font-size: var(--text-2xs);
   letter-spacing: 0.04em;
-  color: var(--hi-color-muted);
-  background: color-mix(in srgb, var(--hi-color-surface) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border) 12%, transparent);
+  color: var(--hi-color-muted, #666);
+  background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
   border-radius: var(--hi-radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;

--- a/packages/vue/src/components/HkSearchInput.scss
+++ b/packages/vue/src/components/HkSearchInput.scss
@@ -30,7 +30,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  padding-left: 0.75rem;
+  padding-inline-start: var(--space-12);
   color: var(--hi-color-muted);
 
   svg {
@@ -47,9 +47,9 @@
   outline: none;
   color: var(--hi-color-text-primary);
   font-family: inherit;
-  font-size: 0.875rem;
+  font-size: var(--text-base);
   line-height: 1.5;
-  padding: 0 0.5rem;
+  padding: 0 var(--space-8);
 
   &::placeholder {
     color: var(--hi-color-muted);
@@ -68,12 +68,11 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 1.75rem;
+  width: var(--space-28);
   height: 100%;
   padding: 0;
   background: transparent;
   border: none;
-  border-radius: 0;
   color: var(--hi-color-muted);
   cursor: pointer;
   transition:
@@ -89,17 +88,21 @@
     background: color-mix(in srgb, var(--hi-color-surface) 60%, transparent);
     color: var(--hi-color-text-primary);
   }
+
+  &:active {
+    background: color-mix(in srgb, var(--hi-color-surface) 80%, transparent);
+  }
 }
 
 /* --- Size variants --- */
 
 .hk-search-input-sm .hk-search-input-field {
-  font-size: 0.75rem;
+  font-size: var(--text-xs);
   height: 1.75rem;
 }
 
 .hk-search-input-sm .hk-search-input-icon {
-  padding-left: 0.5rem;
+  padding-inline-start: var(--space-8);
 
   svg {
     width: 14px;
@@ -108,17 +111,16 @@
 }
 
 .hk-search-input-md .hk-search-input-field {
-  font-size: 0.875rem;
   height: 2.25rem;
 }
 
 .hk-search-input-lg .hk-search-input-field {
-  font-size: 1rem;
+  font-size: var(--text-md);
   height: 2.75rem;
 }
 
 .hk-search-input-lg .hk-search-input-icon {
-  padding-left: 1rem;
+  padding-inline-start: var(--space-16);
 
   svg {
     width: 18px;

--- a/packages/vue/src/components/HkSecretRevealModal.scss
+++ b/packages/vue/src/components/HkSecretRevealModal.scss
@@ -38,18 +38,28 @@
   gap: var(--space-6, 0.375rem);
   padding: var(--space-6, 0.375rem) var(--space-12, 0.75rem);
   border: none;
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm, 4px);
   background: rgb(var(--color-primary));
   color: rgb(var(--color-on-solid-text, 255 255 255));
   font-size: var(--text-sm, 0.8125rem);
   font-weight: 600;
   cursor: pointer;
+  transition: filter 200ms ease;
 }
 
 .s-secret-modal-copy:hover {
   filter: brightness(1.1);
 }
 
+.s-secret-modal-copy:active {
+  filter: brightness(0.92);
+}
+
+.s-secret-modal-copy:focus-visible {
+  box-shadow:
+    0 0 0 2px rgb(var(--color-surface)),
+    0 0 0 4px rgb(var(--color-primary));
+}
 
 .s-secret-modal-copy:disabled {
   opacity: 0.5;

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -21,7 +21,7 @@
 }
 
 .hk-select-required {
-  margin-left: var(--space-2);
+  margin-inline-start: var(--space-2);
   color: rgb(var(--color-error));
 }
 
@@ -29,8 +29,11 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: var(--space-8) var(--space-32) var(--space-8) var(--space-12);
-  min-height: 2.5rem;
+  /* Logical axes (HkAffixPicker rule): the wide side reserves arrow
+   * room at inline-end and flips with the host's direction. */
+  padding-block: var(--space-8);
+  padding-inline: var(--space-12) var(--space-32);
+  min-height: var(--space-40);
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   
   border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
@@ -42,7 +45,12 @@
   text-align: center;
   cursor: pointer;
   outline: none;
-  transition: background-color, border-color, color, box-shadow, opacity, transform, filter var(--duration-normal) var(--ease-standard);
+  /* Longhand on purpose (HkButton rule): the former comma shorthand
+   * bound the duration/easing to `filter` only — every other property
+   * animated at 0s and hover/focus snapped. */
+  transition-property: background-color, border-color, color, box-shadow, opacity, transform, filter;
+  transition-duration: var(--duration-normal);
+  transition-timing-function: var(--ease-standard);
   position: relative;
 }
 
@@ -50,7 +58,13 @@
   border-color: var(--c-primary-strong);
 }
 
-.hk-select-trigger:focus,
+/* Press feedback (HkButton :active rule) — brightness, not background,
+ * so it never clobbers the focus/open ring below. */
+.hk-select-trigger:active:not([data-disabled]) {
+  filter: brightness(0.95);
+}
+
+.hk-select-trigger:focus-visible,
 .hk-select-trigger[data-state="open"] {
   border-color: rgb(var(--color-focused-border));
   box-shadow: var(--shadow-focus);
@@ -61,7 +75,7 @@
   border-color: var(--c-error-strong);
 }
 
-.hk-select-trigger[data-error]:focus,
+.hk-select-trigger[data-error]:focus-visible,
 .hk-select-trigger[data-error][data-state="open"] {
   border-color: rgb(var(--color-error));
   box-shadow: var(--shadow-focus-error);
@@ -81,10 +95,9 @@
 
 .hk-select-arrow {
   position: absolute;
-  right: 0.75rem;
+  inset-inline-end: var(--space-12);
   color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
   pointer-events: none;
-  flex-shrink: 0;
   transition: transform var(--duration-normal) ease;
 }
 
@@ -164,7 +177,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .hk-select-popout-enter-active,
-  .hk-select-popout-leave-active {
+  .hk-select-popout-leave-active,
+  /* The trigger chevron's 180° rotate is a transform animation too. */
+  .hk-select-arrow {
     transition: none;
   }
 }
@@ -228,14 +243,16 @@
 
 /* The highlight face never overrides the checked/active face — a
  * keyboard-highlighted selected option keeps its dim wash + primary
- * text (active > hover precedence, same as the spec mixin). */
-.hk-select-option:hover:not([data-checked]):not([data-active]),
-.hk-select-option[data-highlighted]:not([data-checked]):not([data-active]) {
+ * text (active > hover precedence, same as the spec mixin) — and it
+ * never paints disabled rows (keyboard highlight and pointerenter both
+ * land on them; HkSelect.tsx does not skip disabled options). */
+.hk-select-option:hover:not([data-disabled]):not([data-checked]):not([data-active]),
+.hk-select-option[data-highlighted]:not([data-disabled]):not([data-checked]):not([data-active]) {
   background: var(--c-primary-subtle, rgb(var(--color-primary) / 8%));
   border-color: var(--c-primary-medium, rgb(var(--color-primary) / 25%));
 }
 
-.hk-select-option[data-highlighted]:not(:hover):not([data-checked]):not([data-active]) {
+.hk-select-option[data-highlighted]:not(:hover):not([data-disabled]):not([data-checked]):not([data-active]) {
   color: rgb(var(--color-text));
 }
 
@@ -308,7 +325,7 @@
 
 .hk-select-sheet-grabber {
   flex-shrink: 0;
-  padding: 14px 0 20px;
+  padding: var(--space-14) 0 var(--space-20);
   margin: 0 auto;
   width: 100%;
   cursor: pointer;
@@ -322,7 +339,7 @@
   &::before {
     content: "";
     width: 2.25rem;
-    height: 4px;
+    height: var(--space-4);
     border-radius: 999px;
     background: rgb(var(--color-border, 100 100 100) / 40%);
   }
@@ -340,10 +357,11 @@
 }
 
 .hk-select-sheet-close {
-  // Right-edge pinning with or without a title beside it; the chrome lives
+  // Inline-end pinning with or without a title beside it (push-to-end
+  // via the logical auto margin — mirrors in RTL); the chrome lives
   // on the shared .hk-icon-button / .hk-window-close rules
   // (window-close.scss) since the unified-close wave.
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .hk-select-sheet-title {

--- a/packages/vue/src/components/HkSelectionGrid.scss
+++ b/packages/vue/src/components/HkSelectionGrid.scss
@@ -62,15 +62,28 @@
     box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
   }
 
+  // Keyboard focus indicator drawn inside the border box (negative outline
+  // offset) for the same overlap-immunity as the selected ring below.
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
+  }
+
+  // Selected emphasis is drawn INSIDE the border box (border + inset ring =
+  // 2px on every side). An outer ring (`0 0 0 1px`) lives outside the border
+  // box, where any overlapping chrome — frosted sticky headers, clipping
+  // ancestors, adjacent paint order — can shave individual sides and leave
+  // the frame visibly lopsided (observed as a 1px top vs 2px sides under
+  // HkStepFlow's sticky header).
   &[data-selected] {
     border-color: var(--hi-color-primary, #58a6ff);
     background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
-    box-shadow: 0 0 0 1px var(--hi-color-primary, #58a6ff);
+    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #58a6ff);
 
     &:hover {
       background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.09);
       box-shadow:
-        0 0 0 1px var(--hi-color-primary, #58a6ff),
+        inset 0 0 0 1px var(--hi-color-primary, #58a6ff),
         0 2px 12px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.14);
     }
 

--- a/packages/vue/src/components/HkSelectionGrid.scss
+++ b/packages/vue/src/components/HkSelectionGrid.scss
@@ -1,5 +1,5 @@
 .hk-selection-grid {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-16, 1rem);
 }
 
 .hk-selection-grid-title {
@@ -8,7 +8,7 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--hi-color-text-tertiary, #8b949e);
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-8, 0.5rem);
 }
 
 /* Foot note under the grid — same register as .hk-input-hint so the
@@ -22,17 +22,17 @@
 
 .hk-selection-grid-grid {
   display: grid;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
 
   &[data-cols="2"] { grid-template-columns: repeat(2, 1fr); }
   &[data-cols="3"] { grid-template-columns: repeat(3, 1fr); }
   &[data-cols="4"] { grid-template-columns: repeat(4, 1fr); }
 
   &[data-dense] {
-    gap: 0.375rem;
+    gap: var(--space-6, 0.375rem);
 
     .hk-selection-grid-item {
-      padding: 0.5rem 0.625rem;
+      padding: var(--space-8, 0.5rem) var(--space-10, 0.625rem);
     }
   }
 }
@@ -41,9 +41,9 @@
   position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 0.5rem;
-  padding: 0.75rem;
-  border-radius: 4px;
+  gap: var(--space-8, 0.5rem);
+  padding: var(--space-12, 0.75rem);
+  border-radius: var(--radius-sm, 4px);
   border: 1px solid var(--hi-color-border, #30363d);
   cursor: pointer;
   transition:
@@ -105,17 +105,17 @@
 
 .hk-selection-grid-check {
   position: absolute;
-  top: 0.375rem;
-  right: 0.375rem;
-  width: 1.25rem;
-  height: 1.25rem;
+  top: var(--space-6, 0.375rem);
+  inset-inline-end: var(--space-6, 0.375rem);
+  width: var(--space-20, 1.25rem);
+  height: var(--space-20, 1.25rem);
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--hi-color-primary, #58a6ff);
   color: rgb(var(--color-on-solid-icon, 255 255 255));
-  font-size: 0.625rem;
+  font-size: var(--text-2xs, 0.625rem);
   opacity: 0;
   transform: scale(0.5);
   transition:
@@ -131,7 +131,7 @@
 .hk-selection-grid-header {
   display: flex;
   align-items: center;
-  gap: 0.375rem;
+  gap: var(--space-6, 0.375rem);
   flex-wrap: wrap;
 }
 
@@ -142,7 +142,7 @@
 }
 
 .hk-selection-grid-name {
-  font-size: 0.8125rem;
+  font-size: var(--text-sm, 0.8125rem);
   font-weight: 500;
   line-height: 1.4;
   transition: color 200ms ease;
@@ -151,16 +151,16 @@
 .hk-selection-grid-desc {
   font-size: 0.6875rem;
   color: var(--hi-color-text-tertiary, #8b949e);
-  margin: 0.25rem 0 0;
+  margin: var(--space-4, 0.25rem) 0 0;
   line-height: 1.4;
 }
 
 .hk-selection-grid-badge {
   display: inline-flex;
   align-items: center;
-  padding: 0 0.375rem;
+  padding: 0 var(--space-6, 0.375rem);
   height: 1rem;
-  font-size: 0.625rem;
+  font-size: var(--text-2xs, 0.625rem);
   font-weight: 600;
   border-radius: 9999px;
   background: var(--hi-color-bg-subtle, #21262d);
@@ -195,5 +195,13 @@
   .hk-selection-grid-grid[data-cols="3"],
   .hk-selection-grid-grid[data-cols="4"] {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-selection-grid-check,
+  .hk-selection-grid-item[data-selected] .hk-selection-grid-check {
+    transform: none;
+    transition: opacity 200ms ease;
   }
 }

--- a/packages/vue/src/components/HkSelectionWaterfall.scss
+++ b/packages/vue/src/components/HkSelectionWaterfall.scss
@@ -1,5 +1,5 @@
 .hk-selection-waterfall {
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-16, 1rem);
 }
 
 .hk-selection-waterfall-title {
@@ -8,21 +8,21 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--hi-color-text-tertiary, #8b949e);
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-selection-waterfall-flow {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.375rem;
+  gap: var(--space-6, 0.375rem);
 }
 
 .hk-selection-waterfall-item {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.25rem 0.625rem;
+  gap: var(--space-4, 0.25rem);
+  padding: var(--space-4, 0.25rem) var(--space-10, 0.625rem);
   border-radius: 9999px;
   border: 1px solid var(--hi-color-border, #30363d);
   font-size: 0.6875rem;
@@ -38,6 +38,18 @@
     border-color: var(--hi-color-primary, #58a6ff);
     background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
     box-shadow: 0 2px 8px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.1);
+  }
+
+  // Keyboard focus drawn inside the border box (negative offset), matching
+  // the grid sibling and the inset-emphasis model — pills sit flush in
+  // wrapped flows where outer rings get clipped by adjacent chrome.
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: -2px;
+  }
+
+  &:active {
+    box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
   }
 
   &[data-selected] {
@@ -64,8 +76,8 @@
 }
 
 .hk-selection-waterfall-tag {
-  font-size: 0.625rem;
-  padding: 0 0.25rem;
+  font-size: var(--text-2xs, 0.625rem);
+  padding: 0 var(--space-4, 0.25rem);
   border-radius: 9999px;
   background: var(--hi-color-bg-subtle, #21262d);
   color: var(--hi-color-text-tertiary, #8b949e);
@@ -87,7 +99,7 @@
 }
 
 .hk-selection-waterfall-desc {
-  font-size: 0.625rem;
+  font-size: var(--text-2xs, 0.625rem);
   color: var(--hi-color-text-tertiary, #8b949e);
-  margin-left: 0.25rem;
+  margin-inline-start: var(--space-4, 0.25rem);
 }

--- a/packages/vue/src/components/HkShareBar.scss
+++ b/packages/vue/src/components/HkShareBar.scss
@@ -16,7 +16,7 @@
 
 .hk-share-bar-track {
   position: relative;
-  height: 6px;
+  height: var(--space-6, 0.375rem);
   border-radius: 3px;
   background: rgb(var(--color-border) / 15%);
   overflow: hidden;
@@ -26,15 +26,24 @@
 .hk-share-bar-fill {
   position: absolute;
   inset-block: 0;
-  left: 0;
+  /* Grow from the inline-start edge so the fill mirrors in RTL
+   * (HkProgressBar's logical-fill rule). */
+  inset-inline-start: 0;
   border-radius: 3px;
   background: rgb(var(--color-primary) / 70%);
   transition: width var(--duration-normal, 0.2s) ease;
+}
+
+/* Width is a size animation — the fill snaps instead of animating
+ * (house guard: HkProgressBar's bar fill). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-share-bar-fill {
+    transition: none;
+  }
 }
 
 .hk-share-bar-caption {
   font-size: var(--text-2xs, 0.6875rem);
   color: rgb(var(--color-muted));
   font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
 }

--- a/packages/vue/src/components/HkShareBar.scss
+++ b/packages/vue/src/components/HkShareBar.scss
@@ -31,7 +31,7 @@
   inset-inline-start: 0;
   border-radius: 3px;
   background: rgb(var(--color-primary) / 70%);
-  transition: width var(--duration-normal, 0.2s) ease;
+  transition: width var(--duration-normal, 0.3s) ease;
 }
 
 /* Width is a size animation — the fill snaps instead of animating

--- a/packages/vue/src/components/HkShareBar.scss
+++ b/packages/vue/src/components/HkShareBar.scss
@@ -43,7 +43,7 @@
 }
 
 .hk-share-bar-caption {
-  font-size: var(--text-2xs, 0.6875rem);
+  font-size: var(--text-2xs, 0.625rem);
   color: rgb(var(--color-muted));
   font-variant-numeric: tabular-nums;
 }

--- a/packages/vue/src/components/HkSidebar.scss
+++ b/packages/vue/src/components/HkSidebar.scss
@@ -9,14 +9,16 @@
   flex-direction: column;
   height: 100%;
   background: var(--hk-sidebar-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
-  backdrop-filter: blur(8px);
-  border-right: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  backdrop-filter: blur(var(--blur-sm, 8px));
+  /* Logical edge: the border rides the content-facing side in either
+   * direction (LTR sidebar docks left, RTL docks right). */
+  border-inline-end: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
   transition: width var(--hi-duration-normal, 0.3s) ease;
   overflow: hidden;
 }
 
 .hk-sidebar-header {
-  padding: 16px 12px;
+  padding: var(--space-16) var(--space-12);
   border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
   flex-shrink: 0;
   min-height: 56px;
@@ -38,7 +40,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding-block: 20px 4px;
+  padding-block: var(--space-20) var(--space-4);
   padding-inline: var(--space-12);
 
   /* Overlay scrollbar (useOverlayScrollbar) — the native chrome is
@@ -51,7 +53,7 @@
 }
 
 .hk-sidebar-footer {
-  padding: 16px 10px;
+  padding: var(--space-16) var(--space-10);
   border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
   flex-shrink: 0;
 }
@@ -59,15 +61,15 @@
 .hk-sidebar[data-collapsed] {
   .hk-sidebar-header {
     justify-content: center;
-    padding: 12px 8px;
+    padding: var(--space-12) var(--space-8);
   }
 
   .hk-sidebar-body {
-    padding-block: 12px 4px;
+    padding-block: var(--space-12) var(--space-4);
   }
 
   .hk-sidebar-footer {
-    padding: 12px 8px;
+    padding: var(--space-12) var(--space-8);
   }
 }
 
@@ -81,6 +83,18 @@
   .hk-sidebar-panel {
     width: 280px;
     box-shadow: 4px 0 24px rgba(0, 0, 0, 0.2);
-    border-right: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+    /* Shadow offsets cannot flip via logical properties — mirror the
+     * cast toward the content side in RTL (house [dir=rtl] override). */
+    [dir="rtl"] & {
+      box-shadow: -4px 0 24px rgba(0, 0, 0, 0.2);
+    }
+    border-inline-end: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hk-sidebar,
+  .hk-sidebar-panel {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkSkeleton.scss
+++ b/packages/vue/src/components/HkSkeleton.scss
@@ -1,18 +1,18 @@
 .hk-skeleton {
   display: inline-block;
-  background: color-mix(in srgb, var(--hi-color-primary) 8%, transparent);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
 }
 
 .hk-skeleton[data-tone="muted"] {
-  background: color-mix(in srgb, var(--hi-color-text-primary) 12%, transparent);
+  background: color-mix(in srgb, var(--hi-color-text-primary, #333) 12%, transparent);
 }
 
 .hk-skeleton[data-animated] {
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-primary) 8%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-primary) 18%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-primary) 8%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-skeleton-shimmer 1.5s ease-in-out infinite;
@@ -21,9 +21,9 @@
 .hk-skeleton[data-tone="muted"][data-animated] {
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-text-primary) 10%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-text-primary) 22%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-text-primary) 10%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-text-primary, #333) 10%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-text-primary, #333) 22%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-text-primary, #333) 10%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-skeleton-shimmer 1.5s ease-in-out infinite;
@@ -35,6 +35,14 @@
   }
   100% {
     background-position: -200% 0;
+  }
+}
+
+// Reduced motion: keep the placeholder, drop the shimmer sweep
+// (house pattern: HkImagePreview.scss / HkProgressBar.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-skeleton[data-animated] {
+    animation: none;
   }
 }
 

--- a/packages/vue/src/components/HkSlider.scss
+++ b/packages/vue/src/components/HkSlider.scss
@@ -87,8 +87,10 @@
   pointer-events: none;
 }
 
-.hk-slider:hover .hk-slider-thumb,
-.hk-slider:active .hk-slider-thumb {
+// Disabled stays inert: no press/hover feedback on a non-interactive
+// control (tsx gates the interaction; the dim alone reads as disabled).
+.hk-slider:not(.is-disabled):hover .hk-slider-thumb,
+.hk-slider:not(.is-disabled):active .hk-slider-thumb {
   transform: translateY(-50%) scale(1.15);
 }
 
@@ -96,4 +98,12 @@
   width: 12px;
   height: 12px;
   margin-left: -6px;
+}
+
+// Reduced motion: the hover/press scale snaps instead of animating
+// (house pattern: HkProgressBar.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-slider-thumb {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkSpinner.scss
+++ b/packages/vue/src/components/HkSpinner.scss
@@ -3,6 +3,9 @@
   display: flex;
   align-items: center;
   gap: var(--space-8);
+  /* Transient loading status, not content: selecting it mid-drag
+     produces accidental clipboard noise. Covers circle and text. */
+  user-select: none;
 }
 
 /* center — the shared loading-state placement contract: the spinner is
@@ -25,9 +28,9 @@
   height: 100%;
   box-sizing: border-box;
   align-self: stretch;
-  /* grow without shrink: min-height already floors the box, so letting
-     it shrink cannot go below the floor but avoids a rigid-sibling
-     overflow trap in tight flex rows. */
+  /* grow + shrink: min-height floors the box, so shrinking cannot go
+     below the floor, and growing fills leftover space — avoiding a
+     rigid-sibling overflow trap in tight flex rows. */
   flex: 1 1 auto;
   /* Predictable mid-panel presence on every viewport: a fixed floor,
      not fluid scaling (fluid values hit their cap on all realistic
@@ -86,17 +89,20 @@
   font-size: var(--text-base);
   color: color-mix(in srgb, rgb(var(--color-muted)) 70%, rgb(var(--color-background)));
   /* Transient status, not content: selecting it mid-drag produces
-     accidental clipboard noise. The circle itself stays selectable-free
-     via the wrapper below. */
-  user-select: none;
-}
-
-.hk-spinner-wrapper {
+     accidental clipboard noise. (The wrapper already covers the circle.) */
   user-select: none;
 }
 
 @keyframes hk-spinner-rotate {
   to {
     transform: rotate(360deg);
+  }
+}
+
+// Reduced motion: the wheel rests as a static track + primary arc,
+// still readable as a loading mark (house pattern: HkProgressBar.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-spinner {
+    animation: none;
   }
 }

--- a/packages/vue/src/components/HkSplash.scss
+++ b/packages/vue/src/components/HkSplash.scss
@@ -6,19 +6,19 @@
   min-height: 100vh;
   background: var(--hi-color-bg-canvas, #0d1117);
   color: var(--hi-color-text-primary, #c9d1d9);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif);
 }
 
 .hk-splash-main {
   text-align: center;
   max-width: 480px;
-  padding: 2rem;
+  padding: var(--space-32, 2rem);
 }
 
 .hk-splash-logo {
   width: 80px;
   height: 80px;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-24, 1.5rem);
   border-radius: 16px;
 }
 
@@ -26,35 +26,35 @@
   font-size: 2rem;
   font-weight: 700;
   color: var(--hi-color-primary, #58a6ff);
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-splash-subtitle {
   font-size: 1.1rem;
   color: var(--hi-color-text-secondary, #8b949e);
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-splash-description {
   font-size: 0.9rem;
   color: var(--hi-color-text-tertiary, #6e7681);
-  margin-bottom: 1rem;
+  margin-bottom: var(--space-16, 1rem);
 }
 
 .hk-splash-status {
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--space-24, 1.5rem);
 }
 
 .hk-splash-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: var(--space-12, 0.75rem);
   justify-content: center;
   flex-wrap: wrap;
 }
 
 .hk-splash-footer {
   margin-top: auto;
-  padding: 1rem;
-  font-size: 0.75rem;
+  padding: var(--space-16, 1rem);
+  font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-text-tertiary, #484f58);
 }

--- a/packages/vue/src/components/HkStatCard.scss
+++ b/packages/vue/src/components/HkStatCard.scss
@@ -69,7 +69,7 @@
 }
 
 .hk-stat-card-hint {
-  font-size: var(--text-2xs, 0.6875rem);
+  font-size: var(--text-2xs, 0.625rem);
   color: rgb(var(--color-muted) / 70%);
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/vue/src/components/HkStatCard.scss
+++ b/packages/vue/src/components/HkStatCard.scss
@@ -11,10 +11,14 @@
 
 .hk-stat-card-clickable {
   cursor: pointer;
-  transition: border-color var(--duration-normal, 0.2s) ease;
+  transition: border-color var(--duration-normal, 0.3s) ease;
 
   &:hover {
     border-color: rgb(var(--color-primary) / 35%);
+  }
+
+  &:active {
+    border-color: rgb(var(--color-primary) / 55%);
   }
 
   &:focus-visible {
@@ -55,7 +59,7 @@
 .hk-stat-card-dot-muted { background: rgb(var(--color-muted)); }
 
 .hk-stat-card-value {
-  font-size: 1.5rem;
+  font-size: var(--text-2xl, 1.5rem);
   font-weight: 700;
   line-height: 1.2;
   color: rgb(var(--color-text));

--- a/packages/vue/src/components/HkStatusPill.scss
+++ b/packages/vue/src/components/HkStatusPill.scss
@@ -6,7 +6,7 @@
   align-items: center;
   gap: var(--space-6, 0.375rem);
   padding: 2px var(--space-8, 0.5rem);
-  border-radius: 999px;
+  border-radius: var(--radius-full, 999px);
   font-size: var(--text-2xs, 0.6875rem);
   line-height: 1.4;
   color: rgb(var(--color-text));
@@ -24,10 +24,6 @@
   background: rgb(var(--color-muted));
 }
 
-.hk-status-pill-ok .hk-status-pill-dot {
-  background: rgb(var(--color-success));
-}
-
 .hk-status-pill-warn .hk-status-pill-dot {
   background: rgb(var(--color-warning));
 }
@@ -36,8 +32,9 @@
   background: rgb(var(--color-error));
 }
 
-/* Gentle pulse for the live/ok state so liveness reads at a glance. */
+/* Live/ok state: success dot with a gentle pulse so liveness reads at a glance. */
 .hk-status-pill-ok .hk-status-pill-dot {
+  background: rgb(var(--color-success));
   animation: hk-status-pill-pulse 2.4s ease-in-out infinite;
 }
 

--- a/packages/vue/src/components/HkStatusPill.scss
+++ b/packages/vue/src/components/HkStatusPill.scss
@@ -7,7 +7,7 @@
   gap: var(--space-6, 0.375rem);
   padding: 2px var(--space-8, 0.5rem);
   border-radius: var(--radius-full, 999px);
-  font-size: var(--text-2xs, 0.6875rem);
+  font-size: var(--text-2xs, 0.625rem);
   line-height: 1.4;
   color: rgb(var(--color-text));
   background: rgb(var(--color-surface) / 60%);

--- a/packages/vue/src/components/HkStepFlow.scss
+++ b/packages/vue/src/components/HkStepFlow.scss
@@ -36,10 +36,6 @@
   padding-bottom: var(--hk-stepflow-header-gap, var(--space-16, 1rem));
 }
 
-.hk-stepflow-body {
-  width: 100%;
-}
-
 .hk-stepflow-fwd-enter-active,
 .hk-stepflow-back-enter-active {
   transition:
@@ -72,4 +68,28 @@
 .hk-stepflow-back-leave-to {
   opacity: 0;
   transform: translateX(24px);
+}
+
+/* RTL: reading direction flips, so the slide mirrors — forward enters
+ * from the left and exits right (house pattern: HkListTransition.scss
+ * [dir="rtl"] form). */
+[dir="rtl"] .hk-stepflow-fwd-enter-from,
+[dir="rtl"] .hk-stepflow-back-leave-to {
+  transform: translateX(-24px);
+}
+
+[dir="rtl"] .hk-stepflow-fwd-leave-to,
+[dir="rtl"] .hk-stepflow-back-enter-from {
+  transform: translateX(24px);
+}
+
+/* Reduced motion: the body snaps between steps instead of sliding
+ * (house pattern: HkExpansionPanel.scss / HkAffixPicker.scss). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-stepflow-fwd-enter-active,
+  .hk-stepflow-back-enter-active,
+  .hk-stepflow-fwd-leave-active,
+  .hk-stepflow-back-leave-active {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkSwitch.scss
+++ b/packages/vue/src/components/HkSwitch.scss
@@ -1,7 +1,7 @@
 .hk-switch {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-8, 0.5rem);
   cursor: pointer;
   user-select: none;
 
@@ -19,6 +19,15 @@
   pointer-events: none;
 }
 
+/* Keyboard focus: the native input is visually erased, so the focus ring
+   rides the track through the sibling combinator (input precedes it in
+   the label; house pattern: HkButton double ring). */
+.hk-switch-input:focus-visible ~ .hk-switch-track {
+  box-shadow:
+    0 0 0 2px rgb(var(--color-surface)),
+    0 0 0 4px rgb(var(--color-primary));
+}
+
 /* --- Track --- */
 
 .hk-switch-track {
@@ -29,8 +38,8 @@
   border: 1px solid var(--hi-color-border);
   background: var(--hi-color-surface);
   transition:
-    background-color 0.3s ease,
-    border-color 0.3s ease;
+    background-color 0.2s ease,
+    border-color 0.2s ease;
   flex-shrink: 0;
   overflow: hidden;
 
@@ -74,31 +83,31 @@
 
 .hk-switch-thumb {
   position: absolute;
+  /* Logical anchor: the thumb starts at the inline-start edge and slides
+     toward inline-end when checked (mirrored under [dir="rtl"] below). */
+  inset-inline-start: 2px;
   border-radius: 50%;
   /* A shape on a solid brand fill: theme icon color (default white), not
      the luminance-computed on-primary that went near-black on bright
      primaries (synthwave pink) while HkButton labels stayed white. */
   background: rgb(var(--color-on-solid-icon, 255 255 255));
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 0.2s var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1));
   z-index: 1;
 
   .hk-switch-sm & {
     width: 0.75rem;
     height: 0.75rem;
-    left: 2px;
   }
 
   .hk-switch-md & {
     width: 0.9375rem;
     height: 0.9375rem;
-    left: 2px;
   }
 
   .hk-switch-lg & {
     width: 1.125rem;
     height: 1.125rem;
-    left: 2px;
   }
 
   .hk-switch-sm[data-checked] & {
@@ -111,6 +120,20 @@
 
   .hk-switch-lg[data-checked] & {
     transform: translateX(1.375rem);
+  }
+
+  /* RTL: the checked slide mirrors — the thumb travels back toward the
+     inline-start (physically leftward) edge. */
+  [dir="rtl"] .hk-switch-sm[data-checked] & {
+    transform: translateX(-0.813rem);
+  }
+
+  [dir="rtl"] .hk-switch-md[data-checked] & {
+    transform: translateX(-1.12rem);
+  }
+
+  [dir="rtl"] .hk-switch-lg[data-checked] & {
+    transform: translateX(-1.375rem);
   }
 }
 
@@ -134,12 +157,21 @@
   }
 
   &-off {
-    right: 4px;
+    inset-inline-end: 4px;
     color: var(--hi-color-text-secondary);
   }
 
   &-on {
-    left: 4px;
+    inset-inline-start: 4px;
     color: rgb(var(--color-on-solid-text, 255 255 255));
+  }
+}
+
+/* Reduced motion: the thumb snaps between states instead of sliding
+   (house pattern: HkSlider.scss / HkExpansionPanel.scss). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-switch-thumb,
+  .hk-switch-content {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -24,7 +24,7 @@
 
 .hk-table {
   width: 100%;
-  font-size: var(--text-base, 1rem);
+  font-size: var(--text-base, 0.875rem);
   border-collapse: collapse;
   color: var(--hi-color-text-primary, #c9d1d9);
 }

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -34,8 +34,10 @@
 }
 
 .hk-table-header-cell {
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
-  text-align: left;
+  /* md values live here: the wrapper always carries `hk-table-${size}`
+     (default md), whose override used to mask these base paddings. */
+  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  text-align: start;
   font-size: var(--hi-text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-text-secondary, #8b949e);
@@ -61,7 +63,7 @@
 .hk-table-header-label {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-4, 4px);
 }
 
 .hk-table-sort-icon {
@@ -105,7 +107,8 @@
 }
 
 .hk-table-cell {
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  /* md values (see .hk-table-header-cell). */
+  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
   color: var(--hi-color-text-primary, #c9d1d9);
   vertical-align: middle;
 }
@@ -116,13 +119,6 @@
   .hk-table-cell {
     padding: var(--hi-space-4, 4px) var(--hi-space-8, 8px);
     font-size: var(--hi-text-xs, 0.75rem);
-  }
-}
-
-.hk-table-md {
-  .hk-table-header-cell,
-  .hk-table-cell {
-    padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
   }
 }
 
@@ -139,9 +135,10 @@
   color: var(--hi-color-text-secondary, #8b949e);
 }
 
-/* Alignment helpers */
+/* Alignment helpers (start/end so aligned columns mirror in RTL; the
+   tsx keeps emitting the hk-text-* names) */
 .hk-text-left {
-  text-align: left;
+  text-align: start;
 }
 
 .hk-text-center {
@@ -149,7 +146,7 @@
 }
 
 .hk-text-right {
-  text-align: right;
+  text-align: end;
 }
 
 /* Checkbox styles inline */
@@ -214,4 +211,12 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* Reduced motion: the sort icon snaps between asc/desc instead of
+   rotating (house pattern: HkExpansionPanel.scss). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-table-sort-icon {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -24,7 +24,7 @@
 
 .hk-table {
   width: 100%;
-  font-size: var(--hi-text-base, 1rem);
+  font-size: var(--text-base, 1rem);
   border-collapse: collapse;
   color: var(--hi-color-text-primary, #c9d1d9);
 }
@@ -36,9 +36,9 @@
 .hk-table-header-cell {
   /* md values live here: the wrapper always carries `hk-table-${size}`
      (default md), whose override used to mask these base paddings. */
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  padding: var(--space-8, 8px) var(--space-12, 12px);
   text-align: start;
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-text-secondary, #8b949e);
   text-transform: uppercase;
@@ -108,7 +108,7 @@
 
 .hk-table-cell {
   /* md values (see .hk-table-header-cell). */
-  padding: var(--hi-space-8, 8px) var(--hi-space-12, 12px);
+  padding: var(--space-8, 8px) var(--space-12, 12px);
   color: var(--hi-color-text-primary, #c9d1d9);
   vertical-align: middle;
 }
@@ -117,20 +117,20 @@
 .hk-table-sm {
   .hk-table-header-cell,
   .hk-table-cell {
-    padding: var(--hi-space-4, 4px) var(--hi-space-8, 8px);
-    font-size: var(--hi-text-xs, 0.75rem);
+    padding: var(--space-4, 4px) var(--space-8, 8px);
+    font-size: var(--text-xs, 0.75rem);
   }
 }
 
 .hk-table-lg {
   .hk-table-header-cell,
   .hk-table-cell {
-    padding: var(--hi-space-16, 16px) var(--hi-space-24, 24px);
+    padding: var(--space-16, 16px) var(--space-24, 24px);
   }
 }
 
 .hk-table-empty {
-  padding: var(--hi-space-32, 32px) var(--hi-space-16, 16px);
+  padding: var(--space-32, 32px) var(--space-16, 16px);
   text-align: center;
   color: var(--hi-color-text-secondary, #8b949e);
 }

--- a/packages/vue/src/components/HkTabs.scss
+++ b/packages/vue/src/components/HkTabs.scss
@@ -9,14 +9,18 @@
   width: 100%;
 }
 
-/* === Scrollable (default) === */
+/* === Scrollable (default) + protruding end actions shrink-wrap === */
 
 /* The scroller (a horizontal HkScrollContainer) bounds the list: it
    sizes to the content up to the available width, then the list
    scrolls inside with safe centering. min-width: 0 lets the whole
    chain shrink inside constrained flex parents (status bars, header
-   centres). */
-.hk-tabs[data-scrollable] {
+   centres). With an end action the same shrink-wrap lets the
+   hover-reveal chain cap inside constrained flex parents (the two
+   attributes co-occur — scrollable defaults on — and the declarations
+   are identical, so one rule serves both). */
+.hk-tabs[data-scrollable],
+.hk-tabs[data-actions] {
   width: auto;
   max-width: 100%;
   min-width: 0;
@@ -28,23 +32,13 @@
 
 /* === Protruding end actions (startAction / endAction) === */
 
-/* With an end action the whole strip sits inside an HkHoverRevealAction
-   host (`.hk-tabs-addwrap`) and the button protrudes at the host's edge
-   (left:100% / right:100% in HkHoverRevealAction.scss) — outside the
-   scroll viewport, so it never scrolls away. Shrink-wrap the strip the
-   same way the scrollable variant does, so the hover-reveal chain can
-   cap inside constrained flex parents and the tabs keep their safe
-   centering. */
-.hk-tabs[data-actions] {
-  width: auto;
-  max-width: 100%;
-  min-width: 0;
-}
-
-/* The reveal host itself must be able to shrink below its content and
-   must not be clipped by rigid parents — mirrors HkHoverRevealAction's
-   own min/max rules; no flex shorthand here, the host's natural
-   shrink-wrap keeps the centered-bar geometry. */
+/* The strip sits inside an HkHoverRevealAction host and the button
+   protrudes at the host's edge (left:100% / right:100% in
+   HkHoverRevealAction.scss) — outside the scroll viewport, so it never
+   scrolls away. The reveal host itself must be able to shrink below its
+   content and must not be clipped by rigid parents — mirrors
+   HkHoverRevealAction's own min/max rules; no flex shorthand here, the
+   host's natural shrink-wrap keeps the centered-bar geometry. */
 .hk-tabs-addwrap {
   min-width: 0;
   max-width: 100%;
@@ -55,8 +49,7 @@
 .hk-tabs-list {
   position: relative;
   display: inline-flex;
-  gap: 0;
-  padding: 2px;
+  padding: var(--space-2);
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-faint);
   background: rgb(var(--color-surface) / 60%);
@@ -87,8 +80,15 @@
   transition: color var(--duration-short) ease,
               transform var(--duration-short) ease;
 
-  &:hover {
+  /* A real <button disabled> (tsx) still matches :hover, so a dead tab
+     must be guarded explicitly. House muted state (HkButton). */
+  &:hover:not([data-disabled]) {
     color: rgb(var(--color-text));
+  }
+
+  &[data-disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   /* Tactile press feedback — every button-group click animates, even
@@ -119,8 +119,8 @@
  * pop-in from a stale corner), later frames slide via left/width. */
 .hk-tabs-indicator {
   position: absolute;
-  top: 2px;
-  height: calc(100% - 4px);
+  top: var(--space-2);
+  height: calc(100% - var(--space-4));
   border-radius: var(--radius-sm);
   background: rgb(var(--color-primary) / 12%);
   pointer-events: none;
@@ -167,7 +167,8 @@
 /* === Panel (pill / tablist mode) === */
 
 .hk-tabs-panel {
-  outline: none;
+  /* No outline suppression: the panel div carries no tabindex and can
+     never take focus, so there is nothing to suppress. */
 
   &:not([data-active]) {
     display: none;
@@ -280,4 +281,17 @@
 .hk-tabs-scroller .hk-tabs-list[data-variant="segmented"][data-block="true"][data-slots] > .hk-tabs-merged {
   grid-column: span var(--hk-tabs-span, 1) / span var(--hk-tabs-span, 1);
   min-width: auto;
+}
+
+/* === Reduced motion ===
+ * The indicator slide, the trigger press scale and the swap enter/leave
+ * are pure motion; reduced-motion users get the instant end states
+ * (house pattern: HkExpansionPanel / HkAffixPicker / HkTagInput). */
+@media (prefers-reduced-motion: reduce) {
+  .hk-tabs-trigger,
+  .hk-tabs-indicator,
+  .hk-tabs-swap-enter-active,
+  .hk-tabs-swap-leave-active {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkTag.scss
+++ b/packages/vue/src/components/HkTag.scss
@@ -13,14 +13,13 @@
 }
 
 .hk-tag-sm {
-  font-size: 0.625rem;
-  padding: 1px 6px;
+  font-size: var(--text-2xs, 0.625rem);
+  padding: 1px var(--space-6, 6px);
 }
 
-.hk-tag-md {
-  font-size: var(--hi-text-xs, 0.75rem);
-  padding: var(--hi-space-2, 2px) var(--hi-space-8, 8px);
-}
+/* md is the default size: HkTag always co-applies `.hk-tag` (tsx class
+   list), so the base rule above already carries the md values — the
+   class stays in the markup, but needs no rule of its own. */
 
 .hk-tag-icon {
   display: inline-flex;
@@ -42,8 +41,9 @@
   cursor: pointer;
   opacity: 0.5;
   padding: 0;
-  margin-left: var(--hi-space-2, 2px);
-  border-radius: var(--hi-radius-sm, 2px);
+  /* Trailing edge of the chip in both directions. */
+  margin-inline-start: var(--hi-space-2, 2px);
+  border-radius: var(--hi-radius-sm, 4px);
   transition: opacity var(--hi-duration-fast, 0.15s) ease;
 }
 
@@ -51,38 +51,44 @@
   opacity: 1;
 }
 
+/* Keyboard focus indicator (house HkContextRing pattern). */
+.hk-tag-close:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: 2px;
+}
+
 .hk-tag-default {
-  background: color-mix(in srgb, var(--hi-color-surface) 60%, transparent);
-  color: var(--hi-color-text-primary);
-  border-color: var(--hi-color-border);
+  background: color-mix(in srgb, var(--hi-color-surface, #fff) 60%, transparent);
+  color: var(--hi-color-text-primary, #333);
+  border-color: var(--hi-color-border, #30363d);
 }
 
 .hk-tag-primary {
-  background: color-mix(in srgb, var(--hi-color-primary) 10%, transparent);
-  color: var(--hi-color-primary);
-  border-color: color-mix(in srgb, var(--hi-color-primary) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 10%, transparent);
+  color: var(--hi-color-primary, #58a6ff);
+  border-color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 20%, transparent);
 }
 
 .hk-tag-success {
-  background: color-mix(in srgb, var(--hi-color-success) 10%, transparent);
-  color: var(--hi-color-success);
-  border-color: color-mix(in srgb, var(--hi-color-success) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-success, #3fb950) 10%, transparent);
+  color: var(--hi-color-success, #3fb950);
+  border-color: color-mix(in srgb, var(--hi-color-success, #3fb950) 20%, transparent);
 }
 
 .hk-tag-warning {
-  background: color-mix(in srgb, var(--hi-color-warning) 10%, transparent);
-  color: var(--hi-color-warning);
-  border-color: color-mix(in srgb, var(--hi-color-warning) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-warning, #d29922) 10%, transparent);
+  color: var(--hi-color-warning, #d29922);
+  border-color: color-mix(in srgb, var(--hi-color-warning, #d29922) 20%, transparent);
 }
 
 .hk-tag-danger {
-  background: color-mix(in srgb, var(--hi-color-danger) 10%, transparent);
-  color: var(--hi-color-danger);
-  border-color: color-mix(in srgb, var(--hi-color-danger) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-danger, #f85149) 10%, transparent);
+  color: var(--hi-color-danger, #f85149);
+  border-color: color-mix(in srgb, var(--hi-color-danger, #f85149) 20%, transparent);
 }
 
 .hk-tag-info {
-  background: color-mix(in srgb, var(--hi-color-info) 10%, transparent);
-  color: var(--hi-color-info);
-  border-color: color-mix(in srgb, var(--hi-color-info) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-info, #79c0ff) 10%, transparent);
+  color: var(--hi-color-info, #79c0ff);
+  border-color: color-mix(in srgb, var(--hi-color-info, #79c0ff) 20%, transparent);
 }

--- a/packages/vue/src/components/HkTag.scss
+++ b/packages/vue/src/components/HkTag.scss
@@ -1,14 +1,14 @@
 .hk-tag {
   display: inline-flex;
   align-items: center;
-  gap: var(--hi-space-4, 4px);
-  font-size: var(--hi-text-xs, 0.75rem);
+  gap: var(--space-4, 4px);
+  font-size: var(--text-xs, 0.75rem);
   font-weight: 500;
   line-height: 1.4;
   white-space: nowrap;
   border: 1px solid transparent;
   border-radius: var(--hi-radius-sm, 4px);
-  padding: var(--hi-space-2, 2px) var(--hi-space-8, 8px);
+  padding: var(--space-2, 2px) var(--space-8, 8px);
   user-select: none;
 }
 
@@ -42,7 +42,7 @@
   opacity: 0.5;
   padding: 0;
   /* Trailing edge of the chip in both directions. */
-  margin-inline-start: var(--hi-space-2, 2px);
+  margin-inline-start: var(--space-2, 2px);
   border-radius: var(--hi-radius-sm, 4px);
   transition: opacity var(--hi-duration-fast, 0.15s) ease;
 }

--- a/packages/vue/src/components/HkTagInput.scss
+++ b/packages/vue/src/components/HkTagInput.scss
@@ -130,12 +130,11 @@
   line-height: 1.5;
   color: rgb(var(--color-text));
 
-  /* The shell owns the focus affordance (`:focus-within`); an
-   * element-level focus ring would double it. */
+  /* The shell owns the focus affordance (`:focus-within`); the base
+   * border/outline: none above already holds at all times, so only a
+   * stray element-level box-shadow needs explicit suppression. */
   &:focus,
   &:focus-visible {
-    border: none;
-    outline: none;
     box-shadow: none;
   }
 
@@ -179,6 +178,12 @@
     color: rgb(var(--color-text));
   }
 
+  /* Tactile press, one step past the hover fill (the rows' selected
+     hover). */
+  &:active:not(:disabled) {
+    background: rgb(var(--color-primary) / 16%);
+  }
+
   &:disabled {
     cursor: not-allowed;
     opacity: 0.6;
@@ -199,10 +204,10 @@
    * once when it opens, so a panel that grew with its content would shift
    * its own left edge mid-interaction — toggling a row adds a check glyph,
    * and a query changes which rows (and how much meta text) survive.
-   * min/max stay as the bounds a narrow viewport imposes on that width. */
+   * min-width stays as the lower bound a narrow viewport imposes on
+   * that width (an equal max-width could never constrain further). */
   width: min(19rem, calc(100vw - 2rem));
   min-width: 13rem;
-  max-width: min(19rem, calc(100vw - 2rem));
 }
 
 /* Mobile sheet context (the HkAffixPicker #424 pattern): inside the
@@ -216,7 +221,8 @@
 }
 
 .hk-tag-input-search {
-  padding: 8px 10px 6px;
+  /* Same spellings as the mirrored HkAffixPicker popup head. */
+  padding: var(--space-8, 8px) var(--space-10, 10px) var(--space-6, 6px);
 }
 
 /* NOT a scroll region: the window surface (popout / sheet) owns THE one
@@ -225,20 +231,20 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 4px 6px 8px;
+  padding: var(--space-4, 4px) var(--space-6, 6px) var(--space-8, 8px);
 }
 
 .hk-tag-input-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-8, 8px);
   width: 100%;
   min-height: 2.25rem;
-  padding: 4px 8px;
+  padding: var(--space-4, 4px) var(--space-8, 8px);
   border-radius: var(--radius-sm);
   color: rgb(var(--color-text));
-  font-size: var(--text-sm, 14px);
-  text-align: left;
+  font-size: var(--text-sm);
+  text-align: start;
   cursor: pointer;
   transition: background 0.1s ease;
 
@@ -300,7 +306,7 @@
 
 .hk-tag-input-row-flag {
   flex: none;
-  font-size: calc(var(--text-base, 15px) * 1.05);
+  font-size: calc(var(--text-base) * 1.05);
   line-height: 1;
   font-family: "Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji",
     sans-serif;
@@ -317,7 +323,7 @@
 .hk-tag-input-row-meta {
   flex: none;
   color: rgb(var(--color-muted));
-  font-size: calc(var(--text-sm, 14px) * 0.9);
+  font-size: calc(var(--text-sm) * 0.9);
   font-variant-numeric: tabular-nums;
 }
 
@@ -415,9 +421,9 @@
 }
 
 .hk-tag-input-empty {
-  padding: 14px 12px;
+  padding: var(--space-14, 14px) var(--space-12, 12px);
   color: rgb(var(--color-muted));
-  font-size: var(--text-sm, 14px);
+  font-size: var(--text-sm);
   text-align: center;
 }
 

--- a/packages/vue/src/components/HkTextarea.scss
+++ b/packages/vue/src/components/HkTextarea.scss
@@ -63,7 +63,7 @@
   display: flex;
   justify-content: flex-end;
   margin-top: var(--space-4, 0.25rem);
-  font-size: var(--hi-text-xs, 0.75rem);
+  font-size: var(--text-xs, 0.75rem);
   color: var(--hi-color-muted);
   user-select: none;
 }

--- a/packages/vue/src/components/HkTextarea.scss
+++ b/packages/vue/src/components/HkTextarea.scss
@@ -16,13 +16,13 @@
   display: block;
   width: 100%;
   min-height: 2.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   background: var(--hi-color-surface);
   border: 1px solid var(--hi-color-border);
   border-radius: var(--hi-radius-md, 6px);
   color: var(--hi-color-text-primary);
   font-family: inherit;
-  font-size: 0.875rem;
+  font-size: var(--text-base, 0.875rem);
   line-height: 1.5;
   resize: vertical;
   outline: none;
@@ -37,7 +37,10 @@
     opacity: 0.6;
   }
 
-  &:hover:not(:disabled):not(.hk-textarea-disabled &) {
+  // The tsx ties the wrapper .hk-textarea-disabled class and the field's
+  // disabled attribute to the same prop (always in sync), so one guard
+  // suffices.
+  &:hover:not(:disabled) {
     border-color: var(--hi-color-primary);
   }
 
@@ -48,7 +51,6 @@
 
   &:disabled {
     cursor: not-allowed;
-    opacity: 1;
   }
 }
 
@@ -60,7 +62,7 @@
 .hk-textarea-count {
   display: flex;
   justify-content: flex-end;
-  margin-top: 0.25rem;
+  margin-top: var(--space-4, 0.25rem);
   font-size: var(--hi-text-xs, 0.75rem);
   color: var(--hi-color-muted);
   user-select: none;

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -3,7 +3,7 @@
 .s-theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-2, 2px);
 }
 
 .s-theme-toggle-btn {
@@ -42,6 +42,10 @@
 .s-theme-toggle-btn:hover {
   background: rgb(var(--color-primary) / 12%);
   color: rgb(var(--color-text));
+}
+
+.s-theme-toggle-btn:active {
+  background: rgb(var(--color-primary) / 16%);
 }
 
 .s-theme-menu {
@@ -138,6 +142,15 @@
   outline-offset: -2px;
 }
 
+/* The press scale above rides the transition's transform leg; snap it
+ * under reduced motion while keeping the color/background legs
+ * (house pattern: HkIconButton.scss). */
+@media (prefers-reduced-motion: reduce) {
+  .s-theme-mode-autoalt {
+    transition: color 0.15s ease, background 0.15s ease;
+  }
+}
+
 .s-theme-mode-autoalt-value {
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
@@ -232,7 +245,7 @@
 
 /* Custom rows keep the name clear of the overlaid delete button. */
 .s-theme-item-row[data-custom] .s-theme-item-name {
-  margin-right: 2rem;
+  margin-inline-end: 2rem;
 }
 
 .s-theme-item-check {
@@ -240,25 +253,15 @@
   color: rgb(var(--color-primary));
 }
 
-.s-theme-item-btn:hover:not([data-active]) {
-  background: var(--c-primary-subtle, rgb(var(--color-primary) / 8%));
-  border-color: var(--c-primary-medium, rgb(var(--color-primary) / 25%));
-  color: rgb(var(--color-text));
-}
-
-.s-theme-item-btn[data-active] {
-  background: var(--c-primary-dim, rgb(var(--color-primary) / 10%));
-  border-color: var(--c-primary-strong, rgb(var(--color-primary) / 40%));
-  color: rgb(var(--color-primary));
-  font-weight: 600;
-}
+/* Hover/active states come verbatim from the unified mi.item spec included
+ * on .s-theme-item-btn above — former local copies deleted (R3 sweep). */
 
 /* Delete affordance for custom themes — an overlay pinned inside the
  * pill's trailing edge (the row is relative), not a reserved column:
  * built-in rows show nothing there and the pill runs to the row edge. */
 .s-theme-item-delete {
   position: absolute;
-  right: var(--space-8, 0.5rem);
+  inset-inline-end: var(--space-8, 0.5rem);
   top: 50%;
   transform: translateY(-50%);
   display: inline-flex;
@@ -278,6 +281,13 @@
   color: rgb(var(--color-error));
 }
 
+/* Keyboard parity for the destructive overlay (mi.item-style inset ring,
+ * error-tinted to match its hover). */
+.s-theme-item-delete:focus-visible {
+  outline: 2px solid rgb(var(--color-error));
+  outline-offset: -2px;
+}
+
 /* Touch-sized delete target on phone widths, scaled for the 44px sheet
  * rows that the shared spec applies inside sheet contexts (see
  * ./_menu-item.scss). The name clearance follows so the button and the
@@ -289,7 +299,7 @@
   }
 
   .s-theme-item-row[data-custom] .s-theme-item-name {
-    margin-right: 2.75rem;
+    margin-inline-end: 2.75rem;
   }
 }
 
@@ -302,7 +312,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 2px;
+  gap: var(--space-2, 2px);
   color: inherit;
 }
 
@@ -320,5 +330,5 @@
 }
 
 .s-theme-item-row[data-trailing="slot"] .s-theme-item-name {
-  margin-right: 0;
+  margin-inline-end: 0;
 }

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -53,7 +53,7 @@
 .hk-timeline[data-mode="window"] .hk-timeline-step {
   flex-direction: column;
   align-items: center;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
 
   [data-el="label"] {
     display: block;
@@ -239,7 +239,7 @@
 .hk-timeline-step {
   display: flex;
   align-items: center;
-  gap: var(--hi-space-8, 8px);
+  gap: var(--space-8, 8px);
   position: relative;
   flex: 1 1 auto;
   min-width: 0;
@@ -262,7 +262,7 @@
   }
 
   [data-el="num"] {
-    font-size: var(--hi-text-xs, 0.75rem);
+    font-size: var(--text-xs, 0.75rem);
     font-weight: 600;
     line-height: 1;
     display: block;
@@ -273,7 +273,7 @@
   }
 
   [data-el="label"] {
-    font-size: var(--hi-text-xs, 0.75rem);
+    font-size: var(--text-xs, 0.75rem);
     white-space: nowrap;
     flex-shrink: 0;
   }
@@ -282,7 +282,7 @@
     height: var(--hk-timeline-link-thickness);
     flex: 1 1 0%;
     min-width: 0.5rem;
-    margin: 0 var(--hi-space-4, 4px);
+    margin: 0 var(--space-4, 4px);
   }
 }
 
@@ -299,7 +299,7 @@
   // step's node circle. Padding and rail height share the token, so the
   // rail always lands flush on both circles — no floating dashes, no
   // overlap, whatever the rhythm is tuned to.
-  --hk-timeline-vert-gap: var(--hi-space-24, 24px);
+  --hk-timeline-vert-gap: var(--space-24, 24px);
   padding-bottom: var(--hk-timeline-vert-gap);
 
   [data-el="connector"] {

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -1,7 +1,6 @@
 .hk-timeline {
   display: flex;
   align-items: center;
-  gap: 0;
   width: 100%;
 
   // Shared node geometry — ONE source of truth for the 24px indicator
@@ -121,7 +120,9 @@
     --_link-color: var(--hi-color-primary);
   }
 
-  &[data-status="active"],
+  // Links only ever carry a neighbour's status ("completed" / "pending");
+  // the current step is never a link endpoint (HkTimeline.tsx statusOf),
+  // so no "active" key here.
   &[data-status="pending"] {
     --_link-color: color-mix(in srgb, var(--hi-color-border) 30%, transparent);
   }
@@ -186,26 +187,26 @@
 
   // Vertical rails: centered under the node column, spanning between the
   // cells' node centers (at 1/6, 1/2, 5/6 of the height) minus the same
-  // clearance the horizontal bonds keep from the circles. Each segment
-  // also re-asserts the inline geometry — the horizontal segment rules
-  // above carry the same attribute specificity and must not leak in.
+  // clearance the horizontal bonds keep from the circles. This base rule
+  // ((0,4,0)) already outranks the horizontal segment rules ((0,2,0)) on
+  // width/inset-inline-start and re-asserts the top/height/bottom axes,
+  // so segments below only declare their own top/height/bottom.
   .hk-timeline-link {
     width: var(--hk-timeline-link-thickness);
     height: auto;
     inset-inline-start: var(--hk-timeline-link-top);
+    // Explicitly neutralize the horizontal edge-after rule's
+    // inset-inline-end: 0 leak (same guard as the full-mode rail below).
+    inset-inline-end: auto;
     top: auto;
     bottom: auto;
 
     &[data-segment="before-current"] {
-      inset-inline-start: var(--hk-timeline-link-top);
-      width: var(--hk-timeline-link-thickness);
       top: calc(16.6667% + var(--hk-timeline-link-clearance));
       height: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
     }
 
     &[data-segment="current-after"] {
-      inset-inline-start: var(--hk-timeline-link-top);
-      width: var(--hk-timeline-link-thickness);
       top: calc(50% + var(--hk-timeline-link-clearance));
       height: calc(33.3334% - (var(--hk-timeline-link-clearance) * 2));
     }
@@ -213,16 +214,11 @@
     // Continuation hints: from the container edge toward that cell's node,
     // fading INTO the edge ("more steps exist beyond this side").
     &[data-segment="edge-before"] {
-      inset-inline-start: var(--hk-timeline-link-top);
-      width: var(--hk-timeline-link-thickness);
       top: 0;
       height: calc(16.6667% - var(--hk-timeline-link-clearance));
     }
 
     &[data-segment="edge-after"] {
-      inset-inline-start: var(--hk-timeline-link-top);
-      width: var(--hk-timeline-link-thickness);
-      top: auto;
       bottom: 0;
       height: calc(16.6667% - var(--hk-timeline-link-clearance));
     }
@@ -249,21 +245,20 @@
   min-width: 0;
 
   [data-el="indicator"] {
-    width: 24px;
-    height: 24px;
-    min-width: 24px;
-    min-height: 24px;
-    max-width: 24px;
-    max-height: 24px;
+    // Keyed off the shared node-size token above so the circle, the
+    // window-mode link math and the vertical rail offset stay in sync.
+    width: var(--hk-timeline-node-size);
+    height: var(--hk-timeline-node-size);
+    min-width: var(--hk-timeline-node-size);
+    min-height: var(--hk-timeline-node-size);
+    max-width: var(--hk-timeline-node-size);
+    max-height: var(--hk-timeline-node-size);
     border-radius: 50%;
     box-sizing: border-box;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    flex-grow: 0;
-    visibility: visible;
-    overflow: visible;
   }
 
   [data-el="num"] {
@@ -383,9 +378,31 @@
 .hk-timeline-step[data-clickable] {
   cursor: pointer;
 
+  // Keyboard parity: the tsx gives completed steps role="button" +
+  // tabindex 0 (HkContextRing outer-ring pattern).
+  &:focus-visible {
+    outline: 2px solid var(--hi-color-primary);
+    outline-offset: 2px;
+  }
+
   &:hover [data-el="indicator"] {
     transform: scale(1.12);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary) 15%, transparent);
     transition: transform var(--hi-duration-normal, 0.3s) ease, box-shadow var(--hi-duration-normal, 0.3s) ease;
+  }
+
+  // Press feedback mirroring the hover pop (role="button" affordance).
+  &:active [data-el="indicator"] {
+    transform: scale(0.96);
+  }
+}
+
+// The hover/press rules above drive the indicator scale; snap the
+// animation under reduced motion, keeping the state change itself
+// (house pattern: HkIconButton.scss).
+@media (prefers-reduced-motion: reduce) {
+  .hk-timeline-step[data-clickable]:hover [data-el="indicator"],
+  .hk-timeline-step[data-clickable]:active [data-el="indicator"] {
+    transition: none;
   }
 }

--- a/packages/vue/src/components/HkTitleBar.scss
+++ b/packages/vue/src/components/HkTitleBar.scss
@@ -29,7 +29,7 @@
   user-select: none;
   -webkit-user-select: none;
   background: var(--hk-tb-bg);
-  backdrop-filter: blur(16px);
+  backdrop-filter: blur(var(--blur-md, 16px));
   border-bottom: 1px solid var(--hk-tb-border);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   -webkit-app-region: drag;
@@ -40,7 +40,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding-left: 12px;
+  padding-inline-start: 12px;
   white-space: nowrap;
   cursor: default;
 }
@@ -63,7 +63,7 @@
   font-size: 10px;
   color: var(--hk-tb-fg);
   opacity: 0.7;
-  padding-left: 8px;
+  padding-inline-start: 8px;
   white-space: nowrap;
 }
 
@@ -106,17 +106,23 @@
 /* Only the rightmost (close) button carries the window's top-right
    corner radius; the other captions highlight as plain rectangles. */
 .hk-titlebar-btn-close {
-  border-radius: 0 8px 0 0;
+  border-radius: var(--hk-tb-radius-close);
+}
+
+/* RTL mirrors the caption row, so the close button lands top-left and
+   the window corner radius flips with it. */
+[dir="rtl"] .hk-titlebar-btn-close {
+  border-radius: 8px 0 0 0;
 }
 
 .hk-titlebar-btn-close:hover {
   background: var(--hk-tb-close-hover);
-  color: #fff;
+  color: var(--hi-color-text-on-danger, #fff);
 }
 
 .hk-titlebar-btn-close:active {
   background: var(--hk-tb-close-active);
-  color: #fff;
+  color: var(--hi-color-text-on-danger, #fff);
 }
 
 .hk-titlebar-btn:focus-visible {
@@ -124,5 +130,8 @@
   outline-offset: -2px;
 }
 
-/* Host apps offset their own root container below the bar:
+/* Host apps offset their own root container below the bar. The var is
+   declared on .hk-titlebar and does not inherit to the host root, so
+   hosts re-declare it first:
+   :root { --hk-tb-height: 32px; }
    #app { position: absolute; top: var(--hk-tb-height); … } */

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -13,7 +13,7 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-12, 12px);
+  gap: var(--space-12, 12px);
 }
 
 .hk-toast-item {
@@ -25,10 +25,10 @@
      the text. Centering aligns all three optical axes and distributes
      the height symmetrically for single- and multi-line bodies alike. */
   align-items: center;
-  gap: var(--hi-space-8, 8px);
-  padding: var(--hi-space-12, 12px) var(--hi-space-16, 16px);
+  gap: var(--space-8, 8px);
+  padding: var(--space-12, 12px) var(--space-16, 16px);
   border-radius: var(--hi-radius-sm, 4px);
-  font-size: var(--hi-text-base, 0.875rem);
+  font-size: var(--text-base, 0.875rem);
   line-height: 1.4;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   pointer-events: auto;
@@ -41,7 +41,7 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--hi-space-4, 4px);
+  gap: var(--space-4, 4px);
 }
 
 .hk-toast-icon {

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -1,7 +1,7 @@
 .hk-toast-container {
   position: fixed;
   top: 4rem;
-  right: 1rem;
+  inset-inline-end: var(--space-16, 1rem);
   /* Toast band — the topmost popup z band (POPUP_Z_BANDS.toast; mirror in
      theme.scss). The live value arrives inline from the popup manager. */
   z-index: var(--hk-z-toast, 4000);
@@ -76,12 +76,12 @@
 
 .hk-toast-error {
   background: var(--hi-color-danger, #f85149);
-  color: #fff;
+  color: var(--hi-color-text-on-solid, #fff);
 }
 
 .hk-toast-success {
   background: var(--hi-color-success, #3fb950);
-  color: #fff;
+  color: var(--hi-color-text-on-solid, #fff);
 }
 
 /* Warning toasts use a light, saturated amber background where white text
@@ -104,12 +104,12 @@
 
 .hk-toast-info {
   background: var(--hi-color-info, #58a6ff);
-  color: #fff;
+  color: var(--hi-color-text-on-solid, #fff);
 }
 
 .hk-toast-loading {
   background: var(--hi-color-info, #58a6ff);
-  color: #fff;
+  color: var(--hi-color-text-on-solid, #fff);
 }
 
 .hk-toast-loading-spinner {
@@ -147,6 +147,12 @@
   opacity: 1;
 }
 
+.hk-toast-copy-btn:focus-visible,
+.hk-toast-close:focus-visible {
+  outline: 2px solid rgb(var(--color-primary));
+  outline-offset: 2px;
+}
+
 .hk-toast-enter-active {
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
   transition-duration: var(--hi-duration-normal, 0.3s);
@@ -172,6 +178,13 @@
   transform: translateX(1rem);
 }
 
+/* RTL: the stack sits at inline-end (left), so the slide mirrors to
+   come from the left edge (HkBlockingToast [dir="rtl"] form). */
+[dir="rtl"] .hk-toast-enter-from,
+[dir="rtl"] .hk-toast-leave-to {
+  transform: translateX(-1rem);
+}
+
 /* The leaving toast only switches positioning here; its box is frozen
    by HkToast's before-leave hook (pinLeaveGeometry writes right/top/
    width/height inline). The fixed stack column is shrink-to-fit, so a
@@ -194,4 +207,21 @@
 .hk-toast-msg-enter-from,
 .hk-toast-msg-leave-to {
   opacity: 0;
+}
+
+/* Reduced motion: kill the infinite spinner rotation and the
+   slide/fade transitions entirely (HkSpinner / HkExpansionPanel
+   pattern) — Vue resolves zero-duration transitions immediately. */
+@media (prefers-reduced-motion: reduce) {
+  .hk-toast-loading-spinner {
+    animation: none;
+  }
+
+  .hk-toast-enter-active,
+  .hk-toast-leave-active,
+  .hk-toast-move,
+  .hk-toast-msg-enter-active,
+  .hk-toast-msg-leave-active {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkTokenUsagePanel.scss
+++ b/packages/vue/src/components/HkTokenUsagePanel.scss
@@ -14,7 +14,6 @@
   padding: var(--space-24, 1.5rem) 0;
   text-align: center;
   color: rgb(var(--color-muted));
-  font-size: var(--text-xs, 0.75rem);
 }
 
 .s-token-panel-total {
@@ -51,7 +50,6 @@
 .s-token-panel-models-title {
   font-weight: 600;
   margin-bottom: var(--space-8, 0.5rem);
-  color: rgb(var(--color-text));
 }
 
 .s-token-panel-model-list {
@@ -64,7 +62,6 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: var(--text-xs, 0.75rem);
   margin-bottom: var(--space-4, 0.25rem);
 }
 
@@ -83,14 +80,14 @@
 
 .s-token-panel-model-track {
   height: 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-full, 999px);
   overflow: hidden;
   background: rgb(var(--color-border) / 15%);
 }
 
 .s-token-panel-model-bar {
   height: 100%;
-  border-radius: 999px;
+  border-radius: var(--radius-full, 999px);
   transition: width var(--duration-normal, 0.3s) ease;
 }
 

--- a/packages/vue/src/components/HkTokenUsagePanel.scss
+++ b/packages/vue/src/components/HkTokenUsagePanel.scss
@@ -72,7 +72,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: var(--space-8, 0.5rem);
+  margin-inline-end: var(--space-8, 0.5rem);
 }
 
 .s-token-panel-model-count {
@@ -92,4 +92,12 @@
   height: 100%;
   border-radius: 999px;
   transition: width var(--duration-normal, 0.3s) ease;
+}
+
+/* Size animation (bar fill) — house reduced-motion guard, as in
+   HkExpansionPanel.scss / HkAffixPicker.scss. */
+@media (prefers-reduced-motion: reduce) {
+  .s-token-panel-model-bar {
+    transition: none;
+  }
 }

--- a/packages/vue/src/components/HkToolBlock.scss
+++ b/packages/vue/src/components/HkToolBlock.scss
@@ -59,7 +59,7 @@
 }
 
 .s-tool-header-expand {
-  margin-left: auto;
+  margin-inline-start: auto;
   display: inline-flex;
   color: rgb(var(--color-muted));
 }

--- a/packages/vue/src/components/HkToolBlock.scss
+++ b/packages/vue/src/components/HkToolBlock.scss
@@ -11,6 +11,10 @@
     border-color: rgb(var(--color-error) / 35%);
   }
 
+  &.is-running {
+    border-color: rgb(var(--color-primary) / 35%);
+  }
+
   &.is-success {
     border-color: rgb(var(--color-success) / 25%);
   }
@@ -26,6 +30,12 @@
   user-select: none;
 }
 
+/* Hover affordance mirrors the sibling chat-surface row pattern
+   (.s-jt-row:hover in HkJsonTree.scss). */
+.s-tool-header:hover {
+  background: rgb(var(--color-primary) / 4%);
+}
+
 .s-tool-header-title {
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-weight: 600;
@@ -34,8 +44,6 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  cursor: pointer;
-  user-select: none;
   border-radius: var(--radius-sm, 4px);
   padding: 0 var(--space-2, 0.125rem);
 
@@ -45,7 +53,7 @@
 }
 
 .s-tool-header-badge {
-  padding: 1px var(--space-6, 0.375rem);
+  padding: var(--space-1, 0.0625rem) var(--space-6, 0.375rem);
   border-radius: var(--radius-sm, 4px);
   font-size: var(--text-2xs, 0.625rem);
   font-weight: 600;
@@ -74,7 +82,7 @@
 .s-tool-params {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-2, 0.125rem);
 }
 
 .s-tool-param-line {
@@ -131,11 +139,11 @@
 }
 
 .s-tool-result {
-  border-left: 2px solid rgb(var(--color-success) / 40%);
-  padding-left: var(--space-8, 0.5rem);
+  border-inline-start: 2px solid rgb(var(--color-success) / 40%);
+  padding-inline-start: var(--space-8, 0.5rem);
 
   &.is-error {
-    border-left-color: rgb(var(--color-error) / 40%);
+    border-inline-start-color: rgb(var(--color-error) / 40%);
   }
 }
 
@@ -178,6 +186,10 @@
     display: none;
   }
 
+  &:hover {
+    background: rgb(var(--color-muted) / 10%);
+  }
+
   &:active {
     opacity: 0.85;
   }
@@ -207,15 +219,15 @@
 .s-tool-code-num {
   width: 1%;
   min-width: 2.75em;
-  padding: 0 0.875em 0 1em;
-  text-align: right;
+  padding-inline: 1em 0.875em;
+  text-align: end;
   user-select: none;
   white-space: nowrap;
   color: rgb(var(--color-muted) / 0.45);
 }
 
 .s-tool-code-content {
-  padding: 0 var(--space-12, 0.75rem) 0 0;
+  padding-inline-end: var(--space-12, 0.75rem);
   white-space: pre-wrap;
   word-break: break-word;
 }

--- a/packages/vue/src/components/HkTooltip.scss
+++ b/packages/vue/src/components/HkTooltip.scss
@@ -16,6 +16,9 @@
   padding: var(--space-4) var(--space-8);
   border: none;
   border-radius: var(--radius-sm);
+  /* Default cap lives on the popup so the inline maxWidth prop
+     legitimately overrides it (the content div would shadow the prop). */
+  max-width: 280px;
   font-size: var(--text-xs);
   line-height: 1.4;
   white-space: normal;
@@ -44,15 +47,8 @@
   }
 }
 
-.hk-tooltip-content {
-  max-width: 280px;
-}
-
-[data-mode="light"] .hk-tooltip-popup {
-  background: #ffffff;
-  color: #000000;
-}
-
+/* Light mode needs no override — the base rule above already is the
+   light palette; only dark re-inks the popup. */
 [data-mode="dark"] .hk-tooltip-popup {
   background: #4b4b4b;
   color: #ffffff;

--- a/packages/vue/src/components/HkTree.scss
+++ b/packages/vue/src/components/HkTree.scss
@@ -73,7 +73,7 @@
 .hk-tree[data-size="xs"] .hk-tree-children > .hk-tree-node > .hk-tree-row {
   min-height: 22px;
 
-  .hk-tree-label { font-size: var(--hi-text-xs, 0.75rem); }
+  .hk-tree-label { font-size: var(--text-xs, 0.75rem); }
   .hk-tree-icon { width: 14px; height: 14px; }
   .hk-tree-leaf { width: 4px; height: 4px; }
 }
@@ -82,7 +82,7 @@
 .hk-tree[data-size="sm"] .hk-tree-children > .hk-tree-node > .hk-tree-row {
   min-height: 28px;
 
-  .hk-tree-label { font-size: var(--hi-text-xs, 0.75rem); }
+  .hk-tree-label { font-size: var(--text-xs, 0.75rem); }
   .hk-tree-icon { width: 16px; height: 16px; }
   .hk-tree-leaf { width: 5px; height: 5px; }
 }
@@ -91,7 +91,7 @@
 .hk-tree[data-size="md"] .hk-tree-children > .hk-tree-node > .hk-tree-row {
   min-height: 34px;
 
-  .hk-tree-label { font-size: var(--hi-text-sm, 0.875rem); }
+  .hk-tree-label { font-size: var(--text-sm, 0.875rem); }
   .hk-tree-icon { width: 18px; height: 18px; }
   .hk-tree-leaf { width: 6px; height: 6px; }
 }

--- a/packages/vue/src/components/HkTree.scss
+++ b/packages/vue/src/components/HkTree.scss
@@ -22,21 +22,21 @@
     top: 0;
     bottom: 6px;
     width: 1px;
-    background: color-mix(in srgb, var(--hi-color-border) 30%, transparent);
+    background: color-mix(in srgb, var(--hi-color-border, #30363d) 30%, transparent);
   }
 }
 
 .hk-tree-row {
   display: flex;
   align-items: center;
-  padding: 0 8px;
+  padding: 0 var(--space-8, 0.5rem);
   cursor: pointer;
   transition: background var(--hi-duration-fast, 0.15s) ease;
-  color: var(--hi-color-text-primary);
+  color: var(--hi-color-text-primary, #333);
   position: relative;
 
   &:hover {
-    background: color-mix(in srgb, var(--hi-color-primary) 5%, transparent);
+    background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 5%, transparent);
   }
 }
 
@@ -49,7 +49,7 @@
 }
 
 .hk-tree-row[data-status="failed"] .hk-tree-label {
-  color: var(--hi-color-danger);
+  color: var(--hi-color-danger, #f85149);
 }
 
 .hk-tree-row[data-status="in_progress"],
@@ -60,7 +60,7 @@
 }
 
 .hk-tree-row[data-status="warning"] .hk-tree-label {
-  color: var(--hi-color-warning);
+  color: var(--hi-color-warning, #d29922);
 }
 
 .hk-tree-row[data-status="muted"] {
@@ -105,7 +105,7 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: var(--hi-color-muted);
+  color: var(--hi-color-muted, #666);
   border-radius: var(--hi-radius-sm, 4px);
   transition: color var(--hi-duration-fast, 0.15s), background var(--hi-duration-fast, 0.15s);
 }
@@ -114,8 +114,8 @@
   cursor: pointer;
 
   &:hover {
-    background: color-mix(in srgb, var(--hi-color-surface) 40%, transparent);
-    color: var(--hi-color-text-primary);
+    background: color-mix(in srgb, var(--hi-color-surface, #fff) 40%, transparent);
+    color: var(--hi-color-text-primary, #333);
   }
 }
 
@@ -136,7 +136,7 @@
 .hk-tree-leaf {
   display: block;
   border-radius: 50%;
-  background: color-mix(in srgb, var(--hi-color-muted) 25%, transparent);
+  background: color-mix(in srgb, var(--hi-color-muted, #666) 25%, transparent);
 }
 
 /* ── Icon slot ─────────────────────────────────── */
@@ -146,7 +146,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-inline-start: 4px;
+  margin-inline-start: var(--space-4, 0.25rem);
 }
 
 /* ── Label ─────────────────────────────────────── */
@@ -159,25 +159,10 @@
   text-overflow: ellipsis;
   line-height: 1.4;
   font-weight: 400;
-  margin-inline-start: 4px;
+  margin-inline-start: var(--space-4, 0.25rem);
 }
 
-/* ── Label rich-text parts (agent::skill) ───────── */
-
-.hk-tree-label-agent {
-  font-weight: 600;
-  color: var(--hi-color-primary);
-}
-
-.hk-tree-label-sep {
-  color: var(--hi-color-muted);
-  font-weight: 400;
-}
-
-.hk-tree-label-skill {
-  font-weight: 500;
-  color: var(--hi-color-text-primary);
-}
+/* ── Label tag chip ────────────────────────────── */
 
 .hk-tree-label-tag {
   display: inline-block;
@@ -185,9 +170,9 @@
   padding: 0 0.375em;
   font-size: 0.85em;
   font-weight: 600;
-  color: var(--hi-color-primary);
-  background: color-mix(in srgb, var(--hi-color-primary) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-primary) 18%, transparent);
+  color: var(--hi-color-primary, #58a6ff);
+  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent);
   border-radius: var(--hi-radius-sm, 4px);
   line-height: 1.5;
   letter-spacing: 0.02em;

--- a/packages/vue/src/components/HkTree.scss
+++ b/packages/vue/src/components/HkTree.scss
@@ -18,7 +18,7 @@
   &::before {
     content: "";
     position: absolute;
-    left: var(--guide-left, 8px);
+    inset-inline-start: var(--guide-left, 8px);
     top: 0;
     bottom: 6px;
     width: 1px;
@@ -127,6 +127,12 @@
   transform: rotate(90deg);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .hk-tree-chevron {
+    transition: none;
+  }
+}
+
 .hk-tree-leaf {
   display: block;
   border-radius: 50%;
@@ -140,7 +146,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 /* ── Label ─────────────────────────────────────── */
@@ -153,7 +159,7 @@
   text-overflow: ellipsis;
   line-height: 1.4;
   font-weight: 400;
-  margin-left: 4px;
+  margin-inline-start: 4px;
 }
 
 /* ── Label rich-text parts (agent::skill) ───────── */

--- a/packages/vue/src/components/HkVoiceInputPopup.scss
+++ b/packages/vue/src/components/HkVoiceInputPopup.scss
@@ -33,6 +33,11 @@
   &:hover {
     text-decoration: underline;
   }
+
+  &:focus-visible {
+    outline: 2px solid rgb(var(--color-primary));
+    outline-offset: 2px;
+  }
 }
 
 /* ── Waveform (listening phase) ─────────────────────────────────── */
@@ -56,15 +61,15 @@
   &:nth-child(5) { animation-delay: 0.6s; }
 }
 
-[data-phase="transcribing"] .s-voice-wave-bar {
-  animation: none;
-  height: 25%;
-  opacity: 0.4;
-}
-
 @keyframes s-voice-wave-bounce {
   0%, 100% { transform: scaleY(0.4); }
   50%      { transform: scaleY(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .s-voice-wave-bar {
+    animation: none;
+  }
 }
 
 .s-voice-popup-spinner {

--- a/packages/vue/src/components/HkWindowedItem.scss
+++ b/packages/vue/src/components/HkWindowedItem.scss
@@ -1,17 +1,11 @@
 .hk-windowed-item {
   display: block;
+  break-inside: avoid;
+  page-break-inside: avoid;
+  -webkit-column-break-inside: avoid;
 }
 
 .hk-windowed-item[data-state="placeholder"] {
-  break-inside: avoid;
-  page-break-inside: avoid;
-  -webkit-column-break-inside: avoid;
   pointer-events: none;
   background: transparent;
-}
-
-.hk-windowed-item[data-state="real"] {
-  break-inside: avoid;
-  page-break-inside: avoid;
-  -webkit-column-break-inside: avoid;
 }

--- a/packages/vue/src/components/HkZoomToolbar.scss
+++ b/packages/vue/src/components/HkZoomToolbar.scss
@@ -4,21 +4,21 @@
 .hk-zoom-toolbar {
   display: flex;
   align-items: center;
-  gap: 2px;
+  gap: var(--space-2);
   position: absolute;
-  top: 8px;
-  inset-inline-end: 8px;
+  top: var(--space-8);
+  inset-inline-end: var(--space-8);
   z-index: 10;
   border-radius: var(--radius-md);
   background: rgb(var(--color-surface) / 85%);
   border: 1px solid rgb(var(--color-border) / 8%);
-  padding: 2px 4px;
+  padding: var(--space-2) var(--space-4);
   backdrop-filter: blur(var(--blur-sm));
 }
 
 .hk-zoom-btn.hk-btn {
-  width: 24px;
-  height: 24px;
+  width: var(--space-24);
+  height: var(--space-24);
   padding: 0;
 }
 
@@ -26,12 +26,12 @@
   font-size: var(--text-2xs);
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   color: rgb(var(--color-muted));
-  min-width: 32px;
+  min-width: var(--space-32);
   text-align: center;
   user-select: none;
 }
 
 .hk-zoom-reset-btn {
-  margin-inline-start: 2px;
+  margin-inline-start: var(--space-2);
   border-inline-start: 1px solid rgb(var(--color-border) / 8%);
 }

--- a/packages/vue/src/components/HkZoomToolbar.scss
+++ b/packages/vue/src/components/HkZoomToolbar.scss
@@ -34,4 +34,7 @@
 .hk-zoom-reset-btn {
   margin-inline-start: var(--space-2);
   border-inline-start: 1px solid rgb(var(--color-border) / 8%);
+  /* Breathing room between the divider and the glyph (the zoom
+     buttons carry padding: 0). */
+  padding-inline-start: var(--space-4, 4px);
 }

--- a/packages/vue/src/components/HkZoomToolbar.scss
+++ b/packages/vue/src/components/HkZoomToolbar.scss
@@ -7,7 +7,7 @@
   gap: 2px;
   position: absolute;
   top: 8px;
-  right: 8px;
+  inset-inline-end: 8px;
   z-index: 10;
   border-radius: var(--radius-md);
   background: rgb(var(--color-surface) / 85%);
@@ -32,7 +32,6 @@
 }
 
 .hk-zoom-reset-btn {
-  margin-left: 2px;
-  border-left: 1px solid rgb(var(--color-border) / 8%);
-  padding-left: 4px;
+  margin-inline-start: 2px;
+  border-inline-start: 1px solid rgb(var(--color-border) / 8%);
 }

--- a/packages/vue/src/components/_menu-item.scss
+++ b/packages/vue/src/components/_menu-item.scss
@@ -93,7 +93,6 @@
   @include item-tokens;
   display: flex;
   align-items: center;
-  justify-content: flex-start;
   gap: var(--hk-menu-item-gap);
   width: 100%;
   min-height: var(--hk-menu-item-min-h);
@@ -106,7 +105,7 @@
   font-weight: var(--hk-menu-item-weight);
   font-family: inherit;
   line-height: var(--hk-menu-item-lh);
-  text-align: left;
+  text-align: start;
   cursor: pointer;
   appearance: none;
   user-select: none;
@@ -142,7 +141,9 @@
   &[data-danger] {
     color: rgb(var(--color-danger, 240 70 80) / 90%);
 
-    &:hover:not(:disabled):not([data-disabled]):not([data-active]) {
+    /* Same checked-row guard as the base hover above: a checked danger
+     * row keeps its checked face instead of flashing the hover wash. */
+    &:hover:not(:disabled):not([data-disabled]):not([data-active]):not([data-checked]) {
       background: rgb(var(--color-danger, 240 70 80) / 10%);
       border-color: rgb(var(--color-danger, 240 70 80) / 25%);
       color: rgb(var(--color-danger, 240 70 80));

--- a/packages/vue/src/components/window-close.scss
+++ b/packages/vue/src/components/window-close.scss
@@ -3,16 +3,17 @@
 //
 // Every window chrome close control — modal header, drawer header,
 // popover/select mobile-sheet heading row — renders the SAME thing: an
-// HkIconButton (ghost, 32px box) carrying the registry's X glyph
-// (HkIcon name="X"). No component keeps its own inline ✕ SVG any more;
+// HkIconButton (ghost, 32px box) carrying the registry's close glyph
+// (HIcon name="close"). No component keeps its own inline ✕ SVG any more;
 // the glyph comes from the shared lucide registry and the chrome comes
 // from the icon-button, so there is exactly one source for each.
 //
 // This partial only carries the window-chrome grammar ON TOP of the icon
 // button: a close control never participates in text selection, and it
 // gets the hover tint HkIconButton intentionally leaves to the Glow
-// wrapper (window headers render no Glow). The `--hk-modal-close-hover-*`
-// custom properties stay the shared host tunables for that tint.
+// wrapper (window headers render no Glow). Hover is excluded while the
+// button is pressed so the icon-button's :active press state stays
+// visible through this higher-specificity layer.
 //
 // THE THEME CONTEXT DECIDES THE MOTION (user direction 2026-09-05): the
 // hover choreography is expressed entirely through the --hk-func-icon-*
@@ -39,20 +40,14 @@
       var(--hk-func-icon-hover-duration, 0.15s)
       var(--hk-func-icon-hover-ease, ease);
 
-  &:hover {
+  &:where(:hover:not(:active)) {
     background: var(
       --hk-func-icon-hover-bg,
-      var(
-        --hk-modal-close-hover-bg,
-        var(--hi-secondary-bg, rgba(0, 0, 0, 0.06))
-      )
+      var(--hi-secondary-bg, rgba(0, 0, 0, 0.06))
     );
     color: var(
       --hk-func-icon-hover-color,
-      var(
-        --hk-modal-close-hover-color,
-        var(--hi-color-text-primary, #333)
-      )
+      var(--hi-color-text-primary, #333)
     );
   }
 }


### PR DESCRIPTION
## Summary

Two-part CSS style-hygiene wave for the component library, driven by a webui screenshot of the provider wizard where the selected capability card read with a lopsided frame (top edge visibly thinner than the other three sides).

## Part 1 — the selection-box imbalance (root-caused, not guessed)

Pixel measurement of the screenshot: selected card = 4px left/right/bottom, 2px top (at 200% zoom → 2px CSS vs 1px CSS). Root cause chain:

- `HkSelectionGrid` drew its selected emphasis as an **outer** spread ring (`box-shadow: 0 0 0 1px`) on top of the 1px border — 2px visual, but the ring's pixel lives *outside* the border box.
- The wizard hosts the grid under `HkStepFlow`'s sticky header (`data-sticky-header`: `z-index: 10`, 95%-opaque frosted surface + `backdrop-filter: blur(6px)`). The frosted edge sits right at the cards' top border, so the outer ring's top pixel is what gets shaved — exactly one side, hence the imbalance.

Fix: selected emphasis is now drawn **inside** the border box (`inset 0 0 0 1px`, border + inset ring = 2px on every side), immune to overlapping chrome; same treatment for the selected:hover combined shadow. Added the missing keyboard `:focus-visible` indicator (negative outline offset, same overlap immunity). The outer hover glow stays outer — it is decorative and safe to lose an edge.

## Part 2 — the full-library style sweep

Every one of the 121 component `.scss` files went through **at least three independent subagent passes**:

- **R1 redundancy audit** (dead rules, cascade-dead/duplicate declarations, no-ops, dead tokens, comment drift) — report-only.
- **R2 missing-styles audit** (missing hover/active/focus-visible/disabled states, hardcoded values with token equivalents, physical props in direction-sensitive boxes, unguarded reduced-motion animations, outer state rings) — report-only.
- **R3 adversarial verify + apply** — re-derived every finding from the code with fresh greps, adjudicated VALID/FALSE-POSITIVE/RISKY, and applied only safe CSS-only fixes; ran the per-component sass check and test siblings, reverting anything a contract test pinned.

Plus a central deterministic pass the auditors were told to leave alone: the **`--hi-space-*` / `--hi-text-*` token-name drift** (131 references, zero definitions anywhere — every one silently rendered its fallback) renamed to the real `--space-*` / `--text-*` tokens, and the shared partials (`_menu-item.scss`, `window-close.scss`) fixed for the findings agents had to defer.

**Totals: 111 files, +2039/−1512.** ~350 applied fixes across the waves; every finding was individually adjudicated (false positives documented, ~40 deferred with reasons).

### Representative fixes

- Malformed transition shorthands (`transition: a, b, c 0.3s`) in HkInput/HkPopupSelect/HkSelect that animated six properties at 0s — hover/focus snapped instead of fading (same bug HkButton documents).
- Disabled select options painted the hover/highlight wash; disabled tabs kept pointer cursor + hover highlight.
- Keyboard focus indicators added across radio, switch, tag close, toast buttons, secret-reveal copy, timeline steps, tree-adjacent rows, minimap zoom buttons, keyword-search modal, rich input, image preview/password toggles.
- RTL: physical `left/right/margin-left/padding-left/text-align: left` swapped to logical properties or mirrored with `[dir=rtl]` in ~30 direction-sensitive rules (affix chips, toast slide, menu chevron, share-bar fill, picker drill animations, sidebar border/shadow, model tag seams, table helpers).
- Dead code: `hk-pwd-hint-*` transition blocks (Vue only ever emits `hk-list-*`), `.hk-list-move` (Vue generates `hk-list-<variant>-move`), `.hk-table-md` (always-emitted default folded into base), unconstructible icon/rich-text rules, byte-identical duplicate blocks, an unreachable `--hk-modal-close-hover-*` var layer.
- Reduced-motion guards for infinite shimmer/spin/pulse/marquee animations and transform slides, per the house pattern.

### Conscious rendering changes (token activations)

The drift repair makes referenced tokens resolve for the first time, so a handful of stale fallbacks no longer mask the token value in themed hosts:

- `--text-base` sites (HkAlert, HkDateTimePicker, HkDrawer, HkEmptyState, HkTable): 1rem → **0.875rem** (the base scale; fallbacks aligned). Visible: HkTable body text and HkDrawer title 16→14px; HkAlert md 14→13px / lg 16→14px; date/time picker titles 14→13px and step values 16→14px.
- `--text-sm` on the affix chip (HkPhoneInput): 14px → **0.8125rem** (13px), matching the HkAffixPicker twin.
- `--text-2xs` sites (HkShareBar, HkStatCard, HkStatusPill): 0.6875rem → **0.625rem**.
- Assorted drift repairs by the sweep itself: divergent hex fallbacks (#ffc0cb→#58a6ff, muted 140→108, radius 6→8/4px, duration 0.18s→0.3s), HkMinimap hover timing 100ms→150ms, switch track 0.3s→0.2s house convention.
- `HkAuthSubmitButton` error ink follows the real token (#E53E3E→#F7768E); `HkAltSignIn` divider ink likewise.
- `HkMarkdownRenderer` code blocks are actually selectable now (the removed `user-select:none`/`cursor:pointer` pair had no click handler behind it).
- `HkSelect` trigger uses `:focus-visible` (house pattern) — the mouse-click focus ring is intentionally gone; open/error state rings remain.

LTR rendering is byte-identical everywhere else; all spacing/radius swaps are exact-value (a systematic audit of every renamed `var(--space-N, fallback)` confirmed zero remaining fallback≠token mismatches; the keyword-search modal keeps its historically rendered 1.25rem/0.75rem/3rem rhythm via correctly-named tokens).

### Follow-up inventory (out of CSS scope, recorded for the next waves)

- API-hygiene: the deleted Vue-sheet classes (breadcrumb separator variants, avatar sizes/shapes, `hk-icon-transition`, `hk-tag-md`) remain as constants in the Rust palette crate and in the untouched legacy `packages/components` stylesheet — unreachable through the Vue components, but the two CSS surfaces should be reconciled in a dedicated pass.
- tsx-side gaps found by the audits: `HkInput` size prop visually inert; `HkLocalePicker` inline-styled trigger/options keyboard-dead; `HkMenu` sidebar physical inline indent + unstyled `data-depth`; `HkTable` selectable rows lack a `data-selected` hook; `HkMediaSlider`/`HkTree` rows keyboard-unreachable; `HkQrCode` accepts a disabled prop it never renders; `HkSlider` RTL needs coordinated tsx+scss; `--hk-radius-sm` referenced from HkSkeleton tsx undefined; `--hi-transition-base` phantom token shared by 3 files + docs; HkIconButtonVars CSS double-emitted (@use + tsx import); `HkStatCard` clickable card lacks Enter/Space handling.

### Deferred (documented for follow-up waves; mostly need tsx/design sign-off)

`HkInput` size prop is visually inert (no sm/md/lg styles); `HkLocalePicker` renders an inline-styled trigger/options that are keyboard-dead; `HkMenu` sidebar indent is a physical inline `paddingLeft` with an unstyled `data-depth` hook; `HkTable` selectable rows have no `data-selected` hook; `HkMediaSlider`/`HkTree` rows lack keyboard reachability; `HkQrCode` accepts a disabled prop it never renders; `HkSlider` RTL needs coordinated tsx+scss (inline `style.left` drag math); `--hk-radius-sm` referenced from HkSkeleton tsx is undefined; `--hi-transition-base` phantom token shared by 3 files + docs; `HkIconIconButtonVars` css is double-emitted (@use in scss + import in tsx); `_menu-item` transition 0.12s convention drift; HkToolBlock/HkVoiceInputPopup unstyled hook classes. (Full list with evidence lives in the sweep adjudication records.)

## Verification

- `sass --no-source-map` compiles every one of the 121 component files + `src/styles/index.scss` clean.
- Full `vitest run`: **153/154 files, 1388/1389 tests green** — the single failure is the documented `HkDateTimePicker` load flake (passes 22/22 standalone, re-run twice; same flake recorded in the #470 wave).
- `vue-tsc --noEmit` exit 0.
- Every R3 pass ran its own component test siblings (contract tests that pin scss strings all green, e.g. window-close, func-icon-theme, scrim-fade, HkInput.affix, HkSelect sheetdock/singleScroll, HkPopover surfacevars/sheet-maxwidth, HkModal bodyrhythm/sheetgap).
- Scope discipline: `HkConfirmDialog.*` / `HkMessageBox.*` untouched (in-flight #460 conflict surface); no `.tsx/.ts` modified; CSS-only.

Version bump: rebased onto master after #471/#472 took 0.43.9/0.43.10 — this PR carries **0.43.11**.
