### PR TITLE
🐛 Pin leave geometry in HkListTransition to prevent full-width flash.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celestia-island/hikari",
-  "version": "0.45.1",
+  "version": "0.45.2",
   "private": false,
   "type": "module",
   "description": "Hikari Vue 3 component library — production-grade UI components based on shittim-chest design system",

--- a/packages/vue/src/components/HkListTransition.scss
+++ b/packages/vue/src/components/HkListTransition.scss
@@ -94,13 +94,18 @@
   opacity: 0;
 }
 
+/* The leave ghost keeps its in-flow geometry via the pinLeaveGeometry
+ * hook wired in HkListTransition.tsx (explicit width/top/left inline
+ * pins). Do NOT add `width: 100%` here — without a position:relative
+ * host it resolves against the nearest positioned ancestor's collapsed
+ * box and the row flashes full-width while fading (the toast #306
+ * defect class). */
 .hk-list-grow-leave-active {
   transition:
     transform var(--duration-fast, 0.15s) cubic-bezier(0.5, 0, 0.75, 0),
     opacity var(--duration-fast, 0.15s) ease-in;
   pointer-events: none;
   position: absolute;
-  width: 100%;
 }
 
 .hk-list-grow-leave-to {

--- a/packages/vue/src/components/HkListTransition.test.tsx
+++ b/packages/vue/src/components/HkListTransition.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+
+import HkListTransition from "./HkListTransition";
+
+/**
+ * HkListTransition leave-geometry contract:
+ * - a leaving row in an absolute-leave variant (pop/slide/fade/grow) is
+ *   pinned to its measured in-flow box by the before-leave hook
+ *   (pinLeaveGeometry), so it cannot flash to `width: 100%` of a
+ *   collapsed containing block when the host is not position:relative
+ * - the `reveal` variant animates its own height and must NOT be pinned
+ *
+ * (Repo test convention: raw createApp + document queries, no
+ * @vue/test-utils dependency; happy-dom has no layout engine, so
+ * offset* metrics are stubbed.)
+ */
+
+const mounts: Array<{ app: ReturnType<typeof createApp>; container: HTMLElement }> = [];
+
+type Variant = "pop" | "slide" | "fade" | "grow" | "reveal";
+
+function mountRows(variant: Variant, keys: () => string[]) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp({
+    render: () =>
+      h(
+        HkListTransition,
+        { tag: "ul", variant },
+        { default: () => keys().map((k) => h("li", { key: k }, k)) },
+      ),
+  });
+  mounts.push({ app, container });
+  app.mount(container);
+  return container;
+}
+
+function stubLayout(el: HTMLElement, over: Partial<{
+  offsetTop: number;
+  offsetLeft: number;
+  offsetWidth: number;
+  offsetHeight: number;
+}> = {}): void {
+  const wrapper = el.parentElement as HTMLElement;
+  Object.defineProperty(wrapper, "clientWidth", { value: 300, configurable: true });
+  Object.defineProperty(el, "offsetParent", { value: wrapper, configurable: true });
+  Object.defineProperty(el, "offsetTop", { value: over.offsetTop ?? 0, configurable: true });
+  Object.defineProperty(el, "offsetLeft", { value: over.offsetLeft ?? 0, configurable: true });
+  Object.defineProperty(el, "offsetWidth", { value: over.offsetWidth ?? 300, configurable: true });
+  Object.defineProperty(el, "offsetHeight", { value: over.offsetHeight ?? 40, configurable: true });
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(document.querySelectorAll<HTMLElement>("ul > li"));
+}
+
+afterEach(() => {
+  for (const { app, container } of mounts.splice(0)) {
+    app.unmount();
+    container.remove();
+  }
+});
+
+describe("HkListTransition leave geometry", () => {
+  it("pins the leaving grow row to its in-flow box instead of width:100%", async () => {
+    const keys = ref(["a", "b", "c"]);
+    mountRows("grow", () => keys.value);
+    await nextTick();
+
+    stubLayout(rows()[1]!, { offsetTop: 40, offsetLeft: 0, offsetWidth: 300, offsetHeight: 40 });
+
+    keys.value = ["a", "c"];
+    await nextTick();
+    await nextTick();
+
+    const leaving = document.querySelector<HTMLElement>(".hk-list-grow-leave-active");
+    expect(leaving).not.toBeNull();
+    // The pin mirrors the measured in-flow box exactly; a percentage
+    // width would resolve against a possibly-collapsed containing block.
+    expect(leaving!.style.left).toBe("0px");
+    expect(leaving!.style.top).toBe("40px");
+    expect(leaving!.style.width).toBe("300px");
+    expect(leaving!.style.height).toBe("40px");
+    expect(leaving!.style.boxSizing).toBe("border-box");
+    expect(leaving!.style.width).not.toBe("100%");
+  });
+
+  it("does not pin the reveal variant (its own height drives the squeeze)", async () => {
+    const keys = ref(["a", "b"]);
+    mountRows("reveal", () => keys.value);
+    await nextTick();
+
+    stubLayout(rows()[0]!);
+
+    keys.value = ["b"];
+    await nextTick();
+    await nextTick();
+
+    const leaving = document.querySelector<HTMLElement>(".hk-list-reveal-leave-active");
+    expect(leaving).not.toBeNull();
+    expect(leaving!.style.height).toBe("");
+    expect(leaving!.style.width).toBe("");
+  });
+});

--- a/packages/vue/src/components/HkListTransition.tsx
+++ b/packages/vue/src/components/HkListTransition.tsx
@@ -1,5 +1,6 @@
-import { defineComponent, TransitionGroup, type PropType } from "vue";
+import { defineComponent, onBeforeUpdate, ref, TransitionGroup, type PropType } from "vue";
 
+import { clearLeaveGeometry, pinLeaveGeometry, type LeaveBoxSnapshot } from "../utils/dom";
 import { useReportedTransition } from "../composables/useReportedTransition";
 
 import "./HkListTransition.scss";
@@ -63,10 +64,58 @@ export default defineComponent({
       if (pending === 0) report.cancel();
     };
 
+    // Variants whose leave-active rule lifts the row out of flow with
+    // `position: absolute` (see HkListTransition.scss). Only these need
+    // the geometry pin; `reveal` animates the row's own height in place
+    // and `none` never leaves the flow, so a pin would freeze the very
+    // property they animate.
+    const ABSOLUTE_VARIANTS: ReadonlySet<string> = new Set(["pop", "slide", "fade", "grow"]);
+
+    // Pre-patch geometry of every row, refreshed on each update (the DOM
+    // is still the pre-patch tree at onBeforeUpdate — same pattern as
+    // HkTabs). During a multi-row removal the first leaving sibling gets
+    // its leave-active class (position:absolute) synchronously inside the
+    // patch pass, so a live offset read in a later sibling's beforeLeave
+    // hook would freeze an already-reflowed position. The pin also
+    // replaces `grow`'s old `width: 100%`, which resolved against a
+    // possibly-collapsed containing block when the host is not
+    // position:relative (the full-width leave flash).
+    const hostRef = ref<{ $el?: Element } | null>(null);
+    const prePatchBoxes = new WeakMap<Element, LeaveBoxSnapshot>();
+    onBeforeUpdate(() => {
+      // Fragment hosts (tag="") have a comment anchor as $el — no
+      // element children to measure there.
+      const host = hostRef.value?.$el;
+      if (host == null || host.nodeType !== 1) return;
+      for (const child of Array.from(host.children)) {
+        const e = child as HTMLElement;
+        prePatchBoxes.set(e, {
+          top: e.offsetTop,
+          left: e.offsetLeft,
+          width: e.offsetWidth,
+          height: e.offsetHeight,
+        });
+      }
+    });
+
+    const usesAbsoluteLeave = () =>
+      !props.disabled && ABSOLUTE_VARIANTS.has(props.variant);
+
+    function pinLeaving(el: Element) {
+      if (!usesAbsoluteLeave()) return;
+      pinLeaveGeometry(el, { anchorX: "left", box: prePatchBoxes.get(el) });
+    }
+
+    function unpinLeaving(el: Element) {
+      if (!usesAbsoluteLeave()) return;
+      clearLeaveGeometry(el);
+    }
+
     return () => {
       const name = props.disabled ? "hk-list-none" : `hk-list-${props.variant}`;
       return (
         <TransitionGroup
+          ref={hostRef}
           tag={props.tag}
           name={name}
           appear={props.appear}
@@ -74,9 +123,15 @@ export default defineComponent({
           onBeforeEnter={arm}
           onAfterEnter={settle}
           onEnterCancelled={settle}
-          onBeforeLeave={arm}
+          onBeforeLeave={(el: Element) => {
+            arm();
+            pinLeaving(el);
+          }}
           onAfterLeave={settle}
-          onLeaveCancelled={settle}
+          onLeaveCancelled={(el: Element) => {
+            settle();
+            unpinLeaving(el);
+          }}
         >
           {slots.default?.()}
         </TransitionGroup>


### PR DESCRIPTION
## Defect (AGENTS §4.3 known issue, toast #306 defect class)

`.hk-list-grow-leave-active` carried `position: absolute; width: 100%` while a typical `HkListTransition` host is **not** `position: relative`. Reproduction path:

1. A `TransitionGroup` host that is shrink-to-fit (or has no positioned ancestor between it and a wide positioned ancestor) loses its in-flow children the instant a row starts leaving.
2. The leaving row is lifted out of flow and its `width: 100%` resolves against that (possibly collapsed / unrelated) containing block instead of the list it came from.
3. The ghost flashes to the wrong width and its static position jumps while it fades — a one-frame full-width flash on row removal. `pop`/`slide`/`fade` had the same `position: absolute` leave without any width pin (shrink-to-fit fallback of the same defect class).

## Fix

Same pattern already proven in `HkToast` / `HkTabs`:

- Wire the shared `pinLeaveGeometry` / `clearLeaveGeometry` utils (`src/utils/dom.ts`) into the `TransitionGroup` `before-leave` / `leave-cancelled` hooks. Each leaving row is pinned at its measured in-flow box (`left/top/width/height` + `border-box`, `anchorX: "left"`), so the leave plays as a true mirror of the entrance with no width/position jump.
- Multi-row removals use the `HkTabs` pre-patch snapshot: `onBeforeUpdate` records every row's box (DOM is still pre-patch there; a later sibling's live read would freeze an already-reflowed position after the first sibling's synchronous `position: absolute`). Fragment hosts (`tag=""`, e.g. `HkTagInput`) have a comment anchor as `$el` and are skipped via a `nodeType === 1` guard.
- Only the absolute-leave variants (`pop`/`slide`/`fade`/`grow`) pin; `reveal` animates its own height in place and `none` never leaves the flow — pinning would freeze the very property they animate. `disabled` never pins.
- `.hk-list-grow-leave-active`'s `width: 100%` is removed — the inline pin replaces it.
- Enter choreography, FLIP `move`, stagger delays, reduced-motion rules and the animation-bus report (`arm`/`settle` refcount) are unchanged.

## Verification (mutation-tested, §6.2)

- New `HkListTransition.test.tsx` regression cases: grow leave pins the exact in-flow box (and explicitly not `width: 100%`); `reveal` is never pinned.
- Mutation check: disabling the pin makes the grow regression test fail; restoring it goes green again.
- `vue-tsc --noEmit` exit 0; full `vitest run`: **1448/1448 pass** (163 files), including the `HkTagInput` consumer suite (90 tests) that originally caught the fragment-host regression during development.
- Independent subagent cross-verified pin math against the `pinLeaveGeometry` contract and the consumer matrix.

## Version

`@celestia-island/hikari` 0.43.18 → 0.43.19 (patch bump in this PR; npm publish via the existing release workflow).