### PR TITLE
🔧 Realign the npm series to 0.43.12 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.11",
+  "version": "0.43.12",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
The style-sweep merge (0eb5eb6b) declared 0.43.11, but the tag `v0.43.11` already exists on the repo pointing at e8604d02 (#472) whose 0.43.11 never published (npm latest stays 0.43.10). Advancing the series to 0.43.12 so the style sweep release can ship under a free, unambiguous version. Single-line version bump; no other changes.