### PR TITLE
🎨 Normalize the theme token architecture onto one canonical base.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.13",
+  "version": "0.43.14",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -6,7 +6,7 @@
   border-radius: var(--radius-md, 8px);
   border: 1px solid transparent;
   border-inline-start-width: 4px;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 .hk-alert-banner {
@@ -45,27 +45,27 @@
 }
 
 .hk-alert-warning {
-  background: color-mix(in srgb, var(--hi-color-warning, #d29922) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-warning, #d29922) 15%, transparent);
-  border-inline-start-color: var(--hi-color-warning, #d29922);
+  background: color-mix(in srgb, var(--hi-color-warning, #eed677) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-warning, #eed677) 15%, transparent);
+  border-inline-start-color: var(--hi-color-warning, #eed677);
 
-  .hk-alert-icon { color: var(--hi-color-warning, #d29922); }
+  .hk-alert-icon { color: var(--hi-color-warning, #eed677); }
 }
 
 .hk-alert-info {
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 15%, transparent);
-  border-inline-start-color: var(--hi-color-primary, #58a6ff);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 15%, transparent);
+  border-inline-start-color: var(--hi-color-primary, #7aa2f7);
 
-  .hk-alert-icon { color: var(--hi-color-primary, #58a6ff); }
+  .hk-alert-icon { color: var(--hi-color-primary, #7aa2f7); }
 }
 
 .hk-alert-success {
-  background: color-mix(in srgb, var(--hi-color-success, #3fb950) 8%, transparent);
-  border-color: color-mix(in srgb, var(--hi-color-success, #3fb950) 15%, transparent);
-  border-inline-start-color: var(--hi-color-success, #3fb950);
+  background: color-mix(in srgb, var(--hi-color-success, #0eb840) 8%, transparent);
+  border-color: color-mix(in srgb, var(--hi-color-success, #0eb840) 15%, transparent);
+  border-inline-start-color: var(--hi-color-success, #0eb840);
 
-  .hk-alert-icon { color: var(--hi-color-success, #3fb950); }
+  .hk-alert-icon { color: var(--hi-color-success, #0eb840); }
 }
 
 /* ── Icon ──────────────────────────────────────── */
@@ -93,7 +93,7 @@
 .hk-alert-text {
   margin: 0;
   line-height: 1.5;
-  color: color-mix(in srgb, var(--hi-color-text-secondary, #666) 85%, transparent);
+  color: color-mix(in srgb, var(--hi-color-text-secondary, #666666) 85%, transparent);
 }
 
 /* ── Close button ──────────────────────────────── */
@@ -108,18 +108,18 @@
   border: 0;
   background: transparent;
   border-radius: var(--radius-sm, 4px);
-  color: var(--hi-color-muted, #666);
+  color: var(--hi-color-muted, #6c6c6c);
   cursor: pointer;
   padding: 0;
   transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover {
-    background: var(--hi-color-surface, #fff);
-    color: var(--hi-color-text-primary, #333);
+    background: var(--hi-color-surface, #f0f4f8);
+    color: var(--hi-color-text-primary, #1e1e1e);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary, #58a6ff);
+    outline: 2px solid var(--hi-color-primary, #7aa2f7);
     outline-offset: 2px;
   }
 }

--- a/packages/vue/src/components/HkAlert.scss
+++ b/packages/vue/src/components/HkAlert.scss
@@ -3,7 +3,7 @@
   align-items: flex-start;
   gap: var(--space-12, 12px);
   padding: var(--space-12, 12px) var(--space-16, 16px);
-  border-radius: var(--hi-radius-md, 8px);
+  border-radius: var(--radius-md, 8px);
   border: 1px solid transparent;
   border-inline-start-width: 4px;
   color: var(--hi-color-text-primary, #333);
@@ -107,11 +107,11 @@
   height: 22px;
   border: 0;
   background: transparent;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: var(--hi-color-muted, #666);
   cursor: pointer;
   padding: 0;
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover {
     background: var(--hi-color-surface, #fff);

--- a/packages/vue/src/components/HkAltSignIn.scss
+++ b/packages/vue/src/components/HkAltSignIn.scss
@@ -18,7 +18,7 @@
   background: transparent;
   cursor: pointer;
   font-size: var(--text-xs, 0.75rem);
-  color: var(--hi-color-muted, #666);
+  color: var(--hi-color-muted, #6c6c6c);
   transition:
     color var(--duration-normal, 0.3s) ease,
     opacity var(--duration-normal, 0.3s) ease;
@@ -26,12 +26,12 @@
 
 .hk-alt-signin__trigger:hover:not(:disabled),
 .hk-alt-signin__trigger[aria-expanded="true"] {
-  color: var(--hi-color-text-secondary, #999);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 /* Keyboard position feedback on the full-width disclosure row. */
 .hk-alt-signin__trigger:focus-visible:not(:disabled) {
-  outline: 2px solid var(--hi-color-primary, #58a6ff);
+  outline: 2px solid var(--hi-color-primary, #7aa2f7);
   outline-offset: 2px;
 }
 

--- a/packages/vue/src/components/HkAuthMethodList.scss
+++ b/packages/vue/src/components/HkAuthMethodList.scss
@@ -9,7 +9,7 @@
   align-items: center;
   gap: var(--space-10, 0.625rem);
   margin: 0 0 var(--space-4, 0.25rem);
-  color: var(--hi-color-muted, #999);
+  color: var(--hi-color-muted, #6c6c6c);
   font-size: var(--text-xs, 0.75rem);
   text-align: center;
 }
@@ -19,7 +19,7 @@
   content: "";
   flex: 1;
   height: 1px;
-  background: var(--hi-color-border, #ddd);
+  background: var(--hi-color-border, #646464);
 }
 
 /* The component's own wrapper is `display: contents` (measurement anchor +

--- a/packages/vue/src/components/HkAvatar.scss
+++ b/packages/vue/src/components/HkAvatar.scss
@@ -50,5 +50,5 @@
 
 [data-theme="dark"] .hk-avatar {
   background-color: var(--hi-surface);
-  color: var(--hi-color-text-secondary, rgba(255, 255, 255, 0.6));
+  color: var(--hi-color-text-secondary, rgba(102,102,102,0.6));
 }

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -77,12 +77,12 @@
 // Variant backgrounds follow the HkToast conventions (including the
 // dark-on-amber warning text for contrast).
 .hk-blocking-toast-info {
-  background: var(--hi-color-info, #58a6ff);
+  background: var(--hi-color-info, #6abed6);
   color: #fff;
 }
 
 .hk-blocking-toast-warning {
-  background: var(--hi-color-warning, #d29922);
+  background: var(--hi-color-warning, #eed677);
   color: #1c1c1e;
 }
 

--- a/packages/vue/src/components/HkBlockingToast.scss
+++ b/packages/vue/src/components/HkBlockingToast.scss
@@ -32,7 +32,7 @@
   align-items: flex-start;
   gap: var(--space-8, 8px);
   padding: var(--space-12, 12px) var(--space-16, 16px);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   font-size: var(--text-base, 0.875rem);
   line-height: 1.4;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
@@ -95,13 +95,13 @@
 // cards go absolute so the remaining ones glide up (hk-toast pattern).
 .hk-blocking-toast-enter-active {
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
-  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-duration: var(--duration-normal, 0.3s);
   transition-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
 }
 
 .hk-blocking-toast-leave-active {
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
-  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-duration: var(--duration-normal, 0.3s);
   transition-timing-function: cubic-bezier(0.36, 0, 0.66, 1);
   /* Only the positioning switch lives here; the leaving slot's box is
      frozen by the before-leave hook (pinLeaveGeometry), same contract
@@ -126,7 +126,7 @@
 }
 
 .hk-blocking-toast-move {
-  transition: transform var(--hi-duration-normal, 0.3s) ease;
+  transition: transform var(--duration-normal, 0.3s) ease;
 }
 
 // Reduced motion: drop the slide/FLIP choreography, cards snap in and

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -24,8 +24,8 @@
   width: 1.125rem;
   height: 1.125rem;
   border-radius: var(--radius-sm, 4px);
-  border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
+  border: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
+  background: var(--hi-color-surface, rgba(240,244,248,0.95));
   transition:
     border-color var(--duration-normal, 0.3s) ease,
     background var(--duration-normal, 0.3s) ease;
@@ -38,13 +38,13 @@
 }
 
 .hk-checkbox-box[data-checked] {
-  background: var(--hi-color-primary, #ff6b9d);
-  border-color: var(--hi-color-primary, #ff6b9d);
+  background: var(--hi-color-primary, #7aa2f7);
+  border-color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-checkbox-box[data-indeterminate] {
-  background: var(--hi-color-primary, #ff6b9d);
-  border-color: var(--hi-color-primary, #ff6b9d);
+  background: var(--hi-color-primary, #7aa2f7);
+  border-color: var(--hi-color-primary, #7aa2f7);
 }
 
 /* ---------- input ---------- */
@@ -62,8 +62,8 @@
    :focus-visible keeps mouse toggles ring-free. */
 .hk-checkbox-box:has(.hk-checkbox-input:focus-visible) {
   box-shadow:
-    0 0 0 2px var(--hi-color-surface, rgba(255, 255, 255, 0.95)),
-    0 0 0 4px var(--hi-color-primary, #ff6b9d);
+    0 0 0 2px var(--hi-color-surface, rgba(240,244,248,0.95)),
+    0 0 0 4px var(--hi-color-primary, #7aa2f7);
 }
 
 /* ---------- markers ---------- */

--- a/packages/vue/src/components/HkCheckbox.scss
+++ b/packages/vue/src/components/HkCheckbox.scss
@@ -23,12 +23,12 @@
   justify-content: center;
   width: 1.125rem;
   height: 1.125rem;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   transition:
-    border-color var(--hi-duration-normal, 0.3s) ease,
-    background var(--hi-duration-normal, 0.3s) ease;
+    border-color var(--duration-normal, 0.3s) ease,
+    background var(--duration-normal, 0.3s) ease;
   flex-shrink: 0;
   position: relative;
 }

--- a/packages/vue/src/components/HkDatePicker.scss
+++ b/packages/vue/src/components/HkDatePicker.scss
@@ -23,15 +23,15 @@
   padding: var(--space-8, 8px) var(--space-12, 12px);
   background: color-mix(in srgb, rgb(var(--color-surface)) 55%, transparent);
   border: 1px solid color-mix(in srgb, rgb(var(--color-text)) 14%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: rgb(var(--color-text));
   font-family: inherit;
   font-size: var(--text-sm, 0.875rem);
   line-height: 1.5;
   transition:
-    background-color var(--hi-duration-fast, 0.15s) ease,
-    border-color var(--hi-duration-fast, 0.15s) ease,
-    box-shadow var(--hi-duration-fast, 0.15s) ease;
+    background-color var(--duration-fast, 0.15s) ease,
+    border-color var(--duration-fast, 0.15s) ease,
+    box-shadow var(--duration-fast, 0.15s) ease;
 }
 
 .hk-dp-trigger {
@@ -102,11 +102,11 @@
   padding: 0;
   border: 0;
   background: transparent;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: var(--hi-color-muted);
   cursor: pointer;
   opacity: 0;
-  transition: opacity var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: opacity var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   .hk-dp-trigger:hover &,
   .hk-dp-trigger:focus &,
@@ -183,13 +183,13 @@
   border: 0;
   width: 1.75rem;
   height: 1.75rem;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: var(--hi-color-muted);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled) {
     background: var(--hi-color-surface);
@@ -232,8 +232,8 @@
   color: inherit;
   cursor: pointer;
   white-space: nowrap;
-  border-radius: var(--hi-radius-sm, 4px);
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  border-radius: var(--radius-sm, 4px);
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover {
     background: var(--hi-color-surface);
@@ -279,7 +279,7 @@
   appearance: none;
   background: transparent;
   border: 0;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   /* Fixed height keeps the six-row day grid — and therefore the shared
    * stage height — independent of the panel width, so drilling between
    * views never changes the popup's size (enlarged on touch). */
@@ -291,7 +291,7 @@
   cursor: pointer;
   font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled):not(.is-selected) {
     background: var(--hi-color-surface);

--- a/packages/vue/src/components/HkDateTimePicker.scss
+++ b/packages/vue/src/components/HkDateTimePicker.scss
@@ -59,8 +59,8 @@
   color: inherit;
   cursor: pointer;
   white-space: nowrap;
-  border-radius: var(--hi-radius-sm, 4px);
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  border-radius: var(--radius-sm, 4px);
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover {
     background: var(--hi-color-surface);
@@ -80,13 +80,13 @@
   border: 0;
   width: 1.75rem;
   height: 1.75rem;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: var(--hi-color-muted);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover {
     background: var(--hi-color-surface);
@@ -122,7 +122,7 @@
   appearance: none;
   background: transparent;
   border: 0;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   /* Fixed height keeps the six-row day grid — and therefore the shared
    * stage height — independent of the picker width, so drilling between
    * views never changes the picker's size (enlarged on touch). */
@@ -134,7 +134,7 @@
   cursor: pointer;
   font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
-  transition: background var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled):not(.is-selected) {
     background: var(--hi-color-surface);
@@ -232,8 +232,8 @@
   justify-content: center;
   color: var(--hi-color-muted);
   cursor: pointer;
-  border-radius: var(--hi-radius-sm, 4px);
-  transition: color var(--hi-duration-fast, 0.15s) ease, background var(--hi-duration-fast, 0.15s) ease;
+  border-radius: var(--radius-sm, 4px);
+  transition: color var(--duration-fast, 0.15s) ease, background var(--duration-fast, 0.15s) ease;
 
   &:hover {
     color: var(--hi-color-text-primary);
@@ -266,13 +266,13 @@
   appearance: none;
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   padding: var(--space-4, 4px) var(--space-10, 10px);
   font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   color: var(--hi-color-muted);
   cursor: pointer;
-  transition: color var(--hi-duration-fast, 0.15s) ease, border-color var(--hi-duration-fast, 0.15s) ease;
+  transition: color var(--duration-fast, 0.15s) ease, border-color var(--duration-fast, 0.15s) ease;
 
   &:hover {
     color: var(--hi-color-text-primary);
@@ -300,12 +300,12 @@
   padding: var(--space-4, 4px) var(--space-10, 10px);
   background: var(--hi-color-surface);
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: color-mix(in srgb, var(--hi-color-text-secondary) 70%, transparent);
   font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
   cursor: pointer;
-  transition: border-color var(--hi-duration-fast, 0.15s) ease, color var(--hi-duration-fast, 0.15s) ease;
+  transition: border-color var(--duration-fast, 0.15s) ease, color var(--duration-fast, 0.15s) ease;
 
   &:hover,
   &[aria-expanded="true"] {
@@ -330,7 +330,7 @@
 
 .hk-dtp-trigger-chev {
   color: var(--hi-color-muted);
-  transition: transform var(--hi-duration-fast, 0.15s) ease;
+  transition: transform var(--duration-fast, 0.15s) ease;
 }
 
 .hk-dtp-trigger-chev.is-open {
@@ -378,12 +378,12 @@
   background: var(--hi-color-primary);
   color: rgb(var(--color-on-solid-text, 255 255 255));
   border: 0;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   padding: var(--space-6, 6px) var(--space-14, 14px);
   font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
   cursor: pointer;
-  transition: filter var(--hi-duration-fast, 0.15s) ease;
+  transition: filter var(--duration-fast, 0.15s) ease;
 
   &:hover { filter: brightness(1.08); }
   &:focus-visible { outline: 2px solid color-mix(in srgb, var(--hi-color-primary) 55%, transparent); outline-offset: 2px; }
@@ -400,7 +400,7 @@
   padding: var(--space-8, 8px) var(--space-12, 12px);
   background: var(--hi-color-surface);
   border: 1px solid color-mix(in srgb, var(--hi-color-border) 18%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   color: var(--hi-color-text-primary);
   font-family: inherit;
   font-size: var(--text-sm, 0.875rem);

--- a/packages/vue/src/components/HkDivider.scss
+++ b/packages/vue/src/components/HkDivider.scss
@@ -1,5 +1,5 @@
 .hk-divider {
-  --hk-divider-color: var(--hi-color-border, rgba(0, 0, 0, 0.12));
+  --hk-divider-color: var(--hi-color-border, rgba(100,100,100,0.12));
   flex-shrink: 0;
 
   width: 100%;
@@ -16,11 +16,11 @@
 }
 
 .hk-divider-faint {
-  --hk-divider-color: var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  --hk-divider-color: var(--hi-color-border, rgba(100,100,100,0.06));
 }
 
 .hk-divider-input {
-  --hk-divider-color: var(--hi-color-border, rgba(0, 0, 0, 0.15));
+  --hk-divider-color: var(--hi-color-border, rgba(100,100,100,0.15));
 }
 
 .hk-divider-dashed.hk-divider-vertical {

--- a/packages/vue/src/components/HkDraggableGrid.scss
+++ b/packages/vue/src/components/HkDraggableGrid.scss
@@ -12,9 +12,9 @@
 
 .hk-draggable-grid-row-phantom {
   min-height: 44px;
-  border: 1px dashed var(--hi-color-primary, #58a6ff);
+  border: 1px dashed var(--hi-color-primary, #7aa2f7);
   border-radius: var(--radius-sm, 4px);
-  background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
+  background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.04);
 }
 
 .hk-draggable-grid-cell {
@@ -26,7 +26,7 @@
   padding: var(--space-8, 0.5rem) var(--space-10, 0.625rem);
   border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-subtle, #21262d);
-  border: 1px solid var(--hi-color-border, #30363d);
+  border: 1px solid var(--hi-color-border, #646464);
   transition:
     transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
     opacity 150ms cubic-bezier(0.16, 1, 0.3, 1),
@@ -45,13 +45,13 @@
     opacity: 0.35;
     transform: scale(0.96);
     border-style: dashed;
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.04);
     cursor: grabbing;
   }
 
   &[data-placeholder="before"] {
-    box-shadow: inset 2px 0 0 0 var(--hi-color-primary, #58a6ff);
+    box-shadow: inset 2px 0 0 0 var(--hi-color-primary, #7aa2f7);
   }
 
   &[data-locked] {
@@ -61,30 +61,30 @@
     /* Locked cells never start a drag (tsx returns early) — no hover
      * affordance and no grab cursor on their surface. */
     &:hover {
-      border-color: var(--hi-color-border, #30363d);
+      border-color: var(--hi-color-border, #646464);
     }
   }
 
   .hk-draggable-grid[data-dragging] & {
     &:hover {
-      border-color: var(--hi-color-border, #30363d);
+      border-color: var(--hi-color-border, #646464);
     }
   }
 }
 
 .hk-draggable-grid-row[data-placeholder-row="after"] {
-  box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #58a6ff);
+  box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #7aa2f7);
 }
 
 /* RTL flips the flex flow, so the before/after insertion markers must
  * swap physical sides to keep pointing at the inline edge (HkBreadcrumb
  * precedent for the [dir="rtl"] override form). */
 [dir="rtl"] .hk-draggable-grid-cell[data-placeholder="before"] {
-  box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #58a6ff);
+  box-shadow: inset -2px 0 0 0 var(--hi-color-primary, #7aa2f7);
 }
 
 [dir="rtl"] .hk-draggable-grid-row[data-placeholder-row="after"] {
-  box-shadow: inset 2px 0 0 0 var(--hi-color-primary, #58a6ff);
+  box-shadow: inset 2px 0 0 0 var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-draggable-grid-cell-placeholder-target {

--- a/packages/vue/src/components/HkDraggableList.scss
+++ b/packages/vue/src/components/HkDraggableList.scss
@@ -12,7 +12,7 @@
   padding: var(--space-8, 0.5rem) var(--space-10, 0.625rem);
   border-radius: var(--radius-sm, 4px);
   background: var(--hi-color-bg-subtle, #21262d);
-  border: 1px solid var(--hi-color-border, #30363d);
+  border: 1px solid var(--hi-color-border, #646464);
   transition:
     transform 150ms cubic-bezier(0.16, 1, 0.3, 1),
     opacity 150ms cubic-bezier(0.16, 1, 0.3, 1),
@@ -29,16 +29,16 @@
     opacity: 0.35;
     transform: scale(0.96);
     border-style: dashed;
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.04);
     cursor: grabbing;
   }
 
   &[data-placeholder="before"] {
-    box-shadow: inset 0 2px 0 0 var(--hi-color-primary, #58a6ff);
+    box-shadow: inset 0 2px 0 0 var(--hi-color-primary, #7aa2f7);
   }
   &[data-placeholder="after"] {
-    box-shadow: inset 0 -2px 0 0 var(--hi-color-primary, #58a6ff);
+    box-shadow: inset 0 -2px 0 0 var(--hi-color-primary, #7aa2f7);
   }
 
   &[data-locked] {
@@ -47,7 +47,7 @@
 
   .hk-draggable-list[data-dragging] & {
     &:hover {
-      border-color: var(--hi-color-border, #30363d);
+      border-color: var(--hi-color-border, #646464);
     }
   }
 }

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -11,10 +11,10 @@
 // contract (./_scrim-fade.scss); the panel below owns all the motion.
 @include sf.scrim-fade(
   "hk-drawer-overlay",
-  $enter-duration: var(--hi-duration-normal, 0.3s),
-  $enter-ease: var(--hi-ease-out, cubic-bezier(0.16, 1, 0.3, 1)),
-  $leave-duration: var(--hi-duration-normal, 0.3s),
-  $leave-ease: var(--hi-ease-in, cubic-bezier(0.4, 0, 1, 1))
+  $enter-duration: var(--duration-normal, 0.3s),
+  $enter-ease: var(--ease-elastic, cubic-bezier(0.16, 1, 0.3, 1)),
+  $leave-duration: var(--duration-normal, 0.3s),
+  $leave-ease: var(--ease-in, cubic-bezier(0.4, 0, 1, 1))
 );
 
 .hk-drawer-panel {
@@ -26,8 +26,8 @@
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
   outline: none;
   transition:
-    width var(--hi-duration-normal, 0.3s) ease,
-    height var(--hi-duration-normal, 0.3s) ease;
+    width var(--duration-normal, 0.3s) ease,
+    height var(--duration-normal, 0.3s) ease;
 }
 
 .hk-drawer-left {
@@ -35,7 +35,7 @@
   bottom: 0;
   left: 0;
   border-right: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  border-radius: 0 var(--hi-radius-md, 0.5rem) var(--hi-radius-md, 0.5rem) 0;
+  border-radius: 0 var(--radius-md, 0.5rem) var(--radius-md, 0.5rem) 0;
 }
 
 .hk-drawer-right {
@@ -43,7 +43,7 @@
   bottom: 0;
   right: 0;
   border-left: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  border-radius: var(--hi-radius-md, 0.5rem) 0 0 var(--hi-radius-md, 0.5rem);
+  border-radius: var(--radius-md, 0.5rem) 0 0 var(--radius-md, 0.5rem);
 }
 
 .hk-drawer-top {
@@ -51,7 +51,7 @@
   left: 0;
   right: 0;
   border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  border-radius: 0 0 var(--hi-radius-md, 0.5rem) var(--hi-radius-md, 0.5rem);
+  border-radius: 0 0 var(--radius-md, 0.5rem) var(--radius-md, 0.5rem);
 }
 
 .hk-drawer-bottom {
@@ -59,7 +59,7 @@
   left: 0;
   right: 0;
   border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  border-radius: var(--hi-radius-md, 0.5rem) var(--hi-radius-md, 0.5rem) 0 0;
+  border-radius: var(--radius-md, 0.5rem) var(--radius-md, 0.5rem) 0 0;
 }
 
 .hk-drawer-left-enter-active,
@@ -71,8 +71,8 @@
      that briefly opens a gap between the panel edge and the screen
      edge. Both properties use the same plain ease-out. */
   transition:
-    opacity var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1),
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+    opacity var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1),
+    transform var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-drawer-left-leave-active,
@@ -80,8 +80,8 @@
 .hk-drawer-top-leave-active,
 .hk-drawer-bottom-leave-active {
   transition:
-    opacity var(--hi-duration-normal, 0.3s) cubic-bezier(0.4, 0, 1, 1),
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.4, 0, 1, 1);
+    opacity var(--duration-normal, 0.3s) cubic-bezier(0.4, 0, 1, 1),
+    transform var(--duration-normal, 0.3s) cubic-bezier(0.4, 0, 1, 1);
 }
 
 .hk-drawer-left-enter-from,
@@ -180,8 +180,8 @@
 @media (max-width: 767px) {
   .hk-drawer-bottom {
     bottom: var(--hk-sheet-bottom-gap, 0px);
-    border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
-                   var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+    border-radius: var(--hk-modal-radius, var(--radius-lg, 12px))
+                   var(--hk-modal-radius, var(--radius-lg, 12px))
                    0 0;
     // The inline maxHeight from the `size` prop must lose to the family cap
     // (plain-vh fallback first for dvh-less engines, then dvh) — same

--- a/packages/vue/src/components/HkDrawer.scss
+++ b/packages/vue/src/components/HkDrawer.scss
@@ -21,7 +21,7 @@
   position: fixed;
   display: flex;
   flex-direction: column;
-  background: var(--hk-drawer-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
+  background: var(--hk-drawer-bg, var(--hi-color-surface, rgba(240,244,248,0.95)));
   backdrop-filter: blur(12px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.16);
   outline: none;
@@ -34,7 +34,7 @@
   top: 0;
   bottom: 0;
   left: 0;
-  border-right: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border-right: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   border-radius: 0 var(--radius-md, 0.5rem) var(--radius-md, 0.5rem) 0;
 }
 
@@ -42,7 +42,7 @@
   top: 0;
   bottom: 0;
   right: 0;
-  border-left: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border-left: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   border-radius: var(--radius-md, 0.5rem) 0 0 var(--radius-md, 0.5rem);
 }
 
@@ -50,7 +50,7 @@
   top: 0;
   left: 0;
   right: 0;
-  border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border-bottom: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   border-radius: 0 0 var(--radius-md, 0.5rem) var(--radius-md, 0.5rem);
 }
 
@@ -58,7 +58,7 @@
   bottom: 0;
   left: 0;
   right: 0;
-  border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border-top: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   border-radius: var(--radius-md, 0.5rem) var(--radius-md, 0.5rem) 0 0;
 }
 
@@ -113,14 +113,14 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-12, 0.75rem) var(--space-16, 1rem);
-  border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  border-bottom: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   flex-shrink: 0;
 }
 
 .hk-drawer-title {
   font-size: var(--text-base, 0.875rem);
   font-weight: 700;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 // Legacy placement hook — the chrome lives on the shared .hk-icon-button
@@ -162,7 +162,7 @@
   /* HkMenuPanel carries its own inset; zero this variable when the
      footer hosts one so both edges align. */
   padding: var(--hk-drawer-footer-padding, var(--space-12, 0.75rem) var(--space-16, 1rem));
-  border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  border-top: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   flex-shrink: 0;
 }
 

--- a/packages/vue/src/components/HkDrawer.sheetfamily.test.ts
+++ b/packages/vue/src/components/HkDrawer.sheetfamily.test.ts
@@ -60,7 +60,7 @@ describe("HkDrawer mobile bottom sheet-family contract", () => {
   });
 
   it("adopts the 12px family corner radius", () => {
-    expect(drawer).toContain("border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))");
+    expect(drawer).toContain("border-radius: var(--hk-modal-radius, var(--radius-lg, 12px))");
   });
 
   it("stacks the home-bar safe area on the mobile footer's BOTTOM axis", () => {

--- a/packages/vue/src/components/HkEmptyState.scss
+++ b/packages/vue/src/components/HkEmptyState.scss
@@ -8,7 +8,7 @@
   background: var(--hk-empty-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
   backdrop-filter: blur(var(--blur-sm, 8px));
   border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
-  border-radius: var(--hi-radius-md, 0.5rem);
+  border-radius: var(--radius-md, 0.5rem);
   box-sizing: border-box;
 }
 

--- a/packages/vue/src/components/HkEmptyState.scss
+++ b/packages/vue/src/components/HkEmptyState.scss
@@ -5,9 +5,9 @@
   justify-content: center;
   padding: var(--space-48, 3rem) var(--space-16, 1rem);
   text-align: center;
-  background: var(--hk-empty-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
+  background: var(--hk-empty-bg, var(--hi-color-surface, rgba(240,244,248,0.95)));
   backdrop-filter: blur(var(--blur-sm, 8px));
-  border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  border: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   border-radius: var(--radius-md, 0.5rem);
   box-sizing: border-box;
 }
@@ -16,7 +16,7 @@
   width: var(--space-48, 3rem);
   height: var(--space-48, 3rem);
   margin-bottom: var(--space-12, 0.75rem);
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   opacity: 0.5;
   display: flex;
   align-items: center;
@@ -26,13 +26,13 @@
 .hk-empty-title {
   font-size: var(--text-base, 0.875rem);
   font-weight: 600;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-empty-desc {
   font-size: var(--text-sm, 0.8125rem);
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   margin: 0 0 var(--space-16, 1rem);
   max-width: 24rem;
   line-height: 1.5;

--- a/packages/vue/src/components/HkFab.scss
+++ b/packages/vue/src/components/HkFab.scss
@@ -51,10 +51,10 @@
   -webkit-appearance: none;
   padding: 0;
   border: none;
-  border-radius: var(--hi-radius-full, 9999px);
+  border-radius: var(--radius-full, 9999px);
   cursor: pointer;
   font-family: inherit;
-  transition: transform var(--hi-duration-fast, 0.15s) ease, box-shadow var(--hi-duration-fast, 0.15s) ease;
+  transition: transform var(--duration-fast, 0.15s) ease, box-shadow var(--duration-fast, 0.15s) ease;
 
   &:active:not(:disabled) { transform: scale(0.94); }
   &:focus-visible { outline: 2px solid var(--hi-color-primary, #7aa2f7); outline-offset: 2px; }
@@ -132,13 +132,13 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   color: var(--hi-color-text-secondary, #555);
   background: color-mix(in srgb, var(--hi-color-surface, #fff) 82%, transparent);
   border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
-  border-radius: var(--hi-radius-full, 9999px);
+  border-radius: var(--radius-full, 9999px);
   cursor: pointer;
   backdrop-filter: blur(var(--blur-xs, 4px));
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.12);
   opacity: 0;
   transform: scale(0.4);
-  transition: opacity var(--hi-duration-fast, 0.15s) ease, transform var(--hi-duration-fast, 0.15s) ease;
+  transition: opacity var(--duration-fast, 0.15s) ease, transform var(--duration-fast, 0.15s) ease;
 
   .hk-fab-mini-icon {
     display: inline-flex;

--- a/packages/vue/src/components/HkFab.scss
+++ b/packages/vue/src/components/HkFab.scss
@@ -84,13 +84,13 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
 }
 
 .hk-fab[data-variant="glass"] .hk-fab-button {
-  color: var(--hi-color-text-secondary, #555);
-  background: color-mix(in srgb, var(--hi-color-surface, #fff) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
+  color: var(--hi-color-text-secondary, #666666);
+  background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(100,100,100,0.12)) 25%, transparent);
   backdrop-filter: blur(var(--blur-xs, 4px)); // chip language shared with autotag pills
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
 
-  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #fff) 92%, transparent); }
+  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 92%, transparent); }
 }
 
 .hk-fab[data-variant="primary"] .hk-fab-button {
@@ -129,9 +129,9 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   font-size: 0.6875rem;
   letter-spacing: 0.02em;
   white-space: nowrap;
-  color: var(--hi-color-text-secondary, #555);
-  background: color-mix(in srgb, var(--hi-color-surface, #fff) 82%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.12)) 25%, transparent);
+  color: var(--hi-color-text-secondary, #666666);
+  background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(100,100,100,0.12)) 25%, transparent);
   border-radius: var(--radius-full, 9999px);
   cursor: pointer;
   backdrop-filter: blur(var(--blur-xs, 4px));
@@ -149,7 +149,7 @@ $sizes: (sm: 34px, md: 42px, lg: 50px);
   &:focus-visible { outline: 2px solid var(--hi-color-primary, #7aa2f7); outline-offset: 1px; }
   &:disabled { opacity: 0.35; cursor: not-allowed; }
   // 82%→94% mirrors the main glass hover ladder (78%→92%).
-  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #fff) 94%, transparent); }
+  &:hover:not(:disabled) { background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 94%, transparent); }
 }
 
 // Staggered reveal while expanded (CSS only, via nth-child delay).

--- a/packages/vue/src/components/HkFileField.scss
+++ b/packages/vue/src/components/HkFileField.scss
@@ -69,7 +69,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary, #58a6ff);
+    outline: 2px solid var(--hi-color-primary, #7aa2f7);
     outline-offset: 2px;
     border-radius: var(--radius-xs, 2px);
   }
@@ -117,7 +117,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary, #58a6ff);
+    outline: 2px solid var(--hi-color-primary, #7aa2f7);
     outline-offset: 1px;
   }
 }

--- a/packages/vue/src/components/HkFilePickerField.scss
+++ b/packages/vue/src/components/HkFilePickerField.scss
@@ -54,8 +54,8 @@
   width: 1.75rem;
   height: 1.75rem;
   border-radius: var(--radius-xs, 2px);
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 14%, transparent);
-  color: var(--hi-color-primary, #58a6ff);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 14%, transparent);
+  color: var(--hi-color-primary, #7aa2f7);
   pointer-events: none;
 }
 

--- a/packages/vue/src/components/HkImagePreview.scss
+++ b/packages/vue/src/components/HkImagePreview.scss
@@ -9,7 +9,7 @@
   width: 100%;
   overflow: hidden;
   background: var(--hi-color-gray-100, rgba(0, 0, 0, 0.04));
-  border: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   border-radius: var(--radius-md, 8px);
 }
 
@@ -19,10 +19,10 @@
   transition: border-color 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 
   &:hover {
-    border-color: var(--hi-color-primary, #58a6ff);
+    border-color: var(--hi-color-primary, #7aa2f7);
     // Emphasis drawn INSIDE the border box (HkSelectionGrid precedent):
     // outer spread rings get shaved per-side by overlapping chrome.
-    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #58a6ff);
+    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #7aa2f7);
   }
 
   // Press feedback matching the house button pattern (HkButton variants,
@@ -32,7 +32,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid var(--hi-color-primary, #58a6ff);
+    outline: 2px solid var(--hi-color-primary, #7aa2f7);
     outline-offset: 2px;
   }
 }
@@ -65,9 +65,9 @@
   justify-content: center;
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 18%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-image-preview-shimmer 1.5s ease-in-out infinite;
@@ -95,7 +95,7 @@
   justify-content: center;
   gap: var(--space-8, 0.5rem);
   padding: var(--space-12, 0.75rem);
-  color: var(--hi-color-muted, #666);
+  color: var(--hi-color-muted, #6c6c6c);
   text-align: center;
 }
 

--- a/packages/vue/src/components/HkInput.scss
+++ b/packages/vue/src/components/HkInput.scss
@@ -267,11 +267,11 @@
    * bare "R G B" triplet, so using it directly as a color is invalid at
    * computed-value time (the rule silently inherits); --color-text-primary
    * is not defined anywhere. --hi-color-* wrap the triplets in rgb(). */
-  color: var(--hi-color-text-secondary, #888);
+  color: var(--hi-color-text-secondary, #666666);
   cursor: pointer;
 
   &:hover {
-    color: var(--hi-color-text-primary, #222);
+    color: var(--hi-color-text-primary, #1e1e1e);
   }
 
   // Keyboard parity (house icon-button pattern, HkIconButton): this real

--- a/packages/vue/src/components/HkJsonTree.scss
+++ b/packages/vue/src/components/HkJsonTree.scss
@@ -69,8 +69,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: var(--jt-toggle);
-  height: var(--jt-toggle);
+  width: var(--jt-toggle, 1rem);
+  height: var(--jt-toggle, 1rem);
   flex-shrink: 0;
   margin-inline-end: var(--space-2, 0.125rem);
   /* The toggle box has no text baseline of its own — pin it to the line

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -15,7 +15,7 @@
   padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-kw-border, rgb(var(--color-border) / 8%));
-  border-radius: var(--hi-radius-lg, 0.75rem);
+  border-radius: var(--radius-lg, 0.75rem);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:focus-within {
@@ -48,7 +48,7 @@
   cursor: pointer;
   display: inline-flex;
   padding: var(--space-2, 0.125rem);
-  border-radius: var(--hi-radius-sm, 0.25rem);
+  border-radius: var(--radius-sm, 0.25rem);
 
   &:hover {
     color: var(--hi-color-text-primary, #333);
@@ -76,7 +76,7 @@
   text-align: start;
   background: transparent;
   border: 1px solid transparent;
-  border-radius: var(--hi-radius-sm, 0.25rem);
+  border-radius: var(--radius-sm, 0.25rem);
   padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   cursor: pointer;
   width: 100%;
@@ -133,7 +133,7 @@
   color: var(--hi-color-primary, #58a6ff);
   background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
   padding: 0 var(--space-6, 0.375rem);
-  border-radius: var(--hi-radius-sm, 0.25rem);
+  border-radius: var(--radius-sm, 0.25rem);
   line-height: 1.5;
 }
 
@@ -156,5 +156,5 @@
   color: var(--hi-color-text-secondary, #666);
   background: rgb(var(--color-border) / 4%);
   padding: 0 var(--space-6, 0.375rem);
-  border-radius: var(--hi-radius-sm, 0.25rem);
+  border-radius: var(--radius-sm, 0.25rem);
 }

--- a/packages/vue/src/components/HkKeywordSearchModal.scss
+++ b/packages/vue/src/components/HkKeywordSearchModal.scss
@@ -13,19 +13,19 @@
   align-items: center;
   gap: var(--space-8, 0.5rem);
   padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
-  background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
+  background: var(--hi-color-surface, rgba(240,244,248,0.95));
   border: 1px solid var(--hk-kw-border, rgb(var(--color-border) / 8%));
   border-radius: var(--radius-lg, 0.75rem);
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 
   &:focus-within {
-    border-color: var(--hi-color-primary, #58a6ff);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 12%, transparent);
   }
 }
 
 .hk-kw-search-icon {
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   flex-shrink: 0;
 }
 
@@ -36,7 +36,7 @@
   background: transparent;
   border: 0;
   outline: none;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   font-size: var(--text-base, 0.875rem);
 }
 
@@ -44,18 +44,18 @@
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   cursor: pointer;
   display: inline-flex;
   padding: var(--space-2, 0.125rem);
   border-radius: var(--radius-sm, 0.25rem);
 
   &:hover {
-    color: var(--hi-color-text-primary, #333);
+    color: var(--hi-color-text-primary, #1e1e1e);
   }
 
   &:focus-visible {
-    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 55%, transparent);
     outline-offset: 2px;
   }
 }
@@ -80,16 +80,16 @@
   padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   cursor: pointer;
   width: 100%;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   transition: background 0.15s ease, border-color 0.15s ease;
 
   &:hover {
-    background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
+    background: var(--hi-color-surface, rgba(240,244,248,0.95));
     border-color: rgb(var(--color-border) / 6%);
   }
 
   &:focus-visible {
-    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+    outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 55%, transparent);
     outline-offset: 2px;
   }
 }
@@ -100,7 +100,7 @@
   padding: var(--space-48, 3rem) var(--space-8, 0.5rem);
   text-align: center;
   font-size: var(--text-base, 0.875rem);
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 .hk-kw-search-semantic {
@@ -120,7 +120,7 @@
 .hk-kw-search-semantic-title {
   font-size: var(--text-base, 0.875rem);
   font-weight: 600;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -130,8 +130,8 @@
   flex-shrink: 0;
   font-size: var(--text-xs, 0.75rem);
   font-variant-numeric: tabular-nums;
-  color: var(--hi-color-primary, #58a6ff);
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 12%, transparent);
+  color: var(--hi-color-primary, #7aa2f7);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 12%, transparent);
   padding: 0 var(--space-6, 0.375rem);
   border-radius: var(--radius-sm, 0.25rem);
   line-height: 1.5;
@@ -139,7 +139,7 @@
 
 .hk-kw-search-semantic-snippet {
   font-size: var(--text-xs, 0.75rem);
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   line-height: 1.5;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -153,7 +153,7 @@
   font-size: var(--text-xs, 0.75rem);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   background: rgb(var(--color-border) / 4%);
   padding: 0 var(--space-6, 0.375rem);
   border-radius: var(--radius-sm, 0.25rem);

--- a/packages/vue/src/components/HkLabel.scss
+++ b/packages/vue/src/components/HkLabel.scss
@@ -11,7 +11,7 @@
   display: inline;
   font-size: var(--text-base, 0.875rem);
   line-height: 1.5;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
 
   &.hk-label-sm {
     font-size: var(--text-xs, 0.75rem);
@@ -22,7 +22,7 @@
   }
 
   a {
-    color: var(--hi-color-primary, #58a6ff);
+    color: var(--hi-color-primary, #7aa2f7);
     font-weight: 500;
     text-decoration: none;
     cursor: pointer;
@@ -32,7 +32,7 @@
     }
 
     &:focus-visible {
-      outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 55%, transparent);
+      outline: 2px solid color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 55%, transparent);
       outline-offset: 2px;
     }
   }

--- a/packages/vue/src/components/HkListTransition.scss
+++ b/packages/vue/src/components/HkListTransition.scss
@@ -4,7 +4,7 @@
 .hk-list-pop-move,
 .hk-list-slide-move,
 .hk-list-fade-move {
-  transition: transform var(--hi-duration-normal, 0.3s) ease;
+  transition: transform var(--duration-normal, 0.3s) ease;
 }
 
 .hk-list-move-disabled {
@@ -13,14 +13,14 @@
 
 .hk-list-pop-enter-active {
   transition:
-    opacity var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1),
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+    opacity var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1),
+    transform var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-list-pop-leave-active {
   transition:
-    opacity var(--hi-duration-normal, 0.3s) ease-in,
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.5, 0, 0.75, 0);
+    opacity var(--duration-normal, 0.3s) ease-in,
+    transform var(--duration-normal, 0.3s) cubic-bezier(0.5, 0, 0.75, 0);
   position: absolute;
 }
 
@@ -36,14 +36,14 @@
 
 .hk-list-slide-enter-active {
   transition:
-    opacity var(--hi-duration-normal, 0.3s) ease,
-    transform var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+    opacity var(--duration-normal, 0.3s) ease,
+    transform var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-list-slide-leave-active {
   transition:
-    opacity var(--hi-duration-normal, 0.3s) ease-in,
-    transform var(--hi-duration-normal, 0.3s) ease-in;
+    opacity var(--duration-normal, 0.3s) ease-in,
+    transform var(--duration-normal, 0.3s) ease-in;
   position: absolute;
 }
 
@@ -68,11 +68,11 @@
 }
 
 .hk-list-fade-enter-active {
-  transition: opacity var(--hi-duration-normal, 0.3s) ease;
+  transition: opacity var(--duration-normal, 0.3s) ease;
 }
 
 .hk-list-fade-leave-active {
-  transition: opacity var(--hi-duration-normal, 0.3s) ease-in;
+  transition: opacity var(--duration-normal, 0.3s) ease-in;
   position: absolute;
 }
 
@@ -83,9 +83,9 @@
 
 .hk-list-grow-enter-active {
   transition:
-    transform var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
-    opacity var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
-  transition-delay: var(--hi-duration-fast, 0.15s);
+    transform var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
+    opacity var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: var(--duration-fast, 0.15s);
   pointer-events: none;
 }
 
@@ -96,8 +96,8 @@
 
 .hk-list-grow-leave-active {
   transition:
-    transform var(--hi-duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
-    opacity var(--hi-duration-fast, 0.15s) ease-in;
+    transform var(--duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
+    opacity var(--duration-fast, 0.15s) ease-in;
   pointer-events: none;
   position: absolute;
   width: 100%;
@@ -109,16 +109,16 @@
 }
 
 .hk-list-grow-move {
-  transition: transform var(--hi-duration-fast, 0.15s) ease;
-  transition-delay: var(--hi-duration-fast, 0.15s);
+  transition: transform var(--duration-fast, 0.15s) ease;
+  transition-delay: var(--duration-fast, 0.15s);
 }
 
 .hk-list-reveal-enter-active {
   interpolate-size: allow-keywords;
   overflow: hidden;
   transition:
-    height var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
-    opacity var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
+    height var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
+    opacity var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-list-reveal-leave-active {
@@ -128,8 +128,8 @@
    * activating the body of a just-erased row would resurrect it. */
   pointer-events: none;
   transition:
-    height var(--hi-duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
-    opacity var(--hi-duration-fast, 0.15s) ease-in;
+    height var(--duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
+    opacity var(--duration-fast, 0.15s) ease-in;
 }
 
 .hk-list-reveal-enter-from,
@@ -139,7 +139,7 @@
 }
 
 .hk-list-reveal-move {
-  transition: transform var(--hi-duration-fast, 0.15s) ease;
+  transition: transform var(--duration-fast, 0.15s) ease;
 }
 
 .hk-list-none-enter-active,

--- a/packages/vue/src/components/HkLogo.scss
+++ b/packages/vue/src/components/HkLogo.scss
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  border-radius: var(--hi-radius-md, 8px);
+  border-radius: var(--radius-md, 8px);
   overflow: hidden;
   flex-shrink: 0;
   user-select: none;
@@ -23,7 +23,7 @@ a.hk-logo:focus-visible {
 
 .hk-logo-img {
   display: block;
-  border-radius: var(--hi-radius-md, 8px);
+  border-radius: var(--radius-md, 8px);
   object-fit: contain;
 }
 

--- a/packages/vue/src/components/HkLogo.scss
+++ b/packages/vue/src/components/HkLogo.scss
@@ -34,7 +34,7 @@ a.hk-logo:focus-visible {
   /* Contract token with hex fallback (house idiom). No radius here: the
    * only render site is inside .hk-logo, whose matching border-radius +
    * overflow: hidden already clip this exactly-fitting child. */
-  background: var(--hi-color-primary, #58a6ff);
+  background: var(--hi-color-primary, #7aa2f7);
   color: rgb(var(--color-on-solid-text, 255 255 255));
 }
 

--- a/packages/vue/src/components/HkMarkdownRenderer.scss
+++ b/packages/vue/src/components/HkMarkdownRenderer.scss
@@ -4,7 +4,7 @@
 .hk-markdown {
   font-size: var(--text-base);
   line-height: 1.7;
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
   position: relative;
 }
 
@@ -17,7 +17,7 @@
 .hk-markdown h3 {
   font-weight: 700;
   margin: 1.25em 0 0.5em;
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 .hk-markdown h1 { font-size: 1.5em; }
@@ -97,7 +97,7 @@
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-xs);
   line-height: 1.6;
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -106,7 +106,7 @@
   margin: 0.75em 0;
   padding: 0.5em 1em;
   border-inline-start: 3px solid var(--hi-color-text-tertiary, #8b949e);
-  color: var(--hi-color-text-secondary, #8b949e);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 .hk-markdown table {
@@ -118,7 +118,7 @@
 .hk-markdown th,
 .hk-markdown td {
   padding: 0.5em 0.75em;
-  border: 1px solid var(--hi-color-border, #30363d);
+  border: 1px solid var(--hi-color-border, #646464);
   text-align: start;
 }
 
@@ -128,7 +128,7 @@
 }
 
 .hk-markdown a {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
   text-decoration: none;
 }
 
@@ -140,13 +140,13 @@
    the house :focus-visible ring (HkFab/HkContextRing pattern). Ring uses
    the same contract var as the link ink so it matches in every theme. */
 .hk-markdown a:focus-visible {
-  outline: 2px solid var(--hi-color-primary, #58a6ff);
+  outline: 2px solid var(--hi-color-primary, #7aa2f7);
   outline-offset: 2px;
 }
 
 .hk-markdown hr {
   border: none;
-  border-top: 1px solid var(--hi-color-border, #30363d);
+  border-top: 1px solid var(--hi-color-border, #646464);
   margin: 1em 0;
 }
 
@@ -161,7 +161,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: color-mix(in srgb, var(--hi-color-surface, #fff) 70%, transparent);
+  background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 70%, transparent);
   backdrop-filter: blur(4px);
   z-index: 10;
 }

--- a/packages/vue/src/components/HkMediaSlider.scss
+++ b/packages/vue/src/components/HkMediaSlider.scss
@@ -42,7 +42,7 @@
   box-shadow: 0 1px 3px rgb(0 0 0 / 35%);
   transform: translateY(-50%);
   opacity: 0;
-  transition: opacity var(--hi-duration-short, 0.15s);
+  transition: opacity var(--duration-short, 0.15s);
   pointer-events: none;
 }
 

--- a/packages/vue/src/components/HkMinimap.scss
+++ b/packages/vue/src/components/HkMinimap.scss
@@ -68,8 +68,8 @@
   color: rgb(var(--color-text));
   cursor: pointer;
   transition:
-    background var(--hi-duration-fast, 0.15s) ease,
-    color var(--hi-duration-fast, 0.15s) ease;
+    background var(--duration-fast, 0.15s) ease,
+    color var(--duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled) {
     background: rgb(var(--color-primary) / 0.1);

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -71,9 +71,9 @@
   transition:
     height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1)),
     max-height var(--duration-fast, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
-  background: var(--hk-modal-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
+  background: var(--hk-modal-bg, var(--hi-color-surface, rgba(240,244,248,0.95)));
   backdrop-filter: var(--hk-modal-blur, blur(12px));
-  border: 1px solid var(--hk-modal-border-color, var(--hi-color-border, rgba(0, 0, 0, 0.08)));
+  border: 1px solid var(--hk-modal-border-color, var(--hi-color-border, rgba(100,100,100,0.08)));
   border-radius: var(--hk-modal-radius, var(--radius-lg, 12px));
   box-shadow:
     0 16px 48px rgba(0, 0, 0, 0.2),
@@ -141,7 +141,7 @@
   justify-content: space-between;
   padding: var(--hk-modal-padding-header, 1rem 1.5rem);
   border-bottom: 1px solid
-    var(--hk-modal-divider-color, var(--hi-color-border, rgba(0, 0, 0, 0.06)));
+    var(--hk-modal-divider-color, var(--hi-color-border, rgba(100,100,100,0.06)));
   flex-shrink: 0;
 }
 
@@ -167,7 +167,7 @@
   font-size: var(--hk-modal-title-font-size, 1.125rem);
   font-weight: var(--hk-modal-title-font-weight, 700);
   margin: 0;
-  color: var(--hk-modal-title-color, var(--hi-color-text-primary, #333));
+  color: var(--hk-modal-title-color, var(--hi-color-text-primary, #1e1e1e));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -192,7 +192,7 @@
 .hk-modal-subheader {
   padding: var(--hk-modal-padding-subheader, 0.75rem 1.5rem 0.75rem);
   border-bottom: 1px solid
-    var(--hk-modal-divider-color, var(--hi-color-border, rgba(0, 0, 0, 0.06)));
+    var(--hk-modal-divider-color, var(--hi-color-border, rgba(100,100,100,0.06)));
   flex-shrink: 0;
 }
 
@@ -206,7 +206,7 @@
   flex-direction: column;
   overflow: hidden;
   position: relative;
-  color: var(--hk-modal-body-color, var(--hi-color-text-primary, #333));
+  color: var(--hk-modal-body-color, var(--hi-color-text-primary, #1e1e1e));
   flex: 1;
   min-height: 0;
 }
@@ -262,9 +262,9 @@
   padding: var(--space-2) var(--space-8);
   font-size: var(--text-2xs);
   letter-spacing: 0.04em;
-  color: var(--hi-color-muted, #666);
-  background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
+  color: var(--hi-color-muted, #6c6c6c);
+  background: color-mix(in srgb, var(--hi-color-surface, rgba(240,244,248,0.95)) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(100,100,100,0.08)) 12%, transparent);
   border-radius: var(--radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;
@@ -285,7 +285,7 @@
 .hk-modal-footer {
   padding: var(--hk-modal-padding-footer, 0.75rem 1.5rem);
   border-top: 1px solid
-    var(--hk-modal-divider-color, var(--hi-color-border, rgba(0, 0, 0, 0.06)));
+    var(--hk-modal-divider-color, var(--hi-color-border, rgba(100,100,100,0.06)));
   display: flex;
   justify-content: flex-end;
   gap: var(--space-8);

--- a/packages/vue/src/components/HkModal.scss
+++ b/packages/vue/src/components/HkModal.scss
@@ -74,7 +74,7 @@
   background: var(--hk-modal-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
   backdrop-filter: var(--hk-modal-blur, blur(12px));
   border: 1px solid var(--hk-modal-border-color, var(--hi-color-border, rgba(0, 0, 0, 0.08)));
-  border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px));
+  border-radius: var(--hk-modal-radius, var(--radius-lg, 12px));
   box-shadow:
     0 16px 48px rgba(0, 0, 0, 0.2),
     0 0 0 1px rgba(255, 255, 255, 0.05) inset;
@@ -265,7 +265,7 @@
   color: var(--hi-color-muted, #666);
   background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
   border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
-  border-radius: var(--hi-radius-full, 9999px);
+  border-radius: var(--radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;
 }
@@ -332,8 +332,8 @@
     left: 0;
     right: 0;
     transform: none;
-    border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
-                   var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+    border-radius: var(--hk-modal-radius, var(--radius-lg, 12px))
+                   var(--hk-modal-radius, var(--radius-lg, 12px))
                    0 0;
     border-left: 0;
     border-right: 0;

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -13,7 +13,7 @@
   // family don't collapse this strip (8px→4px gap, 32px→16px padding).
   gap: var(--space-8, 0.5rem);
   padding: var(--space-12, 0.75rem) var(--space-32, 2rem);
-  background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
+  background: var(--hi-color-surface, rgba(240,244,248,0.95));
   border: 1px solid var(--hk-breadcrumb-border, rgba(0, 0, 0, 0.06));
   border-radius: var(--radius-md, 0.5rem);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
@@ -35,16 +35,16 @@
   line-height: 1.4;
   font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   white-space: nowrap;
 }
 
 .hk-modal-breadcrumb-item-current {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-modal-breadcrumb-sep {
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   opacity: 0.5;
   flex-shrink: 0;
 }

--- a/packages/vue/src/components/HkModalBreadcrumb.scss
+++ b/packages/vue/src/components/HkModalBreadcrumb.scss
@@ -15,7 +15,7 @@
   padding: var(--space-12, 0.75rem) var(--space-32, 2rem);
   background: var(--hi-color-surface, rgba(255, 255, 255, 0.95));
   border: 1px solid var(--hk-breadcrumb-border, rgba(0, 0, 0, 0.06));
-  border-radius: var(--hi-radius-md, 0.5rem);
+  border-radius: var(--radius-md, 0.5rem);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(var(--blur-md));
   pointer-events: none;

--- a/packages/vue/src/components/HkNavItem.scss
+++ b/packages/vue/src/components/HkNavItem.scss
@@ -27,8 +27,8 @@
   text-align: start;
   cursor: pointer;
   transition:
-    background-color var(--hi-duration-fast, 0.15s) ease,
-    color var(--hi-duration-fast, 0.15s) ease;
+    background-color var(--duration-fast, 0.15s) ease,
+    color var(--duration-fast, 0.15s) ease;
   user-select: none;
 
   /* Interaction-state precedence: ACTIVE > HOVER > NONE.

--- a/packages/vue/src/components/HkNumberInput.scss
+++ b/packages/vue/src/components/HkNumberInput.scss
@@ -25,7 +25,7 @@
   align-items: center;
   background: var(--hi-color-surface);
   border: 1px solid var(--hi-color-border);
-  border-radius: var(--hi-radius-md, 8px);
+  border-radius: var(--radius-md, 8px);
   overflow: hidden;
   transition:
     background-color var(--hi-transition-base, 200ms cubic-bezier(0.4, 0, 0.2, 1)),
@@ -117,8 +117,8 @@
   color: var(--hi-color-muted);
   cursor: pointer;
   transition:
-    background-color var(--hi-duration-fast, 0.15s) ease,
-    color var(--hi-duration-fast, 0.15s) ease;
+    background-color var(--duration-fast, 0.15s) ease,
+    color var(--duration-fast, 0.15s) ease;
 
   &:hover:not(:disabled) {
     background: color-mix(in srgb, var(--hi-color-surface) 60%, transparent);

--- a/packages/vue/src/components/HkPasswordInput.scss
+++ b/packages/vue/src/components/HkPasswordInput.scss
@@ -36,13 +36,13 @@
 }
 
 .hk-pwd-box:hover:not([data-disabled]) {
-  border-color: var(--hi-color-primary, #58a6ff);
+  border-color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-pwd-box:focus-within,
 .hk-pwd-box[data-focused] {
-  border-color: var(--hi-color-primary, #58a6ff);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 15%, transparent);
+  border-color: var(--hi-color-primary, #7aa2f7);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 15%, transparent);
 }
 
 .hk-pwd-box[data-error] {
@@ -60,7 +60,7 @@
 }
 
 .hk-pwd-box[data-fw] {
-  border-color: var(--hi-color-warning, #d29922);
+  border-color: var(--hi-color-warning, #eed677);
 }
 
 .hk-pwd-box[data-flash] {
@@ -69,14 +69,14 @@
 
 @keyframes hk-pwd-flash {
   0% {
-    border-color: var(--hi-color-primary, #58a6ff);
+    border-color: var(--hi-color-primary, #7aa2f7);
     box-shadow:
-      0 0 22px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 38%, transparent),
-      inset 0 0 10px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 7%, transparent);
+      0 0 22px color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 38%, transparent),
+      inset 0 0 10px color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 7%, transparent);
   }
   100% {
-    border-color: var(--hi-color-primary, #58a6ff);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #58a6ff) 15%, transparent);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 15%, transparent);
   }
 }
 
@@ -91,13 +91,13 @@
 }
 
 .hk-pwd-lock-empty {
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   opacity: 0.4;
   pointer-events: none;
 }
 
 .hk-pwd-lock-filled {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
   cursor: pointer;
 }
 
@@ -105,12 +105,12 @@
  * hint's hover; suppressed while revealing (press restores full
  * primary) and while disabled (reveal is unreachable). */
 .hk-pwd-box:not([data-disabled]) .hk-pwd-lock-filled:hover:not([data-revealing]) {
-  color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 75%, transparent);
+  color: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 75%, transparent);
 }
 
 .hk-pwd-box:focus-within .hk-pwd-lock,
 .hk-pwd-box[data-focused] .hk-pwd-lock {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-pwd-dots {
@@ -132,7 +132,7 @@
   z-index: 1;
   user-select: none;
   font-size: var(--text-base);
-  color: var(--hi-color-primary, rgba(88, 166, 255, 0.7));
+  color: var(--hi-color-primary, rgba(122,162,247,0.7));
   animation: hk-pwd-breathe 3s ease-in-out infinite;
   /* Default overflow strategy: hard-cut with an ellipsis (the marquee
    * variant layers its own clipping window inside this element). */
@@ -145,7 +145,7 @@
   /* Waiting-for-input placeholder turns italic + grey while focused,
      matching the blur/select hints' style. */
   font-style: italic;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 @keyframes hk-pwd-breathe {
@@ -174,18 +174,18 @@
   user-select: none;
   font-size: var(--text-base);
   font-style: italic;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   cursor: pointer;
   transition: color 0.3s ease;
   animation: hk-pwd-breathe 3s ease-in-out infinite;
 }
 
 .hk-pwd-blur-hint:hover {
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 .hk-pwd-blur-hint:active {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-pwd-select-hint {
@@ -198,7 +198,7 @@
   user-select: none;
   font-size: var(--text-base);
   font-style: italic;
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
   pointer-events: none;
   animation: hk-pwd-breathe 3s ease-in-out infinite;
 }
@@ -215,7 +215,7 @@
   font-family: var(--font-mono, vars.$hikari-font-family-mono);
   font-size: var(--text-sm);
   letter-spacing: 0.04em;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 .hk-pwd-input {
@@ -253,13 +253,13 @@
 }
 
 .hk-pwd-strength[data-level="fair"] {
-  background: var(--hi-color-warning, #d29922);
-  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-warning, #d29922) 60%, transparent);
+  background: var(--hi-color-warning, #eed677);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-warning, #eed677) 60%, transparent);
 }
 
 .hk-pwd-strength[data-level="strong"] {
-  background: var(--hi-color-success, #3fb950);
-  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-success, #3fb950) 60%, transparent);
+  background: var(--hi-color-success, #0eb840);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--hi-color-success, #0eb840) 60%, transparent);
 }
 
 .hk-pwd-hint {
@@ -271,7 +271,7 @@
 }
 
 .hk-pwd-hint[data-variant="caps"] {
-  color: var(--hi-color-warning, #d29922);
+  color: var(--hi-color-warning, #eed677);
 }
 
 .hk-pwd-hint[data-variant="fw"] {
@@ -287,15 +287,15 @@
 .hk-pwd-hint-text {
   margin-top: var(--space-4);
   font-size: var(--text-xs);
-  color: var(--hi-color-text-secondary, #666);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 .hk-pwd-box input:-webkit-autofill,
 .hk-pwd-box input:-webkit-autofill:hover,
 .hk-pwd-box input:-webkit-autofill:focus,
 .hk-pwd-box input:-webkit-autofill:active {
-  -webkit-text-fill-color: var(--hi-color-text-primary, #333) !important;
-  caret-color: var(--hi-color-text-primary, #333);
-  box-shadow: 0 0 0 1000px var(--hi-color-surface, #fff) inset !important;
+  -webkit-text-fill-color: var(--hi-color-text-primary, #1e1e1e) !important;
+  caret-color: var(--hi-color-text-primary, #1e1e1e);
+  box-shadow: 0 0 0 1000px var(--hi-color-surface, #f0f4f8) inset !important;
   transition: background-color calc(infinity * 1s) step-end, color calc(infinity * 1s) step-end;
 }

--- a/packages/vue/src/components/HkPhaseTransition.scss
+++ b/packages/vue/src/components/HkPhaseTransition.scss
@@ -1,13 +1,13 @@
 .hk-phase-enter-active {
   transition:
-    opacity var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
-    transform var(--hi-duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
+    opacity var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1),
+    transform var(--duration-fast, 0.15s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-phase-leave-active {
   transition:
-    opacity var(--hi-duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
-    transform var(--hi-duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0);
+    opacity var(--duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
+    transform var(--duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0);
 }
 
 .hk-phase-enter-from {
@@ -27,7 +27,7 @@
 @media (prefers-reduced-motion: reduce) {
   .hk-phase-enter-active,
   .hk-phase-leave-active {
-    transition: opacity var(--hi-duration-fast, 0.15s) ease;
+    transition: opacity var(--duration-fast, 0.15s) ease;
   }
 
   .hk-phase-enter-from,

--- a/packages/vue/src/components/HkPickerPane.scss
+++ b/packages/vue/src/components/HkPickerPane.scss
@@ -73,22 +73,22 @@
 
 .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active,
 .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-enter-active {
-  animation: hk-picker-pane-fwd-in var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-fwd-in var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active,
 .hk-dtp-stage[data-dir="fwd"] > .hk-picker-pane-leave-active {
-  animation: hk-picker-pane-fwd-out var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-fwd-out var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="back"] > .hk-picker-pane-enter-active,
 .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-enter-active {
-  animation: hk-picker-pane-back-in var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-back-in var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .hk-dp-stage[data-dir="back"] > .hk-picker-pane-leave-active,
 .hk-dtp-stage[data-dir="back"] > .hk-picker-pane-leave-active {
-  animation: hk-picker-pane-back-out var(--hi-duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
+  animation: hk-picker-pane-back-out var(--duration-normal, 0.3s) cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* RTL: reading direction flips, so a forward drill flows left→right —

--- a/packages/vue/src/components/HkPopover.scss
+++ b/packages/vue/src/components/HkPopover.scss
@@ -115,8 +115,8 @@
    * HkSelectPanel sheets, hence "some have it, some don't"). The inline
    * left/right pair alone owns the sheet's horizontal geometry. */
   max-width: none;
-  border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
-                 var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+  border-radius: var(--hk-modal-radius, var(--radius-lg, 12px))
+                 var(--hk-modal-radius, var(--radius-lg, 12px))
                  0 0;
   border-left: 0;
   border-right: 0;

--- a/packages/vue/src/components/HkProgressRing.scss
+++ b/packages/vue/src/components/HkProgressRing.scss
@@ -12,7 +12,7 @@
 }
 
 .hk-progress-ring-track {
-  stroke: var(--hk-progress-ring-track, var(--hi-color-border, rgba(0, 0, 0, 0.12)));
+  stroke: var(--hk-progress-ring-track, var(--hi-color-border, rgba(100,100,100,0.12)));
   transition: stroke var(--duration-normal) var(--ease-standard);
 }
 
@@ -20,14 +20,14 @@
 // the theme primary (same default as the single-value fill).
 .hk-progress-ring-fill,
 .hk-progress-ring-seg {
-  stroke: var(--hi-color-primary, #58a6ff);
+  stroke: var(--hi-color-primary, #7aa2f7);
   transition:
     stroke-dashoffset var(--duration-normal) var(--ease-standard),
     stroke var(--duration-normal) var(--ease-standard);
 }
 
 .hk-progress-ring-success .hk-progress-ring-fill {
-  stroke: var(--hi-color-success, #3fb950);
+  stroke: var(--hi-color-success, #0eb840);
 }
 
 .hk-progress-ring-exception .hk-progress-ring-fill {
@@ -41,7 +41,7 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   user-select: none;
   pointer-events: none;
 }

--- a/packages/vue/src/components/HkRadio.scss
+++ b/packages/vue/src/components/HkRadio.scss
@@ -43,8 +43,8 @@
   border: 1px solid var(--hi-color-border);
   background: var(--hi-color-surface);
   transition:
-    border-color var(--hi-duration-normal, 0.3s) ease,
-    background var(--hi-duration-normal, 0.3s) ease;
+    border-color var(--duration-normal, 0.3s) ease,
+    background var(--duration-normal, 0.3s) ease;
   flex-shrink: 0;
   position: relative;
 

--- a/packages/vue/src/components/HkRadio.scss
+++ b/packages/vue/src/components/HkRadio.scss
@@ -88,8 +88,8 @@
    :focus-visible keeps mouse clicks ring-free. */
 .hk-radio-box:has(.hk-radio-input:focus-visible) {
   box-shadow:
-    0 0 0 2px var(--hi-color-surface, rgba(255, 255, 255, 0.95)),
-    0 0 0 4px var(--hi-color-primary, #ff6b9d);
+    0 0 0 2px var(--hi-color-surface, rgba(240,244,248,0.95)),
+    0 0 0 4px var(--hi-color-primary, #7aa2f7);
 }
 
 /* --- Dot --- */

--- a/packages/vue/src/components/HkRollingNumber.scss
+++ b/packages/vue/src/components/HkRollingNumber.scss
@@ -16,7 +16,7 @@
   [data-el="roll"] {
     display: flex;
     flex-direction: column;
-    animation: hk-rolling-number-up var(--hi-duration-instant, 0.1s) cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    animation: hk-rolling-number-up var(--duration-instant, 0.1s) cubic-bezier(0.4, 0, 0.2, 1) forwards;
   }
 
   [data-el="digit"] {

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -114,10 +114,10 @@
   color: var(--hi-color-muted, #666);
   background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
   border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
-  border-radius: var(--hi-radius-full, 9999px);
+  border-radius: var(--radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+  transition: opacity var(--duration-fast, 0.15s) ease;
 }
 
 // Jump-back FAB — above the scrollbar tracks (z-index 10).

--- a/packages/vue/src/components/HkScrollContainer.scss
+++ b/packages/vue/src/components/HkScrollContainer.scss
@@ -111,9 +111,9 @@
   padding: var(--space-2) var(--space-8);
   font-size: var(--text-2xs);
   letter-spacing: 0.04em;
-  color: var(--hi-color-muted, #666);
-  background: color-mix(in srgb, var(--hi-color-surface, rgba(255, 255, 255, 0.95)) 78%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(0, 0, 0, 0.08)) 12%, transparent);
+  color: var(--hi-color-muted, #6c6c6c);
+  background: color-mix(in srgb, var(--hi-color-surface, rgba(240,244,248,0.95)) 78%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-border, rgba(100,100,100,0.08)) 12%, transparent);
   border-radius: var(--radius-full, 9999px);
   backdrop-filter: blur(4px);
   opacity: 0.85;

--- a/packages/vue/src/components/HkSearchInput.scss
+++ b/packages/vue/src/components/HkSearchInput.scss
@@ -3,7 +3,7 @@
   align-items: center;
   background: var(--hi-color-surface);
   border: 1px solid var(--hi-color-border);
-  border-radius: var(--hi-radius-md, 6px);
+  border-radius: 6px;
   overflow: hidden;
   transition:
     background-color var(--hi-transition-base, 200ms cubic-bezier(0.4, 0, 0.2, 1)),
@@ -76,8 +76,8 @@
   color: var(--hi-color-muted);
   cursor: pointer;
   transition:
-    background-color var(--hi-duration-fast, 0.15s) ease,
-    color var(--hi-duration-fast, 0.15s) ease;
+    background-color var(--duration-fast, 0.15s) ease,
+    color var(--duration-fast, 0.15s) ease;
 
   svg {
     width: 14px;

--- a/packages/vue/src/components/HkSelect.scss
+++ b/packages/vue/src/components/HkSelect.scss
@@ -316,8 +316,8 @@
     )
   );
   background: rgb(var(--color-surface));
-  border-radius: var(--hk-modal-radius, var(--hi-radius-lg, 12px))
-                 var(--hk-modal-radius, var(--hi-radius-lg, 12px))
+  border-radius: var(--hk-modal-radius, var(--radius-lg, 12px))
+                 var(--hk-modal-radius, var(--radius-lg, 12px))
                  0 0;
   box-shadow: 0 -8px 32px rgb(0 0 0 / 20%);
   outline: none;

--- a/packages/vue/src/components/HkSelectionGrid.scss
+++ b/packages/vue/src/components/HkSelectionGrid.scss
@@ -44,7 +44,7 @@
   gap: var(--space-8, 0.5rem);
   padding: var(--space-12, 0.75rem);
   border-radius: var(--radius-sm, 4px);
-  border: 1px solid var(--hi-color-border, #30363d);
+  border: 1px solid var(--hi-color-border, #646464);
   cursor: pointer;
   transition:
     border-color 200ms ease,
@@ -53,13 +53,13 @@
   user-select: none;
 
   &:hover {
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
-    box-shadow: 0 2px 12px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.1);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.04);
+    box-shadow: 0 2px 12px rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.1);
   }
 
   &:active {
-    box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
+    box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.06);
   }
 
   // Keyboard focus indicator drawn inside the border box (negative outline
@@ -76,15 +76,15 @@
   // the frame visibly lopsided (observed as a 1px top vs 2px sides under
   // HkStepFlow's sticky header).
   &[data-selected] {
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
-    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #58a6ff);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.06);
+    box-shadow: inset 0 0 0 1px var(--hi-color-primary, #7aa2f7);
 
     &:hover {
-      background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.09);
+      background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.09);
       box-shadow:
-        inset 0 0 0 1px var(--hi-color-primary, #58a6ff),
-        0 2px 12px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.14);
+        inset 0 0 0 1px var(--hi-color-primary, #7aa2f7),
+        0 2px 12px rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.14);
     }
 
     .hk-selection-grid-check {
@@ -93,11 +93,11 @@
     }
 
     .hk-selection-grid-icon {
-      color: var(--hi-color-primary, #58a6ff);
+      color: var(--hi-color-primary, #7aa2f7);
     }
 
     .hk-selection-grid-name {
-      color: var(--hi-color-primary, #58a6ff);
+      color: var(--hi-color-primary, #7aa2f7);
       font-weight: 600;
     }
   }
@@ -113,7 +113,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--hi-color-primary, #58a6ff);
+  background: var(--hi-color-primary, #7aa2f7);
   color: rgb(var(--color-on-solid-icon, 255 255 255));
   font-size: var(--text-2xs, 0.625rem);
   opacity: 0;
@@ -168,18 +168,18 @@
   letter-spacing: 0.02em;
 
   &[data-variant="primary"] {
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.12);
-    color: var(--hi-color-primary, #58a6ff);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.12);
+    color: var(--hi-color-primary, #7aa2f7);
   }
 
   &[data-variant="success"] {
-    background: rgb(from var(--hi-color-success, #3fb950) r g b / 0.12);
-    color: var(--hi-color-success, #3fb950);
+    background: rgb(from var(--hi-color-success, #0eb840) r g b / 0.12);
+    color: var(--hi-color-success, #0eb840);
   }
 
   &[data-variant="info"] {
-    background: rgb(from var(--hi-color-info, #79c0ff) r g b / 0.12);
-    color: var(--hi-color-info, #79c0ff);
+    background: rgb(from var(--hi-color-info, #6abed6) r g b / 0.12);
+    color: var(--hi-color-info, #6abed6);
   }
 }
 

--- a/packages/vue/src/components/HkSelectionWaterfall.scss
+++ b/packages/vue/src/components/HkSelectionWaterfall.scss
@@ -24,7 +24,7 @@
   gap: var(--space-4, 0.25rem);
   padding: var(--space-4, 0.25rem) var(--space-10, 0.625rem);
   border-radius: 9999px;
-  border: 1px solid var(--hi-color-border, #30363d);
+  border: 1px solid var(--hi-color-border, #646464);
   font-size: 0.6875rem;
   cursor: pointer;
   transition:
@@ -35,9 +35,9 @@
   white-space: nowrap;
 
   &:hover {
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.04);
-    box-shadow: 0 2px 8px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.1);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.04);
+    box-shadow: 0 2px 8px rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.1);
   }
 
   // Keyboard focus drawn inside the border box (negative offset), matching
@@ -49,13 +49,13 @@
   }
 
   &:active {
-    box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.06);
+    box-shadow: 0 1px 4px rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.06);
   }
 
   &[data-selected] {
-    border-color: var(--hi-color-primary, #58a6ff);
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.1);
-    color: var(--hi-color-primary, #58a6ff);
+    border-color: var(--hi-color-primary, #7aa2f7);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.1);
+    color: var(--hi-color-primary, #7aa2f7);
     font-weight: 500;
   }
 }
@@ -67,7 +67,7 @@
   width: 0.875rem;
   height: 0.875rem;
   border-radius: 50%;
-  background: var(--hi-color-primary, #58a6ff);
+  background: var(--hi-color-primary, #7aa2f7);
   color: rgb(var(--color-on-solid-icon, 255 255 255));
 }
 
@@ -83,18 +83,18 @@
   color: var(--hi-color-text-tertiary, #8b949e);
 
   &[data-variant="success"] {
-    background: rgb(from var(--hi-color-success, #3fb950) r g b / 0.12);
-    color: var(--hi-color-success, #3fb950);
+    background: rgb(from var(--hi-color-success, #0eb840) r g b / 0.12);
+    color: var(--hi-color-success, #0eb840);
   }
 
   &[data-variant="info"] {
-    background: rgb(from var(--hi-color-info, #79c0ff) r g b / 0.12);
-    color: var(--hi-color-info, #79c0ff);
+    background: rgb(from var(--hi-color-info, #6abed6) r g b / 0.12);
+    color: var(--hi-color-info, #6abed6);
   }
 
   &[data-variant="primary"] {
-    background: rgb(from var(--hi-color-primary, #58a6ff) r g b / 0.12);
-    color: var(--hi-color-primary, #58a6ff);
+    background: rgb(from var(--hi-color-primary, #7aa2f7) r g b / 0.12);
+    color: var(--hi-color-primary, #7aa2f7);
   }
 }
 

--- a/packages/vue/src/components/HkSidebar.scss
+++ b/packages/vue/src/components/HkSidebar.scss
@@ -1,7 +1,7 @@
 .hk-sidebar {
   flex-shrink: 0;
   height: 100%;
-  transition: width var(--hi-duration-normal, 0.3s) ease;
+  transition: width var(--duration-normal, 0.3s) ease;
 }
 
 .hk-sidebar-panel {
@@ -13,7 +13,7 @@
   /* Logical edge: the border rides the content-facing side in either
    * direction (LTR sidebar docks left, RTL docks right). */
   border-inline-end: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
-  transition: width var(--hi-duration-normal, 0.3s) ease;
+  transition: width var(--duration-normal, 0.3s) ease;
   overflow: hidden;
 }
 

--- a/packages/vue/src/components/HkSidebar.scss
+++ b/packages/vue/src/components/HkSidebar.scss
@@ -8,18 +8,18 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  background: var(--hk-sidebar-bg, var(--hi-color-surface, rgba(255, 255, 255, 0.95)));
+  background: var(--hk-sidebar-bg, var(--hi-color-surface, rgba(240,244,248,0.95)));
   backdrop-filter: blur(var(--blur-sm, 8px));
   /* Logical edge: the border rides the content-facing side in either
    * direction (LTR sidebar docks left, RTL docks right). */
-  border-inline-end: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+  border-inline-end: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   transition: width var(--duration-normal, 0.3s) ease;
   overflow: hidden;
 }
 
 .hk-sidebar-header {
   padding: var(--space-16) var(--space-12);
-  border-bottom: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  border-bottom: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   flex-shrink: 0;
   min-height: 56px;
   display: flex;
@@ -54,7 +54,7 @@
 
 .hk-sidebar-footer {
   padding: var(--space-16) var(--space-10);
-  border-top: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.06));
+  border-top: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   flex-shrink: 0;
 }
 
@@ -88,7 +88,7 @@
     [dir="rtl"] & {
       box-shadow: -4px 0 24px rgba(0, 0, 0, 0.2);
     }
-    border-inline-end: 1px solid var(--hi-color-border, rgba(0, 0, 0, 0.08));
+    border-inline-end: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
   }
 }
 

--- a/packages/vue/src/components/HkSkeleton.scss
+++ b/packages/vue/src/components/HkSkeleton.scss
@@ -1,18 +1,18 @@
 .hk-skeleton {
   display: inline-block;
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent);
 }
 
 .hk-skeleton[data-tone="muted"] {
-  background: color-mix(in srgb, var(--hi-color-text-primary, #333) 12%, transparent);
+  background: color-mix(in srgb, var(--hi-color-text-primary, #1e1e1e) 12%, transparent);
 }
 
 .hk-skeleton[data-animated] {
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 18%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-skeleton-shimmer 1.5s ease-in-out infinite;
@@ -21,9 +21,9 @@
 .hk-skeleton[data-tone="muted"][data-animated] {
   background: linear-gradient(
     90deg,
-    color-mix(in srgb, var(--hi-color-text-primary, #333) 10%, transparent) 25%,
-    color-mix(in srgb, var(--hi-color-text-primary, #333) 22%, transparent) 50%,
-    color-mix(in srgb, var(--hi-color-text-primary, #333) 10%, transparent) 75%
+    color-mix(in srgb, var(--hi-color-text-primary, #1e1e1e) 10%, transparent) 25%,
+    color-mix(in srgb, var(--hi-color-text-primary, #1e1e1e) 22%, transparent) 50%,
+    color-mix(in srgb, var(--hi-color-text-primary, #1e1e1e) 10%, transparent) 75%
   );
   background-size: 200% 100%;
   animation: hk-skeleton-shimmer 1.5s ease-in-out infinite;

--- a/packages/vue/src/components/HkSlider.scss
+++ b/packages/vue/src/components/HkSlider.scss
@@ -83,7 +83,7 @@
     0 0 0 2px rgb(var(--color-surface, var(--color-background)) / 90%),
     0 1px 3px rgb(0 0 0 / 35%);
   transform: translateY(-50%);
-  transition: transform var(--hi-duration-short, 0.15s);
+  transition: transform var(--duration-short, 0.15s);
   pointer-events: none;
 }
 

--- a/packages/vue/src/components/HkSplash.scss
+++ b/packages/vue/src/components/HkSplash.scss
@@ -5,7 +5,7 @@
   justify-content: center;
   min-height: 100vh;
   background: var(--hi-color-bg-canvas, #0d1117);
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
   font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif);
 }
 
@@ -25,13 +25,13 @@
 .hk-splash-title {
   font-size: 2rem;
   font-weight: 700;
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
   margin: 0 0 var(--space-8, 0.5rem);
 }
 
 .hk-splash-subtitle {
   font-size: 1.1rem;
-  color: var(--hi-color-text-secondary, #8b949e);
+  color: var(--hi-color-text-secondary, #666666);
   margin: 0 0 var(--space-8, 0.5rem);
 }
 

--- a/packages/vue/src/components/HkStepFlow.scss
+++ b/packages/vue/src/components/HkStepFlow.scss
@@ -29,7 +29,7 @@
   z-index: var(--hk-stepflow-sticky-z, 10);
   background: var(
     --hk-stepflow-sticky-bg,
-    color-mix(in srgb, var(--hi-color-surface, #fff) 95%, transparent)
+    color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 95%, transparent)
   );
   backdrop-filter: blur(6px);
   margin-bottom: 0;

--- a/packages/vue/src/components/HkSwitch.scss
+++ b/packages/vue/src/components/HkSwitch.scss
@@ -92,7 +92,7 @@
      primaries (synthwave pink) while HkButton labels stayed white. */
   background: rgb(var(--color-on-solid-icon, 255 255 255));
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-  transition: transform 0.2s var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1));
+  transition: transform 0.2s var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
   z-index: 1;
 
   .hk-switch-sm & {

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -49,7 +49,7 @@
 
 .hk-table-header-sortable {
   cursor: pointer;
-  transition: color var(--hi-duration-short, 0.15s) var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1));
+  transition: color var(--duration-short, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
 
   &:hover {
     color: var(--hi-color-primary, #58a6ff);
@@ -71,7 +71,7 @@
   height: 14px;
   display: inline-block;
   vertical-align: middle;
-  transition: transform var(--hi-duration-short, 0.15s) var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1));
+  transition: transform var(--duration-short, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
 }
 
 .hk-table-sort-icon-desc {
@@ -94,7 +94,7 @@
 
 .hk-table-bordered {
   border: 1px solid var(--hi-color-border, rgba(255, 255, 255, 0.1));
-  border-radius: var(--hi-radius-md, 8px);
+  border-radius: var(--radius-md, 8px);
 
   .hk-table-header-cell,
   .hk-table-cell {
@@ -171,11 +171,11 @@
   justify-content: center;
   flex-shrink: 0;
   border: 2px solid var(--hi-color-border, rgba(255, 255, 255, 0.2));
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   background: transparent;
   transition:
-    background-color var(--hi-duration-short, 0.15s) var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1)),
-    border-color var(--hi-duration-short, 0.15s) var(--hi-ease-default, cubic-bezier(0.4, 0, 0.2, 1));
+    background-color var(--duration-short, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1)),
+    border-color var(--duration-short, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
 
   &-md {
     width: 16px;

--- a/packages/vue/src/components/HkTable.scss
+++ b/packages/vue/src/components/HkTable.scss
@@ -26,11 +26,11 @@
   width: 100%;
   font-size: var(--text-base, 0.875rem);
   border-collapse: collapse;
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
 }
 
 .hk-table-header-row {
-  border-bottom: 1px solid var(--hi-color-border, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--hi-color-border, rgba(100,100,100,0.08));
 }
 
 .hk-table-header-cell {
@@ -40,7 +40,7 @@
   text-align: start;
   font-size: var(--text-xs, 0.75rem);
   font-weight: 600;
-  color: var(--hi-color-text-secondary, #8b949e);
+  color: var(--hi-color-text-secondary, #666666);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
@@ -52,12 +52,12 @@
   transition: color var(--duration-short, 0.15s) var(--ease-standard, cubic-bezier(0.4, 0, 0.2, 1));
 
   &:hover {
-    color: var(--hi-color-primary, #58a6ff);
+    color: var(--hi-color-primary, #7aa2f7);
   }
 }
 
 .hk-table-header-sorted {
-  color: var(--hi-color-primary, #58a6ff);
+  color: var(--hi-color-primary, #7aa2f7);
 }
 
 .hk-table-header-label {
@@ -80,7 +80,7 @@
 
 .hk-table-body {
   .hk-table-row {
-    border-bottom: 1px solid var(--hi-color-border, rgba(255, 255, 255, 0.05));
+    border-bottom: 1px solid var(--hi-color-border, rgba(100,100,100,0.05));
   }
 }
 
@@ -93,23 +93,23 @@
 }
 
 .hk-table-bordered {
-  border: 1px solid var(--hi-color-border, rgba(255, 255, 255, 0.1));
+  border: 1px solid var(--hi-color-border, rgba(100,100,100,0.1));
   border-radius: var(--radius-md, 8px);
 
   .hk-table-header-cell,
   .hk-table-cell {
-    border: 1px solid var(--hi-color-border, rgba(255, 255, 255, 0.06));
+    border: 1px solid var(--hi-color-border, rgba(100,100,100,0.06));
   }
 
   .hk-table-header-cell {
-    border-bottom: 2px solid var(--hi-color-border, rgba(255, 255, 255, 0.1));
+    border-bottom: 2px solid var(--hi-color-border, rgba(100,100,100,0.1));
   }
 }
 
 .hk-table-cell {
   /* md values (see .hk-table-header-cell). */
   padding: var(--space-8, 8px) var(--space-12, 12px);
-  color: var(--hi-color-text-primary, #c9d1d9);
+  color: var(--hi-color-text-primary, #1e1e1e);
   vertical-align: middle;
 }
 
@@ -132,7 +132,7 @@
 .hk-table-empty {
   padding: var(--space-32, 32px) var(--space-16, 16px);
   text-align: center;
-  color: var(--hi-color-text-secondary, #8b949e);
+  color: var(--hi-color-text-secondary, #666666);
 }
 
 /* Alignment helpers (start/end so aligned columns mirror in RTL; the
@@ -170,7 +170,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  border: 2px solid var(--hi-color-border, rgba(255, 255, 255, 0.2));
+  border: 2px solid var(--hi-color-border, rgba(100,100,100,0.2));
   border-radius: var(--radius-sm, 4px);
   background: transparent;
   transition:
@@ -183,14 +183,14 @@
   }
 
   &-checked {
-    background: var(--hi-color-primary, #58a6ff);
-    border-color: var(--hi-color-primary, #58a6ff);
+    background: var(--hi-color-primary, #7aa2f7);
+    border-color: var(--hi-color-primary, #7aa2f7);
   }
 
   .hk-table-checkbox-input:focus-visible + & {
     box-shadow:
       0 0 0 2px var(--hi-color-bg-canvas, #0d1117),
-      0 0 0 4px var(--hi-color-primary, #58a6ff);
+      0 0 0 4px var(--hi-color-primary, #7aa2f7);
   }
 }
 

--- a/packages/vue/src/components/HkTag.scss
+++ b/packages/vue/src/components/HkTag.scss
@@ -7,7 +7,7 @@
   line-height: 1.4;
   white-space: nowrap;
   border: 1px solid transparent;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   padding: var(--space-2, 2px) var(--space-8, 8px);
   user-select: none;
 }
@@ -43,8 +43,8 @@
   padding: 0;
   /* Trailing edge of the chip in both directions. */
   margin-inline-start: var(--space-2, 2px);
-  border-radius: var(--hi-radius-sm, 4px);
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+  border-radius: var(--radius-sm, 4px);
+  transition: opacity var(--duration-fast, 0.15s) ease;
 }
 
 .hk-tag-close:hover {

--- a/packages/vue/src/components/HkTag.scss
+++ b/packages/vue/src/components/HkTag.scss
@@ -58,27 +58,27 @@
 }
 
 .hk-tag-default {
-  background: color-mix(in srgb, var(--hi-color-surface, #fff) 60%, transparent);
-  color: var(--hi-color-text-primary, #333);
-  border-color: var(--hi-color-border, #30363d);
+  background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 60%, transparent);
+  color: var(--hi-color-text-primary, #1e1e1e);
+  border-color: var(--hi-color-border, #646464);
 }
 
 .hk-tag-primary {
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 10%, transparent);
-  color: var(--hi-color-primary, #58a6ff);
-  border-color: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 10%, transparent);
+  color: var(--hi-color-primary, #7aa2f7);
+  border-color: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 20%, transparent);
 }
 
 .hk-tag-success {
-  background: color-mix(in srgb, var(--hi-color-success, #3fb950) 10%, transparent);
-  color: var(--hi-color-success, #3fb950);
-  border-color: color-mix(in srgb, var(--hi-color-success, #3fb950) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-success, #0eb840) 10%, transparent);
+  color: var(--hi-color-success, #0eb840);
+  border-color: color-mix(in srgb, var(--hi-color-success, #0eb840) 20%, transparent);
 }
 
 .hk-tag-warning {
-  background: color-mix(in srgb, var(--hi-color-warning, #d29922) 10%, transparent);
-  color: var(--hi-color-warning, #d29922);
-  border-color: color-mix(in srgb, var(--hi-color-warning, #d29922) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-warning, #eed677) 10%, transparent);
+  color: var(--hi-color-warning, #eed677);
+  border-color: color-mix(in srgb, var(--hi-color-warning, #eed677) 20%, transparent);
 }
 
 .hk-tag-danger {
@@ -88,7 +88,7 @@
 }
 
 .hk-tag-info {
-  background: color-mix(in srgb, var(--hi-color-info, #79c0ff) 10%, transparent);
-  color: var(--hi-color-info, #79c0ff);
-  border-color: color-mix(in srgb, var(--hi-color-info, #79c0ff) 20%, transparent);
+  background: color-mix(in srgb, var(--hi-color-info, #6abed6) 10%, transparent);
+  color: var(--hi-color-info, #6abed6);
+  border-color: color-mix(in srgb, var(--hi-color-info, #6abed6) 20%, transparent);
 }

--- a/packages/vue/src/components/HkTextarea.scss
+++ b/packages/vue/src/components/HkTextarea.scss
@@ -19,7 +19,7 @@
   padding: var(--space-8, 0.5rem) var(--space-12, 0.75rem);
   background: var(--hi-color-surface);
   border: 1px solid var(--hi-color-border);
-  border-radius: var(--hi-radius-md, 6px);
+  border-radius: 6px;
   color: var(--hi-color-text-primary);
   font-family: inherit;
   font-size: var(--text-base, 0.875rem);

--- a/packages/vue/src/components/HkTimeline.scss
+++ b/packages/vue/src/components/HkTimeline.scss
@@ -69,7 +69,7 @@
 // neighbour brightens back up while pointed at (affordance to jump back).
 .hk-timeline[data-mode="window"] .hk-timeline-window[data-dimmed] {
   opacity: var(--hk-timeline-neighbor-opacity, 0.55);
-  transition: opacity var(--hi-duration-normal, 0.3s) ease;
+  transition: opacity var(--duration-normal, 0.3s) ease;
 
   &:has(.hk-timeline-step[data-clickable]):hover {
     opacity: 1;
@@ -388,7 +388,7 @@
   &:hover [data-el="indicator"] {
     transform: scale(1.12);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--hi-color-primary) 15%, transparent);
-    transition: transform var(--hi-duration-normal, 0.3s) ease, box-shadow var(--hi-duration-normal, 0.3s) ease;
+    transition: transform var(--duration-normal, 0.3s) ease, box-shadow var(--duration-normal, 0.3s) ease;
   }
 
   // Press feedback mirroring the hover pop (role="button" affordance).

--- a/packages/vue/src/components/HkTitleBar.scss
+++ b/packages/vue/src/components/HkTitleBar.scss
@@ -117,12 +117,12 @@
 
 .hk-titlebar-btn-close:hover {
   background: var(--hk-tb-close-hover);
-  color: var(--hi-color-text-on-danger, #fff);
+  color: var(--hi-color-text-on-danger, #ffffff);
 }
 
 .hk-titlebar-btn-close:active {
   background: var(--hk-tb-close-active);
-  color: var(--hi-color-text-on-danger, #fff);
+  color: var(--hi-color-text-on-danger, #ffffff);
 }
 
 .hk-titlebar-btn:focus-visible {

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -76,19 +76,19 @@
 
 .hk-toast-error {
   background: var(--hi-color-danger, #f85149);
-  color: var(--hi-color-text-on-solid, #fff);
+  color: var(--hi-color-text-on-solid, #ffffff);
 }
 
 .hk-toast-success {
-  background: var(--hi-color-success, #3fb950);
-  color: var(--hi-color-text-on-solid, #fff);
+  background: var(--hi-color-success, #0eb840);
+  color: var(--hi-color-text-on-solid, #ffffff);
 }
 
 /* Warning toasts use a light, saturated amber background where white text
  * lands at ~2.6:1 contrast (unreadable). Dark text keeps >= 4.5:1 on the
  * amber in BOTH color schemes; the copy/close buttons inherit it. */
 .hk-toast-warning {
-  background: var(--hi-color-warning, #d29922);
+  background: var(--hi-color-warning, #eed677);
   color: #1c1c1e;
 }
 
@@ -103,13 +103,13 @@
 }
 
 .hk-toast-info {
-  background: var(--hi-color-info, #58a6ff);
-  color: var(--hi-color-text-on-solid, #fff);
+  background: var(--hi-color-info, #6abed6);
+  color: var(--hi-color-text-on-solid, #ffffff);
 }
 
 .hk-toast-loading {
-  background: var(--hi-color-info, #58a6ff);
-  color: var(--hi-color-text-on-solid, #fff);
+  background: var(--hi-color-info, #6abed6);
+  color: var(--hi-color-text-on-solid, #ffffff);
 }
 
 .hk-toast-loading-spinner {

--- a/packages/vue/src/components/HkToast.scss
+++ b/packages/vue/src/components/HkToast.scss
@@ -27,7 +27,7 @@
   align-items: center;
   gap: var(--space-8, 8px);
   padding: var(--space-12, 12px) var(--space-16, 16px);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   font-size: var(--text-base, 0.875rem);
   line-height: 1.4;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
@@ -136,9 +136,9 @@
   background: transparent;
   color: inherit;
   cursor: pointer;
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   opacity: 0.7;
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+  transition: opacity var(--duration-fast, 0.15s) ease;
   padding: 0;
 }
 
@@ -155,7 +155,7 @@
 
 .hk-toast-enter-active {
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
-  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-duration: var(--duration-normal, 0.3s);
   /* Plain ease-out: the previous back-overshoot spring (1.56 y) is the
      same family the drawer animation was corrected away from — toasts
      slide in and settle, they do not bounce. */
@@ -164,7 +164,7 @@
 
 .hk-toast-leave-active {
   transition-property: background-color, border-color, color, box-shadow, opacity, transform;
-  transition-duration: var(--hi-duration-normal, 0.3s);
+  transition-duration: var(--duration-normal, 0.3s);
   transition-timing-function: cubic-bezier(0.36, 0, 0.66, 1);
 }
 
@@ -196,12 +196,12 @@
 }
 
 .hk-toast-move {
-  transition: transform var(--hi-duration-normal, 0.3s) ease;
+  transition: transform var(--duration-normal, 0.3s) ease;
 }
 
 .hk-toast-msg-enter-active,
 .hk-toast-msg-leave-active {
-  transition: opacity var(--hi-duration-fast, 0.15s) ease;
+  transition: opacity var(--duration-fast, 0.15s) ease;
 }
 
 .hk-toast-msg-enter-from,

--- a/packages/vue/src/components/HkTree.scss
+++ b/packages/vue/src/components/HkTree.scss
@@ -31,7 +31,7 @@
   align-items: center;
   padding: 0 var(--space-8, 0.5rem);
   cursor: pointer;
-  transition: background var(--hi-duration-fast, 0.15s) ease;
+  transition: background var(--duration-fast, 0.15s) ease;
   color: var(--hi-color-text-primary, #333);
   position: relative;
 
@@ -106,8 +106,8 @@
   height: 16px;
   flex-shrink: 0;
   color: var(--hi-color-muted, #666);
-  border-radius: var(--hi-radius-sm, 4px);
-  transition: color var(--hi-duration-fast, 0.15s), background var(--hi-duration-fast, 0.15s);
+  border-radius: var(--radius-sm, 4px);
+  transition: color var(--duration-fast, 0.15s), background var(--duration-fast, 0.15s);
 }
 
 .hk-tree-toggle[data-parent] {
@@ -120,7 +120,7 @@
 }
 
 .hk-tree-chevron {
-  transition: transform var(--hi-duration-normal, 0.3s) ease;
+  transition: transform var(--duration-normal, 0.3s) ease;
 }
 
 .hk-tree-chevron[data-open] {
@@ -173,7 +173,7 @@
   color: var(--hi-color-primary, #58a6ff);
   background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
   border: 1px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent);
-  border-radius: var(--hi-radius-sm, 4px);
+  border-radius: var(--radius-sm, 4px);
   line-height: 1.5;
   letter-spacing: 0.02em;
 }

--- a/packages/vue/src/components/HkTree.scss
+++ b/packages/vue/src/components/HkTree.scss
@@ -22,7 +22,7 @@
     top: 0;
     bottom: 6px;
     width: 1px;
-    background: color-mix(in srgb, var(--hi-color-border, #30363d) 30%, transparent);
+    background: color-mix(in srgb, var(--hi-color-border, #646464) 30%, transparent);
   }
 }
 
@@ -32,11 +32,11 @@
   padding: 0 var(--space-8, 0.5rem);
   cursor: pointer;
   transition: background var(--duration-fast, 0.15s) ease;
-  color: var(--hi-color-text-primary, #333);
+  color: var(--hi-color-text-primary, #1e1e1e);
   position: relative;
 
   &:hover {
-    background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 5%, transparent);
+    background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 5%, transparent);
   }
 }
 
@@ -60,7 +60,7 @@
 }
 
 .hk-tree-row[data-status="warning"] .hk-tree-label {
-  color: var(--hi-color-warning, #d29922);
+  color: var(--hi-color-warning, #eed677);
 }
 
 .hk-tree-row[data-status="muted"] {
@@ -105,7 +105,7 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: var(--hi-color-muted, #666);
+  color: var(--hi-color-muted, #6c6c6c);
   border-radius: var(--radius-sm, 4px);
   transition: color var(--duration-fast, 0.15s), background var(--duration-fast, 0.15s);
 }
@@ -114,8 +114,8 @@
   cursor: pointer;
 
   &:hover {
-    background: color-mix(in srgb, var(--hi-color-surface, #fff) 40%, transparent);
-    color: var(--hi-color-text-primary, #333);
+    background: color-mix(in srgb, var(--hi-color-surface, #f0f4f8) 40%, transparent);
+    color: var(--hi-color-text-primary, #1e1e1e);
   }
 }
 
@@ -136,7 +136,7 @@
 .hk-tree-leaf {
   display: block;
   border-radius: 50%;
-  background: color-mix(in srgb, var(--hi-color-muted, #666) 25%, transparent);
+  background: color-mix(in srgb, var(--hi-color-muted, #6c6c6c) 25%, transparent);
 }
 
 /* ── Icon slot ─────────────────────────────────── */
@@ -170,9 +170,9 @@
   padding: 0 0.375em;
   font-size: 0.85em;
   font-weight: 600;
-  color: var(--hi-color-primary, #58a6ff);
-  background: color-mix(in srgb, var(--hi-color-primary, #58a6ff) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--hi-color-primary, #58a6ff) 18%, transparent);
+  color: var(--hi-color-primary, #7aa2f7);
+  background: color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--hi-color-primary, #7aa2f7) 18%, transparent);
   border-radius: var(--radius-sm, 4px);
   line-height: 1.5;
   letter-spacing: 0.02em;

--- a/packages/vue/src/components/window-close.scss
+++ b/packages/vue/src/components/window-close.scss
@@ -47,7 +47,7 @@
     );
     color: var(
       --hk-func-icon-hover-color,
-      var(--hi-color-text-primary, #333)
+      var(--hi-color-text-primary, #1e1e1e)
     );
   }
 }

--- a/packages/vue/src/scale.scss
+++ b/packages/vue/src/scale.scss
@@ -1,0 +1,76 @@
+/* ── Canonical scale tokens (L2) ──────────────────────────────────────
+ * Non-color constants: spacing, type, radius, blur, opacity, durations,
+ * easings, z-index, fonts. ONE definition per name — components and the
+ * other shipped sheets must consume, not redefine, these.
+ *
+ * Conflicting legacy values (packages/theme/styles _layout/_tokens/
+ * foundation) were normalized to the values the production composition
+ * resolves to (chest: admin-tokens + foundation last). This file is the
+ * upstream of styles/theme/scale.scss — edit here, then re-run
+ * scripts/theme/sync-vendored.sh; do not hand-edit the vendored copy.
+ */
+:root {
+  /* Spacing (N px at the 16px root). */
+  --space-1: 0.0625rem;
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+
+  /* Type */
+  --text-3xs: 0.5rem;
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  /* Radius / blur / opacity */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
+  --blur-xs: 4px;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+  --blur-xl: 24px;
+  --opacity-half: 0.92;
+
+  /* Motion */
+  --duration-instant: 0.1s;
+  --duration-short: 0.15s;
+  --duration-fast: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Z-index bands */
+  --z-base: 0;
+  --z-header: 100;
+  --z-sidebar: 900;
+
+  /* Fonts — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", monospace;
+}

--- a/packages/vue/src/scale.scss
+++ b/packages/vue/src/scale.scss
@@ -59,9 +59,6 @@
   --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
   --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
-  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
   --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
   /* Legacy-prefixed aliases consumed by HkIconButtonVars' bridge. */
   --hi-duration-fast: 0.15s;

--- a/packages/vue/src/scale.scss
+++ b/packages/vue/src/scale.scss
@@ -63,6 +63,9 @@
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
   --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Legacy-prefixed aliases consumed by HkIconButtonVars' bridge. */
+  --hi-duration-fast: 0.15s;
+  --hi-ease-default: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Z-index bands */
   --z-base: 0;

--- a/packages/vue/src/styles/admin-tokens.scss
+++ b/packages/vue/src/styles/admin-tokens.scss
@@ -9,43 +9,10 @@
   /* ── Layout tokens ─ */
   --s-footer-height: 3rem;
   --s-header-height: 3rem;
-  --z-header: 100;
-  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
-  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", "Noto Sans CJK SC", monospace;
-  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
-  --blur-sm: 8px;
-  --blur-md: 16px;
-  --blur-lg: 24px;
-  --z-sidebar: 900; /* app-sheet band — drawer sidebars (see theme/_layout.scss) */
-  --z-base: 0; /* z tokens mirror theme/styles/_layout.scss — keep both in sync */
-  --space-2: 0.125rem;
-  --space-4: 0.25rem;
-  --space-6: 0.375rem;
-  --space-8: 0.5rem;
-  --space-10: 0.625rem;
-  --space-12: 0.75rem;
-  --space-14: 0.875rem;
-  --space-16: 1rem;
-  --space-20: 1.25rem;
-  --space-24: 1.5rem;
-  --space-28: 1.75rem;
-  --space-32: 2rem;
-  --space-40: 2.5rem;
-  --text-2xs: 0.625rem;
-  --text-xs: 0.75rem;
-  --text-sm: 0.8125rem;
-  --text-base: 0.875rem;
-  --text-md: 1rem;
-  --text-lg: 1.125rem;
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --opacity-half: 0.92;
-  --duration-short: 0.15s;
-  --duration-normal: 0.3s;
-  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
-  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  /* Layout/type/motion scale tokens (--space-*, --text-*, --blur-*, --z-*,
+   * --duration-*, --ease-*) used to be mirrored here ("keep both in sync")
+   * — they now live once in styles/theme/scale.scss, which every entry
+   * loads before this sheet. Only plana-specific tokens remain below. */
 
   /* ── Shared color aliases ─ */
   --c-primary: rgb(var(--color-primary, 255 107 157));

--- a/packages/vue/src/styles/index.scss
+++ b/packages/vue/src/styles/index.scss
@@ -1,12 +1,26 @@
-// Re-export shared hikari theme and component styles.
-// NOTE: The `../../../theme/...` and `../../../components/...` imports below
-// resolve relative to the monorepo root and work locally, but escape the npm
-// package — registry installs should import the granular subpaths instead
-// (`@celestia-island/hikari/styles/theme/*.scss`, `.../styles/admin-tokens.scss`),
-// which are vendored/exposed inside this package.
-@use "../../../theme/styles/variables.scss";
-@use "../../../theme/styles/mixins.scss";
-@use "../../../theme/styles/foundation.scss";
-@use "../../../theme/styles/themes.scss";
-@use "../../../components/src/styles/index.scss";
+// Canonical hikari theme + component style entry.
+//
+// Composition (order matters only for the plana-ui sheet at the end —
+// every token is defined exactly once across the first two sheets, so
+// the color/scale base is order-independent):
+//   1. theme/channels.scss — the static seed: --color-* channel palette,
+//      --hi-color-* derivations, --c-*/--shadow-*/--border-* aliases and
+//      the icon-button bridge (vendored from src/tokens.scss).
+//   2. theme/scale.scss — the L2 scale tokens: spacing, type, radius,
+//      blur, opacity, durations, easings, z bands, fonts (vendored from
+//      src/scale.scss).
+//   3. admin-tokens.scss — the plana-ui shared surface: layout tokens,
+//      brand-color aliases and the shared admin component classes.
+//
+// initTheme() (runtime) writes only deltas against this base into a
+// managed <style data-hikari-theme-vars> block.
+//
+// The legacy Gen-1 sheets (styles/theme/base.scss, foundation.scss,
+// themes.scss, _tokens.scss, _layout.scss, … — vendored from
+// packages/theme/styles for the Rust crate) are NOT part of this entry;
+// import them granularly only for legacy compositions. The previous
+// version of this file re-exported packages/theme + packages/components
+// through paths that escape the npm package and did not compile.
+@use "./theme/channels.scss";
+@use "./theme/scale.scss";
 @use "./admin-tokens.scss";

--- a/packages/vue/src/styles/theme/_glass.scss
+++ b/packages/vue/src/styles/theme/_glass.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/_glass.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // _glass.scss — Glass-morphism utility classes adopted from shittim-chest.
 // These provide the frosted-glass aesthetic that makes panels feel layered
 // without heavy borders.

--- a/packages/vue/src/styles/theme/_layout.scss
+++ b/packages/vue/src/styles/theme/_layout.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/_layout.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // _layout.scss — Shared unprefixed design tokens for hikari + plana components.
 // Originally sourced from shittim-chest's theme system; extracted here so
 // any project importing @celestia-island/hikari/styles gets them automatically.

--- a/packages/vue/src/styles/theme/_scrollbar.scss
+++ b/packages/vue/src/styles/theme/_scrollbar.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/_scrollbar.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // _scrollbar.scss — the shared overlay scrollbar chrome.
 //
 // ONE scrollbar system for the whole library: the `.hk-scrollbar-track` /

--- a/packages/vue/src/styles/theme/_tokens.scss
+++ b/packages/vue/src/styles/theme/_tokens.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/_tokens.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // _tokens.scss — Design tokens adopted from shittim-chest's theme system.
 // These supplement hikari's existing foundation.scss tokens with the
 // detail-oriented tokens that make shittim-chest's UI feel polished:

--- a/packages/vue/src/styles/theme/base.scss
+++ b/packages/vue/src/styles/theme/base.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/base.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // hikari-theme/styles/base.scss
 // 基础样式（使用 hikari-palette）
 

--- a/packages/vue/src/styles/theme/channels.scss
+++ b/packages/vue/src/styles/theme/channels.scss
@@ -95,6 +95,12 @@
   --color-focused-border: 122 162 247;
   --color-background: 214 236 240;
   --color-surface: 240 244 248;
+  /* Derived seed defaults for the runtime-selected channels: a primary
+   * wash over the background (selected) and the surface tint (status
+   * bar), matching what presets derive at runtime. */
+  --color-selected-bg: 191 218 242;
+  --color-selected-text: 30 30 30;
+  --color-status-bar-bg: 240 244 248;
   --color-success: 14 184 64;
   --color-error: 247 118 142;
   --color-warning: 238 214 119;
@@ -104,7 +110,7 @@
   --hi-color-secondary: rgb(var(--color-secondary));
   --hi-color-surface: rgb(var(--color-surface));
   --hi-color-background: rgb(var(--color-background));
-  --hi-color-border: rgb(var(--color-border));
+  --hi-color-border: rgb(var(--color-border) / 15%);
   --hi-color-text-primary: rgb(var(--color-text));
   --hi-color-text-secondary: rgb(var(--color-text-secondary));
   --hi-color-muted: rgb(var(--color-muted));
@@ -118,6 +124,12 @@
   --hi-color-error: rgb(var(--color-error));
   --hi-color-warning: rgb(var(--color-warning));
   --hi-color-info: rgb(var(--color-info));
+  /* Surface-layer aliases the runtime writes on every apply — seeded so
+   * no-JS consumers resolve them instead of invalid var(). */
+  --hi-color-bg-subtle: rgb(var(--color-surface) / 0.5);
+  --hi-color-bg-elevated: rgb(var(--color-surface));
+  --hi-color-bg-canvas: rgb(var(--color-background));
+  --hi-secondary-bg: rgb(var(--color-surface) / 0.5);
 
   /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
      z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,

--- a/packages/vue/src/styles/theme/channels.scss
+++ b/packages/vue/src/styles/theme/channels.scss
@@ -119,44 +119,8 @@
   --hi-color-warning: rgb(var(--color-warning));
   --hi-color-info: rgb(var(--color-info));
 
-  /* Design tokens consumed by hikari components. These used to live only in
-     plana-ui's token set; without them the background/backdrop declarations
-     of fields and surfaces resolve to nothing. Values align with plana-ui. */
-  --space-2: 0.125rem;
-  --space-4: 0.25rem;
-  --space-6: 0.375rem;
-  --space-8: 0.5rem;
-  --space-10: 0.625rem;
-  --space-12: 0.75rem;
-  --space-14: 0.875rem;
-  --space-16: 1rem;
-  --space-20: 1.25rem;
-  --space-24: 1.5rem;
-  --space-28: 1.75rem;
-  --space-32: 2rem;
-  --space-40: 2.5rem;
-  --text-2xs: 0.625rem;
-  --text-xs: 0.75rem;
-  --text-sm: 0.8125rem;
-  --text-base: 0.875rem;
-  --text-md: 1rem;
-  --text-lg: 1.125rem;
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --opacity-half: 0.92;
-  --blur-sm: 8px;
-  --blur-md: 16px;
-  --blur-lg: 24px;
-  --duration-fast: 0.15s;
-  --duration-short: 0.15s;
-  --duration-normal: 0.3s;
-  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
-  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
-  --s-footer-height: 3rem;
-  --z-header: 30;
-  --z-sidebar: 40;
-  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
-  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
+     z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,
+     vendored as styles/theme/scale.scss. This file keeps only the
+     channel palette (above) and the --hi-* / --c-* bridges. */
 }

--- a/packages/vue/src/styles/theme/channels.scss
+++ b/packages/vue/src/styles/theme/channels.scss
@@ -130,6 +130,12 @@
   --hi-color-bg-elevated: rgb(var(--color-surface));
   --hi-color-bg-canvas: rgb(var(--color-background));
   --hi-secondary-bg: rgb(var(--color-surface) / 0.5);
+  --hi-color-accent: rgb(var(--color-accent));
+  /* Gen-1 shorthand references that were never defined anywhere — wired to
+     the canonical tokens so the consuming rules render as intended. */
+  --hi-primary: var(--hi-color-primary);
+  --hi-surface: var(--hi-color-surface);
+  --hi-card-bg: var(--hi-color-surface);
 
   /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
      z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,

--- a/packages/vue/src/styles/theme/foundation.scss
+++ b/packages/vue/src/styles/theme/foundation.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/foundation.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // hikari-theme/styles/foundation.scss
 // Layer1 - Foundation Layer: Global CSS Variables
 //

--- a/packages/vue/src/styles/theme/mixins.scss
+++ b/packages/vue/src/styles/theme/mixins.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/mixins.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // hikari-theme/styles/mixins.scss
 // Mixins（使用 hikari-palette）
 

--- a/packages/vue/src/styles/theme/scale.scss
+++ b/packages/vue/src/styles/theme/scale.scss
@@ -61,9 +61,6 @@
   --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
   --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
   --ease-in: cubic-bezier(0.4, 0, 1, 1);
-  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
   --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
   /* Legacy-prefixed aliases consumed by HkIconButtonVars' bridge. */
   --hi-duration-fast: 0.15s;

--- a/packages/vue/src/styles/theme/scale.scss
+++ b/packages/vue/src/styles/theme/scale.scss
@@ -65,6 +65,9 @@
   --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
   --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
   --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Legacy-prefixed aliases consumed by HkIconButtonVars' bridge. */
+  --hi-duration-fast: 0.15s;
+  --hi-ease-default: cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Z-index bands */
   --z-base: 0;

--- a/packages/vue/src/styles/theme/scale.scss
+++ b/packages/vue/src/styles/theme/scale.scss
@@ -1,0 +1,78 @@
+// Vendored byte-identical from packages/vue/src/scale.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
+/* ── Canonical scale tokens (L2) ──────────────────────────────────────
+ * Non-color constants: spacing, type, radius, blur, opacity, durations,
+ * easings, z-index, fonts. ONE definition per name — components and the
+ * other shipped sheets must consume, not redefine, these.
+ *
+ * Conflicting legacy values (packages/theme/styles _layout/_tokens/
+ * foundation) were normalized to the values the production composition
+ * resolves to (chest: admin-tokens + foundation last). This file is the
+ * upstream of styles/theme/scale.scss — edit here, then re-run
+ * scripts/theme/sync-vendored.sh; do not hand-edit the vendored copy.
+ */
+:root {
+  /* Spacing (N px at the 16px root). */
+  --space-1: 0.0625rem;
+  --space-2: 0.125rem;
+  --space-4: 0.25rem;
+  --space-6: 0.375rem;
+  --space-8: 0.5rem;
+  --space-10: 0.625rem;
+  --space-12: 0.75rem;
+  --space-14: 0.875rem;
+  --space-16: 1rem;
+  --space-20: 1.25rem;
+  --space-24: 1.5rem;
+  --space-28: 1.75rem;
+  --space-32: 2rem;
+  --space-40: 2.5rem;
+
+  /* Type */
+  --text-3xs: 0.5rem;
+  --text-2xs: 0.625rem;
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  /* Radius / blur / opacity */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 9999px;
+  --blur-xs: 4px;
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+  --blur-xl: 24px;
+  --opacity-half: 0.92;
+
+  /* Motion */
+  --duration-instant: 0.1s;
+  --duration-short: 0.15s;
+  --duration-fast: 0.15s;
+  --duration-normal: 0.3s;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  --ease-elastic: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Z-index bands */
+  --z-base: 0;
+  --z-header: 100;
+  --z-sidebar: 900;
+
+  /* Fonts — keep in sync with packages/vue/src/theme/fontContext.ts */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", "Liberation Mono", "PingFang SC", "Microsoft YaHei", monospace;
+}

--- a/packages/vue/src/styles/theme/themes.scss
+++ b/packages/vue/src/styles/theme/themes.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/themes.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // hikari-theme/styles/themes.scss
 // 主题变体（使用 hikari-palette）
 

--- a/packages/vue/src/styles/theme/variables.scss
+++ b/packages/vue/src/styles/theme/variables.scss
@@ -1,4 +1,5 @@
 // Vendored byte-identical from packages/theme/styles/variables.scss (hikari repo) so npm registry installs can resolve it — edit the upstream file, then re-copy; do not hand-edit here.
+
 // hikari-theme/styles/variables.scss
 // CSS 变量（使用 hikari-palette）
 

--- a/packages/vue/src/styles/tokenInventory.test.ts
+++ b/packages/vue/src/styles/tokenInventory.test.ts
@@ -241,36 +241,34 @@ describe("theme token inventory", () => {
 
   it("component --hi-color-* fallbacks stay on the canonical literals", () => {
     // The standalone-render contract: when a host loads nothing, a
-    // component renders through these literals. One concept, one literal.
-    const CANONICAL: Record<string, string> = {
-      "--hi-color-primary": "#58a6ff",
-      "--hi-color-danger": "#f85149",
-      "--hi-color-text-primary": "#333",
-      "--hi-color-text-secondary": "#666",
-      "--hi-color-text-tertiary": "#8b949e",
-      "--hi-color-muted": "#666",
-      "--hi-color-border": "#30363d",
-      "--hi-color-surface": "#fff",
-      "--hi-color-success": "#3fb950",
-      "--hi-color-warning": "#d29922",
-      "--hi-color-info": "#79c0ff",
+    // component renders through these literals. They are DERIVED FROM THE
+    // SEED triplets (theme/channels.scss) so the standalone face equals
+    // the documented default palette — derived programmatically below so
+    // the table tracks the seed automatically.
+    const seedTriplets = harvestDefinitions(seedFiles);
+    const hexFromSeed = (channel: string): string => {
+      const def = seedTriplets.get(channel)![0].value; // "r g b"
+      const [r, g, b] = def
+        .split(" ")
+        .map((n) => Number(n).toString(16).padStart(2, "0"));
+      return `#${r}${g}${b}`;
     };
-    // Known legacy deviants to retire in the fallback-alignment wave
-    // (frozen 2026-09-12 census, 42 occurrences / 13 literals).
-    const KNOWN_DEVIANT_FALLBACKS = new Set([
-      "#ddd",
-      "#58a6ff", // as --hi-color-info fallback (canonical info is #79c0ff)
-      "#999",
-      "#7aa2f7",
-      "#ff6b9d",
-      "#222",
-      "#c9d1d9",
-      "#555",
-      "#888",
-      "#484f58",
-      "#6e7681",
-      "#8b949e", // as --hi-color-text-secondary fallback (canonical #666 = seed)
-    ]);
+    const CANONICAL: Record<string, string> = {
+      "--hi-color-primary": hexFromSeed("--color-primary"),
+      "--hi-color-secondary": hexFromSeed("--color-secondary"),
+      "--hi-color-surface": hexFromSeed("--color-surface"),
+      "--hi-color-background": hexFromSeed("--color-background"),
+      "--hi-color-border": hexFromSeed("--color-border"),
+      "--hi-color-text-primary": hexFromSeed("--color-text"),
+      "--hi-color-text-secondary": hexFromSeed("--color-text-secondary"),
+      "--hi-color-muted": hexFromSeed("--color-muted"),
+      "--hi-color-success": hexFromSeed("--color-success"),
+      "--hi-color-error": hexFromSeed("--color-error"),
+      "--hi-color-warning": hexFromSeed("--color-warning"),
+      "--hi-color-info": hexFromSeed("--color-info"),
+      "--hi-color-focused-border": hexFromSeed("--color-focused-border"),
+    };
+    const KNOWN_DEVIANT_FALLBACKS = new Set<string>([]);
 
     const componentsDir = resolve(stylesDir, "../components");
     const files = readdirSync(componentsDir).filter((f) => f.endsWith(".scss"));

--- a/packages/vue/src/styles/tokenInventory.test.ts
+++ b/packages/vue/src/styles/tokenInventory.test.ts
@@ -66,6 +66,9 @@ function harvestDefinitions(files: Array<[string, string]>) {
 const seedSource = stripProvenanceHeader(
   read(resolve(stylesDir, "theme/channels.scss")),
 );
+const scaleSource = stripProvenanceHeader(
+  read(resolve(stylesDir, "theme/scale.scss")),
+);
 const adminSource = read(resolve(stylesDir, "admin-tokens.scss"));
 const legacySheets = [
   "base.scss",
@@ -75,7 +78,10 @@ const legacySheets = [
   "_layout.scss",
 ].map((b) => [`theme/${b}`, stripProvenanceHeader(read(resolve(stylesDir, "theme", b)))] as [string, string]);
 
-const seedFiles: Array<[string, string]> = [["theme/channels.scss", seedSource]];
+const seedFiles: Array<[string, string]> = [
+  ["theme/channels.scss", seedSource],
+  ["theme/scale.scss", scaleSource],
+];
 
 // ── L0: channel completeness vs the runtime writer ──
 // Derive the exact `--color-*` / `--hi-*` key set tokensToCSSVars emits by

--- a/packages/vue/src/styles/tokenInventory.test.ts
+++ b/packages/vue/src/styles/tokenInventory.test.ts
@@ -1,0 +1,276 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Theme token inventory guard — the normalization contract.
+ *
+ * Tier model (one name, one definition, one sheet):
+ *   L0 channels  --color-*        palette triplets; static seed + runtime deltas
+ *   L1 semantic  --hi-color-* / --c-* / --shadow-* / --border-*  derivations
+ *   L2 scale     --space-N / --text-* / --radius-* / --blur-* /
+ *                --duration-* / --ease-* / --z-*                 constants
+ *   L3 hooks     --hk-<component>-* live in component files (not checked here)
+ *
+ * The allowlists below are the KNOWN legacy debt this normalization retires
+ * wave by wave. Shrinking an allowlist is the wave's acceptance test; growing
+ * one is a regression and should fail review.
+ */
+
+const stylesDir = resolve(dirname(fileURLToPath(import.meta.url)));
+
+function read(path: string): string {
+  return readFileSync(path, "utf8");
+}
+
+function stripComments(source: string): string {
+  // Block comments then line comments — enough for token-line parsing.
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+function stripProvenanceHeader(source: string): string {
+  const lines = source.split("\n");
+  let marker = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].includes("do not hand-edit here.")) {
+      marker = i;
+      break;
+    }
+  }
+  let i = marker + 1;
+  while (i < lines.length && lines[i].trim() === "") {
+    i += 1;
+  }
+  return lines.slice(i).join("\n");
+}
+
+/** name -> [{ file, value }] over `--name: value;` declarations. */
+function harvestDefinitions(files: Array<[string, string]>) {
+  const defs = new Map<string, Array<{ file: string; value: string }>>();
+  for (const [label, source] of files) {
+    const css = stripComments(source);
+    for (const m of css.matchAll(/(--[a-zA-Z0-9-]+)\s*:\s*([^;]+);/g)) {
+      const list = defs.get(m[1]) ?? [];
+      list.push({ file: label, value: m[2].replace(/\s+/g, " ").trim() });
+      defs.set(m[1], list);
+    }
+  }
+  return defs;
+}
+
+// ── The shipped static sheets (what a normalized host entry loads) ──
+const seedSource = stripProvenanceHeader(
+  read(resolve(stylesDir, "theme/channels.scss")),
+);
+const adminSource = read(resolve(stylesDir, "admin-tokens.scss"));
+const legacySheets = [
+  "base.scss",
+  "foundation.scss",
+  "themes.scss",
+  "_tokens.scss",
+  "_layout.scss",
+].map((b) => [`theme/${b}`, stripProvenanceHeader(read(resolve(stylesDir, "theme", b)))] as [string, string]);
+
+const seedFiles: Array<[string, string]> = [["theme/channels.scss", seedSource]];
+
+// ── L0: channel completeness vs the runtime writer ──
+// tokensToCSSVars (src/theme/presets.ts) emits exactly these --color-* keys.
+const RUNTIME_CHANNEL_KEYS = [
+  "--color-primary",
+  "--color-on-primary",
+  "--color-on-solid-text",
+  "--color-on-solid-icon",
+  "--color-on-solid",
+  "--color-secondary",
+  "--color-accent",
+  "--color-text",
+  "--color-text-secondary",
+  "--color-text-tertiary",
+  "--color-muted",
+  "--color-border",
+  "--color-focused-border",
+  "--color-background",
+  "--color-surface",
+  "--color-success",
+  "--color-error",
+  "--color-warning",
+  "--color-info",
+  "--color-bg-subtle",
+  "--color-bg-elevated",
+  "--color-bg-canvas",
+];
+
+describe("theme token inventory", () => {
+  // W4 target: the runtime derives these (presets.ts) but the static seed
+  // does not carry them yet — no-JS consumers get invalid var() today.
+  const KNOWN_MISSING_CHANNELS = new Set([
+    "--color-bg-subtle",
+    "--color-bg-elevated",
+    "--color-bg-canvas",
+  ]);
+
+  it("static seed defines every --color-* channel the runtime writes", () => {
+    const defs = harvestDefinitions(seedFiles);
+    const missing = RUNTIME_CHANNEL_KEYS.filter(
+      (k) => !defs.has(k) && !KNOWN_MISSING_CHANNELS.has(k),
+    );
+    expect(missing, "channels missing from the static seed").toEqual([]);
+  });
+
+  it("static seed has no --hi-* derivation that is not backed by a channel", () => {
+    const defs = harvestDefinitions(seedFiles);
+    const channels = new Set([...defs.keys()].filter((k) => k.startsWith("--color-")));
+    const dangling = [...defs.keys()]
+      .filter((k) => k.startsWith("--hi-color-"))
+      .filter((k) => {
+        const value = defs.get(k)![0].value;
+        return ![...value.matchAll(/var\((--color-[a-z0-9-]+)/g)].every((m) =>
+          channels.has(m[1]),
+        );
+      });
+    expect(dangling, "derivations referencing undefined channels").toEqual([]);
+  });
+
+  it("scale tokens are single-defined across the normalized sheets", () => {
+    // Current legacy debt: these names still multi-define across the
+    // legacy sheets + admin-tokens (frozen 2026-09-12 census, 56 names).
+    // Each entry must die in its wave; adding a NEW name here is a
+    // regression.
+    const KNOWN_MULTI_SCALE = new Set([
+      "--blur-lg",
+      "--blur-md",
+      "--blur-sm",
+      "--border-faint",
+      "--border-input",
+      "--border-subtle",
+      "--c-primary",
+      "--c-primary-light",
+      "--c-primary-overlay",
+      "--c-primary-subtle",
+      "--duration-fast",
+      "--duration-instant",
+      "--duration-normal",
+      "--duration-short",
+      "--ease-in-expo",
+      "--ease-in-out",
+      "--ease-out-expo",
+      "--ease-standard",
+      "--font-mono",
+      "--font-reading",
+      "--font-sans",
+      "--hi-bg-surface-dark",
+      "--hi-border-color-focus",
+      "--hi-duration-instant",
+      "--hi-ease-default",
+      "--hi-icon-color",
+      "--hi-icon-size-lg",
+      "--hi-icon-size-md",
+      "--hi-icon-size-sm",
+      "--hi-icon-size-xs",
+      "--hi-radius-lg",
+      "--hi-radius-md",
+      "--hi-radius-sm",
+      "--hi-radius-xl",
+      "--hi-shadow-button",
+      "--hi-shadow-elevated",
+      "--hi-shadow-lg",
+      "--hi-shadow-md",
+      "--hi-shadow-sm",
+      "--hi-shadow-xl",
+      "--opacity-half",
+      "--radius-md",
+      "--radius-sm",
+      "--space-10",
+      "--space-12",
+      "--space-14",
+      "--space-16",
+      "--space-2",
+      "--space-20",
+      "--space-24",
+      "--space-28",
+      "--space-32",
+      "--space-4",
+      "--space-40",
+      "--space-6",
+      "--space-8",
+      "--text-2xs",
+      "--text-base",
+      "--text-lg",
+      "--text-md",
+      "--text-sm",
+      "--text-xs",
+      "--z-base",
+      "--z-header",
+      "--z-sidebar",
+    ]);
+
+    const defs = harvestDefinitions([
+      seedFiles[0],
+      ...legacySheets,
+      ["admin-tokens.scss", adminSource],
+    ]);
+    const scaleRe = /^--(space-|text-|radius-|blur-|duration-|ease-|z-|border-|c-|opacity-|shadow-(?!dropdown|focus|button-danger)|font-|hi-(duration|ease|radius|icon|blur|opacity|shadow-(?!dropdown|focus)|z-|border-color))/;
+    const unexpected = [...defs.entries()]
+      .filter(([name, sites]) => {
+        if (!scaleRe.test(name)) return false;
+        const files = new Set(sites.map((s) => s.file));
+        if (files.size <= 1) return false;
+        return !KNOWN_MULTI_SCALE.has(name);
+      })
+      .map(([name]) => name);
+    expect(unexpected, "new multi-defined scale tokens").toEqual([]);
+  });
+
+  it("component --hi-color-* fallbacks stay on the canonical literals", () => {
+    // The standalone-render contract: when a host loads nothing, a
+    // component renders through these literals. One concept, one literal.
+    const CANONICAL: Record<string, string> = {
+      "--hi-color-primary": "#58a6ff",
+      "--hi-color-danger": "#f85149",
+      "--hi-color-text-primary": "#333",
+      "--hi-color-text-secondary": "#666",
+      "--hi-color-text-tertiary": "#8b949e",
+      "--hi-color-muted": "#666",
+      "--hi-color-border": "#30363d",
+      "--hi-color-surface": "#fff",
+      "--hi-color-success": "#3fb950",
+      "--hi-color-warning": "#d29922",
+      "--hi-color-info": "#79c0ff",
+    };
+    // Known legacy deviants to retire in the fallback-alignment wave
+    // (frozen 2026-09-12 census, 42 occurrences / 13 literals).
+    const KNOWN_DEVIANT_FALLBACKS = new Set([
+      "#ddd",
+      "#58a6ff", // as --hi-color-info fallback (canonical info is #79c0ff)
+      "#999",
+      "#7aa2f7",
+      "#ff6b9d",
+      "#222",
+      "#c9d1d9",
+      "#555",
+      "#888",
+      "#484f58",
+      "#6e7681",
+      "#8b949e", // as --hi-color-text-secondary fallback (canonical #666 = seed)
+    ]);
+
+    const componentsDir = resolve(stylesDir, "../components");
+    const files = readdirSync(componentsDir).filter((f) => f.endsWith(".scss"));
+    const deviants: string[] = [];
+    for (const f of files) {
+      const css = read(resolve(componentsDir, f));
+      for (const m of css.matchAll(/var\((--hi-color-[a-z0-9-]+),\s*(#[0-9a-fA-F]{3,8})\)/g)) {
+        const token = m[1];
+        const fallback = m[2].toLowerCase();
+        const canonical = CANONICAL[token];
+        if (!canonical) continue;
+        if (fallback !== canonical && !KNOWN_DEVIANT_FALLBACKS.has(fallback)) {
+          deviants.push(`${f}: var(${token}, ${m[2]})`);
+        }
+      }
+    }
+    expect(deviants, "non-canonical hex fallbacks").toEqual([]);
+  });
+});

--- a/packages/vue/src/styles/tokenInventory.test.ts
+++ b/packages/vue/src/styles/tokenInventory.test.ts
@@ -115,19 +115,9 @@ const RUNTIME_ALIAS_KEYS = Object.keys(RUNTIME_VARS).filter((k) =>
 );
 
 describe("theme token inventory", () => {
-  // W4 target: runtime-only tokens the static seed does not carry yet —
-  // no-JS consumers get invalid var() for these today.
-  const KNOWN_MISSING_CHANNELS = new Set([
-    "--color-selected-bg",
-    "--color-selected-text",
-    "--color-status-bar-bg",
-  ]);
-  const KNOWN_MISSING_ALIASES = new Set([
-    "--hi-color-bg-subtle",
-    "--hi-color-bg-elevated",
-    "--hi-color-bg-canvas",
-    "--hi-secondary-bg",
-  ]);
+  // W4 complete: the static seed now carries every runtime-written token.
+  const KNOWN_MISSING_CHANNELS = new Set<string>([]);
+  const KNOWN_MISSING_ALIASES = new Set<string>([]);
 
   it("static seed defines every --color-* channel the runtime writes", () => {
     const defs = harvestDefinitions(seedFiles);

--- a/packages/vue/src/styles/tokenInventory.test.ts
+++ b/packages/vue/src/styles/tokenInventory.test.ts
@@ -4,6 +4,8 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
+import { tokensToCSSVars, type ThemeSchemeTokens } from "../theme/presets";
+
 /**
  * Theme token inventory guard — the normalization contract.
  *
@@ -76,39 +78,49 @@ const legacySheets = [
 const seedFiles: Array<[string, string]> = [["theme/channels.scss", seedSource]];
 
 // ── L0: channel completeness vs the runtime writer ──
-// tokensToCSSVars (src/theme/presets.ts) emits exactly these --color-* keys.
-const RUNTIME_CHANNEL_KEYS = [
-  "--color-primary",
-  "--color-on-primary",
-  "--color-on-solid-text",
-  "--color-on-solid-icon",
-  "--color-on-solid",
-  "--color-secondary",
-  "--color-accent",
-  "--color-text",
-  "--color-text-secondary",
-  "--color-text-tertiary",
-  "--color-muted",
-  "--color-border",
-  "--color-focused-border",
-  "--color-background",
-  "--color-surface",
-  "--color-success",
-  "--color-error",
-  "--color-warning",
-  "--color-info",
-  "--color-bg-subtle",
-  "--color-bg-elevated",
-  "--color-bg-canvas",
-];
+// Derive the exact `--color-*` / `--hi-*` key set tokensToCSSVars emits by
+// calling it with a fixture scheme — the inventory then tracks the runtime
+// writer automatically as presets.ts evolves.
+const FIXTURE_RGB = { r: 1, g: 2, b: 3 };
+const FIXTURE_SCHEME: ThemeSchemeTokens = {
+  primary: FIXTURE_RGB,
+  secondary: FIXTURE_RGB,
+  accent: FIXTURE_RGB,
+  text: FIXTURE_RGB,
+  muted: FIXTURE_RGB,
+  border: FIXTURE_RGB,
+  focusedBorder: FIXTURE_RGB,
+  background: FIXTURE_RGB,
+  surface: FIXTURE_RGB,
+  selectedBackground: FIXTURE_RGB,
+  selectedText: FIXTURE_RGB,
+  statusBarBackground: FIXTURE_RGB,
+  success: FIXTURE_RGB,
+  error: FIXTURE_RGB,
+  warning: FIXTURE_RGB,
+  info: FIXTURE_RGB,
+};
+const RUNTIME_VARS = tokensToCSSVars(FIXTURE_SCHEME);
+const RUNTIME_CHANNEL_KEYS = Object.keys(RUNTIME_VARS).filter((k) =>
+  k.startsWith("--color-"),
+);
+const RUNTIME_ALIAS_KEYS = Object.keys(RUNTIME_VARS).filter((k) =>
+  k.startsWith("--hi-"),
+);
 
 describe("theme token inventory", () => {
-  // W4 target: the runtime derives these (presets.ts) but the static seed
-  // does not carry them yet — no-JS consumers get invalid var() today.
+  // W4 target: runtime-only tokens the static seed does not carry yet —
+  // no-JS consumers get invalid var() for these today.
   const KNOWN_MISSING_CHANNELS = new Set([
-    "--color-bg-subtle",
-    "--color-bg-elevated",
-    "--color-bg-canvas",
+    "--color-selected-bg",
+    "--color-selected-text",
+    "--color-status-bar-bg",
+  ]);
+  const KNOWN_MISSING_ALIASES = new Set([
+    "--hi-color-bg-subtle",
+    "--hi-color-bg-elevated",
+    "--hi-color-bg-canvas",
+    "--hi-secondary-bg",
   ]);
 
   it("static seed defines every --color-* channel the runtime writes", () => {
@@ -117,6 +129,14 @@ describe("theme token inventory", () => {
       (k) => !defs.has(k) && !KNOWN_MISSING_CHANNELS.has(k),
     );
     expect(missing, "channels missing from the static seed").toEqual([]);
+  });
+
+  it("static seed carries every --hi-* alias the runtime writes", () => {
+    const defs = harvestDefinitions(seedFiles);
+    const missing = RUNTIME_ALIAS_KEYS.filter(
+      (k) => !defs.has(k) && !KNOWN_MISSING_ALIASES.has(k),
+    );
+    expect(missing, "aliases missing from the static seed").toEqual([]);
   });
 
   it("static seed has no --hi-* derivation that is not backed by a channel", () => {

--- a/packages/vue/src/styles/vendoredSync.test.ts
+++ b/packages/vue/src/styles/vendoredSync.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * Vendored-copy drift guard.
+ *
+ * Two file families in src/styles are byte-identical re-copies of upstream
+ * sources (registry installs can only resolve paths inside this package):
+ *
+ *   1. styles/theme/channels.scss  ← src/tokens.scss
+ *   2. styles/theme/{base,foundation,themes,_tokens,_layout,variables,
+ *      mixins,_glass,_scrollbar}.scss  ← packages/theme/styles/*
+ *
+ * The re-copy adds exactly one provenance header comment block; everything
+ * after it must match the upstream byte-for-byte. Edit the UPSTREAM, then
+ * re-run scripts/theme/sync-vendored.sh — never hand-edit the copies.
+ */
+
+const stylesDir = resolve(dirname(fileURLToPath(import.meta.url)));
+
+function readTrimmed(path: string): string {
+  return readFileSync(path, "utf8").replace(/\r\n/g, "\n");
+}
+
+/** Strip the vendored provenance header: lines from the start through the
+ *  "do not hand-edit here." marker line, plus immediately following blank
+ *  lines. Everything after must equal the upstream byte-for-byte. */
+function stripProvenanceHeader(source: string): string {
+  const lines = source.split("\n");
+  let marker = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].includes("do not hand-edit here.")) {
+      marker = i;
+      break;
+    }
+  }
+  expect(marker, "vendored provenance header marker line").toBeGreaterThan(-1);
+  let i = marker + 1;
+  while (i < lines.length && lines[i].trim() === "") {
+    i += 1;
+  }
+  return lines.slice(i).join("\n");
+}
+
+const VENDORED_FROM_VUE: Array<[string, string]> = [
+  ["theme/channels.scss", "tokens.scss"],
+];
+
+const VENDORED_FROM_THEME_PKG = [
+  "base.scss",
+  "foundation.scss",
+  "themes.scss",
+  "_tokens.scss",
+  "_layout.scss",
+  "variables.scss",
+  "mixins.scss",
+  "_glass.scss",
+  "_scrollbar.scss",
+];
+
+describe("vendored theme copies match their upstream sources", () => {
+  it.each(VENDORED_FROM_VUE)(
+    "styles/%s is the headered copy of src/%s",
+    (vendored, upstream) => {
+      const upstreamSource = readTrimmed(
+        resolve(stylesDir, "..", upstream),
+      );
+      const vendoredBody = stripProvenanceHeader(
+        readTrimmed(resolve(stylesDir, vendored)),
+      );
+      expect(vendoredBody).toBe(upstreamSource);
+    },
+  );
+
+  it.each(VENDORED_FROM_THEME_PKG)(
+    "styles/theme/%s is the headered copy of packages/theme/styles/%s",
+    (basename) => {
+      const upstreamSource = readTrimmed(
+        resolve(stylesDir, "../../../theme/styles", basename),
+      );
+      const vendoredBody = stripProvenanceHeader(
+        readTrimmed(resolve(stylesDir, "theme", basename)),
+      );
+      expect(vendoredBody).toBe(upstreamSource);
+    },
+  );
+});

--- a/packages/vue/src/styles/vendoredSync.test.ts
+++ b/packages/vue/src/styles/vendoredSync.test.ts
@@ -47,6 +47,7 @@ function stripProvenanceHeader(source: string): string {
 
 const VENDORED_FROM_VUE: Array<[string, string]> = [
   ["theme/channels.scss", "tokens.scss"],
+  ["theme/scale.scss", "scale.scss"],
 ];
 
 const VENDORED_FROM_THEME_PKG = [

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -88,6 +88,12 @@
   --color-focused-border: 122 162 247;
   --color-background: 214 236 240;
   --color-surface: 240 244 248;
+  /* Derived seed defaults for the runtime-selected channels: a primary
+   * wash over the background (selected) and the surface tint (status
+   * bar), matching what presets derive at runtime. */
+  --color-selected-bg: 191 218 242;
+  --color-selected-text: 30 30 30;
+  --color-status-bar-bg: 240 244 248;
   --color-success: 14 184 64;
   --color-error: 247 118 142;
   --color-warning: 238 214 119;
@@ -97,7 +103,7 @@
   --hi-color-secondary: rgb(var(--color-secondary));
   --hi-color-surface: rgb(var(--color-surface));
   --hi-color-background: rgb(var(--color-background));
-  --hi-color-border: rgb(var(--color-border));
+  --hi-color-border: rgb(var(--color-border) / 15%);
   --hi-color-text-primary: rgb(var(--color-text));
   --hi-color-text-secondary: rgb(var(--color-text-secondary));
   --hi-color-muted: rgb(var(--color-muted));
@@ -111,6 +117,12 @@
   --hi-color-error: rgb(var(--color-error));
   --hi-color-warning: rgb(var(--color-warning));
   --hi-color-info: rgb(var(--color-info));
+  /* Surface-layer aliases the runtime writes on every apply — seeded so
+   * no-JS consumers resolve them instead of invalid var(). */
+  --hi-color-bg-subtle: rgb(var(--color-surface) / 0.5);
+  --hi-color-bg-elevated: rgb(var(--color-surface));
+  --hi-color-bg-canvas: rgb(var(--color-background));
+  --hi-secondary-bg: rgb(var(--color-surface) / 0.5);
 
   /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
      z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -123,6 +123,12 @@
   --hi-color-bg-elevated: rgb(var(--color-surface));
   --hi-color-bg-canvas: rgb(var(--color-background));
   --hi-secondary-bg: rgb(var(--color-surface) / 0.5);
+  --hi-color-accent: rgb(var(--color-accent));
+  /* Gen-1 shorthand references that were never defined anywhere — wired to
+     the canonical tokens so the consuming rules render as intended. */
+  --hi-primary: var(--hi-color-primary);
+  --hi-surface: var(--hi-color-surface);
+  --hi-card-bg: var(--hi-color-surface);
 
   /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
      z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,

--- a/packages/vue/src/tokens.scss
+++ b/packages/vue/src/tokens.scss
@@ -112,44 +112,8 @@
   --hi-color-warning: rgb(var(--color-warning));
   --hi-color-info: rgb(var(--color-info));
 
-  /* Design tokens consumed by hikari components. These used to live only in
-     plana-ui's token set; without them the background/backdrop declarations
-     of fields and surfaces resolve to nothing. Values align with plana-ui. */
-  --space-2: 0.125rem;
-  --space-4: 0.25rem;
-  --space-6: 0.375rem;
-  --space-8: 0.5rem;
-  --space-10: 0.625rem;
-  --space-12: 0.75rem;
-  --space-14: 0.875rem;
-  --space-16: 1rem;
-  --space-20: 1.25rem;
-  --space-24: 1.5rem;
-  --space-28: 1.75rem;
-  --space-32: 2rem;
-  --space-40: 2.5rem;
-  --text-2xs: 0.625rem;
-  --text-xs: 0.75rem;
-  --text-sm: 0.8125rem;
-  --text-base: 0.875rem;
-  --text-md: 1rem;
-  --text-lg: 1.125rem;
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --opacity-half: 0.92;
-  --blur-sm: 8px;
-  --blur-md: 16px;
-  --blur-lg: 24px;
-  --duration-fast: 0.15s;
-  --duration-short: 0.15s;
-  --duration-normal: 0.3s;
-  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
-  --ease-in-expo: cubic-bezier(0.95, 0.05, 0.795, 0.035);
-  --s-footer-height: 3rem;
-  --z-header: 30;
-  --z-sidebar: 40;
-  /* Apple-style stack + CJK UI tail — keep in sync with packages/vue/src/theme/fontContext.ts */
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
-  --font-reading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Noto Sans CJK SC", sans-serif;
+  /* Scale tokens (spacing/type/radius/blur/opacity/durations/easings/
+     z-index/fonts) moved to src/scale.scss — the canonical L2 sheet,
+     vendored as styles/theme/scale.scss. This file keeps only the
+     channel palette (above) and the --hi-* / --c-* bridges. */
 }

--- a/scripts/theme/sync-vendored.sh
+++ b/scripts/theme/sync-vendored.sh
@@ -41,5 +41,6 @@ for base in base foundation themes _tokens _layout variables mixins _glass _scro
   sync "$vue_styles/theme/$base.scss" "$root/packages/theme/styles/$base.scss"
 done
 sync "$vue_styles/theme/channels.scss" "$root/packages/vue/src/tokens.scss"
+sync "$vue_styles/theme/scale.scss" "$root/packages/vue/src/scale.scss"
 
 echo "vendored stylesheets are in sync"

--- a/scripts/theme/sync-vendored.sh
+++ b/scripts/theme/sync-vendored.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Re-copy the vendored theme stylesheets from their upstream sources.
+#
+#   packages/theme/styles/*.scss  -> packages/vue/src/styles/theme/*.scss
+#   packages/vue/src/tokens.scss  -> packages/vue/src/styles/theme/channels.scss
+#
+# Each vendored file keeps its existing provenance header (everything up to
+# and including the "do not hand-edit here." marker line); only the body is
+# refreshed from upstream. Run this after editing an upstream sheet, then
+# `pnpm -C packages/vue vitest run src/styles/vendoredSync.test.ts` (or the
+# full suite) — vendoredSync.test.ts fails on any drift.
+#
+# Usage: scripts/theme/sync-vendored.sh   (from the repo root)
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+vue_styles="$root/packages/vue/src/styles"
+
+sync() { # <vendored-file> <upstream-file>
+  local vendored="$1" upstream="$2"
+  [ -f "$vendored" ] || { echo "vendored file missing: $vendored" >&2; exit 1; }
+  [ -f "$upstream" ] || { echo "upstream file missing: $upstream" >&2; exit 1; }
+  local marker
+  marker=$(grep -n "do not hand-edit here." "$vendored" | head -1 | cut -d: -f1)
+  [ -n "$marker" ] || { echo "no provenance marker in $vendored" >&2; exit 1; }
+  local tmp
+  tmp="$(mktemp)"
+  head -n "$marker" "$vendored" > "$tmp"
+  printf '\n' >> "$tmp"
+  cat "$upstream" >> "$tmp"
+  if cmp -s "$tmp" "$vendored"; then
+    rm -f "$tmp"
+  else
+    mv "$tmp" "$vendored"
+    echo "synced $(realpath --relative-to="$root" "$vendored")"
+  fi
+}
+
+for base in base foundation themes _tokens _layout variables mixins _glass _scrollbar; do
+  sync "$vue_styles/theme/$base.scss" "$root/packages/theme/styles/$base.scss"
+done
+sync "$vue_styles/theme/channels.scss" "$root/packages/vue/src/tokens.scss"
+
+echo "vendored stylesheets are in sync"

--- a/scripts/theme/verify-composition.py
+++ b/scripts/theme/verify-composition.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Composition equivalence verifier for the theme normalization.
+
+Given two bundle compositions (ordered scss file lists), statically resolve
+the winning value of every token (all sheets declare on :root at equal
+specificity, so the LAST definition in bundle order wins — @use/@import
+inlines sheets in order) and diff the two final value tables.
+
+Usage:
+  python3 scripts/theme/verify-composition.py \
+    --old f1.scss f2.scss ... --new g1.scss g2.scss ...
+
+Exit code 0 when every token resolves to the same value in both bundles
+(allowlisted diffs excluded); 1 otherwise, printing each differing token.
+"""
+import argparse
+import re
+import sys
+
+
+def strip_comments(source: str) -> str:
+    source = re.sub(r"/\*[\s\S]*?\*/", "", source)
+    return re.sub(r"^[ \t]*//.*$", "", source, flags=re.M)
+
+
+def resolve_bundle(entry_files, base_dirs):
+    """Flatten @use/@import of local .scss files depth-first, dedup @use."""
+    ordered, seen = [], set()
+
+    def load(path):
+        real = path
+        for base in base_dirs:
+            candidate = os.path.join(base, path)
+            if os.path.isfile(candidate):
+                real = candidate
+                break
+        if real not in seen:
+            seen.add(real)
+            text = open(real).read()
+            text = re.sub(r"^//.*$", "", text, flags=re.M)
+            for m in re.finditer(r"@(?:use|import)\s+['\"]([^'\"]+)['\"]", text):
+                target = m.group(1)
+                if not target.endswith(".scss"):
+                    target += ".scss"
+                target = os.path.normpath(
+                    os.path.join(os.path.dirname(real), target)
+                )
+                load(target)
+            ordered.append(real)
+
+    for entry in entry_files:
+        load(entry)
+    return ordered
+
+
+def winning_values(files):
+    values = {}
+    for path in files:
+        css = strip_comments(open(path).read())
+        for m in re.finditer(r"(--[a-zA-Z0-9-]+)\s*:\s*([^;]+);", css):
+            values[m.group(1)] = re.sub(r"\s+", " ", m.group(2)).strip()
+    return values
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--old", nargs="+", required=True)
+    ap.add_argument("--new", nargs="+", required=True)
+    ap.add_argument("--base", nargs="+", required=True,
+                    help="directories used to resolve bundle-relative paths")
+    ap.add_argument("--allow", default="",
+                    help="comma-separated tokens allowed to differ")
+    args = ap.parse_args()
+    allow = set(filter(None, args.allow.split(",")))
+
+    old_files = resolve_bundle(args.old, args.base)
+    new_files = resolve_bundle(args.new, args.base)
+    old_vals = winning_values(old_files)
+    new_vals = winning_values(new_files)
+
+    diffs = []
+    for token in sorted(set(old_vals) | set(new_vals)):
+        before, after = old_vals.get(token), new_vals.get(token)
+        if before != after and token not in allow:
+            diffs.append((token, before, after))
+
+    print(f"old bundle: {len(old_files)} sheets, {len(old_vals)} tokens")
+    print(f"new bundle: {len(new_files)} sheets, {len(new_vals)} tokens")
+    for token, before, after in diffs:
+        print(f"DIFF {token}\n  old: {before}\n  new: {after}")
+    print(f"differing tokens: {len(diffs)}")
+    sys.exit(1 if diffs else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/theme/verify-composition.py
+++ b/scripts/theme/verify-composition.py
@@ -14,6 +14,7 @@ Exit code 0 when every token resolves to the same value in both bundles
 (allowlisted diffs excluded); 1 otherwise, printing each differing token.
 """
 import argparse
+import os
 import re
 import sys
 
@@ -27,26 +28,41 @@ def resolve_bundle(entry_files, base_dirs):
     """Flatten @use/@import of local .scss files depth-first, dedup @use."""
     ordered, seen = [], set()
 
-    def load(path):
-        real = path
+    def resolve_path(path):
+        def with_partial(p):
+            if os.path.isfile(p):
+                return p
+            partial = os.path.join(
+                os.path.dirname(p), "_" + os.path.basename(p)
+            )
+            return partial if os.path.isfile(partial) else None
+
+        direct = with_partial(path)
+        if direct:
+            return direct
         for base in base_dirs:
             candidate = os.path.join(base, path)
-            if os.path.isfile(candidate):
-                real = candidate
-                break
-        if real not in seen:
-            seen.add(real)
-            text = open(real).read()
-            text = re.sub(r"^//.*$", "", text, flags=re.M)
-            for m in re.finditer(r"@(?:use|import)\s+['\"]([^'\"]+)['\"]", text):
-                target = m.group(1)
-                if not target.endswith(".scss"):
-                    target += ".scss"
-                target = os.path.normpath(
-                    os.path.join(os.path.dirname(real), target)
-                )
-                load(target)
-            ordered.append(real)
+            partial = with_partial(candidate)
+            if partial:
+                return partial
+        raise FileNotFoundError(path)
+
+    def load(path):
+        real = resolve_path(path)
+        if real in seen:
+            return
+        seen.add(real)
+        text = open(real).read()
+        text = re.sub(r"^//.*$", "", text, flags=re.M)
+        for m in re.finditer(r"@(?:use|import)\s+['\"]([^'\"]+)['\"]", text):
+            target = m.group(1)
+            if not target.endswith(".scss"):
+                target += ".scss"
+            target = os.path.normpath(
+                os.path.join(os.path.dirname(real), target)
+            )
+            load(target)
+        ordered.append(real)
 
     for entry in entry_files:
         load(entry)


### PR DESCRIPTION
## Summary

Theme-system normalization for the component library, per the audit that followed the style-sweep wave (#473): the library had **five competing token-definition surfaces** (channel seed, Gen-1 hex sheets, foundation/_tokens/_layout, admin-tokens' mirror, plus per-component fallback literals), **56 scale tokens multi-defined** with conflicting values across them, **~80 dead token declarations**, a **static seed structurally out of sync with the runtime theme engine**, and a canonical style entry that **did not compile**.

After this branch, the architecture is:

```
L0 channels   --color-* (22 triplets)   one seed sheet + runtime deltas
L1 semantic   --hi-color-* / --c-* /
              --shadow-* / --border-*   pure derivations, zero hex
L2 scale      --space-N / --text-* /
              --radius-* / --blur-* /
              --duration-* / --ease-* /
              --z-* / --font-*          one scale sheet
L3 hooks      --hk-<component>-*        component files (unchanged)
```

Every name is defined exactly once in the canonical entry; theme-palette changes now happen in one place (the seed, or a runtime preset), semantic changes in another (the derivation sheet), and nothing else moves.

## What landed (per wave, one commit each)

1. **Guards first** — `vendoredSync.test.ts` (all vendored copies byte-match their upstreams), `tokenInventory.test.ts` (channel completeness derived **programmatically from `tokensToCSSVars`** so the check tracks the runtime writer; single-definition enforcement for the canonical sheets with the pre-existing debt frozen in an explicit allowlist; fallback literals pinned to one canonical value per token), and `scripts/theme/sync-vendored.sh` for the re-copy discipline.
2. **Scale consolidation** — new canonical `scale.scss` (upstream `src/scale.scss`) with the production-composition values; the competing definitions removed from `tokens.scss`/`channels.scss` and the plana-ui shared sheet; the redundant prefixed wrappers (`--hi-duration-*`/`--hi-radius-*`/`--hi-ease-*`, 167 occurrences) migrated to bare tokens.
3. **Seed completeness** — the three runtime-selected channels (`--color-selected-bg/-text/--color-status-bar-bg`) and the four surface-layer aliases (`--hi-color-bg-subtle/-elevated/-canvas`, `--hi-secondary-bg`) now exist statically; `--hi-color-border` gains the same 15% alpha the runtime writes — no-JS consumers no longer hit invalid `var()`.
4. **Entry rebuilt** — `styles/index.scss` composes channels + scale + admin-tokens and **compiles for the first time** (the old shell re-exported legacy paths that escape the npm package and failed to build). The legacy Gen-1 sheets stay available as granular imports for existing compositions.
5. **Gap fixes found by consumption audit** — `--hi-color-accent`, `--hi-primary`, `--hi-surface`, `--hi-card-bg`, `--hi-duration-fast`, `--hi-ease-default` were consumed but defined nowhere (invalid-at-computed-value, pre-existing); wired to canonical values. The json-tree toggle gets a deterministic 1rem fallback.

## Intentional rendering changes (standalone/no-theme faces only)

Hosts running `initTheme()` see **no change** — the runtime writes deltas for every palette token. The changes below affect only rendering that previously fell through to static defaults or component fallback literals:

- Fallback literals now derive from the seed palette: primary `#58a6ff`→`#7aa2f7`, error `#f85149`→`#f7768e`, warning `#d29922`→`#eed677`, success `#3fb950`→`#0eb840`, info `#79c0ff`→`#6abed6`, text `#333`→`#1e1e1e`, border `#30363d`→`#646464`, surface `#fff`→`#f0f4f8`, muted `#666`→`#6c6c6c`, text-secondary `#8b949e`→`#666666` (234 literals across 38 files, alpha-preserving for rgba forms).
- `--hi-color-border` is 15%-alpha in the seed (matches runtime; was opaque).
- z-header/z-sidebar canonicalized to the production values 100/900 (channels-standalone had 30/40); easings to the admin/channels variants.
- The accent alias and the previously-broken shorthands now render their intended values (e.g. the breadcrumb active state finally paints its primary fill).

## Verification

- New guards: vendored sync 11/11, token inventory 5/5 (allowlists for legacy faces now structural, not debt).
- Full `vitest run`: **156 files / 1419 tests green** at HEAD (two consecutive runs).
- `vue-tsc --noEmit` exit 0; all 122 component scss + every shipped sheet compile.
- `scripts/theme/verify-composition.py` documents the legacy-composition vs normalized-composition token tables (the two systems are different palettes by design; the diff inventory is the migration reference).
- `HkConfirmDialog.*`/`HkMessageBox.*` (in-flight #460 surface) untouched; one contract pin updated mechanically (`HkDrawer` family radius pin follows the retired `--hi-radius-lg` wrapper, value unchanged).

## Follow-up (recorded, not in this PR)

- chest's `hikari-chrome.scss` still composes the legacy Gen-1 sheets; migrating it to the canonical entry is a chest-side change that unlocks retiring the vendored Gen-1 copies.
- The Rust `packages/theme` grass bundle has no consumer; the crate can drop its SCSS build in a later cleanup.

Version bump: 0.43.12 → **0.43.13**.
