### PR TITLE
🎨 Align theme menu host strip rows to the shared lead column.

### DIFF
--- a/packages/vue/src/components/HkThemeToggle.contract.test.ts
+++ b/packages/vue/src/components/HkThemeToggle.contract.test.ts
@@ -7,12 +7,15 @@
  * assertion: the theme-row lead cell must carry an explicit size that
  * fits the widest host lead mark, not just the mixin's generic box.
  *
- * The widened cell must stay scoped to the lead slot (2026-09-12 field
- * report): shipped first as a bare `.s-theme-item-btn .hk-menu-item-icon`
- * rule, it also matched the 自定义 row and every host row reusing
- * s-theme-item-btn (chest's mode-extra DPI entry) — and mi.icon
- * normalizes those cells' svg to the cell, so their 14px glyphs rendered
- * 28px wide.
+ * The widened cell must stay scoped (2026-09-12 field report): shipped
+ * first as a bare `.s-theme-item-btn .hk-menu-item-icon` rule, it also
+ * matched the 自定义 row and every host row reusing s-theme-item-btn —
+ * and mi.icon normalizes those cells' svg to the cell, so their 14px
+ * glyphs rendered 28px wide. The widening therefore targets named scopes
+ * (lead slot, customize row) plus the toggle-owned mode-extra strip, the
+ * last one widening the CELL while pinning the glyph back to the
+ * standard box so host strip rows (chest's DPI entry) align their labels
+ * with the theme rows' names without rescaling their icons.
  */
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
@@ -33,12 +36,12 @@ describe("HkThemeToggle row lead-cell contract", () => {
     expect(block![0]).toContain("height: 28px");
   });
 
-  it("does not widen icon cells outside the leading slot", () => {
+  it("does not widen icon cells with a bare unscoped theme-row rule", () => {
     const css = read("HkThemeToggle.scss");
     // A bare `.s-theme-item-btn .hk-menu-item-icon {` rule also hits the
     // customize row and host mode-extra rows; the widened cell may only
-    // target the lead slot class.
-    expect(css).not.toMatch(/\.s-theme-item-btn \.hk-menu-item-icon\s*\{/);
+    // target named scopes (lead slot, customize row, mode-extra strip).
+    expect(css).not.toMatch(/^\.s-theme-item-btn \.hk-menu-item-icon\s*\{/m);
   });
 
   it("aligns the customize row to the lead column without rescaling its glyph", () => {
@@ -56,6 +59,25 @@ describe("HkThemeToggle row lead-cell contract", () => {
 
     const svgBlock = css.match(
       /\.s-theme-item-customize \.hk-menu-item-icon > svg\s*\{[^}]*\}/,
+    );
+    expect(svgBlock).not.toBeNull();
+    expect(svgBlock![0]).toContain("var(--hk-menu-item-icon-box)");
+  });
+
+  it("aligns mode-extra host rows to the lead column without rescaling their glyph", () => {
+    const css = read("HkThemeToggle.scss");
+    // Host strip rows (chest's DPI entry) join the 28px lead column so
+    // their label starts at the same x as the theme rows' names
+    // (2026-09-12 field report), but the glyph keeps the standard box.
+    const block = css.match(
+      /\.s-theme-mode-extra \.s-theme-item-btn \.hk-menu-item-icon\s*\{[^}]*\}/,
+    );
+    expect(block).not.toBeNull();
+    expect(block![0]).toContain("width: 28px");
+    expect(block![0]).toContain("height: 28px");
+
+    const svgBlock = css.match(
+      /\.s-theme-mode-extra \.s-theme-item-btn \.hk-menu-item-icon > svg\s*\{[^}]*\}/,
     );
     expect(svgBlock).not.toBeNull();
     expect(svgBlock![0]).toContain("var(--hk-menu-item-icon-box)");

--- a/packages/vue/src/components/HkThemeToggle.scss
+++ b/packages/vue/src/components/HkThemeToggle.scss
@@ -243,6 +243,27 @@
   height: var(--hk-menu-item-icon-box);
 }
 
+/* Host rows in the mode-extra strip (chest's DPI entry row reuses
+ * s-theme-item-btn) join the same 28px lead column, so every row's name
+ * in the toggle starts at one x — desktop popover and mobile sheet both
+ * (2026-09-12 field report: with the strip row at the generic 16px cell
+ * its label sat a full cell-width left of the theme rows' names). The
+ * strip container is the toggle's own, so the scope needs no host
+ * class-name contract. As with the customize row, the cell widens but
+ * the GLYPH keeps the standard menu icon size — widening a cell must
+ * never re-scale its glyph (the 0.42.2 regression class). */
+.s-theme-mode-extra .s-theme-item-btn .hk-menu-item-icon {
+  @include mi.icon;
+
+  width: 28px;
+  height: 28px;
+}
+
+.s-theme-mode-extra .s-theme-item-btn .hk-menu-item-icon > svg {
+  width: var(--hk-menu-item-icon-box);
+  height: var(--hk-menu-item-icon-box);
+}
+
 /* Custom rows keep the name clear of the overlaid delete button. */
 .s-theme-item-row[data-custom] .s-theme-item-name {
   margin-inline-end: 2rem;


### PR DESCRIPTION
## Problem

Field report (chest, mobile sheet screenshot): the **DPI 控制** entry row in the theme menu is not left-aligned with the theme rows below it — its label sits ~12px further left.

## Root cause

Theme rows widen their leading icon cell to 28px (`.s-theme-item-btn .hk-menu-item-icon.s-theme-item-lead`, #475-class fix) and the customize row was widened separately — both so every row's name starts at the same x. Host rows in the `mode-extra` strip (chest's DPI entry, which correctly reuses `s-theme-item-btn` + `hk-menu-item-icon` + `s-theme-item-name`) kept the generic 16px cell: label x = 12+16+8 = 36px vs the theme rows' 12+28+8 = 48px (sheet: 52 vs 64). The 2026-09-12 scoping deliberately excluded host rows from the widening to avoid glyph rescaling — which fixed the 0.42.2 regression class but left this alignment hole.

## Fix

- Widen the icon **cell** to 28px for rows inside the toggle-owned `.s-theme-mode-extra` strip (no host class-name contract needed), and pin the **glyph** back to `var(--hk-menu-item-icon-box)` — widening a cell must never re-scale its glyph (0.42.2 regression class).
- Contract test: the anti-bare-rule guard is anchored to the rule start (`^…/m`) so the new scoped rule is legal, and a new case pins the strip cell widening + glyph geometry. Mutation-verified (28px→16px turns the new case red).
- Version bump: `@celestia-island/hikari` 0.44.0 → 0.44.1 (CSS-only change).

## Verification

- Independent subagent: geometry check for desktop popover and mobile sheet contexts, glyph-pin specificity/source-order check, mutation red→green, 14/14 tests pass, blast-radius grep clean.
- `vitest run HkThemeToggle.contract.test.ts HkThemeToggle.test.ts` → 14/14 green.

## Follow-ups (audit findings, not in this PR)

Independent audit of chest/hikari row grammar drift recorded in PLAN: PlatformSwitcher add-row bespoke divider/padding, AccountSwitch/LocalePickerModal hand-rolled rows diverging from `mi.item`, host slots (`menu-extra`/`user-menu-extra`/HkMenu header/footer) lacking a row-grammar wrapper, PlatformSwitcher parallel mi.icon/mi.label copy.

---
Rebased onto master (b8c7cd21); head force-pushed to 737bbdf6 to pick up #487. Version rebased to 0.45.1 (npm latest 0.45.0 from #485). Tests re-run green locally (14/14 incl. contract).