### PR TITLE
🔧 Realign the npm series to 0.43.17 after a release tag race.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.43.16",
+  "version": "0.43.17",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",


### PR DESCRIPTION
The legacy-sheet retirement merge (cb54f736, #480) declared 0.43.16, but tag `v0.43.16` was already taken by #479's release. Advancing the series to 0.43.17 so the retirement content ships under a free version. Single-line version bump.