### PR TITLE
🛡️ Drop the links caption from the about modal.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.45.0",
+  "version": "0.45.1",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkAboutModal.tsx
+++ b/packages/vue/src/components/HkAboutModal.tsx
@@ -160,7 +160,6 @@ export const HkAboutModal = defineComponent({
 
             {props.links.length > 0 && (
               <div class="s-about-modal-links">
-                <span class="s-about-modal-row-label">{t("hikari::about.links", "Links")}</span>
                 <div class="s-about-modal-links-list">
                   {props.links.map((link) => (
                     <a

--- a/packages/vue/src/i18n/locales/ar/platform.json
+++ b/packages/vue/src/i18n/locales/ar/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "البناء",
     "hikari::about.engineVersion": "إصدار المحرك",
     "hikari::about.engineBuildHash": "بناء المحرك",
-    "hikari::about.links": "روابط",
     "hikari::about.author": "المؤلف",
     "hikari::about.license": "الترخيص",
     "hikari::theme.mode": "وضع السمة",

--- a/packages/vue/src/i18n/locales/de/platform.json
+++ b/packages/vue/src/i18n/locales/de/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Build",
     "hikari::about.engineVersion": "Engine-Version",
     "hikari::about.engineBuildHash": "Engine-Build",
-    "hikari::about.links": "Links",
     "hikari::about.author": "Autor",
     "hikari::about.license": "Lizenz",
     "hikari::theme.mode": "Design-Modus",

--- a/packages/vue/src/i18n/locales/en/platform.json
+++ b/packages/vue/src/i18n/locales/en/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Build",
     "hikari::about.engineVersion": "Engine version",
     "hikari::about.engineBuildHash": "Engine build",
-    "hikari::about.links": "Links",
     "hikari::about.author": "Author",
     "hikari::about.license": "License",
     "hikari::theme.mode": "Theme mode",

--- a/packages/vue/src/i18n/locales/es/platform.json
+++ b/packages/vue/src/i18n/locales/es/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Compilación",
     "hikari::about.engineVersion": "Versión del motor",
     "hikari::about.engineBuildHash": "Compilación del motor",
-    "hikari::about.links": "Enlaces",
     "hikari::about.author": "Autor",
     "hikari::about.license": "Licencia",
     "hikari::theme.mode": "Modo de tema",

--- a/packages/vue/src/i18n/locales/fr/platform.json
+++ b/packages/vue/src/i18n/locales/fr/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Build",
     "hikari::about.engineVersion": "Version du moteur",
     "hikari::about.engineBuildHash": "Build du moteur",
-    "hikari::about.links": "Liens",
     "hikari::about.author": "Auteur",
     "hikari::about.license": "Licence",
     "hikari::theme.mode": "Mode du thème",

--- a/packages/vue/src/i18n/locales/ja/platform.json
+++ b/packages/vue/src/i18n/locales/ja/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "ビルド",
     "hikari::about.engineVersion": "エンジンバージョン",
     "hikari::about.engineBuildHash": "エンジンビルド",
-    "hikari::about.links": "リンク",
     "hikari::about.author": "作者",
     "hikari::about.license": "ライセンス",
     "hikari::theme.mode": "テーマモード",

--- a/packages/vue/src/i18n/locales/ko/platform.json
+++ b/packages/vue/src/i18n/locales/ko/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "빌드",
     "hikari::about.engineVersion": "엔진 버전",
     "hikari::about.engineBuildHash": "엔진 빌드",
-    "hikari::about.links": "링크",
     "hikari::about.author": "제작자",
     "hikari::about.license": "라이선스",
     "hikari::theme.mode": "테마 모드",

--- a/packages/vue/src/i18n/locales/pt/platform.json
+++ b/packages/vue/src/i18n/locales/pt/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Build",
     "hikari::about.engineVersion": "Versão do motor",
     "hikari::about.engineBuildHash": "Build do motor",
-    "hikari::about.links": "Links",
     "hikari::about.author": "Autor",
     "hikari::about.license": "Licença",
     "hikari::theme.mode": "Modo do tema",

--- a/packages/vue/src/i18n/locales/ru/platform.json
+++ b/packages/vue/src/i18n/locales/ru/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "Сборка",
     "hikari::about.engineVersion": "Версия движка",
     "hikari::about.engineBuildHash": "Сборка движка",
-    "hikari::about.links": "Ссылки",
     "hikari::about.author": "Автор",
     "hikari::about.license": "Лицензия",
     "hikari::theme.mode": "Режим темы",

--- a/packages/vue/src/i18n/locales/zh-Hans/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hans/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "构建",
     "hikari::about.engineVersion": "引擎版本",
     "hikari::about.engineBuildHash": "引擎构建",
-    "hikari::about.links": "链接",
     "hikari::about.author": "作者",
     "hikari::about.license": "许可证",
     "hikari::theme.mode": "主题模式",

--- a/packages/vue/src/i18n/locales/zh-Hant/platform.json
+++ b/packages/vue/src/i18n/locales/zh-Hant/platform.json
@@ -17,7 +17,6 @@
     "hikari::about.buildHash": "建置",
     "hikari::about.engineVersion": "引擎版本",
     "hikari::about.engineBuildHash": "引擎建置",
-    "hikari::about.links": "連結",
     "hikari::about.author": "作者",
     "hikari::about.license": "授權條款",
     "hikari::theme.mode": "主題模式",


### PR DESCRIPTION
User feedback on the branded about dialog (chest #813/#816): the chips row carried a "Links" caption that reads as a stray subtitle above self-explanatory chips. Remove the caption (chips render directly) and the now-unused `hikari::about.links` keys from all 11 locale bundles. Version 0.45.0 → 0.45.1.

Verification: `vue-tsc --noEmit` exit 0 · `vitest run HkAboutModal.test.tsx src/i18n` 20/20 green (flat-key parity still passes with the key removed everywhere).