### PR TITLE
🔧 Realign the npm series to 0.43.15 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.14",
+  "version": "0.43.15",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
## Why

Automated release tagging picked up #476 (theme tokens) and published npm `0.43.14` at 07:00:19Z — five minutes before #477 merged at 07:05:06Z. #477 therefore landed on master with a version number that was already on the registry and already tagged (`v0.43.14` → `9beb98e7`, the #476 merge commit).

Consequences if left alone:

- the published `0.43.14` does NOT contain #477 (verified against the registry tarball: `src/composables/layoutGeometry.ts` is present but has no `laidOffsetWithin`, and the rework in `HkMinimap`/`HkScrollContainer`/`useZoomPan` is absent);
- master's own version is already published, so the release automation cannot tag/publish the wave that IS on master;
- shittim-chest resolves `@celestia-island/hikari: ^*`, so its pickup PR would install a `0.43.14` that silently lacks every geometry fix in this wave — including the chest-side call sites that now import `laidOffsetWithin`.

Same class of collision as #474, same fix: move the series forward one patch so master's content has a version of its own.

## What

`packages/vue/package.json`: `0.43.14` → `0.43.15`.

No code changes; the tree is exactly #477's merge commit otherwise. After this merges, `v0.43.15` tags #477 + this bump, and the chest pickup PR targets `0.43.15`.